### PR TITLE
fix(ui): missing agent for avatar

### DIFF
--- a/desk/src/components/global/AgentAvatar.vue
+++ b/desk/src/components/global/AgentAvatar.vue
@@ -20,7 +20,13 @@ export default {
 	},
 	computed: {
 		agent() {
-			return this.agents.find((x) => x.name === this.agent)
+			const a = this.agents.find((x) => x.name === this.agent);
+
+			// Agent could be missing, corrupt or invalid. It is better to
+			// have a fallback value, which in this case is an empty object.
+			if (!a) return {};
+
+			return a;
 		},
 	},
 }


### PR DESCRIPTION
UI will crash outright without any warnings if it is unable to render agent avatar (due to missing agent). It is better to handle this case (silently).