### PR TITLE
fix: add members in team from UI

### DIFF
--- a/desk/src/components/UniInput2.vue
+++ b/desk/src/components/UniInput2.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="flex items-center gap-2 px-6 pb-1 leading-5 first:mt-3">
-    <div class="w-[106px] shrink-0 text-sm text-gray-600">
+    <div
+      class="w-[106px] shrink-0 truncate text-sm text-gray-600 hover:overflow-visible"
+    >
       {{ field.label }}
       <span v-if="field.required" class="text-red-500"> * </span>
     </div>

--- a/desk/src/components/ticket/TicketAgentFields.vue
+++ b/desk/src/components/ticket/TicketAgentFields.vue
@@ -5,7 +5,7 @@
       :key="o.field"
       class="flex items-center gap-2 px-6 pb-1 leading-5 first:mt-3"
     >
-      <div class="w-[106px] shrink-0 text-sm text-gray-600">
+      <div class="w-[106px] shrink-0 truncate text-sm text-gray-600">
         {{ o.label }}
       </div>
       <div class="min-h-[28px] flex-1 items-center overflow-hidden text-base">

--- a/desk/src/pages/desk/team/TeamSingle.vue
+++ b/desk/src/pages/desk/team/TeamSingle.vue
@@ -51,10 +51,9 @@
                 :disabled="team.loading"
                 theme="gray"
                 variant="outline"
-                @click="removeMember(member.user)"
               >
                 <template #suffix>
-                  <IconX class="h-3 w-3" />
+                  <IconX class="h-3 w-3" @click="removeMember(member.user)" />
                 </template>
               </Button>
             </div>
@@ -95,8 +94,20 @@
     <Dialog v-model="showAddMember" :options="addMemberDialogOptions">
       <template #body-content>
         <div class="space-y-2">
+          <div v-if="agentStore.agents.data.length === 0">
+            <p class="text-base text-gray-600">
+              No agents found, please add
+              <span
+                class="cursor-pointer underline"
+                @click="router.push('/agents')"
+                >agents</span
+              >
+              in the system.
+            </p>
+          </div>
           <div
-            v-for="agent in agentStore.options"
+            v-for="agent in agentStore.agents.data"
+            v-else
             :key="agent.name"
             class="flex items-center justify-between"
           >


### PR DESCRIPTION
**Issue:**
When adding a member into the team the dialog shows empty
<img width="1440" alt="Screenshot 2024-07-10 at 2 40 03 PM" src="https://github.com/frappe/helpdesk/assets/65544983/2f20c83c-ad49-4a80-b8db-5c5860791d38">

**Reason:**
We were looping over wrong property in agentStore.

**Solution:**
use agentStore.agents.data instead of agentStore.options
&
if no members are present show them a dialog with a link to add new agents

<img width="1440" alt="Screenshot 2024-07-10 at 2 41 47 PM" src="https://github.com/frappe/helpdesk/assets/65544983/d4b014aa-8fee-46de-aaeb-017c7fa67e64">

