### PR TITLE
feat: filter by agent group (team)

### DIFF
--- a/desk/src/components/desk/settings/teams/TeamInfo.vue
+++ b/desk/src/components/desk/settings/teams/TeamInfo.vue
@@ -27,7 +27,7 @@
 					<Input
 						label="Title"
 						type="text"
-						:value="team.team_name"
+						:value="teamDisplayName(team)"
 						@input="onNameChange"
 					/>
 					<ErrorMessage :message="teamInputErrors['title']" />
@@ -221,6 +221,11 @@ export default {
 						path: `/frappedesk/settings/teams/${title}`,
 					});
 				});
+		},
+		teamDisplayName(team) {
+			if (team.team_name) return team.team_name;
+			if (team.name) return team.name;
+			if (this.teamId) return this.teamId;
 		},
 		/**
 		 * What to show in user list. This has to be done because some users may not

--- a/desk/src/components/desk/settings/teams/TeamInfo.vue
+++ b/desk/src/components/desk/settings/teams/TeamInfo.vue
@@ -158,6 +158,8 @@ export default {
 					renameTeam: "rename_self",
 				},
 				onSuccess(data) {
+					// Only need user's name, not full object
+					data.users = data.users.map((user) => user.user);
 					this.team = data;
 				},
 				onError: (err) => {

--- a/desk/src/components/desk/settings/teams/TeamInfo.vue
+++ b/desk/src/components/desk/settings/teams/TeamInfo.vue
@@ -69,6 +69,17 @@
 						</li>
 					</ul>
 				</div>
+				<div class="w-max">
+					<Tooltip
+						text="Agents belonging to this group can ignore any restrictions"
+					>
+						<Input
+							v-model="team.ignore_restrictions"
+							label="Ignore Restrictions"
+							type="checkbox"
+						/>
+					</Tooltip>
+				</div>
 			</div>
 		</div>
 	</div>
@@ -76,7 +87,7 @@
 
 <script>
 import { ref } from "vue";
-import { FeatherIcon, ErrorMessage } from "frappe-ui";
+import { FeatherIcon, ErrorMessage, Tooltip } from "frappe-ui";
 import Autocomplete from "@/components/global/Autocomplete.vue";
 
 export default {
@@ -85,6 +96,7 @@ export default {
 		Autocomplete,
 		ErrorMessage,
 		FeatherIcon,
+		Tooltip,
 	},
 	props: {
 		teamId: {
@@ -95,6 +107,7 @@ export default {
 	setup() {
 		const isTeamNameChanged = false;
 		const team = ref({
+			ignore_restrictions: false,
 			team_name: "",
 			users: [],
 		});
@@ -248,6 +261,7 @@ export default {
 			this.$resources.newTeam.submit({
 				doc: {
 					doctype: "Agent Group",
+					ignore_restrictions: this.team.ignore_restrictions,
 					team_name: this.team.team_name,
 					users: this.mapUsers(this.team.users),
 				},
@@ -256,6 +270,7 @@ export default {
 		save() {
 			this.$resources.team.setValue
 				.submit({
+					ignore_restrictions: this.team.ignore_restrictions,
 					users: this.mapUsers(this.team.users),
 				})
 				.then(this.renameTeam);

--- a/frappedesk/extends/client.py
+++ b/frappedesk/extends/client.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+from __future__ import unicode_literals
+import frappe
+from frappe.model.base_document import get_controller
+
+
+@frappe.whitelist()
+def get_list(
+	doctype=None,
+	fields=None,
+	filters=None,
+	order_by=None,
+	start=0,
+	limit=20,
+	group_by=None,
+	parent=None,
+	debug=False,
+):
+	check_permissions(doctype, parent)
+
+	query = frappe.qb.get_query(
+		table=doctype,
+		fields=fields,
+		filters=filters,
+		order_by=order_by,
+		offset=start,
+		limit=limit,
+		group_by=group_by,
+	)
+
+	custom_query = apply_custom_filters(doctype, query)
+
+	return custom_query.run(as_dict=True, debug=debug)
+
+
+def check_permissions(doctype, parent):
+	user = frappe.session.user
+	has_select_permission = frappe.has_permission(
+		doctype, "select", user=user, parent_doctype=parent
+	)
+	has_read_permission = frappe.has_permission(
+		doctype, "read", user=user, parent_doctype=parent
+	)
+
+	if not has_select_permission and not has_read_permission:
+		frappe.throw(f"Insufficient Permission for {doctype}", frappe.PermissionError)
+
+
+def apply_custom_filters(doctype, query):
+	"""
+	Apply custom filters to query
+	"""
+	controller = get_controller(doctype)
+
+	if hasattr(controller, "get_list_query"):
+		return_value = controller.get_list_query(query)
+		if return_value is not None:
+			query = return_value
+
+	return query

--- a/frappedesk/frappedesk/doctype/agent_group/agent_group.json
+++ b/frappedesk/frappedesk/doctype/agent_group/agent_group.json
@@ -1,66 +1,84 @@
 {
-	"actions": [],
-	"allow_rename": 1,
-	"autoname": "field:team_name",
-	"creation": "2022-02-24 20:55:48.766967",
-	"doctype": "DocType",
-	"editable_grid": 1,
-	"engine": "InnoDB",
-	"field_order": ["team_name", "assignment_rule", "users"],
-	"fields": [
-		{
-			"fieldname": "team_name",
-			"fieldtype": "Data",
-			"label": "Name",
-			"unique": 1
-		},
-		{
-			"fieldname": "assignment_rule",
-			"fieldtype": "Link",
-			"label": "Assignment Rule",
-			"options": "Assignment Rule",
-			"read_only": 1
-		},
-		{
-			"fieldname": "users",
-			"fieldtype": "Table MultiSelect",
-			"label": "Users",
-			"options": "Teams User"
-		}
-	],
-	"index_web_pages_for_search": 1,
-	"links": [],
-	"modified": "2023-01-03 13:16:16.718714",
-	"modified_by": "Administrator",
-	"module": "FrappeDesk",
-	"name": "Agent Group",
-	"naming_rule": "By fieldname",
-	"owner": "Administrator",
-	"permissions": [
-		{
-			"create": 1,
-			"delete": 1,
-			"email": 1,
-			"export": 1,
-			"print": 1,
-			"read": 1,
-			"report": 1,
-			"role": "System Manager",
-			"share": 1,
-			"write": 1
-		},
-		{
-			"email": 1,
-			"export": 1,
-			"print": 1,
-			"read": 1,
-			"report": 1,
-			"role": "Agent",
-			"share": 1
-		}
-	],
-	"quick_entry": 1,
-	"sort_field": "modified",
-	"sort_order": "DESC",
-	"states": []
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:team_name",
+ "creation": "2022-02-24 20:55:48.766967",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "team_name",
+  "assignment_rule",
+  "users",
+  "column_break_feto",
+  "ignore_restrictions"
+ ],
+ "fields": [
+  {
+   "fieldname": "team_name",
+   "fieldtype": "Data",
+   "label": "Name",
+   "unique": 1
+  },
+  {
+   "fieldname": "assignment_rule",
+   "fieldtype": "Link",
+   "label": "Assignment Rule",
+   "options": "Assignment Rule",
+   "read_only": 1
+  },
+  {
+   "fieldname": "users",
+   "fieldtype": "Table MultiSelect",
+   "label": "Users",
+   "options": "Teams User"
+  },
+  {
+   "default": "0",
+   "description": "Do not apply filters and restrictions to agents of this team",
+   "fieldname": "ignore_restrictions",
+   "fieldtype": "Check",
+   "label": "Ignore Restrictions"
+  },
+  {
+   "fieldname": "column_break_feto",
+   "fieldtype": "Column Break",
+   "label": "Settings"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2023-02-24 13:35:17.651047",
+ "modified_by": "Administrator",
+ "module": "FrappeDesk",
+ "name": "Agent Group",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Agent",
+   "share": 1
+  }
+ ],
+ "quick_entry": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
 }

--- a/frappedesk/frappedesk/doctype/agent_group/agent_group.json
+++ b/frappedesk/frappedesk/doctype/agent_group/agent_group.json
@@ -48,7 +48,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-02-24 13:35:17.651047",
+ "modified": "2023-02-24 14:38:07.004329",
  "modified_by": "Administrator",
  "module": "FrappeDesk",
  "name": "Agent Group",
@@ -68,13 +68,16 @@
    "write": 1
   },
   {
+   "create": 1,
+   "delete": 1,
    "email": 1,
    "export": 1,
    "print": 1,
    "read": 1,
    "report": 1,
    "role": "Agent",
-   "share": 1
+   "share": 1,
+   "write": 1
   }
  ],
  "quick_entry": 1,

--- a/frappedesk/frappedesk/doctype/agent_group/agent_group.py
+++ b/frappedesk/frappedesk/doctype/agent_group/agent_group.py
@@ -2,12 +2,16 @@
 # For license information, please see license.txt
 
 import frappe
-from frappe.model.document import Document
 from frappe.exceptions import DoesNotExistError
+from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists
 
 
 class AgentGroup(Document):
+	@frappe.whitelist()
+	def rename_self(self, new_name: str):
+		self.rename(new_name)
+
 	def after_insert(self):
 		self.create_assignment_rule()
 

--- a/frappedesk/frappedesk/doctype/frappe_desk_settings/frappe_desk_settings.json
+++ b/frappedesk/frappedesk/doctype/frappe_desk_settings/frappe_desk_settings.json
@@ -1,225 +1,251 @@
 {
-	"actions": [],
-	"creation": "2017-02-17 13:07:35.686409",
-	"doctype": "DocType",
-	"editable_grid": 1,
-	"engine": "InnoDB",
-	"field_order": [
-		"sb_00",
-		"track_service_level_agreement",
-		"allow_resetting_service_level_agreement",
-		"column_break_4",
-		"helpdesk_name",
-		"issues_sb",
-		"default_ticket_type",
-		"close_issue_after_days",
-		"portal_sb",
-		"get_started_sections",
-		"show_latest_forum_posts",
-		"forum_sb",
-		"forum_url",
-		"get_latest_query",
-		"response_key_list",
-		"column_break_10",
-		"post_title_key",
-		"post_description_key",
-		"post_route_key",
-		"post_route_string",
-		"setup_complete",
-		"initial_agent_set",
-		"initial_demo_ticket_created",
-		"initial_helpdesk_name_setup_skipped",
-		"assignment_rules_section",
-		"base_support_rotation",
-		"knowledge_base_section",
-		"suggest_articles_in_new_ticket_page"
-	],
-	"fields": [
-		{
-			"fieldname": "issues_sb",
-			"fieldtype": "Section Break",
-			"label": "Issues"
-		},
-		{
-			"default": "7",
-			"fieldname": "close_issue_after_days",
-			"fieldtype": "Int",
-			"label": "Close Issue After Days"
-		},
-		{
-			"fieldname": "portal_sb",
-			"fieldtype": "Section Break",
-			"label": "Support Portal"
-		},
-		{
-			"fieldname": "get_started_sections",
-			"fieldtype": "Code",
-			"label": "Get Started Sections"
-		},
-		{
-			"default": "0",
-			"fieldname": "show_latest_forum_posts",
-			"fieldtype": "Check",
-			"label": "Show Latest Forum Posts"
-		},
-		{
-			"depends_on": "show_latest_forum_posts",
-			"fieldname": "forum_sb",
-			"fieldtype": "Section Break",
-			"label": "Forum Posts"
-		},
-		{
-			"fieldname": "forum_url",
-			"fieldtype": "Data",
-			"label": "Forum URL"
-		},
-		{
-			"fieldname": "get_latest_query",
-			"fieldtype": "Data",
-			"label": "Get Latest Query"
-		},
-		{
-			"fieldname": "response_key_list",
-			"fieldtype": "Data",
-			"label": "Response Key List"
-		},
-		{
-			"fieldname": "column_break_10",
-			"fieldtype": "Column Break"
-		},
-		{
-			"fieldname": "post_title_key",
-			"fieldtype": "Data",
-			"label": "Post Title Key"
-		},
-		{
-			"fieldname": "post_description_key",
-			"fieldtype": "Data",
-			"label": "Post Description Key"
-		},
-		{
-			"fieldname": "post_route_key",
-			"fieldtype": "Data",
-			"label": "Post Route Key"
-		},
-		{
-			"fieldname": "post_route_string",
-			"fieldtype": "Data",
-			"label": "Post Route String"
-		},
-		{
-			"fieldname": "sb_00",
-			"fieldtype": "Section Break",
-			"label": "SLAs"
-		},
-		{
-			"default": "1",
-			"fieldname": "track_service_level_agreement",
-			"fieldtype": "Check",
-			"label": "Track SLA"
-		},
-		{
-			"default": "0",
-			"depends_on": "eval:doc.track_service_level_agreement;",
-			"fieldname": "allow_resetting_service_level_agreement",
-			"fieldtype": "Check",
-			"label": "Allow Resetting SLA"
-		},
-		{
-			"fieldname": "helpdesk_name",
-			"fieldtype": "Data",
-			"label": "Helpdesk Name"
-		},
-		{
-			"default": "0",
-			"fieldname": "setup_complete",
-			"fieldtype": "Check",
-			"hidden": 1,
-			"label": "Setup Complete"
-		},
-		{
-			"default": "0",
-			"fieldname": "initial_agent_set",
-			"fieldtype": "Check",
-			"hidden": 1,
-			"label": "Initial Agent Set"
-		},
-		{
-			"default": "0",
-			"fieldname": "initial_demo_ticket_created",
-			"fieldtype": "Check",
-			"hidden": 1,
-			"label": "Initial Demo Ticket Created"
-		},
-		{
-			"fieldname": "column_break_4",
-			"fieldtype": "Column Break"
-		},
-		{
-			"default": "0",
-			"fieldname": "initial_helpdesk_name_setup_skipped",
-			"fieldtype": "Check",
-			"label": "Initial Helpdesk Name Setup Skipped"
-		},
-		{
-			"fieldname": "assignment_rules_section",
-			"fieldtype": "Section Break",
-			"label": "Assignment Rules"
-		},
-		{
-			"fieldname": "base_support_rotation",
-			"fieldtype": "Link",
-			"label": "Base Support Rotation",
-			"options": "Assignment Rule",
-			"read_only": 1
-		},
-		{
-			"fieldname": "knowledge_base_section",
-			"fieldtype": "Section Break",
-			"label": "Knowledge Base"
-		},
-		{
-			"default": "0",
-			"fieldname": "suggest_articles_in_new_ticket_page",
-			"fieldtype": "Check",
-			"label": "Suggest Articles in New TIcket Page"
-		},
-		{
-			"fieldname": "default_ticket_type",
-			"fieldtype": "Link",
-			"label": "Default Ticket Type",
-			"options": "Ticket Type"
-		}
-	],
-	"issingle": 1,
-	"links": [],
-	"modified": "2022-12-30 14:45:58.112267",
-	"modified_by": "Administrator",
-	"module": "FrappeDesk",
-	"name": "Frappe Desk Settings",
-	"owner": "Administrator",
-	"permissions": [
-		{
-			"create": 1,
-			"delete": 1,
-			"email": 1,
-			"print": 1,
-			"read": 1,
-			"role": "System Manager",
-			"share": 1,
-			"write": 1
-		},
-		{
-			"email": 1,
-			"print": 1,
-			"read": 1,
-			"role": "Agent",
-			"share": 1
-		}
-	],
-	"quick_entry": 1,
-	"sort_field": "modified",
-	"sort_order": "DESC",
-	"states": [],
-	"track_changes": 1
+ "actions": [],
+ "creation": "2017-02-17 13:07:35.686409",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "sb_00",
+  "track_service_level_agreement",
+  "allow_resetting_service_level_agreement",
+  "column_break_4",
+  "helpdesk_name",
+  "issues_sb",
+  "default_ticket_type",
+  "close_issue_after_days",
+  "agent_groups_section",
+  "restrict_tickets_by_agent_group",
+  "do_not_restrict_tickets_without_an_agent_group",
+  "column_break_dxlq",
+  "portal_sb",
+  "get_started_sections",
+  "show_latest_forum_posts",
+  "forum_sb",
+  "forum_url",
+  "get_latest_query",
+  "response_key_list",
+  "column_break_10",
+  "post_title_key",
+  "post_description_key",
+  "post_route_key",
+  "post_route_string",
+  "setup_complete",
+  "initial_agent_set",
+  "initial_demo_ticket_created",
+  "initial_helpdesk_name_setup_skipped",
+  "assignment_rules_section",
+  "base_support_rotation",
+  "knowledge_base_section",
+  "suggest_articles_in_new_ticket_page"
+ ],
+ "fields": [
+  {
+   "fieldname": "issues_sb",
+   "fieldtype": "Section Break",
+   "label": "Issues"
+  },
+  {
+   "default": "7",
+   "fieldname": "close_issue_after_days",
+   "fieldtype": "Int",
+   "label": "Close Issue After Days"
+  },
+  {
+   "fieldname": "portal_sb",
+   "fieldtype": "Section Break",
+   "label": "Support Portal"
+  },
+  {
+   "fieldname": "get_started_sections",
+   "fieldtype": "Code",
+   "label": "Get Started Sections"
+  },
+  {
+   "default": "0",
+   "fieldname": "show_latest_forum_posts",
+   "fieldtype": "Check",
+   "label": "Show Latest Forum Posts"
+  },
+  {
+   "depends_on": "show_latest_forum_posts",
+   "fieldname": "forum_sb",
+   "fieldtype": "Section Break",
+   "label": "Forum Posts"
+  },
+  {
+   "fieldname": "forum_url",
+   "fieldtype": "Data",
+   "label": "Forum URL"
+  },
+  {
+   "fieldname": "get_latest_query",
+   "fieldtype": "Data",
+   "label": "Get Latest Query"
+  },
+  {
+   "fieldname": "response_key_list",
+   "fieldtype": "Data",
+   "label": "Response Key List"
+  },
+  {
+   "fieldname": "column_break_10",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "post_title_key",
+   "fieldtype": "Data",
+   "label": "Post Title Key"
+  },
+  {
+   "fieldname": "post_description_key",
+   "fieldtype": "Data",
+   "label": "Post Description Key"
+  },
+  {
+   "fieldname": "post_route_key",
+   "fieldtype": "Data",
+   "label": "Post Route Key"
+  },
+  {
+   "fieldname": "post_route_string",
+   "fieldtype": "Data",
+   "label": "Post Route String"
+  },
+  {
+   "fieldname": "sb_00",
+   "fieldtype": "Section Break",
+   "label": "SLAs"
+  },
+  {
+   "default": "1",
+   "fieldname": "track_service_level_agreement",
+   "fieldtype": "Check",
+   "label": "Track SLA"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.track_service_level_agreement;",
+   "fieldname": "allow_resetting_service_level_agreement",
+   "fieldtype": "Check",
+   "label": "Allow Resetting SLA"
+  },
+  {
+   "fieldname": "helpdesk_name",
+   "fieldtype": "Data",
+   "label": "Helpdesk Name"
+  },
+  {
+   "default": "0",
+   "fieldname": "setup_complete",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Setup Complete"
+  },
+  {
+   "default": "0",
+   "fieldname": "initial_agent_set",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Initial Agent Set"
+  },
+  {
+   "default": "0",
+   "fieldname": "initial_demo_ticket_created",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Initial Demo Ticket Created"
+  },
+  {
+   "fieldname": "column_break_4",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "initial_helpdesk_name_setup_skipped",
+   "fieldtype": "Check",
+   "label": "Initial Helpdesk Name Setup Skipped"
+  },
+  {
+   "fieldname": "assignment_rules_section",
+   "fieldtype": "Section Break",
+   "label": "Assignment Rules"
+  },
+  {
+   "fieldname": "base_support_rotation",
+   "fieldtype": "Link",
+   "label": "Base Support Rotation",
+   "options": "Assignment Rule",
+   "read_only": 1
+  },
+  {
+   "fieldname": "knowledge_base_section",
+   "fieldtype": "Section Break",
+   "label": "Knowledge Base"
+  },
+  {
+   "default": "0",
+   "fieldname": "suggest_articles_in_new_ticket_page",
+   "fieldtype": "Check",
+   "label": "Suggest Articles in New TIcket Page"
+  },
+  {
+   "fieldname": "default_ticket_type",
+   "fieldtype": "Link",
+   "label": "Default Ticket Type",
+   "options": "Ticket Type"
+  },
+  {
+   "fieldname": "agent_groups_section",
+   "fieldtype": "Section Break",
+   "label": "Agent Groups"
+  },
+  {
+   "default": "0",
+   "fieldname": "restrict_tickets_by_agent_group",
+   "fieldtype": "Check",
+   "label": "Restrict Tickets by Agent Group"
+  },
+  {
+   "fieldname": "column_break_dxlq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "depends_on": "restrict_tickets_by_agent_group",
+   "fieldname": "do_not_restrict_tickets_without_an_agent_group",
+   "fieldtype": "Check",
+   "label": "Do Not Restrict Tickets Without an Agent Group"
+  }
+ ],
+ "issingle": 1,
+ "links": [],
+ "modified": "2023-02-24 03:57:23.892702",
+ "modified_by": "Administrator",
+ "module": "FrappeDesk",
+ "name": "Frappe Desk Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "Agent",
+   "share": 1
+  }
+ ],
+ "quick_entry": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
 }

--- a/frappedesk/frappedesk/doctype/ticket/ticket.py
+++ b/frappedesk/frappedesk/doctype/ticket/ticket.py
@@ -609,10 +609,11 @@ def has_website_permission(doc, ptype, user, verbose=False):
 
 
 def update_ticket(contact, method):
-	"""Called when Contact is deleted"""
-	frappe.db.sql(
-		"""UPDATE `tabTicket` set contact='' where contact=%s""", contact.name
-	)
+	"""
+	Called when Contact is deleted
+	"""
+	QBTicket = frappe.qb.DocType("Ticket")
+	QBTicket.update().set(QBTicket.contact, "").where(QBTicket.contact == contact.name)
 
 
 @frappe.whitelist()

--- a/frappedesk/hooks.py
+++ b/frappedesk/hooks.py
@@ -15,6 +15,10 @@ has_website_permission = {
 	"Ticket": "frappedesk.frappedesk.doctype.ticket.ticket.has_website_permission",
 }
 
+override_whitelisted_methods = {
+	"frappe.client.get_list": "frappedesk.extends.client.get_list",
+}
+
 doc_events = {
 	"*": {"validate": "frappedesk.frappedesk.doctype.sla.sla.apply",},
 	"Communication": {


### PR DESCRIPTION
This PR aims to implement filter tickets by agent group (https://github.com/frappe/helpdesk/issues/973)

This is achieved by having an API filter, instead of framework level user permissions. Using latter method might result in unwanted entries in user permissions

This PR also did a minor refactor to `TeamInfo.vue` whose core logic remains the same

The current behaviour is

- Get agent groups (teams) of current user
- Fetch tickets of above agent groups
- Fetch tickets without any assigned agent group

Pending

- [x] Checkbox to enable/disable this feature