### PR TITLE
fix(ux): suppress default email toast

### DIFF
--- a/desk/src/pages/desk/Desk.vue
+++ b/desk/src/pages/desk/Desk.vue
@@ -193,6 +193,7 @@ export default {
 			}
 			// default email account
 			if (
+				!this.$resources.frappedeskSettings.data.suppress_default_email_toast &&
 				this.defaultOutgoingEmailAccountSetup != "NOT SET" &&
 				!this.defaultOutgoingEmailAccountSetup
 			) {

--- a/desk/src/pages/desk/Desk.vue
+++ b/desk/src/pages/desk/Desk.vue
@@ -1,25 +1,25 @@
 <template>
 	<div
 		v-if="user.isLoggedIn() && user.has_desk_access"
-		class="w-screen h-screen"
+		class="h-screen w-screen"
 	>
 		<div v-if="initialized">
-			<div class="flex flex-row w-screen">
-				<SideBarMenu class="bg-gray-50 shrink-0 w-[200px]" />
-				<router-view class="grow" :key="$route.fullPath" />
+			<div class="flex w-screen flex-row">
+				<SideBarMenu class="w-[200px] shrink-0 bg-gray-50" />
+				<router-view :key="$route.fullPath" class="grow" />
 			</div>
 		</div>
-		<div v-else class="h-full w-full flex max-w-full grow-0">
-			<div class="mx-auto my-auto text-base font-normal">
+		<div v-else class="flex h-full w-full max-w-full grow-0">
+			<div class="m-auto text-base font-normal">
 				<CustomIcons name="frappedesk" class="w-[200px]" />
 			</div>
 		</div>
 	</div>
 </template>
 <script>
-import SideBarMenu from "@/components/desk/SideBarMenu.vue"
-import { inject, provide, ref } from "vue"
-import CustomIcons from "@/components/desk/global/CustomIcons.vue"
+import SideBarMenu from "@/components/desk/SideBarMenu.vue";
+import { inject, provide, ref } from "vue";
+import CustomIcons from "@/components/desk/global/CustomIcons.vue";
 
 export default {
 	name: "Desk",
@@ -28,34 +28,34 @@ export default {
 		CustomIcons,
 	},
 	setup() {
-		const mounted = ref(false)
-		const user = inject("user")
+		const mounted = ref(false);
+		const user = inject("user");
 
-		const ticketTypes = ref([])
-		const ticketPriorities = ref([])
-		const ticketStatuses = ref([])
+		const ticketTypes = ref([]);
+		const ticketPriorities = ref([]);
+		const ticketStatuses = ref([]);
 
-		const ticketController = ref({})
+		const ticketController = ref({});
 
-		const contacts = ref([])
-		const contactController = ref({})
+		const contacts = ref([]);
+		const contactController = ref({});
 
-		const agents = ref([])
-		const agentGroups = ref([])
-		const agentController = ref({})
+		const agents = ref([]);
+		const agentGroups = ref([]);
+		const agentController = ref({});
 
-		provide("ticketTypes", ticketTypes)
-		provide("ticketPriorities", ticketPriorities)
-		provide("ticketStatuses", ticketStatuses)
+		provide("ticketTypes", ticketTypes);
+		provide("ticketPriorities", ticketPriorities);
+		provide("ticketStatuses", ticketStatuses);
 
-		provide("ticketController", ticketController)
+		provide("ticketController", ticketController);
 
-		provide("contacts", contacts)
-		provide("contactController", contactController)
+		provide("contacts", contacts);
+		provide("contactController", contactController);
 
-		provide("agents", agents)
-		provide("agentGroups", agentGroups)
-		provide("agentController", agentController)
+		provide("agents", agents);
+		provide("agentGroups", agentGroups);
+		provide("agentController", agentController);
 
 		return {
 			mounted,
@@ -73,33 +73,39 @@ export default {
 			agents,
 			agentGroups,
 			agentController,
-		}
+		};
 	},
 	computed: {
 		initialized() {
-			if (!this.mounted) return false
-			if (!this.user.isLoggedIn()) return false
-			if (!this.user.has_desk_access) return false
-			if (this.$resources.frappedeskSettings.loading) return false
+			if (!this.mounted) return false;
+			if (!this.user.isLoggedIn()) return false;
+			if (!this.user.has_desk_access) return false;
+			if (this.$resources.frappedeskSettings.loading) return false;
 			if (!this.$resources.frappedeskSettings.data.initial_agent_set) {
-				this.$resources.setupInitialAgent.submit()
-				return false
+				this.$resources.setupInitialAgent.submit();
+				return false;
 			}
 			if (
-				!this.$resources.frappedeskSettings.data
-					.initial_demo_ticket_created
+				!this.$resources.frappedeskSettings.data.initial_demo_ticket_created
 			) {
-				this.$resources.createInitialDemoTicket.submit()
-				return false
+				this.$resources.createInitialDemoTicket.submit();
+				return false;
 			}
 
-			return true
+			return true;
 		},
 		defaultOutgoingEmailAccountSetup() {
 			if (this.$resources.defaultOutgoingEmailAccount.loading) {
-				return "NOT SET"
+				return "NOT SET";
 			}
-			return this.$resources.defaultOutgoingEmailAccount.data > 0
+			return this.$resources.defaultOutgoingEmailAccount.data > 0;
+		},
+	},
+	watch: {
+		initialized(val) {
+			if (val) {
+				this.handlePostOnboardSetupReqs();
+			}
 		},
 	},
 	mounted() {
@@ -107,78 +113,71 @@ export default {
 			this.$router.push({
 				name: "DeskLogin",
 				query: { route: this.$route.path },
-			})
-			return
+			});
+			return;
 		}
 		if (!this.user.has_desk_access) {
-			this.$router.push({ path: "/support/tickets" })
-			return
+			this.$router.push({ path: "/support/tickets" });
+			return;
 		}
-		this.$resources.frappedeskSettings.fetch()
+		this.$resources.frappedeskSettings.fetch();
 		this.ticketController.set = (ticketId, type, ref = null) => {
 			switch (type) {
 				case "type":
 					return this.$resources.assignTicketType.submit({
 						ticket_id: ticketId,
 						type: ref,
-					})
+					});
 				case "status":
 					return this.$resources.assignTicketStatus.submit({
 						ticket_id: ticketId,
 						status: ref,
-					})
+					});
 				case "priority":
 					return this.$resources.assignTicketPriority.submit({
 						ticket_id: ticketId,
 						priority: ref,
-					})
+					});
 				case "contact":
 					return this.$resources.updateTicketContact.submit({
 						ticket_id: ticketId,
 						contact: ref,
-					})
+					});
 				case "agent":
 					return this.$resources.assignTicketToAgent.submit({
 						ticket_id: ticketId,
 						agent_id: ref,
-					})
+					});
 			}
-		}
+		};
 		this.ticketController.new = (type, values) => {
 			switch (type) {
 				case "ticket":
 					return this.$resources.createTicket.submit({
 						values,
-					})
+					});
 				case "type":
 					this.$resources.createTicketType.submit({
 						type: values,
-					})
-					break
+					});
+					break;
 			}
-		}
+		};
 		this.$socket.on("list_update", (data) => {
 			switch (data.doctype) {
 				case "Ticket Type":
-					this.$resources.types.reload()
-					break
+					this.$resources.types.reload();
+					break;
 				case "Agent":
-					this.$resources.agents.reload()
-					break
+					this.$resources.agents.reload();
+					break;
 			}
-		})
+		});
 
-		this.mounted = true
+		this.mounted = true;
 	},
 	unmounted() {
-		this.$socket.off("list_update")
-	},
-	watch: {
-		initialized(val) {
-			if (val) {
-				this.handlePostOnboardSetupReqs()
-			}
-		},
+		this.$socket.off("list_update");
 	},
 	methods: {
 		handlePostOnboardSetupReqs() {
@@ -188,8 +187,8 @@ export default {
 				!this.$resources.frappedeskSettings.data
 					.initial_helpdesk_name_setup_skipped
 			) {
-				this.showHelpdeskNameSetupToast()
-				return
+				this.showHelpdeskNameSetupToast();
+				return;
 			}
 			// default email account
 			if (
@@ -197,8 +196,8 @@ export default {
 				this.defaultOutgoingEmailAccountSetup != "NOT SET" &&
 				!this.defaultOutgoingEmailAccountSetup
 			) {
-				this.showDefaultEmailAccountSetupToast()
-				return
+				this.showDefaultEmailAccountSetupToast();
+				return;
 			}
 			// add agents
 			if (
@@ -206,11 +205,11 @@ export default {
 				this.$resources.agentCount.data == 0
 			) {
 				// this block should theoretically never fire, since the initial agent is created during the setup process
-				this.showAddAgentsToast()
+				this.showAddAgentsToast();
 			}
 		},
 		showHelpdeskNameSetupToast() {
-			console.log("showing helpdesk name setup toast")
+			console.log("showing helpdesk name setup toast");
 			this.$toast({
 				title: "Setup Helpdesk Name",
 				form: {
@@ -225,7 +224,7 @@ export default {
 						if (values.helpdesk_name) {
 							this.$resources.setHelpdeskName.submit({
 								name: values.helpdesk_name,
-							})
+							});
 						}
 					},
 				},
@@ -233,9 +232,9 @@ export default {
 				appearance: "info",
 				position: "bottom-right",
 				onClose: () => {
-					this.$resources.skipHelpdeskNameSetup.submit()
+					this.$resources.skipHelpdeskNameSetup.submit();
 				},
-			})
+			});
 		},
 		showDefaultEmailAccountSetupToast() {
 			this.$toast({
@@ -249,11 +248,11 @@ export default {
 				action: {
 					title: "Setup now",
 					onClick: () => {
-						this.$clearToasts()
-						this.$router.push({ name: "Emails" })
+						this.$clearToasts();
+						this.$router.push({ name: "Emails" });
 					},
 				},
-			})
+			});
 		},
 		showAddAgentsToast() {
 			this.$toast({
@@ -267,11 +266,11 @@ export default {
 				action: {
 					title: "Add now",
 					onClick: () => {
-						this.$clearToasts()
-						this.$router.push({ name: "Agents" })
+						this.$clearToasts();
+						this.$router.push({ name: "Agents" });
 					},
 				},
-			})
+			});
 		},
 	},
 	resources: {
@@ -282,7 +281,7 @@ export default {
 			return {
 				method: "frappedesk.api.setup.initial_agent_setup",
 				onSuccess: (res) => {
-					this.$resources.frappedeskSettings.fetch()
+					this.$resources.frappedeskSettings.fetch();
 				},
 				onError: (err) => {
 					this.$toast({
@@ -290,16 +289,16 @@ export default {
 						text: "Please try again later.",
 						customIcon: "circle-fail",
 						appearance: "danger",
-					})
+					});
 				},
-			}
+			};
 		},
 		createInitialDemoTicket() {
 			// creates a demo ticket
 			return {
 				method: "frappedesk.api.setup.create_initial_demo_ticket",
 				onSuccess: (res) => {
-					this.$resources.frappedeskSettings.fetch()
+					this.$resources.frappedeskSettings.fetch();
 				},
 				onError: (err) => {
 					this.$toast({
@@ -307,21 +306,21 @@ export default {
 						text: "Please try again later.",
 						customIcon: "circle-fail",
 						appearance: "danger",
-					})
+					});
 				},
-			}
+			};
 		},
 		setHelpdeskName() {
 			// set helpdesk name in Frappe Desk Settings
 			return {
 				method: "frappedesk.api.settings.update_helpdesk_name",
 				onSuccess: (res) => {
-					document.title = `Frappe Desk ${res ? ` | ${res}` : ""}`
+					document.title = `Frappe Desk ${res ? ` | ${res}` : ""}`;
 					this.$toast({
 						title: "Helpdesk name updated!!",
 						customIcon: "circle-check",
 						appearance: "success",
-					})
+					});
 				},
 				onError: (err) => {
 					this.$toast({
@@ -329,15 +328,15 @@ export default {
 						text: "Please try again later.",
 						customIcon: "circle-fail",
 						appearance: "danger",
-					})
+					});
 				},
-			}
+			};
 		},
 		skipHelpdeskNameSetup() {
 			// sets the values of skip_helpdesk_name_setup to true inside Frappe Desk Settings
 			return {
 				method: "frappedesk.api.settings.skip_helpdesk_name_setup",
-			}
+			};
 		},
 		// getters
 		frappedeskSettings() {
@@ -353,9 +352,9 @@ export default {
 						text: "Please try again later.",
 						customIcon: "circle-fail",
 						appearance: "danger",
-					})
+					});
 				},
-			}
+			};
 		},
 		defaultOutgoingEmailAccount() {
 			return {
@@ -369,7 +368,7 @@ export default {
 					],
 				},
 				auto: true,
-			}
+			};
 		},
 		agentCount() {
 			return {
@@ -378,7 +377,7 @@ export default {
 					doctype: "Agent",
 				},
 				auto: true,
-			}
+			};
 		},
 
 		// ticket related resources
@@ -391,7 +390,7 @@ export default {
 				onError: () => {
 					// TODO:
 				},
-			}
+			};
 		},
 		updateTicketContact() {
 			return {
@@ -402,7 +401,7 @@ export default {
 				onError: () => {
 					// TODO:
 				},
-			}
+			};
 		},
 		types() {
 			return {
@@ -413,12 +412,12 @@ export default {
 				},
 				auto: this.user.has_desk_access,
 				onSuccess: (data) => {
-					this.ticketTypes = data
+					this.ticketTypes = data;
 				},
 				onError: () => {
 					// TODO:
 				},
-			}
+			};
 		},
 		priorities() {
 			return {
@@ -428,24 +427,24 @@ export default {
 				},
 				auto: this.user.has_desk_access,
 				onSuccess: (data) => {
-					this.ticketPriorities = data
+					this.ticketPriorities = data;
 				},
 				onError: () => {
 					// TODO:
 				},
-			}
+			};
 		},
 		statuses() {
 			return {
 				method: "frappedesk.api.ticket.get_all_ticket_statuses",
 				auto: this.user.has_desk_access,
 				onSuccess: (data) => {
-					this.ticketStatuses = data
+					this.ticketStatuses = data;
 				},
 				onError: () => {
 					// TODO:
 				},
-			}
+			};
 		},
 		contacts() {
 			return {
@@ -457,32 +456,28 @@ export default {
 				},
 				auto: this.user.has_desk_access,
 				onSuccess: (data) => {
-					this.contacts = data
+					this.contacts = data;
 				},
 				onError: () => {
 					// TODO:
 				},
-			}
+			};
 		},
 		agents() {
 			return {
 				method: "frappe.client.get_list",
 				params: {
 					doctype: "Agent",
-					fields: [
-						"name",
-						"agent_name",
-						"user_image",
-					],
+					fields: ["name", "agent_name", "user_image"],
 				},
 				auto: this.user.has_desk_access,
 				onSuccess: (data) => {
-					this.agents = data
+					this.agents = data;
 				},
 				onError: () => {
 					// TODO:
 				},
-			}
+			};
 		},
 		agentGroups() {
 			return {
@@ -492,23 +487,23 @@ export default {
 				},
 				auto: this.user.has_desk_access,
 				onSuccess: (data) => {
-					this.agentGroups = data
+					this.agentGroups = data;
 				},
 				onError: () => {
 					// TODO:
 				},
-			}
+			};
 		},
 		assignTicketToAgent() {
 			return {
 				method: "frappedesk.api.ticket.assign_ticket_to_agent",
 				onSuccess: async () => {
-					this.$event.emit("update_ticket_list")
+					this.$event.emit("update_ticket_list");
 				},
 				onError: () => {
 					// TODO:
 				},
-			}
+			};
 		},
 		assignTicketType() {
 			return {
@@ -517,18 +512,18 @@ export default {
 				onError: () => {
 					// TODO:
 				},
-			}
+			};
 		},
 		assignTicketStatus() {
 			return {
 				method: "frappedesk.api.ticket.assign_ticket_status",
 				onSuccess: async () => {
-					this.$event.emit("update_ticket_list")
+					this.$event.emit("update_ticket_list");
 				},
 				onError: () => {
 					// TODO:
 				},
-			}
+			};
 		},
 		assignTicketPriority() {
 			return {
@@ -537,20 +532,20 @@ export default {
 				onError: () => {
 					// TODO:
 				},
-			}
+			};
 		},
 		createTicketType() {
 			return {
 				method: "frappedesk.api.ticket.check_and_create_ticket_type",
 				onSuccess: () => {
-					this.$resources.types.fetch()
+					this.$resources.types.fetch();
 				},
 				onError: () => {
 					// TODO:
 				},
-			}
+			};
 		},
 	},
 	directivs: {},
-}
+};
 </script>

--- a/frappedesk/frappedesk/doctype/frappe_desk_settings/frappe_desk_settings.json
+++ b/frappedesk/frappedesk/doctype/frappe_desk_settings/frappe_desk_settings.json
@@ -36,7 +36,11 @@
   "assignment_rules_section",
   "base_support_rotation",
   "knowledge_base_section",
-  "suggest_articles_in_new_ticket_page"
+  "suggest_articles_in_new_ticket_page",
+  "misc_tab",
+  "toasts_column",
+  "suppress_default_email_toast",
+  "column_break_qkui"
  ],
  "fields": [
   {
@@ -215,11 +219,31 @@
    "fieldname": "do_not_restrict_tickets_without_an_agent_group",
    "fieldtype": "Check",
    "label": "Do not restrict tickets without a Team"
+  },
+  {
+   "fieldname": "misc_tab",
+   "fieldtype": "Tab Break",
+   "label": "Misc"
+  },
+  {
+   "fieldname": "toasts_column",
+   "fieldtype": "Column Break",
+   "label": "Toasts"
+  },
+  {
+   "default": "1",
+   "fieldname": "suppress_default_email_toast",
+   "fieldtype": "Check",
+   "label": "Suppress default email toast"
+  },
+  {
+   "fieldname": "column_break_qkui",
+   "fieldtype": "Column Break"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2023-02-24 03:57:23.892702",
+ "modified": "2023-03-06 00:33:09.638082",
  "modified_by": "Administrator",
  "module": "FrappeDesk",
  "name": "Frappe Desk Settings",


### PR DESCRIPTION
This PR add a checkbox in "Frappe Desk Settings" to suppress default email toast. This toast shown whenever you are logged into dashboard and there is no default email set

> <img width="307" alt="image" src="https://user-images.githubusercontent.com/28098330/222981183-ad23dcf0-1776-4b7f-9df9-45b636f3675e.png">
