### PR TITLE
fix: Cmd instead of Ctrl on Mac

### DIFF
--- a/desk/src/pages/desk/Ticket.vue
+++ b/desk/src/pages/desk/Ticket.vue
@@ -167,9 +167,9 @@ export default {
 					keyboard: {
 						bindings: {
 							// Ctrl+Enter to send reply
-							cmdEnter: {
+							ctrlEnter: {
 								key: 13,
-								ctrlKey: true,
+								shortKey: true,
 								handler: () => {
 									this.submitConversation();
 								}

--- a/desk/src/pages/portal/Ticket.vue
+++ b/desk/src/pages/portal/Ticket.vue
@@ -135,10 +135,10 @@ export default {
 					],
 					keyboard: {
 						bindings: {
-							// Cmd+Enter to send reply
-							cmdEnter: {
+							// Ctrl+Enter to send reply
+							ctrlEnter: {
 								key: 13,
-								ctrlKey: true,
+								shortKey: true,
 								handler: () => {
 									this.submitConversation();
 								}


### PR DESCRIPTION
Use `Cmd` key instead of `Ctrl` key on a mac. The `shortKey` property in Quill Keyboard Module config will take care of this.

### ✌️