### PR TITLE
fix: set session user as sender when creating a reply

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -553,7 +553,7 @@ class HDTicket(Document):
 				"sent_or_received": "Received",
 				"email_status": "Open",
 				"subject": "Re: " + ticket_doc.subject,
-				"sender": ticket_doc.raised_by,
+				"sender": frappe.session.user,
 				"content": message,
 				"status": "Linked",
 				"reference_doctype": "HD Ticket",


### PR DESCRIPTION
since, now a ticket can be accessed by two different contacts under same customer,
if User A has raised a ticket, and User B tries to reply on the same ticket, then the communication is inserted shows User A's name and image