### PR TITLE
feat: agent portal: response editor: conditionally hide email fields

### DIFF
--- a/desk/src/pages/desk/ticket/editor/ResponseEditor.vue
+++ b/desk/src/pages/desk/ticket/editor/ResponseEditor.vue
@@ -17,7 +17,7 @@
 				@change="(v) => (editor.content = v)"
 			>
 				<template #top>
-					<TopSection />
+					<TopSection v-if="!configStore.skipEmailWorkflow" />
 				</template>
 				<template #editor="{ editor: e }">
 					<TextEditorContent :editor="e" />
@@ -42,12 +42,14 @@ import { computed, onUnmounted, ref, watch } from "vue";
 import { Avatar, TextEditor, TextEditorContent } from "frappe-ui";
 import { useAuthStore } from "@/stores/auth";
 import { useAgentStore } from "@/stores/agent";
+import { useConfigStore } from "@/stores/config";
 import { useTicketStore } from "../data";
 import BottomSection from "./BottomSection.vue";
 import TopSection from "./TopSection.vue";
 
 const authStore = useAuthStore();
 const agentStore = useAgentStore();
+const configStore = useConfigStore();
 const { editor } = useTicketStore();
 const editorRef = ref(null);
 const placeholder = "Add a reply / comment";

--- a/desk/src/stores/config.ts
+++ b/desk/src/stores/config.ts
@@ -23,8 +23,8 @@ export const useConfigStore = defineStore("config", () => {
 	const isSetupComplete: ComputedRef<boolean> = computed(
 		() => config.value.is_setup_complete
 	);
-	const suppressEmailToast: ComputedRef<boolean> = computed(
-		() => config.value.suppress_default_email_toast ?? true
+	const skipEmailWorkflow: ComputedRef<string> = computed(
+		() => config.value.skip_email_workflow
 	);
 	const pageTitle = ref(null);
 	const windowTitle = computed(() =>
@@ -43,11 +43,11 @@ export const useConfigStore = defineStore("config", () => {
 	socket.on("helpdesk:settings-updated", () => configRes.reload());
 
 	return {
-		config,
 		brandLogo,
+		config,
 		helpdeskName,
 		isSetupComplete,
-		suppressEmailToast,
 		setTitle,
+		skipEmailWorkflow,
 	};
 });

--- a/helpdesk/api/config.py
+++ b/helpdesk/api/config.py
@@ -3,18 +3,12 @@ import frappe
 
 @frappe.whitelist(allow_guest=True)
 def get_config():
-	brand_logo = frappe.db.get_single_value("HD Settings", "brand_logo")
-	brand_favicon = frappe.db.get_single_value("HD Settings", "brand_favicon")
-	helpdesk_name = frappe.db.get_single_value("HD Settings", "helpdesk_name")
-	is_setup_complete = frappe.db.get_single_value("HD Settings", "setup_complete")
-	suppress_default_email_toast = frappe.db.get_single_value(
-		"HD Settings", "suppress_default_email_toast"
-	)
+	settings = frappe.get_single("HD Settings")
 
 	return {
-		"brand_logo": brand_logo,
-		"brand_favicon": brand_favicon,
-		"helpdesk_name": helpdesk_name,
-		"is_setup_complete": is_setup_complete,
-		"suppress_default_email_toast": suppress_default_email_toast,
+		"brand_logo": settings.brand_logo,
+		"brand_favicon": settings.brand_favicon,
+		"helpdesk_name": settings.helpdesk_name,
+		"is_setup_complete": settings.setup_complete,
+		"skip_email_workflow": settings.skip_email_workflow,
 	}


### PR DESCRIPTION
### With email workflow enabled
<img width="760" alt="image" src="https://github.com/frappe/helpdesk/assets/28098330/107e04be-25ba-4a33-af27-d2a37bf4f086">

### With email workflow disabled
<img width="759" alt="image" src="https://github.com/frappe/helpdesk/assets/28098330/4658907b-4213-46e3-bbf6-951dc2cbff60">