### PR TITLE
fix: Updated empty message for all list items

### DIFF
--- a/desk/src/pages/desk/agent/AgentList.vue
+++ b/desk/src/pages/desk/agent/AgentList.vue
@@ -18,6 +18,7 @@
       class="grow"
       :columns="columns"
       :data="contacts.list?.data || []"
+      :empty-message="emptyMessage"
       row-key="name"
       :hide-checkbox="true"
       :hide-column-selector="true"
@@ -66,6 +67,9 @@ import IconPlus from "~icons/lucide/plus";
 const router = useRouter();
 const filters = useListFilters();
 const isDialogVisible = ref(false);
+
+const emptyMessage = "No Agents Found";
+
 const columns = [
   {
     title: "Name",

--- a/desk/src/pages/desk/canned_response/CannedResponseList.vue
+++ b/desk/src/pages/desk/canned_response/CannedResponseList.vue
@@ -18,6 +18,7 @@
       class="grow"
       :columns="columns"
       :data="responses.list?.data || []"
+      :empty-message="emptyMessage"
       row-key="name"
       :emit-row-click="true"
       :hide-checkbox="true"
@@ -44,6 +45,8 @@ import IconPlus from "~icons/lucide/plus";
 
 const router = useRouter();
 const showNewDialog = ref(false);
+const emptyMessage = "No Canned Responses Found";
+
 const columns = [
   {
     title: "Name",

--- a/desk/src/pages/desk/contact/ContactList.vue
+++ b/desk/src/pages/desk/contact/ContactList.vue
@@ -20,6 +20,7 @@
       :data="contacts.list?.data || []"
       row-key="name"
       :emit-row-click="true"
+      :empty-message="emptyMessage"
       :hide-checkbox="true"
       :hide-column-selector="true"
       @row-click="openContact"
@@ -55,6 +56,9 @@ import IconPlus from "~icons/lucide/plus";
 const isDialogVisible = ref(false);
 const isContactDialogVisible = ref(false);
 const selectedContact = ref(null);
+
+const emptyMessage = "No Contacts Found";
+
 const columns = [
   {
     title: "Name",

--- a/desk/src/pages/desk/customer/CustomerList.vue
+++ b/desk/src/pages/desk/customer/CustomerList.vue
@@ -18,6 +18,7 @@
       class="grow"
       :columns="columns"
       :data="customers.list?.data || []"
+      :empty-message="emptyMessage"
       row-key="name"
       :emit-row-click="true"
       :hide-checkbox="true"
@@ -58,6 +59,9 @@ import IconPlus from "~icons/lucide/plus";
 const isDialogVisible = ref(false);
 const isCustomerDialogVisible = ref(false);
 const selectedCustomer = ref(null);
+
+const emptyMessage = "No Customers Found";
+
 const columns = [
   {
     title: "Name",

--- a/desk/src/pages/desk/email/EmailList.vue
+++ b/desk/src/pages/desk/email/EmailList.vue
@@ -15,6 +15,7 @@
       class="grow"
       :columns="columns"
       :data="accounts.list?.data || []"
+      :empty-message="emptyMessage"
       row-key="name"
       :emit-row-click="true"
       :hide-checkbox="true"
@@ -63,6 +64,9 @@ import ListNavigation from "@/components/ListNavigation.vue";
 import IconPlus from "~icons/lucide/plus";
 
 const router = useRouter();
+
+const emptyMessage = "No Email Accounts Found";
+
 const columns = [
   {
     title: "Name",

--- a/desk/src/pages/desk/escalation/EscalationRuleList.vue
+++ b/desk/src/pages/desk/escalation/EscalationRuleList.vue
@@ -18,6 +18,7 @@
       class="grow"
       :columns="columns"
       :data="rules.list?.data || []"
+      :empty-message="emptyMessage"
       row-key="name"
       :emit-row-click="true"
       :hide-checkbox="true"
@@ -51,6 +52,9 @@ import IconPlus from "~icons/lucide/plus";
 
 const showDialog = ref(false);
 const selectedRule = ref(null);
+
+const emptyMessage = "No Escalation Rules Found";
+
 const columns = [
   {
     title: "Priority",

--- a/desk/src/pages/desk/sla/SlaList.vue
+++ b/desk/src/pages/desk/sla/SlaList.vue
@@ -15,6 +15,7 @@
       class="grow"
       :columns="columns"
       :data="policies.list?.data || []"
+      :empty-message="emptyMessage"
       row-key="name"
       :emit-row-click="true"
       :hide-checkbox="true"
@@ -46,6 +47,9 @@ import ListNavigation from "@/components/ListNavigation.vue";
 import IconPlus from "~icons/lucide/plus";
 
 const router = useRouter();
+
+const emptyMessage = "No Support Policies Found";
+
 const columns = [
   {
     title: "Name",

--- a/desk/src/pages/desk/team/TeamList.vue
+++ b/desk/src/pages/desk/team/TeamList.vue
@@ -18,6 +18,7 @@
       class="grow"
       :columns="columns"
       :data="teams.list?.data || []"
+      :empty-message="emptyMessage"
       row-key="name"
       :emit-row-click="true"
       :hide-checkbox="true"
@@ -67,6 +68,9 @@ import IconPlus from "~icons/lucide/plus";
 const router = useRouter();
 const showNewDialog = ref(false);
 const newTeamTitle = ref(null);
+
+const emptyMessage = "No Teams Found";
+
 const columns = [
   {
     title: "Name",

--- a/desk/src/pages/desk/ticket_type/TicketTypeList.vue
+++ b/desk/src/pages/desk/ticket_type/TicketTypeList.vue
@@ -15,6 +15,7 @@
       class="grow"
       :columns="columns"
       :data="ticketTypes.list?.data || []"
+      :empty-message="emptyMessage"
       row-key="name"
       :emit-row-click="true"
       :hide-checkbox="true"
@@ -37,6 +38,9 @@ import ListNavigation from "@/components/ListNavigation.vue";
 import IconPlus from "~icons/lucide/plus";
 
 const router = useRouter();
+
+const emptyMessage = "No Ticket Types Found";
+
 const columns = [
   {
     title: "Name",


### PR DESCRIPTION
empty message added for all the list items excluding, tickets,
Now respective category shows its own empty response,
Earlier there was a generic response (🙇 Such empty).
Now contact shows ( No Contacts Found )
I Believe this will help User to stay in context 