### PR TITLE
fix(ui): tickets: id size

### DIFF
--- a/desk/src/pages/desk/Tickets.vue
+++ b/desk/src/pages/desk/Tickets.vue
@@ -81,7 +81,7 @@
 				>
 					<!-- Field Templates -->
 					<template #field-name="{ value }">
-						<div class="text-xs text-gray-500">
+						<div class="text-gray-500">
 							{{ value }}
 						</div>
 					</template>


### PR DESCRIPTION
We don't have to explicitly set font size since default size is good enough

ref: https://github.com/frappe/helpdesk/issues/958