### PR TITLE
fix: add resolution_date default field

### DIFF
--- a/desk/src/pages/ticket/TicketNewArticles.vue
+++ b/desk/src/pages/ticket/TicketNewArticles.vue
@@ -19,7 +19,7 @@
       <div
         v-for="a in articles.data"
         :key="a.id"
-        class="focus:ring-cyan-30 rounded-md border-2 border-hidden hover:bg-cyan-100 focus:outline-none focus:ring active:bg-cyan-50"
+        class="focus:ring-cyan-30 rounded-md border-2 border-hidden p-4 hover:bg-cyan-100 focus:outline-none focus:ring active:bg-cyan-50"
       >
         <RouterLink
           class="group cursor-pointer space-x-1 hover:text-gray-900"

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -803,7 +803,8 @@ class HDTicket(Document):
 			"first_responded_on",
 			"modified",
 			"creation",
-			"_assign"
+			"_assign",
+			"resolution_date",
 		]
 		return {'columns': columns, 'rows': rows}
 


### PR DESCRIPTION
**Issue:**
<img width="379" alt="Screenshot 2024-08-22 at 1 24 41 PM" src="https://github.com/user-attachments/assets/678a188f-4a27-4b4a-9ab8-e896a3388402">

<img width="544" alt="Screenshot 2024-08-22 at 1 24 09 PM" src="https://github.com/user-attachments/assets/d496c135-4fd7-4920-8225-9c787c311a4e">

Even tho the resolution was provided and if fulfilled, in the List view the status was showing as failed / in an hour.

**Reason**
The calculation we did in the frontend(list view) was based on a field called "resolution_date" which was not present in the default fields which were fetched.

**Solution:**
Add "resolution_date" field in default fields
