### PR TITLE
fix: fetch only HD Customer contacts

### DIFF
--- a/helpdesk/utils.py
+++ b/helpdesk/utils.py
@@ -86,6 +86,7 @@ def get_customer(contact: str) -> tuple[str]:
 			.select(QBDynamicLink.link_name)
 			.where(QBDynamicLink.parentfield == "links")
 			.where(QBDynamicLink.parenttype == "Contact")
+			.where(QBDynamicLink.link_doctype == "HD Customer")
 			.join(QBContact)
 			.on(QBDynamicLink.parent == QBContact.name)
 			.where(Criterion.any(conditions))


### PR DESCRIPTION
Currently, system doesn't check if the fetched contact belongs to an HD Customer or not.
Added a where condition to fetch only HD Customer.