### PR TITLE
fix: don't allow replying on resolved or closed tickets

### DIFF
--- a/desk/src/pages/ticket/TicketCustomer.vue
+++ b/desk/src/pages/ticket/TicketCustomer.vue
@@ -30,6 +30,7 @@
     <TicketConversation class="grow" />
     <span class="m-5">
       <TicketTextEditor
+        v-if="showEditor"
         ref="editor"
         v-model:attachments="attachments"
         v-model:content="editorContent"
@@ -128,6 +129,10 @@ const showReopenButton = computed(
   () => ticket.data.status === "Resolved" && !ticket.data.feedback
 );
 const showResolveButton = computed(() =>
+  ["Open", "Replied"].includes(ticket.data.status)
+);
+
+const showEditor = computed(() =>
   ["Open", "Replied"].includes(ticket.data.status)
 );
 </script>


### PR DESCRIPTION
#### Problem:
Customers/ Users were able to reply and thus re-open the tickets which were closed and marked as resolved.

#### Fix:
Users won't be able to reply on the ticket if its marked as resolved or closed.

#### Screenshot:
![image](https://github.com/frappe/helpdesk/assets/30501401/06325283-8048-40a5-987a-f8294b787d3b)
