### PR TITLE
fix(ux): stores: set a high number as `pageLimit`

### DIFF
--- a/desk/src/stores/agent.ts
+++ b/desk/src/stores/agent.ts
@@ -13,6 +13,7 @@ export const useAgentStore = defineStore("agent", () => {
 		doctype: "HD Agent",
 		fields: ["*"],
 		auto: true,
+		pageLength: 99999,
 	});
 
 	const options: ComputedRef<Array<Agent>> = computed(

--- a/desk/src/stores/contact.ts
+++ b/desk/src/stores/contact.ts
@@ -15,6 +15,7 @@ export const useContactStore = defineStore("contact", () => {
 		doctype: "Contact",
 		fields: ["*"],
 		auto: true,
+		pageLength: 99999,
 	});
 
 	const options: ComputedRef<Array<Contact>> = computed(

--- a/desk/src/stores/team.ts
+++ b/desk/src/stores/team.ts
@@ -10,6 +10,7 @@ export const useTeamStore = defineStore("team", () => {
 	const d__ = createListResource({
 		doctype: "HD Team",
 		auto: true,
+		pageLength: 99999,
 	});
 
 	const options: ComputedRef<Array<Team>> = computed(

--- a/desk/src/stores/ticketPriority.ts
+++ b/desk/src/stores/ticketPriority.ts
@@ -12,6 +12,7 @@ export const useTicketPriorityStore = defineStore("ticketPriority", () => {
 		doctype: "HD Ticket Priority",
 		orderBy: "integer_value desc",
 		auto: true,
+		pageLength: 99999,
 	});
 
 	const options: ComputedRef<Array<TicketPriority>> = computed(

--- a/desk/src/stores/ticketType.ts
+++ b/desk/src/stores/ticketType.ts
@@ -13,6 +13,7 @@ export const useTicketTypeStore = defineStore("ticketType", () => {
 		doctype: "HD Ticket Type",
 		fields: ["*"],
 		auto: true,
+		pageLength: 99999,
 	});
 
 	const options: ComputedRef<Array<TicketType>> = computed(


### PR DESCRIPTION
This is because frappe-ui defaults to `pageLimit` 20. This is undesirable for stores, since they need `all` entries. As a workaround, a `pageLimit` of 99999 is used.