### PR TITLE
fix: unable to view ticket if no assignee

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/api.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/api.py
@@ -84,7 +84,7 @@ def get_customer_criteria():
 
 def get_assignee(_assign: str):
 	j = frappe.parse_json(_assign)
-	if len(j) < 1:
+	if not j or len(j) < 1:
 		return
 	return get_user_info_for_avatar(j.pop())
 


### PR DESCRIPTION

![image](https://github.com/frappe/helpdesk/assets/52111700/01411246-4539-44b8-b31d-68c44734fe07)


```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 95, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 47, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1622, in call
    return fn(*args, **newargs)
  File "apps/helpdesk/helpdesk/helpdesk/doctype/hd_ticket/api.py", line 62, in get_one
    "assignee": get_assignee(ticket._assign),
  File "apps/helpdesk/helpdesk/helpdesk/doctype/hd_ticket/api.py", line 87, in get_assignee
    if len(j) < 1:
TypeError: object of type 'NoneType' has no len()
index-c9e099b3.js:269:1597

```