### PR TITLE
Fix: Reset Form Fields After Creating a New Category in Knowledge Base from Agent Portal

### DIFF
--- a/desk/src/pages/knowledge-base/KnowledgeBaseCategoryNew.vue
+++ b/desk/src/pages/knowledge-base/KnowledgeBaseCategoryNew.vue
@@ -48,9 +48,9 @@ const newCategoryDescription = ref("");
 const newCategoryIcon = ref("");
 
 const resetForm = () => {
-  newCategoryName.value = '';
-  newCategoryDescription.value = '';
-  newCategoryIcon.value = '';
+  newCategoryName.value = "";
+  newCategoryDescription.value = "";
+  newCategoryIcon.value = "";
 };
 
 const newCategoryRes = createResource({

--- a/desk/src/pages/knowledge-base/KnowledgeBaseCategoryNew.vue
+++ b/desk/src/pages/knowledge-base/KnowledgeBaseCategoryNew.vue
@@ -46,6 +46,13 @@ const emit = defineEmits<E>();
 const newCategoryName = ref("");
 const newCategoryDescription = ref("");
 const newCategoryIcon = ref("");
+
+const resetForm = () => {
+  newCategoryName.value = '';
+  newCategoryDescription.value = '';
+  newCategoryIcon.value = '';
+};
+
 const newCategoryRes = createResource({
   url: "frappe.client.insert",
   makeParams() {
@@ -68,6 +75,7 @@ const newCategoryRes = createResource({
   },
   onSuccess(data) {
     emit("success", data.name);
+    resetForm();
   },
 });
 </script>


### PR DESCRIPTION
**Summary**

This PR addresses an issue in the Knowledge Base category creation dialog where form fields (title, description, and icon) were not being reset after successfully creating a new category.

**Changes**

- Implemented a reset for form fields only after a new category is successfully created.
- No changes were made to the behavior when the dialog is closed without creating a category; the form data remains intact, allowing users to continue their input if the dialog is reopened.

**Testing**

- Verified that the form fields are reset only after successful creation of a category.
- Confirmed that form data persists if the dialog is closed without creating a category.

**Impact**

The form fields in the Knowledge Base category creation dialog will now reset only after a successful category creation. If the dialog is closed without creating a category, the form fields will retain their values, allowing users to continue with their input as usual.
