### PR TITLE
fix: Don't attempt rename if old DocType doesn't exist

### DIFF
--- a/helpdesk/patches/rename_doctypes_prefix_with_hd.py
+++ b/helpdesk/patches/rename_doctypes_prefix_with_hd.py
@@ -50,5 +50,8 @@ def execute():
 		if frappe.db.exists("DocType", new):
 			continue
 
+		if not frappe.db.exists("DocType", old):
+			continue
+
 		frappe.rename_doc("DocType", old, new)
 		print("Migrated", old, "to", new)


### PR DESCRIPTION
Ref: https://frappecloud.com/app/agent-job/cab67ab0d4
