### PR TITLE
fix: header breadcrumb styling

### DIFF
--- a/desk/src/components/LayoutHeader.vue
+++ b/desk/src/components/LayoutHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <header class="flex h-12 items-center justify-between border-b py-2.5 pl-5">
-    <div class="flex items-center gap-2">
+    <div class="left-header flex max-w-[70%] items-center gap-2">
       <slot name="left-header" />
     </div>
     <div class="flex items-center gap-2 px-5">
@@ -8,3 +8,17 @@
     </div>
   </header>
 </template>
+
+<script setup>
+import { onMounted } from "vue";
+
+onMounted(() => {
+  const leftHeader = document.querySelector(".left-header");
+
+  const currentRoute = leftHeader.querySelector('[aria-current="page"]');
+  currentRoute.classList.add("truncate");
+
+  const span = currentRoute.querySelector("span");
+  span.classList.add("truncate");
+});
+</script>

--- a/desk/src/pages/TicketAgent.vue
+++ b/desk/src/pages/TicketAgent.vue
@@ -210,11 +210,8 @@ const breadcrumbs = computed(() => {
   let items = [{ label: "Tickets", route: { name: "TicketsAgent" } }];
   items.push({
     label: ticket.data?.subject,
-    onClick: () => {
-      showSubjectDialog.value = true;
-    },
+    route: { name: "TicketAgent" },
   });
-
   return items;
 });
 

--- a/desk/src/pages/desk/team/TeamSingle.vue
+++ b/desk/src/pages/desk/team/TeamSingle.vue
@@ -13,6 +13,9 @@
               },
               {
                 label: teamId,
+                route: {
+                  name: AGENT_PORTAL_TEAM_SINGLE,
+                },
               },
             ]"
           />


### PR DESCRIPTION
**Issue:**
<img width="1212" alt="Screenshot 2024-07-13 at 12 36 26 PM" src="https://github.com/user-attachments/assets/e3035117-1d27-489c-a91b-507d3c9046ac">

1. The breadcrumb UI looks cheap (it has a button in the breadcrumb) and has an on click functionality to update the "subject" of the ticket, which does not make any sense.

2. When the subject of the ticket is too long there is an overflow in screen.
