### PR TITLE
Resolve customer portal view issue

### DIFF
--- a/helpdesk/extends/client.py
+++ b/helpdesk/extends/client.py
@@ -35,7 +35,7 @@ def get_list(
 		group_by=group_by,
 	)
 
-	query = apply_custom_filters(doctype, query)
+	query = apply_custom_filters(doctype, query,fields=fields)
 	query = apply_hook(doctype, query)
 	query = apply_sort(doctype, order_by, query)
 
@@ -104,14 +104,14 @@ def check_permissions(doctype, parent):
 		frappe.throw(f"Insufficient Permission for {doctype}", frappe.PermissionError)
 
 
-def apply_custom_filters(doctype: str, query):
+def apply_custom_filters(doctype: str, query,fields:dict={}):
 	"""
 	Apply custom filters to query
 	"""
 	controller = get_controller(doctype)
 
 	if hasattr(controller, "get_list_query"):
-		return_value = controller.get_list_query(query)
+		return_value = controller.get_list_query(query,fields)
 		if return_value is not None:
 			query = return_value
 

--- a/helpdesk/extends/client.py
+++ b/helpdesk/extends/client.py
@@ -104,7 +104,7 @@ def check_permissions(doctype, parent):
 		frappe.throw(f"Insufficient Permission for {doctype}", frappe.PermissionError)
 
 
-def apply_custom_filters(doctype: str, query,fields:dict={}):
+def apply_custom_filters(doctype: str, query,fields:list=[]):
 	"""
 	Apply custom filters to query
 	"""

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -31,11 +31,12 @@ from helpdesk.utils import publish_event, capture_event
 
 class HDTicket(Document):
 	@staticmethod
-	def get_list_query(query: Query):
+	def get_list_query(query: Query,fields):
 		QBTicket = frappe.qb.DocType("HD Ticket")
 
 		query = HDTicket.filter_by_team(query)
-		query = query.select(QBTicket.star)
+		if not fields:
+			query = query.select(QBTicket.star)
 
 		return query
 


### PR DESCRIPTION
### Issue
- The user cannot access the previously created ticket on the customer portal view. The SQL exception that occurred when loading the view was what caused this problem.

- It was noticed that even if the fields were set for the desired column, the final query still had an additional `*`.

<img width="1027" alt="Screenshot 2023-06-14 at 3 24 37 PM" src="https://github.com/frappe/helpdesk/assets/28840468/2bb30167-32cf-4ebd-b355-4e929b769f47">

### Solution
- Add conditional check for adding filters to the final query.

Issue ticket: #1254