### PR TITLE
fix(get_query): add `order_by` for v14

### DIFF
--- a/frappedesk/extends/qb.py
+++ b/frappedesk/extends/qb.py
@@ -1,10 +1,21 @@
 import frappe
+from frappe.query_builder import Order
 
 VERSION = frappe.__version__
 
 
 def get_query(*args, **kwargs):
 	if not VERSION.startswith("15"):
-		return frappe.qb.engine.get_query(*args, **kwargs)
+		query = frappe.qb.engine.get_query(*args, **kwargs)
+
+		# Frappe framework version below 15 (as of this) does not support
+		# order by for `get_query`. Hence it is needed to manually add it
+		# to our query
+		table = kwargs.get("table")
+		order_field, order_dir = kwargs.get("order_by").split(" ")
+		QBTable = frappe.qb.DocType(table)
+		query = query.orderby(QBTable[order_field], order=Order[order_dir])
+
+		return query
 
 	return frappe.qb.get_query(*args, **kwargs)


### PR DESCRIPTION
`get_query` from version 14 of frappe framework does not seem to support `order_by`. This PR will add this field to our version of `get_query`