### PR TITLE
fix(api): fallback value for order by field

### DIFF
--- a/frappedesk/extends/qb.py
+++ b/frappedesk/extends/qb.py
@@ -2,9 +2,17 @@ import frappe
 from frappe.query_builder import Order
 
 VERSION = frappe.__version__
+ORDER_BY_FIELD = "order_by"
+DEFAULT_ORDER_FIELD = "modified"
+DEFAULT_ORDER_DIR = "desc"
 
 
 def get_query(*args, **kwargs):
+	"""
+	Create a query builder instance, with backward compatibility.
+
+	:return: QueryBuilder instance
+	"""
 	if not VERSION.startswith("15"):
 		query = frappe.qb.engine.get_query(*args, **kwargs)
 
@@ -12,10 +20,25 @@ def get_query(*args, **kwargs):
 		# order by for `get_query`. Hence it is needed to manually add it
 		# to our query
 		table = kwargs.get("table")
-		order_field, order_dir = kwargs.get("order_by").split(" ")
+		order_by_field, order_by_dir = extract_order_by(kwargs)
 		QBTable = frappe.qb.DocType(table)
-		query = query.orderby(QBTable[order_field], order=Order[order_dir])
+		query = query.orderby(QBTable[order_by_field], order=Order[order_by_dir])
 
 		return query
 
 	return frappe.qb.get_query(*args, **kwargs)
+
+
+def extract_order_by(params: dict) -> tuple[str, str]:
+	"""
+	Extract order by field from parameters. Needed for backward compatibility.
+
+	:param params: Dict of call parameters
+	:return: Order by field and order direction
+	"""
+	order_by: list = params.get(ORDER_BY_FIELD, DEFAULT_ORDER_FIELD).split(" ")
+
+	if len(order_by) < 2:
+		return order_by.pop(), DEFAULT_ORDER_DIR
+
+	return order_by


### PR DESCRIPTION
Currently, if there is no specified `order_by` field, the query fails.

This PR adds fallback values for order by field and direction, `modified` and `desc`