### PR TITLE
Remove branding - favicon & custom name

### DIFF
--- a/desk/src/pages/desk/AgentRoot.vue
+++ b/desk/src/pages/desk/AgentRoot.vue
@@ -1,19 +1,18 @@
 <template>
   <div class="flex h-screen w-screen">
     <SideBar />
-    <RouterView :key="route.fullPath" class="z-0 grow overflow-auto" />
+    <RouterView :key="$route.fullPath" class="z-0 grow overflow-auto" />
   </div>
 </template>
 
 <script setup lang="ts">
 import { onBeforeMount } from "vue";
-import { useRoute, useRouter } from "vue-router";
+import { useRouter } from "vue-router";
 import { useAuthStore } from "@/stores/auth";
 import { useConfigStore } from "@/stores/config";
 import { CUSTOMER_PORTAL_LANDING, ONBOARDING_PAGE } from "@/router";
 import SideBar from "@/components/desk/sidebar/SideBar.vue";
 
-const route = useRoute();
 const router = useRouter();
 const authStore = useAuthStore();
 const configStore = useConfigStore();

--- a/desk/src/pages/desk/DeskDashboard.vue
+++ b/desk/src/pages/desk/DeskDashboard.vue
@@ -48,7 +48,7 @@
 </template>
 
 <script setup lang="ts">
-import { createResource, Tooltip } from "frappe-ui";
+import { createResource, usePageMeta, Tooltip } from "frappe-ui";
 import { isEmpty } from "lodash";
 import PageTitle from "@/components/PageTitle.vue";
 import LineChart from "@/components/charts/LineChart.vue";
@@ -63,4 +63,10 @@ const items = createResource({
 
 const dateInfo =
   "📊 The information displayed in these charts are derived from data collected over the past 30 days";
+
+usePageMeta(() => {
+  return {
+    title: "Dashboard",
+  };
+});
 </script>

--- a/desk/src/pages/desk/agent/AgentList.vue
+++ b/desk/src/pages/desk/agent/AgentList.vue
@@ -51,7 +51,7 @@
 </template>
 <script setup lang="ts">
 import { ref } from "vue";
-import { Avatar, Badge } from "frappe-ui";
+import { usePageMeta, Avatar, Badge } from "frappe-ui";
 import { AGENT_PORTAL_TICKET_LIST } from "@/router";
 import { createListManager } from "@/composables/listManager";
 import { useFilter } from "@/composables/filter";
@@ -99,6 +99,12 @@ const agents = createListManager({
     }
     return data;
   },
+});
+
+usePageMeta(() => {
+  return {
+    title: "Agents",
+  };
 });
 
 function toTickets(user: string) {

--- a/desk/src/pages/desk/canned_response/CannedResponseList.vue
+++ b/desk/src/pages/desk/canned_response/CannedResponseList.vue
@@ -30,6 +30,7 @@
 </template>
 <script setup lang="ts">
 import { ref } from "vue";
+import { usePageMeta } from "frappe-ui";
 import { AGENT_PORTAL_CANNED_RESPONSE_SINGLE } from "@/router";
 import { createListManager } from "@/composables/listManager";
 import PageTitle from "@/components/PageTitle.vue";
@@ -68,5 +69,11 @@ const responses = createListManager({
     }
     return data;
   },
+});
+
+usePageMeta(() => {
+  return {
+    title: "Canned responses",
+  };
 });
 </script>

--- a/desk/src/pages/desk/contact/ContactList.vue
+++ b/desk/src/pages/desk/contact/ContactList.vue
@@ -40,7 +40,7 @@
 </template>
 <script setup lang="ts">
 import { ref } from "vue";
-import { Avatar } from "frappe-ui";
+import { usePageMeta, Avatar } from "frappe-ui";
 import { createListManager } from "@/composables/listManager";
 import NewContactDialog from "@/components/desk/global/NewContactDialog.vue";
 import PageTitle from "@/components/PageTitle.vue";
@@ -81,6 +81,12 @@ const contacts = createListManager({
     }
     return data;
   },
+});
+
+usePageMeta(() => {
+  return {
+    title: "Contacts",
+  };
 });
 
 function openContact(id: string) {

--- a/desk/src/pages/desk/customer/CustomerList.vue
+++ b/desk/src/pages/desk/customer/CustomerList.vue
@@ -43,7 +43,7 @@
 </template>
 <script setup lang="ts">
 import { ref } from "vue";
-import { Avatar } from "frappe-ui";
+import { usePageMeta, Avatar } from "frappe-ui";
 import { createListManager } from "@/composables/listManager";
 import NewCustomerDialog from "@/components/desk/global/NewCustomerDialog.vue";
 import PageTitle from "@/components/PageTitle.vue";
@@ -79,6 +79,12 @@ const customers = createListManager({
     }
     return data;
   },
+});
+
+usePageMeta(() => {
+  return {
+    title: "Customers",
+  };
 });
 
 function openCustomer(id: string) {

--- a/desk/src/pages/desk/email/EmailList.vue
+++ b/desk/src/pages/desk/email/EmailList.vue
@@ -50,7 +50,7 @@
   </div>
 </template>
 <script setup lang="ts">
-import { Badge, FormControl } from "frappe-ui";
+import { usePageMeta, Badge, FormControl } from "frappe-ui";
 import { AGENT_PORTAL_EMAIL_NEW, AGENT_PORTAL_EMAIL_SINGLE } from "@/router";
 import { createListManager } from "@/composables/listManager";
 import PageTitle from "@/components/PageTitle.vue";
@@ -110,5 +110,11 @@ const accounts = createListManager({
     }
     return data;
   },
+});
+
+usePageMeta(() => {
+  return {
+    title: "Email accounts",
+  };
 });
 </script>

--- a/desk/src/pages/desk/escalation/EscalationRuleList.vue
+++ b/desk/src/pages/desk/escalation/EscalationRuleList.vue
@@ -43,7 +43,7 @@
 </template>
 <script setup lang="ts">
 import { ref } from "vue";
-import { Badge } from "frappe-ui";
+import { usePageMeta, Badge } from "frappe-ui";
 import { socket } from "@/socket";
 import { createListManager } from "@/composables/listManager";
 import { ListView } from "@/components";
@@ -82,6 +82,12 @@ const rules = createListManager({
   doctype: "HD Escalation Rule",
   fields: ["name", "priority", "team", "ticket_type", "is_enabled"],
   auto: true,
+});
+
+usePageMeta(() => {
+  return {
+    title: "Escalation rules",
+  };
 });
 
 function openDialog(rule: string | null) {

--- a/desk/src/pages/desk/sla/SlaList.vue
+++ b/desk/src/pages/desk/sla/SlaList.vue
@@ -33,7 +33,7 @@
   </div>
 </template>
 <script setup lang="ts">
-import { Badge } from "frappe-ui";
+import { usePageMeta, Badge } from "frappe-ui";
 import { AGENT_PORTAL_SLA_NEW, AGENT_PORTAL_SLA_SINGLE } from "@/router";
 import { createListManager } from "@/composables/listManager";
 import PageTitle from "@/components/PageTitle.vue";
@@ -75,5 +75,11 @@ const policies = createListManager({
     }
     return data;
   },
+});
+
+usePageMeta(() => {
+  return {
+    title: "Support policies",
+  };
 });
 </script>

--- a/desk/src/pages/desk/team/TeamList.vue
+++ b/desk/src/pages/desk/team/TeamList.vue
@@ -51,7 +51,7 @@
 <script setup lang="ts">
 import { ref } from "vue";
 import { useRouter } from "vue-router";
-import { createResource, Dialog, FormControl } from "frappe-ui";
+import { createResource, usePageMeta, Dialog, FormControl } from "frappe-ui";
 import { isEmpty } from "lodash";
 import { AGENT_PORTAL_TEAM_SINGLE } from "@/router";
 import { createListManager } from "@/composables/listManager";
@@ -118,5 +118,11 @@ const newTeam = createResource({
     });
   },
   onError: useError({ title: "Error creating team" }),
+});
+
+usePageMeta(() => {
+  return {
+    title: "Teams",
+  };
 });
 </script>

--- a/desk/src/pages/desk/ticket-list/PresetFilters.vue
+++ b/desk/src/pages/desk/ticket-list/PresetFilters.vue
@@ -86,20 +86,13 @@ export default {
       return options;
     },
   },
-  watch: {
-    title(newTitle) {
-      this.configStore.setTitle(newTitle);
-    },
-  },
   mounted() {
-    this.configStore.setTitle(this.title);
     this.$socket.on("helpdesk:new-preset-filter", (data) => {
       if (data.reference_doctype !== "HD Ticket") return;
       this.$resources.presetFilterOptions.reload();
     });
   },
   unmounted() {
-    this.configStore.setTitle();
     this.$socket.off("helpdesk:new-preset-filter");
   },
   resources: {

--- a/desk/src/pages/desk/ticket-list/TicketList.vue
+++ b/desk/src/pages/desk/ticket-list/TicketList.vue
@@ -50,7 +50,13 @@
 
 <script setup lang="ts">
 import { computed, ref } from "vue";
-import { createResource, Button, Dialog, Dropdown } from "frappe-ui";
+import {
+  createResource,
+  usePageMeta,
+  Button,
+  Dialog,
+  Dropdown,
+} from "frappe-ui";
 import { Icon } from "@iconify/vue";
 import { AGENT_PORTAL_TICKET } from "@/router";
 import { socket } from "@/socket";
@@ -198,4 +204,10 @@ const columns = [
     width: "w-36",
   },
 ];
+
+usePageMeta(() => {
+  return {
+    title: "Tickets",
+  };
+});
 </script>

--- a/desk/src/pages/desk/ticket/TicketSingle.vue
+++ b/desk/src/pages/desk/ticket/TicketSingle.vue
@@ -15,7 +15,7 @@
 
 <script setup lang="ts">
 import { onBeforeUnmount, onMounted, toRef } from "vue";
-import { createResource } from "frappe-ui";
+import { createResource, usePageMeta } from "frappe-ui";
 import { emitter } from "@/emitter";
 import { socket } from "@/socket";
 import ConversationBox from "./ConversationBox.vue";
@@ -67,5 +67,11 @@ onMounted(() =>
 onBeforeUnmount(() => {
   events.forEach((e) => socket.off(e));
   ticket.value = null;
+});
+
+usePageMeta(() => {
+  return {
+    title: ticket.value.data.subject,
+  };
 });
 </script>

--- a/desk/src/pages/desk/ticket_type/TicketTypeList.vue
+++ b/desk/src/pages/desk/ticket_type/TicketTypeList.vue
@@ -22,6 +22,7 @@
   </div>
 </template>
 <script setup lang="ts">
+import { usePageMeta } from "frappe-ui";
 import {
   AGENT_PORTAL_TICKET_TYPE_NEW,
   AGENT_PORTAL_TICKET_TYPE_SINGLE,
@@ -61,5 +62,11 @@ const ticketTypes = createListManager({
     }
     return data;
   },
+});
+
+usePageMeta(() => {
+  return {
+    title: "Ticket types",
+  };
 });
 </script>

--- a/desk/src/pages/knowledge-base/KnowledgeBase.vue
+++ b/desk/src/pages/knowledge-base/KnowledgeBase.vue
@@ -3,7 +3,7 @@
     <PageTitle title="Knowledge base" />
     <div class="flex grow border-t">
       <KnowledgeBaseSidebar />
-      <RouterView :key="route.fullPath" v-slot="{ Component }">
+      <RouterView :key="$route.fullPath" v-slot="{ Component }">
         <component :is="Component" v-if="Component" />
         <EmptyMessage v-else message="Select a category" />
       </RouterView>
@@ -12,10 +12,14 @@
 </template>
 
 <script setup lang="ts">
-import { useRoute } from "vue-router";
+import { usePageMeta } from "frappe-ui";
 import PageTitle from "@/components/PageTitle.vue";
 import EmptyMessage from "@/components/EmptyMessage.vue";
 import KnowledgeBaseSidebar from "./KnowledgeBaseSidebar.vue";
 
-const route = useRoute();
+usePageMeta(() => {
+  return {
+    title: "Knowledge base",
+  };
+});
 </script>

--- a/desk/src/pages/portal/TicketList.vue
+++ b/desk/src/pages/portal/TicketList.vue
@@ -168,7 +168,4 @@ function transformStatus(status: string) {
 function isHighlight(ticket) {
   return ticket.status === "Replied";
 }
-
-onMounted(() => configStore.setTitle("My Tickets"));
-onUnmounted(() => configStore.setTitle());
 </script>

--- a/desk/src/pages/portal/TicketNew.vue
+++ b/desk/src/pages/portal/TicketNew.vue
@@ -24,7 +24,7 @@
         <RouterLink
           v-for="article in articles.data"
           :key="article.name"
-          class="group flex cursor-pointer gap-2  hover:text-gray-900"
+          class="group flex cursor-pointer gap-2 hover:text-gray-900"
           :to="getArticleLink(article.name, article.title)"
           target="_blank"
         >
@@ -236,7 +236,4 @@ function searchArticles(term: string) {
 
   articles.reload();
 }
-
-onMounted(() => configStore.setTitle("New ticket"));
-onUnmounted(() => configStore.setTitle());
 </script>

--- a/desk/src/stores/config.ts
+++ b/desk/src/stores/config.ts
@@ -1,25 +1,16 @@
-import { computed, ComputedRef, ref } from "vue";
+import { computed, ComputedRef } from "vue";
 import { defineStore } from "pinia";
 import { createResource } from "frappe-ui";
-import { useFavicon } from "@vueuse/core";
-import { useTitle } from "@vueuse/core";
 import { socket } from "@/socket";
-
-const URI_CONFIG = "helpdesk.api.config.get_config";
-const DEFAULT_TITLE = "Helpdesk";
 
 export const useConfigStore = defineStore("config", () => {
   const configRes = createResource({
-    url: URI_CONFIG,
+    url: "helpdesk.api.config.get_config",
     auto: true,
   });
 
   const config = computed(() => configRes.data || {});
   const brandLogo = computed(() => config.value.brand_logo);
-  const brandFavicon = computed(() => config.value.brand_favicon);
-  const helpdeskName: ComputedRef<string> = computed(
-    () => config.value.helpdesk_name || DEFAULT_TITLE
-  );
   const isSetupComplete: ComputedRef<boolean> = computed(
     () => !!parseInt(config.value.setup_complete)
   );
@@ -29,19 +20,6 @@ export const useConfigStore = defineStore("config", () => {
   const preferKnowledgeBase = computed(
     () => !!parseInt(config.value.prefer_knowledge_base)
   );
-  const pageTitle = ref(null);
-  const windowTitle = computed(() =>
-    pageTitle.value
-      ? `${pageTitle.value} • ${helpdeskName.value}`
-      : helpdeskName.value
-  );
-
-  function setTitle(title?: string) {
-    pageTitle.value = title ? title : null;
-  }
-
-  useFavicon(brandFavicon);
-  useTitle(windowTitle);
 
   socket.on("helpdesk:settings-updated", () => configRes.reload());
 
@@ -49,9 +27,7 @@ export const useConfigStore = defineStore("config", () => {
     brandLogo,
     config,
     preferKnowledgeBase,
-    helpdeskName,
     isSetupComplete,
-    setTitle,
     skipEmailWorkflow,
   };
 });

--- a/helpdesk/api/config.py
+++ b/helpdesk/api/config.py
@@ -4,9 +4,7 @@ import frappe
 @frappe.whitelist(allow_guest=True)
 def get_config():
 	fields = [
-		"brand_favicon",
 		"brand_logo",
-		"helpdesk_name",
 		"prefer_knowledge_base",
 		"setup_complete",
 		"skip_email_workflow",

--- a/helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+++ b/helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -9,7 +9,6 @@
   "track_service_level_agreement",
   "allow_resetting_service_level_agreement",
   "column_break_4",
-  "helpdesk_name",
   "priority_section",
   "default_priority",
   "column_break_nvbf",
@@ -33,7 +32,6 @@
   "branding_tab",
   "images_column",
   "brand_logo",
-  "brand_favicon",
   "column_break_fsjn",
   "misc_tab",
   "toasts_column",
@@ -62,11 +60,6 @@
    "fieldname": "allow_resetting_service_level_agreement",
    "fieldtype": "Check",
    "label": "Allow Resetting SLA"
-  },
-  {
-   "fieldname": "helpdesk_name",
-   "fieldtype": "Data",
-   "label": "Helpdesk Name"
   },
   {
    "fieldname": "column_break_4",
@@ -223,12 +216,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "description": "Image to be used as website ",
-   "fieldname": "brand_favicon",
-   "fieldtype": "Attach Image",
-   "label": "Favicon"
-  },
-  {
    "default": "0",
    "fieldname": "prefer_knowledge_base",
    "fieldtype": "Check",
@@ -252,7 +239,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2023-07-30 21:55:54.516451",
+ "modified": "2023-08-23 17:59:49.761375",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Settings",


### PR DESCRIPTION
**Don't use `brand_favicon` and `helpdesk_name`!**

Branding helps in customisation but it breaks product integrity. From this PR on, its not possible to have custom favicon and name. Custom logo can be used but will be removed at a later stage

closes: https://github.com/frappe/helpdesk/issues/1524