### PR TITLE
Update hd_team.py

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_team/hd_team.py
+++ b/helpdesk/helpdesk/doctype/hd_team/hd_team.py
@@ -43,7 +43,7 @@ class HDTeam(Document):
 			"Assignment Rule", f"{self.name} - Support Rotation"
 		)
 		rule_doc.document_type = "HD Ticket"
-		rule_doc.assign_condition = f"status == 'Open' and agent_group == '{self.name}'"
+		rule_doc.assign_condition = f"""status == 'Open' and agent_group == "{self.name}" """
 		rule_doc.priority = 1
 		rule_doc.disabled = True  # Disable the rule by default, when agents are added to the group, the rule will be enabled
 


### PR DESCRIPTION
some team names in other languages contain ' symbol like french 

[Systeme d'infomation] for example throws syntax error because of the enclosing quotes  ( ' )

f"status == 'Open' and agent_group == 'self.name}'"  => parsing error 
FIX:
f"""status == 'Open' and agent_group == "{self.name}" """