### PR TITLE
feat: add filter for category filed in articles

### DIFF
--- a/helpdesk/helpdesk/doctype/article/article.js
+++ b/helpdesk/helpdesk/doctype/article/article.js
@@ -3,6 +3,14 @@
 
 frappe.ui.form.on('Article', {
 	refresh: function(frm) {
+		frm.set_query("category", function() {
+			return {
+				"filters": {
+					"is_group": "0",
+				}
+			};
+		});
+
 		show_content_wrt_type(frm);
 		
 		frm.dashboard.clear_headline();


### PR DESCRIPTION
Since the leaf categories can only have articles, It does not make sense to show all the categories while setting article, so here I have added a filter for the categories field, now only the leaf categories will be shown to the user while setting category for an article

Before
![image](https://user-images.githubusercontent.com/22856401/151703122-1ddf553e-4a38-4474-9fd0-ba7dfb328277.png)

After adding the filter
![image](https://user-images.githubusercontent.com/22856401/151703099-691b45cf-54b3-4eea-aaff-8bb733f40746.png)

resolves #54 