### PR TITLE
fix: set `Open` status on `Reopen` button click

### DIFF
--- a/desk/src/pages/portal/ticketing/Ticket.vue
+++ b/desk/src/pages/portal/ticketing/Ticket.vue
@@ -100,7 +100,7 @@
 								@click="
 									() => {
 										$resources.ticket.setValue.submit({
-											status: 'Closed',
+											status: 'Open',
 										})
 									}
 								"


### PR DESCRIPTION
closes https://github.com/frappe/helpdesk/issues/1059