### PR TITLE
feat(ticketcustomer): show datetime on hover on sla times

### DIFF
--- a/desk/src/pages/ticket/TicketCustomerTemplateFields.vue
+++ b/desk/src/pages/ticket/TicketCustomerTemplateFields.vue
@@ -13,7 +13,9 @@
       </span>
     </div>
     <div v-for="data in slaData" :key="data.label" class="space-y-1.5">
-      <span class="block text-sm text-gray-700">{{ data.title }}</span>
+      <Tooltip :text="dayjs(data.value).long()">
+          <span class="block text-sm text-gray-700">{{ data.title }}</span>
+      </Tooltip>
       <span class="block break-words text-base font-medium text-gray-900">
         <Badge
           v-if="data.showSla"
@@ -21,9 +23,9 @@
           :theme="data.theme"
           variant="outline"
         />
-        <Tooltip v-else :text="dayjs(data.value).long()">
+        <span v-else>
           {{ dayjs(data.value).fromNow() }}
-        </Tooltip>
+        </span>
       </span>
     </div>
     <div


### PR DESCRIPTION

<img width="1027" alt="Screenshot 2024-01-22 at 10 27 06 AM" src="https://github.com/frappe/helpdesk/assets/9103781/cb8238a2-6123-467c-a8dd-2de45b152af3">

In customer ticket, Tooltip with datetime will appear on hover at First Response and Resolution labels

closes https://github.com/frappe/helpdesk/issues/1678