### PR TITLE
Update hd_ticket.py

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -74,7 +74,7 @@ class HDTicket(Document):
 		)
 		query = query.where(Criterion.any(conditions))
 
-		restricttions = frappe.get_value(
+		restrictions = frappe.get_value(
 			doctype="HD Settings",
 			fieldname=[
 				"restrict_tickets_by_agent_group",
@@ -83,9 +83,9 @@ class HDTicket(Document):
 			as_dict=1
 		)
 		enable_restrictions = ignore_restrictions = 0
-		if restricttions:
-			enable_restrictions =  bool(int(restricttions['restrict_tickets_by_agent_group']))
-			ignore_restrictions =  bool(int(restricttions['do_not_restrict_tickets_without_an_agent_group']))
+		if restrictions:
+			enable_restrictions =  bool(int(restrictions['restrict_tickets_by_agent_group']))
+			ignore_restrictions =  bool(int(restrictions['do_not_restrict_tickets_without_an_agent_group']))
 
 
 		if not enable_restrictions:

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -74,15 +74,19 @@ class HDTicket(Document):
 		)
 		query = query.where(Criterion.any(conditions))
 
-		enable_restrictions, ignore_restrictions = frappe.get_value(
+		restricttions = frappe.get_value(
 			doctype="HD Settings",
 			fieldname=[
 				"restrict_tickets_by_agent_group",
 				"do_not_restrict_tickets_without_an_agent_group",
 			],
+			as_dict=1
 		)
-		enable_restrictions = bool(int(enable_restrictions))
-		ignore_restrictions = bool(int(ignore_restrictions))
+		enable_restrictions = ignore_restrictions = 0
+		if restricttions:
+			enable_restrictions =  bool(int(restricttions['restrict_tickets_by_agent_group']))
+			ignore_restrictions =  bool(int(restricttions['do_not_restrict_tickets_without_an_agent_group']))
+
 
 		if not enable_restrictions:
 			return query


### PR DESCRIPTION
frappe.get_value does not guarantee returned  fields order from database, we have situations where values are reversed between enable_restrictions and ignore_restrictions (one's take the other field value)

`value = get_list(  <============== IN FRAPPE THIS DOES NOT GUARANTEE FIELDS ORDER
			doctype,
			filters=filters,
			fields=fields,
			debug=debug,
			limit_page_length=1,
			parent=parent,
			as_dict=as_dict,
		) 

	if as_dict:
		return value[0] if value else {}

	if not value:
		return

	return value[0] if len(fields) > 1 else value[0][0]
`

fixing by reading the result