### PR TITLE
fix(ui): Created By field empty issue fixed

### DIFF
--- a/desk/src/pages/desk/ticket-list/NewTicketDialog.vue
+++ b/desk/src/pages/desk/ticket-list/NewTicketDialog.vue
@@ -57,7 +57,7 @@
 									return {
 										doctype: 'Contact',
 										pluck: 'name',
-										filters: [['name', 'like', `%${query}%`]],
+										filters: [['Contact','name', 'like', `%${query}%`]],
 									};
 								},
 								responseMap: (res) => {


### PR DESCRIPTION
Issue:https://github.com/frappe/helpdesk/issues/1178

The issue has been resolved by adding Doctype to the reference in Contact filters.
As the table was not given reference db was throwing ambiguous errors.
error has been solved in this Merge   