### PR TITLE
feat: actions

### DIFF
--- a/desk/src/pages/ticket/TicketAgentActions.vue
+++ b/desk/src/pages/ticket/TicketAgentActions.vue
@@ -46,6 +46,7 @@
       </template>
     </Button>
     <Dropdown
+      v-if="actions.data?.length > 1"
       :options="
         actions.data?.slice(1).map((o) => ({
           label: o.button_label,
@@ -117,6 +118,9 @@ const actions = createListResource({
   doctype: "HD Action",
   auto: true,
   cache: "Actions",
+  filters: {
+    is_enabled: true,
+  },
   fields: [
     "name",
     "button_label",

--- a/desk/src/pages/ticket/TicketAgentActions.vue
+++ b/desk/src/pages/ticket/TicketAgentActions.vue
@@ -1,5 +1,5 @@
 <template>
-  <span>
+  <span class="flex gap-2">
     <Autocomplete
       :options="agentStore.dropdown"
       :value="
@@ -30,12 +30,47 @@
         />
       </template>
     </Autocomplete>
+    <Button
+      v-for="a in actions.data?.slice(0, 1)"
+      :key="a.name"
+      :label="a.button_label"
+      theme="gray"
+      variant="solid"
+      @click="() => eic.call(ticket.data, a.action)"
+    >
+      <template v-if="a.button_icon" #prefix>
+        <Icon :icon="a.button_icon" />
+      </template>
+      <template v-if="a.is_external_link" #suffix>
+        <Icon icon="lucide:external-link" />
+      </template>
+    </Button>
+    <Dropdown
+      :options="
+        actions.data?.slice(1).map((o) => ({
+          label: o.button_label,
+          onClick: () => eic.call(ticket.data, o.action),
+        }))
+      "
+    >
+      <Button theme="gray" variant="ghost">
+        <Icon icon="lucide:more-horizontal" />
+      </Button>
+    </Dropdown>
   </span>
 </template>
 
 <script setup lang="ts">
 import { computed, inject } from "vue";
-import { createResource, Autocomplete, Avatar } from "frappe-ui";
+import {
+  createResource,
+  createListResource,
+  Autocomplete,
+  Avatar,
+  Button,
+  Dropdown,
+} from "frappe-ui";
+import { Icon } from "@iconify/vue";
 import { emitter } from "@/emitter";
 import { createToast } from "@/utils";
 import { useAgentStore } from "@/stores/agent";
@@ -76,5 +111,35 @@ function assignAgent(agent: string) {
     },
     onError: useError(),
   });
+}
+
+const actions = createListResource({
+  doctype: "HD Action",
+  auto: true,
+  cache: "Actions",
+  fields: [
+    "name",
+    "button_label",
+    "button_icon",
+    "is_external_link",
+    "action",
+    "cond_hidden",
+  ],
+  transform: (data) => {
+    const res = [];
+    for (const row of data) {
+      const isHidden = eic.call(ticket.data, row.cond_hidden);
+      if (!isHidden) res.push(row);
+    }
+    return res;
+  },
+});
+
+/**
+ * Wrapper function for eval. Can be used with `.call()`. Helps in
+ * forcing context
+ */
+function eic(s: string) {
+  return eval(s);
 }
 </script>

--- a/helpdesk/helpdesk/doctype/hd_action/hd_action.js
+++ b/helpdesk/helpdesk/doctype/hd_action/hd_action.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2023, Frappe Technologies and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("HD Action", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/helpdesk/helpdesk/doctype/hd_action/hd_action.json
+++ b/helpdesk/helpdesk/doctype/hd_action/hd_action.json
@@ -1,0 +1,98 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2023-08-30 03:05:16.121736",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "button_section",
+  "button_label",
+  "button_icon",
+  "is_external_link",
+  "section_break_nbjl",
+  "action",
+  "cond_hidden"
+ ],
+ "fields": [
+  {
+   "fieldname": "button_section",
+   "fieldtype": "Section Break",
+   "label": "Button"
+  },
+  {
+   "fieldname": "section_break_nbjl",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "cond_hidden",
+   "fieldtype": "Code",
+   "label": "Hide condition",
+   "options": "Javascript"
+  },
+  {
+   "fieldname": "button_label",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Label",
+   "reqd": 1
+  },
+  {
+   "fieldname": "button_icon",
+   "fieldtype": "Data",
+   "label": "Icon"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_external_link",
+   "fieldtype": "Check",
+   "label": "External link"
+  },
+  {
+   "description": "Action to perform when clicking the button. The doc will be available as `this`",
+   "fieldname": "action",
+   "fieldtype": "Code",
+   "label": "On click (Javascript)",
+   "options": "Javascript",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2023-08-30 03:41:52.274380",
+ "modified_by": "Administrator",
+ "module": "Helpdesk",
+ "name": "HD Action",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Agent",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "button_label"
+}

--- a/helpdesk/helpdesk/doctype/hd_action/hd_action.json
+++ b/helpdesk/helpdesk/doctype/hd_action/hd_action.json
@@ -7,6 +7,8 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "is_enabled",
+  "column_break_hzgg",
   "button_section",
   "button_label",
   "button_icon",
@@ -56,11 +58,21 @@
    "label": "On click (Javascript)",
    "options": "Javascript",
    "reqd": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_enabled",
+   "fieldtype": "Check",
+   "label": "Enabled"
+  },
+  {
+   "fieldname": "column_break_hzgg",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-08-30 03:41:52.274380",
+ "modified": "2023-08-30 03:45:51.830906",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Action",

--- a/helpdesk/helpdesk/doctype/hd_action/hd_action.py
+++ b/helpdesk/helpdesk/doctype/hd_action/hd_action.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class HDAction(Document):
+	pass

--- a/helpdesk/helpdesk/doctype/hd_action/test_hd_action.py
+++ b/helpdesk/helpdesk/doctype/hd_action/test_hd_action.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023, Frappe Technologies and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestHDAction(FrappeTestCase):
+	pass


### PR DESCRIPTION
This is a customisation which lets you add arbitrary button on top of ticket page (agent portal only). JavaScript snippets can be run (basic). This helps for things like
- Open Frappe Cloud dashboard from site name
- Search Google/Wiki with ticket subject

This is available for only tickets. The scripting is basic too. Expect changes/additions later

<img width="374" alt="image" src="https://github.com/frappe/helpdesk/assets/28098330/e7f8a92e-79af-4da5-9af5-dd6552ff743a">

closes: https://github.com/frappe/helpdesk/issues/1505