### PR TITLE
refactor: make ticket id random alphanumeric

### DIFF
--- a/frappedesk/frappedesk/doctype/ticket/ticket.json
+++ b/frappedesk/frappedesk/doctype/ticket/ticket.json
@@ -1,7 +1,7 @@
 {
 	"actions": [],
 	"allow_import": 1,
-	"autoname": "format:{#######}",
+	"autoname": "hash",
 	"creation": "2022-03-02 03:10:19.254460",
 	"doctype": "DocType",
 	"document_type": "Setup",
@@ -424,11 +424,11 @@
 	"icon": "fa fa-issue",
 	"idx": 7,
 	"links": [],
-	"modified": "2022-12-29 12:53:14.989213",
+	"modified": "2023-01-25 17:30:06.038898",
 	"modified_by": "Administrator",
 	"module": "FrappeDesk",
 	"name": "Ticket",
-	"naming_rule": "Expression",
+	"naming_rule": "Random",
 	"owner": "Administrator",
 	"permissions": [
 		{


### PR DESCRIPTION
Currently, a ticket id will be a number with `0` padding. It works fine for most use-cases. But a random alphanumeric (`random` in framework) makes more sense. This does not fix anything per se, but avoids other known bugs affecting autoinc/expression.

Related:
- https://github.com/frappe/frappe/issues/19813
- https://github.com/frappe/helpdesk/issues/946