### PR TITLE
Fix: Correct Doctype reference for "Ticket Type and Ticket Priority"

### DIFF
--- a/helpdesk/helpdesk/report/ticket_summary/ticket_summary.py
+++ b/helpdesk/helpdesk/report/ticket_summary/ticket_summary.py
@@ -58,7 +58,7 @@ class TicketSummary(object):
 					"label": _("Ticket Type"),
 					"fieldname": "ticket_type",
 					"fieldtype": "Link",
-					"options": "Ticket Type",
+					"options": "HD Ticket Type",
 					"width": 200,
 				}
 			)
@@ -69,7 +69,7 @@ class TicketSummary(object):
 					"label": _("Ticket Priority"),
 					"fieldname": "priority",
 					"fieldtype": "Link",
-					"options": "Ticket Priority",
+					"options": "HD Ticket Priority",
 					"width": 200,
 				}
 			)


### PR DESCRIPTION
@ssiyad The current code encounters an issue when selecting the filter "Ticket Type and Ticket Priority" within the "Based on" field. The problem arises due to an incorrect Doctype being referenced in lines 61 and 72.

![image](https://github.com/frappe/helpdesk/assets/92985225/6c7ec62f-431e-40c5-ba4f-415e417e3c5e)
