### PR TITLE
fix(doctype): template field types

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket_template_docfield/hd_ticket_template_docfield.json
+++ b/helpdesk/helpdesk/doctype/hd_ticket_template_docfield/hd_ticket_template_docfield.json
@@ -58,7 +58,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Type",
-   "options": "Custom Link\nLink\nData\nLong Text\nText Editor\nSelect",
+   "options": "Link\nSelect",
    "reqd": 1
   },
   {
@@ -135,7 +135,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2022-11-23 00:32:43.222772",
+ "modified": "2023-07-25 12:56:45.328643",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Ticket Template DocField",


### PR DESCRIPTION
Only allow `Link` and `Select`
https://github.com/frappe/helpdesk/issues/1326