### PR TITLE
fix(ui): tickets: id column width

### DIFF
--- a/desk/src/components/global/ListManager.vue
+++ b/desk/src/components/global/ListManager.vue
@@ -57,6 +57,45 @@ export default {
 			return listResource.list.loading
 		})
 
+		const idWidth = computed(() => {
+			// Default width for id column in cases where calculation is impossible
+			const defaultWidth = 1;
+
+			// Minimum length of id. This is an assumed value, and could be wrong
+			const minIdLength = 3;
+
+			// Spread operator is used to clone original array
+			const data = [...(listResource.data || [])];
+
+			// Find row with longest id from data.
+			const longest = data
+				.sort((a, b) => a.name.length - b.name.length)
+				.pop();
+
+			// Default width if longest name is not found. This could happen in
+			// case of an empty list
+			if (!longest) return defaultWidth;
+
+			// Length is the length of name string. `name` here the key and should not
+			// be confused with other properties like subject
+			const idLength = longest.name.length;
+
+			// Default width is enough for short ids
+			if (idLength <= minIdLength) return defaultWidth;
+
+			// Reduce minimum width, to adjust width according to remaining width
+			const extraWidth = idLength - minIdLength;
+
+			// This value will be passed to tailwind width classes, which does not
+			// support fractional values. (It does support some, but not all).
+			// Refer https://tailwindcss.com/docs/width for more
+			//
+			// Extra width is here is the number of characters and we don't need that
+			// number in pixels/css. Hence the it is divided by another number. This
+			// could be a flaw and improved if possible
+			return Math.ceil(extraWidth / 3);
+		})
+
 		const countResource = createResource(
 			{
 				method: "frappe.client.get_count",
@@ -328,6 +367,7 @@ export default {
 			list,
 			loading,
 			totalCount,
+			idWidth,
 
 			reload,
 			update,

--- a/desk/src/pages/desk/Tickets.vue
+++ b/desk/src/pages/desk/Tickets.vue
@@ -40,7 +40,7 @@
 						fields: {
 							name: {
 								label: '#',
-								width: '2',
+								width: manager.idWidth,
 							},
 							subject: {
 								label: 'Subject',


### PR DESCRIPTION
### Problem
Id column width in tickets view is set as a constant value. (2 currently). While this works for out of the box setups, it might not work for dynamic formats (eg: expression).

### Investigation
Interestingly, this used to be dynamic
```
width: manager.totalCount > 999 ? '2' : '1'
```
This behavior was changed in 7329f863bdfb553c283627078faa3269ea130ed6. While this is not perfect, it could have worked for at-least some cases.

### Solution
I introduced another logic to calculate width, depending on the widest (longest string) id from the table. It is safe to assume that all ids will be of same length, and this logic will work for most cases. There could be room for improvement though, as more cases pop up.

ref: https://github.com/frappe/helpdesk/issues/958