### PR TITLE
fix: replace toggle with icon in knowledge base with tab buttons

### DIFF
--- a/desk/src/components/global/TabButtons.vue
+++ b/desk/src/components/global/TabButtons.vue
@@ -1,0 +1,31 @@
+<template>
+    <div class="flex p-1 text-sm bg-gray-100 rounded-md">
+      <button
+        v-for="button in buttons"
+        class="px-2 py-1 leading-none transition-all rounded"
+        :class="
+          modelValue === button.label
+            ? 'bg-white shadow text-gray-900'
+            : 'text-gray-700'
+        "
+        @click="$emit('update:modelValue', button.label)"
+      >
+        {{ button.label }}
+      </button>
+    </div>
+  </template>
+  <script>
+  export default {
+    name: 'TabButtons',
+    props: {
+      buttons: {
+        type: Array,
+        required: true,
+      },
+      modelValue: {
+        type: String,
+      },
+    },
+    emits: ['update:modelValue'],
+  }
+  </script>

--- a/desk/src/components/global/kb/EditableBlock.vue
+++ b/desk/src/components/global/kb/EditableBlock.vue
@@ -2,7 +2,15 @@
 	<div class="flex flex-col space-y-4">
 		<div v-if="editable" class="flex flex-row items-center">
 			<slot name="top-left-section">
-				<div v-if="!editMode"><LayoutSwitcher viewMode="Web" /></div>
+				<div v-if="!editMode">
+					<TabButtons
+						:buttons="[
+							{ label: 'Articles', active: true },
+							{ label: 'Webview' },
+						]"
+						v-model="activeTab"
+					/>
+				</div>
 				<div v-else class="text-base text-gray-700 italic">
 					Editing - Knowledge Base
 				</div>
@@ -63,7 +71,8 @@
 </template>
 
 <script>
-import LayoutSwitcher from "@/components/global/kb/LayoutSwitcher.vue"
+
+import TabButtons from "@/components/global/TabButtons.vue"
 
 export default {
 	name: "EditableBlock",
@@ -86,7 +95,22 @@ export default {
 		},
 	},
 	components: {
-		LayoutSwitcher,
+		TabButtons,
+	},
+	data() {
+		return {
+			activeTab: "Webview",
+		}
+	},
+	resources: {
+		articles() {
+			if (this.activeTab == "Articles") {
+				this.$router.push({ path: "/frappedesk/kb/articles" })
+			}
+			return {
+				auto: true,
+			}
+		},
 	},
 }
 </script>

--- a/desk/src/components/global/kb/EditableBlock.vue
+++ b/desk/src/components/global/kb/EditableBlock.vue
@@ -5,8 +5,8 @@
 				<div v-if="!editMode">
 					<TabButtons
 						:buttons="[
-							{ label: 'Articles', active: true },
-							{ label: 'Webview' },
+							{ label: 'Articles' },
+							{ label: 'Webview', active: true },
 						]"
 						v-model="activeTab"
 					/>
@@ -71,7 +71,6 @@
 </template>
 
 <script>
-
 import TabButtons from "@/components/global/TabButtons.vue"
 
 export default {

--- a/desk/src/pages/desk/kb/Articles.vue
+++ b/desk/src/pages/desk/kb/Articles.vue
@@ -57,7 +57,13 @@
 					class="text-base h-[calc(100vh-6.5rem)]"
 				>
 					<template #top-sub-section-1>
-						<LayoutSwitcher viewMode="List" />
+						<TabButtons
+							:buttons="[
+								{ label: 'Articles', active: true },
+								{ label: 'Webview' },
+							]"
+							v-model="activeTab"
+						/>
 					</template>
 					<template #bulk-actions="{ selectedItems }">
 						<div class="flex flex-row space-x-2">
@@ -192,9 +198,9 @@
 <script>
 import ListManager from "@/components/global/ListManager.vue"
 import ListViewer from "@/components/global/ListViewer.vue"
-import LayoutSwitcher from "@/components/global/kb/LayoutSwitcher.vue"
 import CategorySelector from "@/components/desk/kb/CategorySelector.vue"
 import { Dropdown } from "frappe-ui"
+import TabButtons from "@/components/global/TabButtons.vue"
 
 export default {
 	name: "Articles",
@@ -204,12 +210,17 @@ export default {
 			default: "",
 		},
 	},
+	data() {
+		return {
+			activeTab: "Articles",
+		}
+	},
 	components: {
 		ListManager,
 		ListViewer,
-		LayoutSwitcher,
 		CategorySelector,
 		Dropdown,
+		TabButtons,
 	},
 	resources: {
 		moveArticlesToCategory() {
@@ -225,6 +236,14 @@ export default {
 		deleteArticles() {
 			return {
 				method: "frappedesk.api.kb.delete_articles",
+			}
+		},
+		knowledgeBase() {
+			if (this.activeTab == "Webview") {
+				this.$router.push({ path: "/frappedesk/kb" })
+			}
+			return {
+				auto: true,
 			}
 		},
 	},


### PR DESCRIPTION
Replaced toggle with icons in knowledge base with tab buttons. Currently it is hard to understand the toggle between articles and web view in the knowledge base.

Resolves #961

https://user-images.githubusercontent.com/73826691/215023439-74ff4d21-25be-4a0f-80d6-e5669a8d6f8a.mp4

