### PR TITLE
fix(ux): new agent: do not add `System Manager` role

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_agent/hd_agent.py
+++ b/helpdesk/helpdesk/doctype/hd_agent/hd_agent.py
@@ -16,7 +16,7 @@ class HDAgent(Document):
 	def set_user_roles(self):
 		user = frappe.get_doc("User", self.user)
 
-		for role in ["Agent", "System Manager"]:
+		for role in ["Agent"]:
 			user.append("roles", {"role": role})
 
 		user.save()


### PR DESCRIPTION
Do not add `System Manager` role when creating an `Agent`