### PR TITLE
fix(HelpdeskSearch): Improve search of knowledge base articles

### DIFF
--- a/desk/src/components/command-palette/CP.vue
+++ b/desk/src/components/command-palette/CP.vue
@@ -6,11 +6,7 @@
   >
     <template #body>
       <div>
-        <Combobox
-          v-slot="{ activeIndex }"
-          nullable
-          @update:model-value="onSelection"
-        >
+        <Combobox nullable @update:model-value="onSelection">
           <div class="relative">
             <div class="pl-4.5 absolute inset-y-0 left-0 flex items-center">
               <LucideSearch class="h-4 w-4" />
@@ -28,7 +24,7 @@
             :hold="true"
           >
             <div
-              v-for="(group, index) in groupedSearchResults"
+              v-for="group in groupedSearchResults"
               :key="group.title"
               class="mt-4.5 mb-2 first:mt-3"
             >
@@ -69,10 +65,8 @@ import {
 } from "@headlessui/vue";
 import CPGroup from "./CPGroup.vue";
 import CPGroupResult from "./CPGroupResult.vue";
-import LucideLayoutGrid from "~icons/lucide/layout-grid";
 import LucideSearch from "~icons/lucide/file-search";
 import LucideTicket from "~icons/lucide/ticket";
-import LucideUser from "~icons/lucide/user";
 import LucideBookOpen from "~icons/lucide/book-open";
 
 let show = ref(false);
@@ -133,9 +127,9 @@ export default {
             } else if (group.title === "Articles") {
               group.component = "CPGroupResult";
               group.items = group.items.map((item) => {
-								if (item.headings) {
-									item.subject = item.subject + " / " + item.headings;
-								}
+                if (item.headings) {
+                  item.subject = item.subject + " / " + item.headings;
+                }
                 item.route = {
                   name: "DeskKBArticle",
                   params: {

--- a/desk/src/components/command-palette/CP.vue
+++ b/desk/src/components/command-palette/CP.vue
@@ -133,7 +133,9 @@ export default {
             } else if (group.title === "Articles") {
               group.component = "CPGroupResult";
               group.items = group.items.map((item) => {
-                item.subject = item.payload.category + " / " + item.subject;
+								if (item.headings) {
+									item.subject = item.subject + " / " + item.headings;
+								}
                 item.route = {
                   name: "DeskKBArticle",
                   params: {

--- a/desk/src/pages/ticket/TicketNewArticles.vue
+++ b/desk/src/pages/ticket/TicketNewArticles.vue
@@ -4,7 +4,7 @@
     class="rounded border bg-cyan-50 px-5 py-3 text-base"
   >
     <div class="mb-2 font-medium">
-      These articles may already cover what you looking for
+      These articles may already cover what you are looking for
       <RouterLink
         class="group cursor-pointer space-x-1 hover:text-gray-900"
         :to="{
@@ -33,6 +33,7 @@
           target="_blank"
         >
           <dt class="font-semibold">{{ a.subject }} - {{ a.headings }}</dt>
+          <!-- eslint-disable-next-line vue/no-v-html -->
           <dd class="font-light" v-html="a.description"></dd>
         </RouterLink>
       </div>

--- a/desk/src/pages/ticket/TicketNewArticles.vue
+++ b/desk/src/pages/ticket/TicketNewArticles.vue
@@ -26,8 +26,9 @@
           :to="{
             name: 'KBArticlePublic',
             params: {
-              articleId: a.id.split(':')[1],
+              articleId: a.name.split('#')[0],
             },
+            hash: `#${a.name.split('#')[1]}`,
           }"
           target="_blank"
         >

--- a/desk/src/pages/ticket/TicketNewArticles.vue
+++ b/desk/src/pages/ticket/TicketNewArticles.vue
@@ -4,7 +4,7 @@
     class="rounded border bg-cyan-50 px-5 py-3 text-base"
   >
     <div class="mb-2 font-medium">
-      Did you know? These articles might cover what you looking for
+      These articles may already cover what you looking for
       <RouterLink
         class="group cursor-pointer space-x-1 hover:text-gray-900"
         :to="{
@@ -15,31 +15,27 @@
         <span class="text-xs">(View All)</span>
       </RouterLink>
     </div>
-    <ul class="space-y-2">
-      <li
+    <dl class="space-y-2">
+      <div
         v-for="a in articles.data"
-        :key="a.name"
-        class="list-inside list-disc"
+        :key="a.id"
+        class="focus:ring-cyan-30 rounded-md border-2 border-hidden hover:bg-cyan-100 focus:outline-none focus:ring active:bg-cyan-50"
       >
         <RouterLink
           class="group cursor-pointer space-x-1 hover:text-gray-900"
           :to="{
             name: 'KBArticlePublic',
             params: {
-              articleId: a.name,
+              articleId: a.id.split(':')[1],
             },
           }"
           target="_blank"
         >
-          <span class="text-gray-800">
-            {{ a.title }}
-          </span>
-          <span class="opacity-0 transition-all group-hover:opacity-100">
-            &LongRightArrow;
-          </span>
+          <dt class="font-semibold">{{ a.subject }} - {{ a.headings }}</dt>
+          <dd class="font-light" v-html="a.description"></dd>
         </RouterLink>
-      </li>
-    </ul>
+      </div>
+    </dl>
   </div>
 </template>
 

--- a/helpdesk/api/article.py
+++ b/helpdesk/api/article.py
@@ -6,7 +6,6 @@ from helpdesk.search import search as hd_search
 @frappe.whitelist()
 def search(query: str):
 	out = hd_search(query, only_articles=True)
-	breakpoint()
 	if not out:
 		return []
 	return out[0].get("items", [])

--- a/helpdesk/api/article.py
+++ b/helpdesk/api/article.py
@@ -1,30 +1,12 @@
 import frappe
 
+from helpdesk.search import search as hd_search
+
 
 @frappe.whitelist()
-def search(query):
-	min_charecters = 2
-	if len(query) < min_charecters:
+def search(query: str):
+	out = hd_search(query, only_articles=True)
+	breakpoint()
+	if not out:
 		return []
-
-	queries = query.split(" ")
-	queries = [query for query in queries if len(query) >= min_charecters]
-	if len(queries) == 0:
-		return []
-
-	or_filters = []
-
-	for i in range(len(queries)):
-		or_filters.append(["title", "like", "%{search}%".format(search=queries[i])])
-
-	data = (
-		frappe.get_all(
-			"HD Article",
-			fields=["name", "title"],
-			or_filters=or_filters,
-			page_length=5,
-		)
-		or []
-	)
-
-	return data
+	return out[0].get("items", [])

--- a/helpdesk/search.py
+++ b/helpdesk/search.py
@@ -36,7 +36,9 @@ class Search:
 		schema = []
 		for field in self.schema:
 			kwargs = {
-				k: v for k, v in field.items() if k in ["weight", "sortable", "no_index", "no_stem"]
+				k: v
+				for k, v in field.items()
+				if k in ["weight", "sortable", "no_index", "no_stem"]
 			}
 			if field.type == "tag":
 				schema.append(TagField(field.name, **kwargs))

--- a/helpdesk/search.py
+++ b/helpdesk/search.py
@@ -56,9 +56,7 @@ class Search:
 			if field.name in doc:
 				mapping[field.name] = cstr(doc[field.name])
 		if self.index_exists():
-			self.redis.ft(self.index_name).add_document(
-				doc_id, payload=json.dumps(payload), replace=True, **mapping
-			)
+			self.redis.ft(self.index_name).add_document(doc_id, replace=True, **mapping)
 
 	def remove_document(self, id):
 		key = self.redis.make_key(f"{self.prefix}:{id}").decode()
@@ -237,7 +235,6 @@ class HelpdeskSearch(Search):
 					section = ""
 					heading = tag.text
 			sections.append((heading, section))
-			print(sections)
 			return sections
 
 	def scrub(self, text: str):

--- a/helpdesk/search.py
+++ b/helpdesk/search.py
@@ -163,19 +163,14 @@ class HelpdeskSearch(Search):
 
 	def index_doc(self, doc):
 		id = f"{doc.doctype}:{doc.name}"
-		fields, payload = None, None
+		fields = None
 		if doc.doctype == "HD Ticket":
 			fields = {
 				"doctype": doc.doctype,
 				"name": doc.name,
 				"subject": doc.subject,
 				"team": doc.agent_group,
-				"headings": doc.headings,
 				"modified": doc.modified,
-			}
-			payload = {
-				"subject": doc.subject,
-				"team": doc.agent_group,
 			}
 		if doc.doctype == "HD Article":
 			fields = {
@@ -186,11 +181,8 @@ class HelpdeskSearch(Search):
 				"headings": doc.headings,
 				"modified": doc.modified,
 			}
-			payload = {
-				"category": doc.category,
-			}
-		if fields and payload:
-			self.add_document(id, fields, payload)
+		if fields:
+			self.add_document(id, fields)
 
 	def remove_doc(self, doc):
 		key = f"{doc.doctype}:{doc.name}"
@@ -233,7 +225,6 @@ class HelpdeskSearch(Search):
 		return re.sub(r"[^a-zA-Z0-9]+", "-", text).lower()
 
 	def get_records(self, doctype):
-		print(f"Getting records for {doctype}")
 		records = []
 		for d in frappe.db.get_all(doctype, fields=self.DOCTYPE_FIELDS[doctype]):
 			d.doctype = doctype

--- a/helpdesk/search.py
+++ b/helpdesk/search.py
@@ -67,7 +67,7 @@ class Search:
 		self,
 		query,
 		start=0,
-		page_length=20,
+		page_length=5,
 		highlight=False,
 	):
 		query = self.clean_query(query)
@@ -243,8 +243,6 @@ class HelpdeskSearch(Search):
 
 @frappe.whitelist()
 def search(query, only_articles=False):
-	if not is_agent():
-		return []
 	search = HelpdeskSearch()
 	query = search.clean_query(query)
 	query_parts = query.split(" ")
@@ -258,7 +256,9 @@ def search(query, only_articles=False):
 		doctype, name = r.id.split(":")
 		r.doctype = doctype
 		r.name = name
-		if doctype == "HD Ticket":
+		if doctype == "HD Ticket" and not only_articles:
+			if not is_agent():
+				r = []
 			groups.setdefault("Tickets", []).append(r)
 		if doctype == "HD Article":
 			groups.setdefault("Articles", []).append(r)

--- a/helpdesk/search.py
+++ b/helpdesk/search.py
@@ -159,8 +159,7 @@ class HelpdeskSearch(Search):
 		for i, doc in enumerate(records):
 			self.index_doc(doc)
 			if not hasattr(frappe.local, "request"):
-				pass
-				# update_progress_bar("Indexing", i, total)
+				update_progress_bar("Indexing", i, total)
 
 	def index_doc(self, doc):
 		id = f"{doc.doctype}:{doc.name}"


### PR DESCRIPTION
## Before
![image](https://github.com/user-attachments/assets/fa8646a7-3723-47a8-b872-32416fd0dadb)
## After
![image](https://github.com/user-attachments/assets/d093ed12-e634-42f7-b500-d0fc9100c48a)



# To be done in UI

~- [ ] Fix ticket id search~ Not doing this as it's too out of the way. Filter already exists for this anyway
- [x] Show headings instead of subject
- [x] Show description in search results. Render mark tags
- [x] Put # in url instead of %23 
- [x] Replace the sql search in /my-tickets with HelpdeskSearch
- [x] Add permalinks to headings so urls will scroll to relevant section