### PR TITLE
feat: Implemented email sending for new ticket creation

### DIFF
--- a/desk/src/pages/ticket/TicketAgent.vue
+++ b/desk/src/pages/ticket/TicketAgent.vue
@@ -74,7 +74,7 @@
               <div class="my-2.5 space-y-2 border-y py-2">
                 <div>
                   <span class="mr-3 text-xs text-gray-500">TO:</span>
-                  <Button :label="ticket.data.raised_by" />
+                  <Button :label="ticket.data.contact.email_id" />
                 </div>
                 <div v-if="showCc">
                   <span class="inline-flex flex-wrap items-center gap-1">

--- a/desk/src/pages/ticket/TicketAgent2.vue
+++ b/desk/src/pages/ticket/TicketAgent2.vue
@@ -74,7 +74,7 @@
               <div class="my-2.5 space-y-2 border-y py-2">
                 <div>
                   <span class="mr-3 text-xs text-gray-500">TO:</span>
-                  <Button :label="ticket.data.raised_by" />
+                  <Button :label="ticket.data.contact.email_id" />
                 </div>
                 <div v-if="showCc">
                   <span class="inline-flex flex-wrap items-center gap-1">

--- a/desk/src/pages/ticket/TicketNew.vue
+++ b/desk/src/pages/ticket/TicketNew.vue
@@ -13,14 +13,6 @@
         @change="templateFields[field.fieldname] = $event.value"
       />
     </div>
-    <div class="m-5">
-      <FormControl
-        v-model="subject"
-        type="text"
-        label="Subject"
-        placeholder="A short description"
-      />
-    </div>
     <TicketNewArticles :search="subject" class="mx-5 mb-5" />
     <span class="mx-5 mb-5">
       <TicketTextEditor
@@ -30,6 +22,82 @@
         placeholder="Detailed explanation"
         expand
       >
+        <template #top-right>
+          <span class="flex gap-2">
+            <Button
+              v-if="mode === Mode.Response"
+              label="CC"
+              :theme="showCc ? 'blue' : 'gray'"
+              variant="subtle"
+              @click="() => (showCc = !showCc)"
+            />
+            <Button
+              v-if="mode === Mode.Response"
+              label="BCC"
+              :theme="showBcc ? 'blue' : 'gray'"
+              variant="subtle"
+              @click="() => (showBcc = !showBcc)"
+            />
+            <TabButtons
+              v-model="mode"
+              :buttons="Object.values(Mode).map((m) => ({ label: m }))"
+            />
+          </span>
+        </template>
+        <template v-if="mode == Mode.Response" #top-bottom>
+          <div class="my-3 flex flex-col gap-y-1">
+            <span class="inline-flex flex-wrap items-center gap-1">
+              <span class="mr-2 text-xs text-gray-500">TO:</span>
+              <FormControl
+                v-model="email_id"
+                type="email"
+                placeholder="hello@example.com"
+                class="w-1/6"
+              />
+            </span>
+            <span class="inline-flex flex-wrap items-center gap-1">
+              <span v-if="showCc" class="mr-2 text-xs text-gray-500">CC:</span>
+              <FormControl
+                v-if="showCc"
+                v-model="cc"
+                type="email"
+                placeholder="hello@example.com"
+                class="w-1/6"
+              />
+            </span>
+            <span class="inline-flex flex-wrap items-center gap-1">
+              <span v-if="showBcc" class="mr-2 text-xs text-gray-500"
+                >BCC:</span
+              >
+              <FormControl
+                v-if="showBcc"
+                v-model="bcc"
+                type="email"
+                placeholder="hello@example.com"
+                class="w-1/6"
+              />
+            </span>
+
+            <div class="mt-3">
+              <FormControl
+                v-model="subject"
+                type="text"
+                label="Subject"
+                placeholder="A short description"
+              />
+            </div>
+          </div>
+        </template>
+        <template v-else #top-bottom>
+          <div class="my-3 flex flex-col gap-y-3">
+            <FormControl
+              v-model="subject"
+              type="text"
+              label="Subject"
+              placeholder="A short description"
+            />
+          </div>
+        </template>
         <template #bottom-right>
           <Button
             label="Submit"
@@ -49,7 +117,13 @@
 <script setup lang="ts">
 import { ref, computed, reactive } from "vue";
 import { useRoute, useRouter } from "vue-router";
-import { createResource, usePageMeta, Button, FormControl } from "frappe-ui";
+import {
+  createResource,
+  usePageMeta,
+  Button,
+  FormControl,
+  TabButtons,
+} from "frappe-ui";
 import sanitizeHtml from "sanitize-html";
 import { isEmpty } from "lodash";
 import { useError } from "@/composables/error";
@@ -62,16 +136,26 @@ interface P {
   templateId?: string;
 }
 
+enum Mode {
+  Comment = "Comment",
+  Response = "Response",
+}
+
 const props = withDefaults(defineProps<P>(), {
   templateId: "",
 });
-
 const route = useRoute();
 const router = useRouter();
 const subject = ref("");
+const email_id = ref("");
+const cc = ref("");
+const bcc = ref("");
 const description = ref("");
 const attachments = ref([]);
 const templateFields = reactive({});
+const showCc = ref(false);
+const showBcc = ref(false);
+const mode = ref(Mode.Comment);
 
 const template = createResource({
   url: "helpdesk.helpdesk.doctype.hd_ticket_template.api.get_one",
@@ -82,9 +166,7 @@ const template = createResource({
 });
 
 const visibleFields = computed(() =>
-  template.data?.fields?.filter(
-    (f) => route.meta.agent || !f.hide_from_customer
-  )
+  template.data?.fields.filter((f) => route.meta.agent || !f.hide_from_customer)
 );
 const ticket = createResource({
   url: "helpdesk.helpdesk.doctype.hd_ticket.api.new",
@@ -97,9 +179,12 @@ const ticket = createResource({
       ...templateFields,
     },
     attachments: attachments.value,
+    email_id: email_id.value,
+    cc: cc.value,
+    bcc: bcc.value,
   }),
   validate: (params) => {
-    const fields = visibleFields.value?.filter((f) => f.required) || [];
+    const fields = visibleFields.value.filter((f) => f.required);
     const toVerify = [...fields, "subject", "description"];
     for (const field of toVerify) {
       if (isEmpty(params.doc[field.fieldname || field])) {

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -172,9 +172,9 @@ class HDTicket(Document):
 		self.set_feedback_values()
 		self.apply_escalation_rule()
 		self.set_sla()
+		self.set_contact()
 
 		if self.via_customer_portal:
-			self.set_contact()
 			self.set_customer()
 
 	def validate(self):


### PR DESCRIPTION
This enhancement enables users to send an email response when creating a new ticket. Within the Helpdesk UI, users can now select the new ticket type as either a 'comment' or 'response'. If the user selects the response type, they are able to send an email response. I have added the fields TO, CC, and BCC to facilitate email sending.


![image](https://github.com/frappe/helpdesk/assets/89442027/c5f2172b-ced6-401e-99d0-b7c0314faf30)




![image](https://github.com/frappe/helpdesk/assets/89442027/be776151-895b-4037-911e-01cb7e9754d6)

