### PR TITLE
Agents Not shown in Agent List (Partial Fix) 

### DIFF
--- a/desk/src/pages/desk/agent/AgentList.vue
+++ b/desk/src/pages/desk/agent/AgentList.vue
@@ -90,10 +90,10 @@ const agents = createListManager({
   fields: [
     "name",
     "is_active",
-    "user.full_name",
-    "user.user_image",
-    "user.email",
-    "user.username",
+    // "user.full_name",
+    // "user.user_image",
+    // "user.email",
+    // "user.username",
   ],
   auto: true,
 });

--- a/helpdesk/helpdesk/doctype/hd_ticket/api.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/api.py
@@ -53,7 +53,6 @@ def get_one(name):
 		.select(
 			QBContact.company_name,
 			QBContact.email_id,
-			QBContact.full_name,
 			QBContact.image,
 			QBContact.mobile_no,
 			QBContact.name,


### PR DESCRIPTION
Earlier agents screen don't show Agent List
I have tried to fix it partially
![image](https://github.com/frappe/helpdesk/assets/23412311/3d7c1a42-bfee-43e8-b7d5-5a7a14d851d7)
Now it shows list of user but not full_name and other things.
@ssiyad Please added the fields which are required.