### PR TITLE
feat: settings: add a check to instantly send email

### DIFF
--- a/frappedesk/frappedesk/doctype/frappe_desk_settings/frappe_desk_settings.json
+++ b/frappedesk/frappedesk/doctype/frappe_desk_settings/frappe_desk_settings.json
@@ -24,6 +24,7 @@
   "suggest_articles_in_new_ticket_page",
   "workflow_tab",
   "skip_email_workflow",
+  "instantly_send_email",
   "column_break_aomm",
   "misc_tab",
   "toasts_column",
@@ -197,11 +198,17 @@
   {
    "fieldname": "column_break_aomm",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "instantly_send_email",
+   "fieldtype": "Check",
+   "label": "Instantly send e-mail"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2023-03-14 17:05:08.053813",
+ "modified": "2023-03-15 21:50:32.939856",
  "modified_by": "Administrator",
  "module": "FrappeDesk",
  "name": "Frappe Desk Settings",

--- a/frappedesk/frappedesk/doctype/ticket/ticket.py
+++ b/frappedesk/frappedesk/doctype/ticket/ticket.py
@@ -306,6 +306,14 @@ class Ticket(Document):
 
 		return bool(int(skip))
 
+	def instantly_send_email(self):
+		check: str = (
+			frappe.get_value("Frappe Desk Settings", None, "instantly_send_email")
+			or "0"
+		)
+
+		return bool(int(check))
+
 	def last_communication(self):
 		filters = {"reference_doctype": "Ticket", "reference_name": ["=", self.name]}
 
@@ -419,6 +427,12 @@ class Ticket(Document):
 			"portal_link": self.portal_uri,
 			"ticket_id": self.name,
 		}
+		send_delayed = True
+		send_now = False
+
+		if self.instantly_send_email():
+			send_delayed = False
+			send_now = True
 
 		try:
 			frappe.sendmail(
@@ -427,9 +441,9 @@ class Ticket(Document):
 				bcc=bcc,
 				cc=cc,
 				communication=communication.name,
-				delayed=False,
+				delayed=send_delayed,
 				message=message,
-				now=True,
+				now=send_now,
 				recipients=recipients,
 				reference_doctype="Ticket",
 				reference_name=self.name,


### PR DESCRIPTION
This PR adds a check in `Frappe Desk Settings` to decide if the reply e-mail should be sent instantly (instead of adding to a queue)