### PR TITLE
Modify replied email subject:

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -393,7 +393,7 @@ class HDTicket(Document):
 	):
 		skip_email_workflow = self.skip_email_workflow()
 		medium = "" if skip_email_workflow else "Email"
-		subject = f"Re: {self.subject} {self.name}"
+		subject = f"Re: {self.subject} (#{self.name})"
 		sender = frappe.session.user
 		recipients = self.raised_by
 		sender_email = None if skip_email_workflow else self.sender_email()


### PR DESCRIPTION
Change the email subject which is replied by an agent. Example is below.

from `Re: Example email subject 10`
to `Re: Example email subject (#10)`

Note: 10 is a ticket number.

This makes emails that sent to customers look more slick and easy to understand.