### PR TITLE
feat: cc and bcc in ticket conversation reply

### DIFF
--- a/desk/src/components/desk/global/CustomIcons.vue
+++ b/desk/src/components/desk/global/CustomIcons.vue
@@ -1506,10 +1506,10 @@
 			/>
 		</svg>
 		<svg
-			v-if="this.name == 'arrow-down'"
-			:class="this.class"
-			:width="this.width"
-			:height="this.height"
+			v-if="name == 'arrow-down'"
+			:class="class"
+			:width="width"
+			:height="height"
 			viewBox="0 0 24 24"
 			fill="none"
 			xmlns="http://www.w3.org/2000/svg"

--- a/desk/src/components/desk/global/CustomIcons.vue
+++ b/desk/src/components/desk/global/CustomIcons.vue
@@ -1505,6 +1505,23 @@
 				stroke-linejoin="round"
 			/>
 		</svg>
+		<svg
+			v-if="this.name == 'arrow-down'"
+			:class="this.class"
+			:width="this.width"
+			:height="this.height"
+			viewBox="0 0 24 24"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path
+				d="M8 10L12 14L16 10"
+				stroke="#4C5A67"
+				stroke-miterlimit="10"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			/>
+		</svg>
 		<div v-if="this.name == 'company'" :class="this.class">
 			<div
 				v-if="$resources.brandHtml.data"

--- a/desk/src/components/desk/ticket/ConversationCard.vue
+++ b/desk/src/components/desk/ticket/ConversationCard.vue
@@ -19,11 +19,11 @@
 				>{{ $dayjs.longFormating($dayjs(time).fromNow()) }}</a
 			>
 		</div>
-		<div class="pl-[32px] pt-[0px]">
+		<div class="pl-8 pt-0">
 			<div class="flex flex-col">
 				<div
 					v-if="cc || bcc"
-					class="flex flex-row gap-1 text-[12px] text-[#74808B] font-inter"
+					class="flex flex-row gap-1 text-[12px] text-gray-600 font-inter"
 				>
 					<div v-if="cc">cc: {{ cc }},</div>
 					<div v-if="bcc">bcc: {{ bcc }}</div>

--- a/desk/src/components/desk/ticket/ConversationCard.vue
+++ b/desk/src/components/desk/ticket/ConversationCard.vue
@@ -22,6 +22,12 @@
 		<div class="pl-[32px] pt-[6px]">
 			<div class="flex flex-col">
 				<div
+					class="flex flex-row gap-1 text-[12px] text-[#74808B] font-inter"
+				>
+					<div v-if="cc">cc: {{ cc }},</div>
+					<div v-if="bcc">bcc: {{ bcc }}</div>
+				</div>
+				<div
 					class="message text-[13px]"
 					style="border: 0px"
 					v-html="cleanedMessage"
@@ -65,6 +71,8 @@ export default {
 		"message",
 		"color",
 		"attachments",
+		"cc",
+		"bcc",
 	],
 	components: {
 		FeatherIcon,

--- a/desk/src/components/desk/ticket/ConversationCard.vue
+++ b/desk/src/components/desk/ticket/ConversationCard.vue
@@ -22,6 +22,7 @@
 		<div class="pl-[32px] pt-[6px]">
 			<div class="flex flex-col">
 				<div
+					v-if="cc || bcc"
 					class="flex flex-row gap-1 text-[12px] text-[#74808B] font-inter"
 				>
 					<div v-if="cc">cc: {{ cc }},</div>

--- a/desk/src/components/desk/ticket/ConversationCard.vue
+++ b/desk/src/components/desk/ticket/ConversationCard.vue
@@ -92,6 +92,6 @@ export default {
 
 <style scoped>
 .message >>> .content-block {
-	@apply prose prose-p:my-1 prose-table:table-fixed prose-td:p-2 prose-th:p-2 prose-td:border prose-th:border prose-td:border-gray-300 prose-th:border-gray-300 prose-td:relative prose-th:relative prose-th:bg-gray-100 max-w-full;
+	@apply prose prose-p:my-1 prose-table:table-fixed prose-td:p-2 prose-th:p-2 prose-td:border prose-th:border prose-td:border-gray-300 prose-th:border-gray-300 prose-td:relative prose-th:relative prose-th:bg-gray-100 max-w-full text-[13px];
 }
 </style>

--- a/desk/src/components/desk/ticket/ConversationCard.vue
+++ b/desk/src/components/desk/ticket/ConversationCard.vue
@@ -19,7 +19,7 @@
 				>{{ $dayjs.longFormating($dayjs(time).fromNow()) }}</a
 			>
 		</div>
-		<div class="pl-[32px] pt-[6px]">
+		<div class="pl-[32px] pt-[0px]">
 			<div class="flex flex-col">
 				<div
 					v-if="cc || bcc"

--- a/desk/src/components/desk/ticket/Conversations.vue
+++ b/desk/src/components/desk/ticket/Conversations.vue
@@ -26,6 +26,8 @@
 								:time="conversation.creation"
 								:message="conversation.content"
 								:attachments="conversation.attachments"
+								:cc="conversation.cc"
+								:bcc="conversation.bcc"
 							/>
 						</div>
 						<CommentCard v-else :comment="conversation" />
@@ -109,6 +111,7 @@ export default {
 			return conversations
 		},
 		communications() {
+			console.log(this.$resources.communications.data, "commu")
 			return this.$resources.communications.data || []
 		},
 		comments() {

--- a/desk/src/pages/desk/Ticket.vue
+++ b/desk/src/pages/desk/Ticket.vue
@@ -109,22 +109,64 @@
 						>
 							<template #top>
 								<div
-									class="flex flex-row items-center text-[12px] font-normal pb-[8px]"
+									class="flex flex-row text-[12px] font-normal pb-[8px] border-[#F4F5F6] border-b-[1px]"
 								>
-									<div v-if="editingType == 'reply'">
+									<div
+										class="flex flex-col w-[85%]"
+										v-if="editingType == 'reply'"
+									>
 										<div
 											v-if="ticket.raised_by"
 											class="flex flex-row space-x-2 items-center"
 										>
-											<span class="text-gray-700"
-												>to</span
-											>
+											<div class="text-gray-700">To</div>
 											<div
 												class="bg-gray-50 rounded-[6px] px-[10px] py-[4px]"
 											>
 												{{ ticket.raised_by }}
 											</div>
 										</div>
+										<div
+											v-if="showCc"
+											class="flex flex-row space-x-2 items-center bg-transparent"
+										>
+											<div class="text-gray-700">Cc</div>
+											<Input
+												class="py-[4px] bg-white w-11/12 focus:bg-white text-[12px] font-inter pl-[4px]"
+												@input="
+													(val) => {
+														this.cc = val
+													}
+												"
+											/>
+										</div>
+										<ErrorMessage
+											v-if="showCc"
+											:message="ccValidationError"
+										/>
+										<div
+											v-if="showBcc"
+											class="flex flex-row space-x-2 items-center"
+										>
+											<div
+												class="text-gray-700 bg-transparent"
+											>
+												Bcc
+											</div>
+
+											<Input
+												class="py-[4px] bg-white w-11/12 focus:bg-white text-[12px] font-inter pl-[2px]"
+												@input="
+													(val) => {
+														this.bcc = val
+													}
+												"
+											/>
+										</div>
+										<ErrorMessage
+											v-if="showBcc"
+											:message="bccValidationError"
+										/>
 									</div>
 									<div
 										v-else
@@ -136,17 +178,48 @@
 											>Comment</span
 										>
 									</div>
-									<div class="grow flex flex-row-reverse">
+									<div
+										class="grow gap-1.5 flex flex-row-reverse"
+									>
 										<a
 											role="button"
 											@click="cancelEditing"
 											title="Hide Editor"
 										>
-											<FeatherIcon
-												name="chevron-down"
-												class="h-4 w-4"
+											<CustomIcons
+												name="arrow-down"
+												class="h-[24px] w-[24px]"
 											/>
 										</a>
+										<div v-if="editingType == 'reply'">
+											<Button
+												v-if="showCcBtn"
+												class="h-[24px] w-[24px] bg-transparent text-[#4C5A67]"
+												label="Cc"
+												@click="
+													() => {
+														showCc = true
+														showCcBtn = false
+													}
+												"
+												title="Cc"
+											>
+											</Button>
+											<Button
+												v-if="showBccBtn"
+												class="h-[24px] w-[24px] bg-transparent text-[#4C5A67]"
+												appearenece="secondary"
+												label="Bcc"
+												@click="
+													() => {
+														showBcc = true
+														showBccBtn = false
+													}
+												"
+												title="Bcc"
+											>
+											</Button>
+										</div>
 									</div>
 								</div>
 							</template>
@@ -207,29 +280,32 @@
 										class="pt-2 select-none flex flex-row items-center space-x-2 gap-2"
 										v-if="$refs.replyEditor"
 									>
-										<Button
-											:loading="
-												editingType == 'reply'
-													? $resources
-															.submitConversation
-															.loading
-													: $resources.submitComment
-															.loading
-											"
-											@click="submit()"
-											appearance="primary"
-											:disabled="
-												(!user.agent &&
-													!user.isAdmin) ||
-												sendingDissabled
-											"
-										>
-											{{
-												editingType == "reply"
-													? "Send"
-													: "Create"
-											}}
-										</Button>
+											<Button
+												
+												:loading="
+													editingType == 'reply'
+														? $resources
+																.submitConversation
+																.loading
+														: $resources
+																.submitComment
+																.loading
+												"
+												@click="submit()"
+												appearance="primary"
+												:disabled="
+													(!user.agent &&
+														!user.isAdmin) ||
+													sendingDissabled
+												"
+											>
+												{{
+													editingType == "reply"
+														? "Send"
+														: "Create"
+												}}
+											</Button>
+										
 										<div
 											class="flex flex-row items-center space-x-2"
 										>
@@ -366,6 +442,7 @@
 </template>
 <script>
 import {
+	ErrorMessage,
 	Badge,
 	Card,
 	Dropdown,
@@ -384,7 +461,7 @@ import CannedResponsesDialog from "@/components/desk/global/CannedResponsesDialo
 import ArticleResponseDialog from "@/components/desk/global/ArticleResponseDialog.vue"
 import { inject, ref } from "vue"
 import TicketStatus from "@/components/global/ticket_list_item/TicketStatus.vue"
-
+import { color } from "echarts"
 export default {
 	name: "Ticket",
 	props: ["ticketId"],
@@ -405,12 +482,15 @@ export default {
 		TextEditorFixedMenu,
 		ArticleResponseDialog,
 		TicketStatus,
+		ErrorMessage,
 	},
 	data() {
 		return {
 			editing: false,
 			scrollConversationsToBottom: false,
 			content: "",
+			cc: "",
+			bcc: "",
 		}
 	},
 	setup() {
@@ -419,17 +499,19 @@ export default {
 		const user = inject("user")
 		const agents = inject("agents")
 		const attachments = ref([])
-
 		const editingType = ref("")
-
+		const replied = ref("Replied")
 		const tempTextEditorData = ref({})
-
 		const showCannedResponsesDialog = ref(false)
 		const tempMessage = ref("")
-
 		const showArticleResponseDialog = ref(false)
 		const tempContent = ref("")
-
+		const ccValidationError = ref("")
+		const bccValidationError = ref("")
+		const showCc = ref(false)
+		const showBcc = ref(false)
+		const showCcBtn = ref(true)
+		const showBccBtn = ref(true)
 		return {
 			showTextFormattingMenu,
 			viewportWidth,
@@ -442,6 +524,13 @@ export default {
 			tempMessage,
 			showArticleResponseDialog,
 			tempContent,
+			replied,
+			ccValidationError,
+			bccValidationError,
+			showCc,
+			showBcc,
+			showCcBtn,
+			showBccBtn,
 		}
 	},
 	resources: {
@@ -463,7 +552,6 @@ export default {
 								text: "No default outgoing email available",
 							},
 						}[res.error_code]
-
 						this.$toast({
 							fixed: true,
 							title: error.title,
@@ -620,7 +708,6 @@ export default {
 			function delay(time) {
 				return new Promise((resolve) => setTimeout(resolve, time))
 			}
-
 			delay(400).then(() => (this.scrollConversationsToBottom = true))
 			delay(1000).then(() => (this.scrollConversationsToBottom = false))
 		},
@@ -636,6 +723,9 @@ export default {
 			}
 		},
 		submit() {
+			// if (this.validateInputs()) {
+			// 	return
+			// }
 			switch (this.editingType) {
 				case "reply":
 					this.submitConversation()
@@ -649,13 +739,26 @@ export default {
 			this.tempTextEditorData.content = this.content
 			this.tempTextEditorData.attachments = this.attachments
 			const content = `<div class='content-block'><div>${this.content}</div></div>`
-
 			this.$resources.submitConversation.submit({
 				ticket_id: this.ticketId,
 				message: content,
+				cc: this.cc,
+				bcc: this.bcc,
 				attachments: this.attachments.map((x) => x.name),
 			})
-
+			this.content = ""
+			this.attachments = []
+		},
+		submitResolvedTicket() {
+			this.tempTextEditorData.content = this.content
+			this.tempTextEditorData.attachments = this.attachments
+			const content = `<div class='content-block'><div>${this.content}</div></div>`
+			this.$resources.submitConversation.submit({
+				ticket_id: this.ticketId,
+				message: content,
+				status: "Resolved",
+				attachments: this.attachments.map((x) => x.name),
+			})
 			this.content = ""
 			this.attachments = []
 		},
@@ -663,7 +766,6 @@ export default {
 			this.tempTextEditorData.attachments = this.attachments
 			this.tempTextEditorData.content = this.content
 			const content = `<div class='content-block'><div>${this.content}</div></div>`
-
 			this.$resources.submitComment.submit({
 				doc: {
 					doctype: "Frappe Desk Comment",
@@ -672,13 +774,11 @@ export default {
 					commented_by: this.user.user,
 				},
 			})
-
 			this.content = ""
 			this.attachments = []
 		},
 		getNextTicket() {},
 		getPreviousTicket() {},
-
 		getMessage(message) {
 			this.tempMessage = message
 			this.content = this.tempMessage
@@ -687,6 +787,32 @@ export default {
 			this.tempContent = content
 			this.content = this.tempContent
 		},
+		validateInputs() {
+			if (this.cc || this.bcc != "") {
+				let error = this.validateCcInput(this.cc)
+				error += this.validateBccInput(this.bcc)
+				return error
+			}
+		},
+		validateCcInput(value) {
+			this.ccValidationError = ""
+			const reg =
+				/^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,24}))$/
+			if (!reg.test(value)) {
+				this.ccValidationError = "Enter a valid email"
+			}
+			return this.ccValidationError
+		},
+		validateBccInput(value) {
+			this.bccValidationError = ""
+			const reg =
+				/^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,24}))$/
+			if (!reg.test(value)) {
+				this.bccValidationError = "Enter a valid email"
+			}
+			return this.bccValidationError
+		},
 	},
 }
 </script>
+

--- a/desk/src/pages/desk/Ticket.vue
+++ b/desk/src/pages/desk/Ticket.vue
@@ -133,11 +133,7 @@
 											<div class="text-gray-700">Cc</div>
 											<Input
 												class="py-[4px] bg-white w-11/12 focus:bg-white text-[12px] font-inter pl-[4px]"
-												@input="
-													(val) => {
-														this.cc = val
-													}
-												"
+												@input="cc = $event"
 											/>
 										</div>
 										<ErrorMessage
@@ -156,11 +152,7 @@
 
 											<Input
 												class="py-[4px] bg-white w-11/12 focus:bg-white text-[12px] font-inter pl-[2px]"
-												@input="
-													(val) => {
-														this.bcc = val
-													}
-												"
+												@input="bcc = $event"
 											/>
 										</div>
 										<ErrorMessage
@@ -280,32 +272,30 @@
 										class="pt-2 select-none flex flex-row items-center space-x-2 gap-2"
 										v-if="$refs.replyEditor"
 									>
-											<Button
-												
-												:loading="
-													editingType == 'reply'
-														? $resources
-																.submitConversation
-																.loading
-														: $resources
-																.submitComment
-																.loading
-												"
-												@click="submit()"
-												appearance="primary"
-												:disabled="
-													(!user.agent &&
-														!user.isAdmin) ||
-													sendingDissabled
-												"
-											>
-												{{
-													editingType == "reply"
-														? "Send"
-														: "Create"
-												}}
-											</Button>
-										
+										<Button
+											:loading="
+												editingType == 'reply'
+													? $resources
+															.submitConversation
+															.loading
+													: $resources.submitComment
+															.loading
+											"
+											@click="submit()"
+											appearance="primary"
+											:disabled="
+												(!user.agent &&
+													!user.isAdmin) ||
+												sendingDissabled
+											"
+										>
+											{{
+												editingType == "reply"
+													? "Send"
+													: "Create"
+											}}
+										</Button>
+
 										<div
 											class="flex flex-row items-center space-x-2"
 										>
@@ -749,19 +739,6 @@ export default {
 			this.content = ""
 			this.attachments = []
 		},
-		submitResolvedTicket() {
-			this.tempTextEditorData.content = this.content
-			this.tempTextEditorData.attachments = this.attachments
-			const content = `<div class='content-block'><div>${this.content}</div></div>`
-			this.$resources.submitConversation.submit({
-				ticket_id: this.ticketId,
-				message: content,
-				status: "Resolved",
-				attachments: this.attachments.map((x) => x.name),
-			})
-			this.content = ""
-			this.attachments = []
-		},
 		submitComment() {
 			this.tempTextEditorData.attachments = this.attachments
 			this.tempTextEditorData.content = this.content
@@ -815,4 +792,3 @@ export default {
 	},
 }
 </script>
-

--- a/frappedesk/api/ticket.py
+++ b/frappedesk/api/ticket.py
@@ -380,7 +380,6 @@ def assign_ticket_status(ticket_id, status):
 
 		return ticket_doc
 
-
 @frappe.whitelist()
 def set_ticket_notes(ticket_id, notes):
 	if ticket_id:
@@ -455,8 +454,8 @@ def get_conversations(ticket_id):
 
 
 @frappe.whitelist()
-def submit_conversation_via_agent(ticket_id, message, attachments):
-	return create_communication_via_agent(ticket_id, message, attachments)
+def submit_conversation_via_agent(ticket_id, message,cc,bcc, attachments):
+	return create_communication_via_agent(ticket_id, message,cc,bcc, attachments)
 
 
 @frappe.whitelist()

--- a/frappedesk/frappedesk/doctype/ticket/ticket.py
+++ b/frappedesk/frappedesk/doctype/ticket/ticket.py
@@ -409,7 +409,7 @@ def get_all_conversations(ticket):
 		"Communication",
 		filters={"reference_doctype": ["=", "Ticket"], "reference_name": ["=", ticket]},
 		order_by="creation asc",
-		fields=["name", "content", "creation", "sent_or_received", "sender"],
+		fields=["name", "content", "creation", "sent_or_received", "sender","cc","bcc"],
 	)
 
 	for conversation in conversations:

--- a/frappedesk/frappedesk/doctype/ticket/ticket.py
+++ b/frappedesk/frappedesk/doctype/ticket/ticket.py
@@ -263,7 +263,7 @@ def create_communication_via_contact(ticket, message, attachments=[]):
 
 
 @frappe.whitelist(allow_guest=True)
-def create_communication_via_agent(ticket, message, attachments=None):
+def create_communication_via_agent(ticket, message, cc,bcc,attachments=None):
 	ticket_doc = frappe.get_doc("Ticket", ticket)
 	last_ticket_communication_doc = frappe.get_last_doc(
 		"Communication", filters={"reference_name": ["=", ticket_doc.name]}
@@ -331,6 +331,8 @@ def create_communication_via_agent(ticket, message, attachments=None):
 			"recipients": frappe.get_value("User", "Administrator", "email")
 			if ticket_doc.raised_by == "Administrator"
 			else ticket_doc.raised_by,
+			"cc":cc,
+			"bcc":bcc,
 			"content": message,
 			"status": "Linked",
 			"reference_doctype": "Ticket",
@@ -360,6 +362,8 @@ def create_communication_via_agent(ticket, message, attachments=None):
 				sender=reply_to_email,
 				reply_to=reply_to_email,
 				recipients=[ticket_doc.raised_by],
+				cc=cc,
+				bcc=bcc,
 				reference_doctype="Ticket",
 				reference_name=ticket_doc.name,
 				communication=communication.name,


### PR DESCRIPTION
Resolves https://github.com/frappe/helpdesk/issues/945

1.User will have the ability to add cc and bcc in ticket conversation reply.
2. Cc and bcc values will be displayed in ticket conversation

![Frappe Desk (29)](https://user-images.githubusercontent.com/73826691/213154159-752b1960-b6a7-49ae-960e-8247c31ed70c.png)
![Frappe Desk (28)](https://user-images.githubusercontent.com/73826691/213154169-933ad005-c94f-4cf2-a5d7-0754f4de5af8.png)
![Frappe Desk (30)](https://user-images.githubusercontent.com/73826691/213545736-9607410f-8202-4583-8d92-38bf8a7aff19.png)
