### PR TITLE
Username added in Ticket history

### DIFF
--- a/desk/src/pages/desk/ticket/TicketHistory.vue
+++ b/desk/src/pages/desk/ticket/TicketHistory.vue
@@ -18,7 +18,7 @@
         >
           <IconDot class="absolute -left-3 h-6 w-6 bg-white text-gray-500" />
           <div class="mb-1 font-medium text-gray-900 first-letter:capitalize">
-            {{ activity.action }}
+            {{ activity.owner }} {{ activity.action }}
           </div>
           <Tooltip :text="activity.dateLong">
             <div class="text-gray-700 first-letter:capitalize">

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -167,7 +167,7 @@ class HDTicket(Document):
 		self.validate_ticket_type()
 
 	def after_insert(self):
-		log_ticket_activity(self.name, "created")
+		log_ticket_activity(self.name, "created this ticket")
 		capture_event("ticket_created")
 
 	def on_update(self):
@@ -536,7 +536,7 @@ class HDTicket(Document):
 
 		if ticket_doc.status == "Replied":
 			ticket_doc.status = "Open"
-			log_ticket_activity(self.name, f"status set to Open")
+			log_ticket_activity(self.name, f"set status to Open")
 			ticket_doc.save(ignore_permissions=True)
 
 		communication = frappe.new_doc("Communication")
@@ -733,7 +733,7 @@ def create_communication_via_contact(ticket, message, attachments=[]):
 
 	if ticket_doc.status == "Replied":
 		ticket_doc.status = "Open"
-		log_ticket_activity(ticket, f"status set to Open")
+		log_ticket_activity(ticket, f"set status to Open")
 		ticket_doc.save(ignore_permissions=True)
 
 	communication = frappe.new_doc("Communication")

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -225,7 +225,7 @@ class HDTicket(Document):
 		]:
 			if self.has_value_changed(field):
 				log_ticket_activity(
-					self.name, f"{field_maps[field]} set to {self.as_dict()[field]}"
+					self.name, f"set {field_maps[field]} to {self.as_dict()[field]}"
 				)
 
 	def remove_assignment_if_not_in_team(self):


### PR DESCRIPTION
Earlier, Ticket history didn't show which user has done the changes.
(Message for all the Update has been slightly changed)

![image](https://github.com/frappe/helpdesk/assets/23412311/0a4e8584-4785-471e-97aa-d31f05f057d5)

Now, Ticket History shows which user has done the changes (Now it works as shown in Helpdesk Homepage UI)

![image](https://github.com/frappe/helpdesk/assets/23412311/b0eb4c59-2fee-4a69-a97e-9022748e36c8)

Also Ticket creation message has been updated.

