### PR TITLE
fix: change Resolve btn to 'Resolve and Close' on portal

### DIFF
--- a/desk/src/pages/ticket/TicketCustomer.vue
+++ b/desk/src/pages/ticket/TicketCustomer.vue
@@ -15,7 +15,7 @@
         </Button>
         <Button
           v-if="showResolveButton"
-          label="Resolve"
+          label="Resolve and Close"
           theme="gray"
           variant="solid"
           @click="showFeedbackDialog = !showFeedbackDialog"

--- a/desk/src/pages/ticket/TicketCustomer.vue
+++ b/desk/src/pages/ticket/TicketCustomer.vue
@@ -15,7 +15,7 @@
         </Button>
         <Button
           v-if="showResolveButton"
-          label="Resolve and Close"
+          label="Close"
           theme="gray"
           variant="solid"
           @click="showFeedbackDialog = !showFeedbackDialog"

--- a/desk/src/pages/ticket/TicketFeedback.vue
+++ b/desk/src/pages/ticket/TicketFeedback.vue
@@ -12,7 +12,7 @@
           onClick: () =>
             setValue.submit({
               fieldname: {
-                status: 'Resolved',
+                status: 'Closed',
                 feedback: preset,
                 feedback_extra: text,
               },


### PR DESCRIPTION
On Resolve and Close, change the status to close

[On Resolve and Close, change the status to close](https://github.com/frappe/helpdesk/assets/30501401/fbc1624b-2ab4-437a-9b29-f8d90fb8c227)
