### PR TITLE
fix: add helpdesk to apps page

### DIFF
--- a/helpdesk/hooks.py
+++ b/helpdesk/hooks.py
@@ -7,6 +7,13 @@ app_color = "grey"
 app_email = "hello@frappe.io"
 app_license = "AGPLv3"
 
+add_to_apps_screen = [{
+    "name": "helpdesk",
+    "logo": "/assets/helpdesk/desk/favicon.svg",
+    "title": "Helpdesk",
+    "route": "/helpdesk",
+}]
+
 before_install = "helpdesk.setup.install.before_install"
 after_install = "helpdesk.setup.install.after_install"
 after_migrate = "helpdesk.search.build_index_in_background"


### PR DESCRIPTION
Dependent on https://github.com/frappe/frappe/pull/27292

Updated hooks.py to include helpdesk app in apps page