### PR TITLE
fix: communication button separated

### DIFF
--- a/desk/src/pages/desk/ticket/editor/BottomSection.vue
+++ b/desk/src/pages/desk/ticket/editor/BottomSection.vue
@@ -22,27 +22,21 @@
       <template #actions-right>
         <div class="flex">
           <Button
+            label="Comment"
+            :disabled="isDisabled"
+            class="m-1 flex h-8 cursor-pointer items-center justify-center rounded-lg bg-gray-900 p-1 hover:bg-gray-800"
+            theme="blue"
+            variant="outline"
+            @click="newComment"
+          />
+          <Button
             label="Reply"
             :disabled="isDisabled"
-            class="rounded-r-none"
+            class="m-1 flex h-8 cursor-pointer items-center justify-center rounded-lg bg-gray-900 px-2 py-1 hover:bg-gray-800"
             theme="gray"
             variant="solid"
             @click="newCommunication"
           />
-          <Dropdown :options="dropdownOptions">
-            <template #default="{ open }">
-              <Button
-                :icon="open ? 'chevron-up' : 'chevron-down'"
-                :disabled="isDisabled"
-                class="rounded-l-none"
-                :class="{
-                  'cursor-pointer': !isDisabled,
-                }"
-                theme="gray"
-                variant="solid"
-              />
-            </template>
-          </Dropdown>
         </div>
       </template>
     </TextEditorBottom>
@@ -74,16 +68,6 @@ const authStore = useAuthStore();
 const { clean, editor, ticket } = useTicketStore();
 const showArticleResponse = ref(false);
 const showCannedResponses = ref(false);
-const dropdownOptions = [
-  {
-    label: "Reply",
-    onClick: () => newCommunication(),
-  },
-  {
-    label: "Comment",
-    onClick: () => newComment(),
-  },
-];
 
 const insertRes = createResource({
   url: "frappe.client.insert",


### PR DESCRIPTION
Tried to resolve Issue#1269

When text box is empty
![image](https://github.com/frappe/helpdesk/assets/23412311/43320c4d-269d-48ec-ba0c-34a082307edb)

When text is entered.
![image](https://github.com/frappe/helpdesk/assets/23412311/6100ac8c-d19d-4d86-84aa-190d92e39339)