### PR TITLE
fix: show proper error message

### DIFF
--- a/desk/src/pages/TicketAgent.vue
+++ b/desk/src/pages/TicketAgent.vue
@@ -330,10 +330,16 @@ function updateTicket(fieldname: string, value: string) {
         iconClasses: "text-green-600",
       });
     },
-    onError: () => {
+    onError: (e) => {
       isLoading.value = false;
+
+      const title =
+        e.messages && e.messages.length > 0
+          ? e.messages[0]
+          : "Failed to update ticket";
+
       createToast({
-        title: "Failed to update ticket",
+        title,
         icon: "x",
         iconClasses: "text-red-600",
       });


### PR DESCRIPTION
**Before**
We get errors like these, which doesn't actually tell why the error was thrown

<img width="381" alt="Screenshot 2024-08-16 at 11 50 04 AM" src="https://github.com/user-attachments/assets/b585bee6-6734-4317-977f-797e9b92df3e">


**After**
Show the error message properly

<img width="486" alt="Screenshot 2024-08-16 at 11 50 47 AM" src="https://github.com/user-attachments/assets/12e232cc-656c-468a-8a78-267af413dd34">

closes #1840


