### PR TITLE
fix: Attach attachments after the ticket is saved

### DIFF
--- a/desk/src/pages/ticket/TicketTextEditor.vue
+++ b/desk/src/pages/ticket/TicketTextEditor.vue
@@ -33,7 +33,6 @@
         <slot name="bottom-left" />
         <FileUploader
           :upload-args="{
-            doctype: 'HD Ticket',
             folder: 'Home/Helpdesk',
             private: true,
           }"


### PR DESCRIPTION
### Issue:
When we upload an attachment in ticket `doctype` as parameter is passed, which will breaks the file upload
https://github.com/frappe/frappe/blob/develop/frappe/core/doctype/file/file.py#L140

### Solution:
While uploading attachments, we do not need to pass the `doctype` parameter, it will be automatically handled by `create_communication_via_contact` method

issue ref: #1695 ,#1712
