### PR TITLE
feat(ux):username added in ticket history

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -225,7 +225,7 @@ class HDTicket(Document):
 		]:
 			if self.has_value_changed(field):
 				log_ticket_activity(
-					self.name, f"{field_maps[field]} set to {self.as_dict()[field]}"
+					self.name, f"set {field_maps[field]} to {self.as_dict()[field]}"
 				)
 
 	def remove_assignment_if_not_in_team(self):


### PR DESCRIPTION
Username added to ticket history tab,
As shown in the Demo image of the product, now other users(agents) will be able to see which user has changed the state.
and username will be reflected in the ticket history timeline.