### PR TITLE
fix: get article category and sub category from query params

### DIFF
--- a/desk/src/pages/KnowledgeBaseArticle.vue
+++ b/desk/src/pages/KnowledgeBaseArticle.vue
@@ -122,12 +122,8 @@ const router = useRouter();
 const authStore = useAuthStore();
 const isNew = props.articleId === "new";
 const editMode = ref(isNew);
-const categoryId = computed(
-  () => article.data?.category.name || route.query.category
-);
-const subCategoryId = computed(
-  () => article.data?.sub_category.name || route.query.subCategory
-);
+const categoryId = computed(() => route.query.category);
+const subCategoryId = computed(() => route.query.subCategory);
 const breadcrumbs = computed(() => {
   const items = [
     {

--- a/desk/src/pages/KnowledgeBaseArticle.vue
+++ b/desk/src/pages/KnowledgeBaseArticle.vue
@@ -130,9 +130,7 @@ const breadcrumbs = computed(() => {
       label: options__.value.categoryName,
       route: {
         name: AGENT_PORTAL_KNOWLEDGE_BASE_CATEGORY,
-        params: {
-          categoryId: options__.value.categoryId,
-        },
+        params: { categoryId: options__.value.categoryId },
       },
     },
     {
@@ -154,6 +152,10 @@ const breadcrumbs = computed(() => {
         name: AGENT_PORTAL_KNOWLEDGE_BASE_ARTICLE,
         params: {
           articleId: article.data?.name,
+        },
+        query: {
+          category: options__.value.categoryId,
+          subCategory: options__.value.subCategoryId,
         },
       },
     });

--- a/desk/src/pages/knowledge-base/KnowledgeBaseSubcategory.vue
+++ b/desk/src/pages/knowledge-base/KnowledgeBaseSubcategory.vue
@@ -145,6 +145,10 @@ const articles = createListManager({
         params: {
           articleId: d.name,
         },
+        query: {
+          category: route.params.categoryId,
+          subCategory: route.params.subCategoryId,
+        },
       };
     }
     return data;


### PR DESCRIPTION
**Issue:**
While navigating to article page from article sub category, the article component gets async data in the breadcrumb which causes the following issue
<img width="519" alt="Screenshot 2024-08-30 at 11 48 48 AM" src="https://github.com/user-attachments/assets/a871ae84-8d19-425f-87b0-0c4eed0a84a5">


**Reason:**
In breadcrumbs the route is coming asynchronously, hence the error.

**Fix:**
Get article's category and sub category from query params.

