### PR TITLE
fix: fix avatar size and remove frappe mail support for now

### DIFF
--- a/desk/src/components/Settings/Branding.vue
+++ b/desk/src/components/Settings/Branding.vue
@@ -6,7 +6,11 @@
     <div v-for="config in brandingConfig" class="flex flex-col gap-2">
       <p class="text-sm text-gray-600">{{ config.title }}</p>
       <div class="flex gap-4 items-center">
-        <Avatar size="3xl" :image="config.image" />
+        <Avatar
+          v-if="config.image && !websiteSettings.loading"
+          size="3xl"
+          :image="config.image"
+        />
         <FileUploader
           v-if="!config.image"
           :fileTypes="['image/*']"

--- a/desk/src/components/Settings/EmailAccountList.vue
+++ b/desk/src/components/Settings/EmailAccountList.vue
@@ -51,8 +51,6 @@ const emailAccounts = createListResource({
     "enable_outgoing",
     "default_incoming",
     "default_outgoing",
-    "api_key",
-    "api_secret",
     "password",
   ],
   filters: {

--- a/desk/src/components/Settings/emailConfig.ts
+++ b/desk/src/components/Settings/emailConfig.ts
@@ -79,13 +79,13 @@ export const customProviderFields = [
 ];
 
 export const services: EmailService[] = [
-  {
-    name: "FrappeMail",
-    icon: LogoFrappeMail,
-    info: `Setting up Frappe Mail requires you to have an API key and API Secret of your email account. Read more `,
-    link: "https://yandex.com/support/id/authorization/app-passwords.html",
-    custom: true,
-  },
+  // {
+  //   name: "Frappe Mail",
+  //   icon: LogoFrappeMail,
+  //   info: `Setting up Frappe Mail requires you to have an API key and API Secret of your email account. Read more `,
+  //   link: "https://yandex.com/support/id/authorization/app-passwords.html",
+  //   custom: true,
+  // },
   {
     name: "GMail",
     icon: LogoGmail,


### PR DESCRIPTION
1. Avatar size was too big for sidebar when the sidebar was collapsed, so altered the size.
2. Remove api_key and api_secret support for now,  reason is those fields are only available in develop branch, and not in version 15, so for users using version 15 of frappe the following error is thrown...
`field not permitted in query api_key`