### PR TITLE
Fix: Filter Out Inactive Agents in Assign To Dialog

### DIFF
--- a/desk/src/components/AssignmentModal.vue
+++ b/desk/src/components/AssignmentModal.vue
@@ -9,9 +9,9 @@
     <template #body-content>
       <SearchComplete
         class="form-control"
-        value="1"
-        valueField="is_active"
+        value=""
         doctype="HD Agent"
+        :customFilters="customFilters"
         :reset-input="true"
         @change="
           (option) => {
@@ -116,5 +116,9 @@ const removeCurrentAssignee = (value) => {
       emit("update");
     },
   });
+};
+
+const customFilters = {
+  is_active: ["=", 1],
 };
 </script>

--- a/desk/src/components/AssignmentModal.vue
+++ b/desk/src/components/AssignmentModal.vue
@@ -9,7 +9,8 @@
     <template #body-content>
       <SearchComplete
         class="form-control"
-        value=""
+        value="1"
+        valueField="is_active"
         doctype="HD Agent"
         :reset-input="true"
         @change="

--- a/desk/src/components/SearchComplete.vue
+++ b/desk/src/components/SearchComplete.vue
@@ -57,6 +57,11 @@ const props = defineProps({
     required: false,
     default: false,
   },
+  customFilters: {
+    type: Object,
+    required: false,
+    default: () => ({}),
+  },
 });
 
 const r = createListResource({
@@ -66,6 +71,7 @@ const r = createListResource({
   fields: [props.labelField, props.searchField, props.valueField],
   filters: {
     [props.searchField]: ["like", `%${props.value}%`],
+    ...props.customFilters,
   },
   onSuccess: () => {
     selection.value = props.value
@@ -86,6 +92,7 @@ function onUpdateQuery(query: string) {
   r.update({
     filters: {
       [props.searchField]: ["like", `%${query}%`],
+      ...props.customFilters,
     },
   });
 


### PR DESCRIPTION
### Summary
This PR fixes a bug where inactive agents were showing up in the "Assign To" dialog in the Agent Portal. 

### Changes Made
- Updated the dialog to filter out inactive agents, so only active ones appear in the list.

### Screenshots
![image](https://github.com/user-attachments/assets/976c033a-d279-413a-bd8e-170af99d7594)

**Before:**
![image](https://github.com/user-attachments/assets/519a38cd-1993-4dd2-a4c2-2a6c79dd109f)
*Inactive agents are shown in the list.*

**After:**
![image](https://github.com/user-attachments/assets/6f6595ed-c116-44d0-829e-582d29d7430d)
*Only active agents are shown.*
