### PR TITLE
fix: error when change status replied to open due to self._assign

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -190,10 +190,10 @@ class HDTicket(Document):
 	def on_update(self):
 		if self.status == "Open":
 			if self.get_doc_before_save() and self.get_doc_before_save().status != "Open":
-				
-				agent = json.loads(self._assign)
-				if len(agent) > 0:
-					self.notify_agent(agent[0], "Reaction")
+
+				agent = self.get_assigned_agent()
+				if agent:
+					self.notify_agent(agent.name, "Reaction")
 		
 		self.handle_ticket_activity_update()
 		self.remove_assignment_if_not_in_team()


### PR DESCRIPTION
On HD Ticket, if you change status from Replied to Open, it will show following error,

![image](https://github.com/frappe/helpdesk/assets/1973598/72943242-e4d0-407f-8b73-3fcdbdbd94de)

```
  File "apps/helpdesk/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py", line 194, in on_update
    agent = json.loads(self._assign)
                       ^^^^^^^^^^^^
AttributeError: 'HDTicket' object has no attribute '_assign'
```

This PR fix it by using get_assigned_agent() instead.