### PR TITLE
fix: Ticket Activity doesn't exist.

### DIFF
--- a/helpdesk/api/ticket.py
+++ b/helpdesk/api/ticket.py
@@ -496,7 +496,7 @@ def activities(name):
 	activities = frappe.db.sql(
 		"""
 		SELECT action, creation, owner
-		FROM `tabTicket Activity`
+		FROM `tabHD Ticket Activity`
 		WHERE ticket = %(ticket)s
 		ORDER BY creation DESC
 	""",


### PR DESCRIPTION
When clicking on `TICKET HISTORY` on a ticket page, there is an error saying, a table Ticket Activity doesn't exist.

This PR fix this issue. By changing `tabTicket Activity` to `tabHD Ticket Activity`.