### PR TITLE
Filter out communications coming from Notifications in on_communication_u…

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -714,6 +714,9 @@ class HDTicket(Document):
 	# is an external dependency. Refer `communication.py` of Frappe framework for more.
 	# Since this is called from communication itself, `c` is the communication doc.
 	def on_communication_update(self, c):
+		# ignore frappe notifications as they also trigger on_communication_update
+		if c.sender_full_name=="Notifications":
+			return
 		if c.sent_or_received == "Sent":
 			# If communication is outgoing, then it is a reply from agent.
 			self.status = "Replied"


### PR DESCRIPTION
ignore frappe notifications as they also trigger on_communication_update and cause ticket to become Open when Notification is triggered as it creates a Communication also.

The solution is not perfect, as the system could have a notification account name other then "Notifications" but wanted to point to the problem.