### PR TITLE
fix(ux): use template only if raised via customer portal

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -445,7 +445,11 @@ class HDTicket(Document):
 			frappe.throw(_("Can not send email. No sender email set up!"))
 
 		reply_to_email = sender_email.email_id
-		template = "new_reply_on_customer_portal_notification"
+		template = (
+			"new_reply_on_customer_portal_notification"
+			if self.via_customer_portal
+			else None
+		)
 		args = {
 			"message": message,
 			"portal_link": self.portal_uri,
@@ -476,7 +480,7 @@ class HDTicket(Document):
 				sender=reply_to_email,
 				subject=subject,
 				template=template,
-				with_container=True,
+				with_container=False,
 			)
 		except Exception as e:
 			frappe.throw(_(e))


### PR DESCRIPTION
- remove container from reply email
- use template only if ticket is raised via customer portal