### PR TITLE
feat: brand logo for auth pages

### DIFF
--- a/desk/src/App.vue
+++ b/desk/src/App.vue
@@ -7,8 +7,11 @@
 <script setup lang="ts">
 import { provide, ref, onMounted } from "vue";
 import { createToast } from "@/utils/toasts";
+import { useConfigStore } from "@/stores/config";
 import KeymapDialog from "@/pages/KeymapDialog.vue";
 import { Toasts } from "@/components/global/toast";
+
+useConfigStore();
 
 const viewportWidth = ref(
 	Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0)

--- a/desk/src/components/global/LoginBox.vue
+++ b/desk/src/components/global/LoginBox.vue
@@ -1,37 +1,36 @@
 <template>
-	<div class="h-full pt-4 sm:pt-16">
-		<div>
-			<div class="flex">
-				<div class="mx-auto h-4 w-auto">
-					<CustomIcons name="frappedesk" class="`w-5 h-5" />
+	<div class="flex h-screen w-screen items-center justify-center">
+		<span>
+			<img
+				v-if="configStore.brandLogo"
+				:src="configStore.brandLogo"
+				class="m-auto h-6"
+			/>
+			<div v-else class="flex">
+				<div class="mx-auto h-6 w-auto">
+					<CustomIcons name="frappedesk" class="h-6" />
 				</div>
 			</div>
-			<div
-				class="sm:w-0112 mx-auto bg-white px-4 py-8 sm:mt-6 sm:w-96 sm:rounded-lg sm:px-10 sm:shadow-xl"
-			>
-				<div class="mb-6 text-center">
-					<span class="text-lg">{{ title }}</span>
+			<div class="w-96 rounded-xl py-8 px-10 shadow-xl">
+				<div class="mb-6 text-center text-lg">
+					{{ title }}
 				</div>
 				<slot></slot>
 			</div>
-		</div>
+		</span>
 	</div>
 </template>
 
-<script>
-import CustomIcons from "@/components/desk/global/CustomIcons.vue"
+<script setup lang="ts">
+import { useConfigStore } from "@/stores/config";
+import CustomIcons from "@/components/desk/global/CustomIcons.vue";
 
-export default {
-	name: "LoginBox",
-	props: ["title"],
-	components: {
-		CustomIcons,
+defineProps({
+	title: {
+		type: String,
+		required: true,
 	},
-	methods: {
-		redirectForFrappeioAuth() {
-			// TODO: ref (https://github.com/frappe/press/commit/f38b26dca5ea44c9b57de37a0162f9707356a903)
-			window.location = "/f-login"
-		},
-	},
-}
+});
+
+const configStore = useConfigStore();
 </script>

--- a/desk/src/components/global/LoginBox.vue
+++ b/desk/src/components/global/LoginBox.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="flex h-screen w-screen items-center justify-center">
-		<span>
+		<div class="rounded-xl shadow-xl">
 			<img
 				v-if="configStore.brandLogo"
 				:src="configStore.brandLogo"
@@ -11,13 +11,13 @@
 					<CustomIcons name="frappedesk" class="h-6" />
 				</div>
 			</div>
-			<div class="w-96 rounded-xl py-8 px-10 shadow-xl">
+			<div class="w-96 py-8 px-10">
 				<div class="mb-6 text-center text-lg">
 					{{ title }}
 				</div>
 				<slot></slot>
 			</div>
-		</span>
+		</div>
 	</div>
 </template>
 

--- a/desk/src/router.js
+++ b/desk/src/router.js
@@ -1,7 +1,6 @@
 import { createRouter, createWebHistory } from "vue-router";
 import { call } from "frappe-ui";
 import { useAuthStore } from "@/stores/auth";
-import { useConfigStore } from "@/stores/config";
 
 export const LOGIN = "Login";
 export const SIGNUP = "Signup";
@@ -385,5 +384,4 @@ router.beforeEach(async (to) => {
 	const authStore = useAuthStore();
 
 	await authStore.init().catch(() => router.replace({ name: LOGIN }));
-	useConfigStore();
 });

--- a/desk/src/stores/config.ts
+++ b/desk/src/stores/config.ts
@@ -14,6 +14,7 @@ export const useConfigStore = defineStore("config", () => {
 	});
 
 	const config = computed(() => configRes.data || {});
+	const brandLogo = computed(() => config.value.brand_logo);
 	const helpdeskName: ComputedRef<string> = computed(
 		() => config.value.helpdesk_name || DEFAULT_TITLE
 	);
@@ -27,6 +28,7 @@ export const useConfigStore = defineStore("config", () => {
 
 	return {
 		config,
+		brandLogo,
 		helpdeskName,
 		suppressEmailToast,
 	};

--- a/helpdesk/api/config.py
+++ b/helpdesk/api/config.py
@@ -1,14 +1,16 @@
 import frappe
 
 
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
 def get_config():
+	brand_logo = frappe.db.get_single_value("HD Settings", "brand_logo")
 	helpdesk_name = frappe.db.get_single_value("HD Settings", "helpdesk_name")
 	suppress_default_email_toast = frappe.db.get_single_value(
 		"HD Settings", "suppress_default_email_toast"
 	)
 
 	return {
+		"brand_logo": brand_logo,
 		"helpdesk_name": helpdesk_name,
 		"suppress_default_email_toast": suppress_default_email_toast,
 	}

--- a/helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+++ b/helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -26,6 +26,10 @@
   "skip_email_workflow",
   "instantly_send_email",
   "column_break_aomm",
+  "branding_tab",
+  "images_column",
+  "brand_logo",
+  "column_break_fsjn",
   "misc_tab",
   "toasts_column",
   "suppress_default_email_toast",
@@ -192,11 +196,31 @@
    "fieldname": "instantly_send_email",
    "fieldtype": "Check",
    "label": "Instantly send e-mail"
+  },
+  {
+   "fieldname": "branding_tab",
+   "fieldtype": "Tab Break",
+   "label": "Branding"
+  },
+  {
+   "fieldname": "images_column",
+   "fieldtype": "Column Break",
+   "label": "Images"
+  },
+  {
+   "description": "Image to be used in various places, including Login and Signup pages. An image with transparent background and 160 x 32 is preferred",
+   "fieldname": "brand_logo",
+   "fieldtype": "Attach Image",
+   "label": "Logo"
+  },
+  {
+   "fieldname": "column_break_fsjn",
+   "fieldtype": "Column Break"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2023-04-14 04:03:58.330687",
+ "modified": "2023-05-05 12:52:41.086826",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Settings",


### PR DESCRIPTION
This PR
- Adds a field in `HD Settings` - `brand_logo` which can be used to attach an image
- This image is then used in auth pages (Login and Signup)

> 
![screely-1683272485852](https://user-images.githubusercontent.com/28098330/236402338-e5237cda-6c67-4427-933c-8caaf1c4bc47.png)

_Logo taken from https://commons.wikimedia.org/wiki/File:Wikipedia_name_logo.png_