### PR TITLE
feat: add support for retrieving the ticket type when creating a new ticket

### DIFF
--- a/desk/src/pages/ticket/TicketNew.vue
+++ b/desk/src/pages/ticket/TicketNew.vue
@@ -28,7 +28,6 @@
       <div class="relative w-full">
         <Autocomplete
           v-model="ticketType"
-          :body-classes="w - full"
           :options="ticketTypeData.store.dropdown"
           :placeholder="`Select a ${ticketTypeData.label}`"
         />
@@ -62,7 +61,13 @@
 <script setup lang="ts">
 import { ref, computed, reactive } from "vue";
 import { useRoute, useRouter } from "vue-router";
-import { createResource, usePageMeta, Button, FormControl } from "frappe-ui";
+import {
+  createResource,
+  usePageMeta,
+  Button,
+  FormControl,
+  Autocomplete,
+} from "frappe-ui";
 import sanitizeHtml from "sanitize-html";
 import { isEmpty } from "lodash";
 import { useError } from "@/composables/error";
@@ -104,12 +109,6 @@ const ticketTypeData = computed(() => {
   };
 });
 
-console.log(ticketTypeData.value.store.dropdown);
-
-function update(fieldname: string, value: string) {
-  console.log(fieldname, value);
-}
-
 const visibleFields = computed(() =>
   template.data?.fields.filter((f) => route.meta.agent || !f.hide_from_customer)
 );
@@ -121,6 +120,7 @@ const ticket = createResource({
       description: description.value,
       subject: subject.value,
       template: props.templateId,
+      ticket_type: ticketType.value ? ticketType.value.value : "",
       ...templateFields,
     },
     attachments: attachments.value,

--- a/desk/src/pages/ticket/TicketNew.vue
+++ b/desk/src/pages/ticket/TicketNew.vue
@@ -21,6 +21,19 @@
         placeholder="A short description"
       />
     </div>
+    <div class="m-5 mt-0">
+      <div class="mb-2 block text-sm text-gray-600">
+        {{ ticketTypeData.label }}
+      </div>
+      <div class="relative w-full">
+        <Autocomplete
+          v-model="ticketType"
+          :body-classes="w - full"
+          :options="ticketTypeData.store.dropdown"
+          :placeholder="`Select a ${ticketTypeData.label}`"
+        />
+      </div>
+    </div>
     <TicketNewArticles :search="subject" class="mx-5 mb-5" />
     <span class="mx-5 mb-5">
       <TicketTextEditor
@@ -54,9 +67,11 @@ import sanitizeHtml from "sanitize-html";
 import { isEmpty } from "lodash";
 import { useError } from "@/composables/error";
 import { UniInput } from "@/components";
+import { useTicketTypeStore } from "@/stores/ticketType";
 import TicketBreadcrumbs from "./TicketBreadcrumbs.vue";
 import TicketNewArticles from "./TicketNewArticles.vue";
 import TicketTextEditor from "./TicketTextEditor.vue";
+import { ITicket } from "./symbols";
 
 interface P {
   templateId?: string;
@@ -68,6 +83,7 @@ const props = withDefaults(defineProps<P>(), {
 const route = useRoute();
 const router = useRouter();
 const subject = ref("");
+const ticketType = ref("");
 const description = ref("");
 const attachments = ref([]);
 const templateFields = reactive({});
@@ -79,6 +95,20 @@ const template = createResource({
   }),
   auto: true,
 });
+
+const ticketTypeData = computed(() => {
+  return {
+    field: "ticket_type",
+    label: "Ticket type",
+    store: useTicketTypeStore(),
+  };
+});
+
+console.log(ticketTypeData.value.store.dropdown);
+
+function update(fieldname: string, value: string) {
+  console.log(fieldname, value);
+}
 
 const visibleFields = computed(() =>
   template.data?.fields.filter((f) => route.meta.agent || !f.hide_from_customer)

--- a/desk/src/pages/ticket/TicketNew.vue
+++ b/desk/src/pages/ticket/TicketNew.vue
@@ -76,7 +76,6 @@ import { useTicketTypeStore } from "@/stores/ticketType";
 import TicketBreadcrumbs from "./TicketBreadcrumbs.vue";
 import TicketNewArticles from "./TicketNewArticles.vue";
 import TicketTextEditor from "./TicketTextEditor.vue";
-import { ITicket } from "./symbols";
 
 interface P {
   templateId?: string;
@@ -85,6 +84,7 @@ interface P {
 const props = withDefaults(defineProps<P>(), {
   templateId: "",
 });
+
 const route = useRoute();
 const router = useRouter();
 const subject = ref("");


### PR DESCRIPTION
Issue: #1698

Updated the code to take the ticket type input.

### Output
<img width="1470" alt="Screenshot 2024-02-20 at 3 33 16 PM" src="https://github.com/frappe/helpdesk/assets/69882648/dbf59d3b-c56b-4d8e-b9e7-9b3a674a3400">

<img width="1470" alt="Screenshot 2024-02-20 at 3 33 36 PM" src="https://github.com/frappe/helpdesk/assets/69882648/dd436dab-95de-4b25-816a-7c1c2271ad8d">


<img width="1470" alt="Screenshot 2024-02-20 at 3 34 09 PM" src="https://github.com/frappe/helpdesk/assets/69882648/50398af2-9bf1-4a0a-9a9b-a77b5e8867fb">