### PR TITLE
fix: remove pluck field option

### DIFF
--- a/desk/src/pages/portal/NewTicket.vue
+++ b/desk/src/pages/portal/NewTicket.vue
@@ -225,8 +225,7 @@ export default {
 						list = await call(field.api_method)
 						break;
 					case 'frappe.get_list()':
-						list = [...new Set((await call('frappe.client.get_list', { doctype, filters: field.filters, fields: [field.pluck] })).map(x => x[field.pluck]))]
-						console.log(list)
+						list = (await call('frappe.client.get_list', { doctype, filters: field.filters })).map(x => x.name)
 						break;
 				}
 				list.forEach(doc => {

--- a/frappedesk/frappedesk/doctype/ticket_template_docfield/ticket_template_docfield.json
+++ b/frappedesk/frappedesk/doctype/ticket_template_docfield/ticket_template_docfield.json
@@ -10,7 +10,6 @@
   "fieldtype",
   "filter_using",
   "filters",
-  "pluck",
   "api_method",
   "reqd",
   "options",
@@ -79,13 +78,6 @@
    "label": "Filters"
   },
   {
-   "default": "name",
-   "depends_on": "eval:(doc.fieldtype=='Link' && doc.filter_using!='API Response' && !doc.auto_set)",
-   "fieldname": "pluck",
-   "fieldtype": "Data",
-   "label": "Pluck"
-  },
-  {
    "depends_on": "eval:(doc.fieldtype=='Link' && !doc.auto_set)",
    "fieldname": "filter_using",
    "fieldtype": "Select",
@@ -101,7 +93,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2022-04-29 14:27:25.423702",
+ "modified": "2022-04-29 14:51:18.176251",
  "modified_by": "Administrator",
  "module": "FrappeDesk",
  "name": "Ticket Template DocField",


### PR DESCRIPTION
Since the field (default: 'name') is used also for routing, this cannot be any other field other than 'name', hence removing this feature