### PR TITLE
fix(dep): add cheerio in resolutions

### DIFF
--- a/desk/package.json
+++ b/desk/package.json
@@ -42,5 +42,8 @@
 		"vue-router": "^4.2.2",
 		"vuedraggable": "^4.1.0",
 		"zod": "^3.21.4"
+	},
+	"resolutions": {
+		"cheerio": "1.0.0-rc.12"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
 		"prettier": "2.8.4",
 		"tailwindcss": "^3.2.6",
 		"typescript": "^5.0.2"
+	},
+	"resolutions": {
+		"cheerio": "1.0.0-rc.12"
 	}
 }


### PR DESCRIPTION
add cheerio in package.json resolutions to support node version 18.16 instead of >18.17