### PR TITLE
feat : Added Email Signature 

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -460,6 +460,11 @@ class HDTicket(Document):
 		recipients = self.raised_by
 		sender_email = None if skip_email_workflow else self.sender_email()
 		last_communication = self.get_last_communication()
+		user = frappe.get_doc("User",frappe.session.user)
+		email_signature = user.email_signature
+		if email_signature:
+			signature = email_signature.replace('\n', '<br>')
+			message = message + str('<p>'+ signature + '</p>')
 
 		if last_communication:
 			cc = cc or last_communication.cc


### PR DESCRIPTION
This enhancement enabling user to include an email signature when responding to tickets.Users can  add their email signature in  "Email Signature" field in "User" doctype.

![image](https://github.com/frappe/helpdesk/assets/89442027/4b862a49-38f8-4450-ac9b-20e46e3467e7)

whenever a user sends a response to a ticket, the email signature will be automatically appended with the message.

![image](https://github.com/frappe/helpdesk/assets/89442027/3152e5d8-e7a5-479e-b17f-1d62baf68f3f)



![image](https://github.com/frappe/helpdesk/assets/89442027/0bb0d92b-0b2d-4386-b334-6d3cd5c9310e)


