### PR TITLE
fix: Canned response list view

### DIFF
--- a/desk/src/components/layouts/MobileSidebar.vue
+++ b/desk/src/components/layouts/MobileSidebar.vue
@@ -14,7 +14,7 @@
           class="relative z-10 flex h-full w-[230px] flex-col border-r bg-gray-50 transition-all duration-300 ease-in-out"
         >
           <!-- user dropwdown -->
-          <UserMenu class="p-2 mb-2" :options="profileSettings" />
+          <div><UserMenu class="p-2 mb-2" :options="profileSettings" /></div>
           <!-- notifications -->
           <div class="overflow-y-auto px-2">
             <div class="mb-3 flex flex-col">

--- a/desk/src/components/ticket/TicketAgentFields.vue
+++ b/desk/src/components/ticket/TicketAgentFields.vue
@@ -117,9 +117,10 @@ const options = computed(() => {
 });
 
 const customFields = computed(() => {
-  const _custom_fields = props.ticket.template.fields
-    .filter((field: Field) => !field.hide_from_customer)
-    .filter((f) => ["subject", "team", "priority"].indexOf(f.fieldname) === -1);
+  const _custom_fields = props.ticket.template.fields.filter(
+    (f) => ["subject", "team", "priority"].indexOf(f.fieldname) === -1
+  );
+
   return _custom_fields;
 });
 

--- a/desk/src/pages/CannedResponses.vue
+++ b/desk/src/pages/CannedResponses.vue
@@ -25,11 +25,11 @@
     </LayoutHeader>
     <div class="flex-1 overflow-y-auto p-2">
       <div
-        v-if="cannedResponses?.data?.data?.length"
+        v-if="!cannedResponses.loading"
         class="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-4 px-5 pb-3"
       >
         <div
-          v-for="cannedResponse in cannedResponses.data.data"
+          v-for="cannedResponse in cannedResponses.data"
           :key="cannedResponse.name"
           class="group flex h-56 cursor-pointer flex-col justify-between gap-2 rounded-lg border px-5 py-4 shadow-sm hover:bg-gray-50"
           @click="editItem(cannedResponse)"
@@ -109,7 +109,7 @@
 <script setup lang="ts">
 import { ref } from "vue";
 import {
-  createResource,
+  createListResource,
   Breadcrumbs,
   Dropdown,
   TextEditor,
@@ -133,11 +133,9 @@ const message = ref(null);
 const name = ref(null);
 const showNewDialog = ref(false);
 
-const cannedResponses = createResource({
-  url: "helpdesk.api.doc.get_list_data",
-  params: {
-    doctype: "HD Canned Response",
-  },
+const cannedResponses = createListResource({
+  doctype: "HD Canned Response",
+  fields: ["name", "title", "message", "owner", "modified"],
   auto: true,
 });
 

--- a/desk/src/pages/ticket/TicketNewArticles.vue
+++ b/desk/src/pages/ticket/TicketNewArticles.vue
@@ -15,7 +15,7 @@
         <span class="text-xs">(View All)</span>
       </RouterLink>
     </div>
-    <dl class="space-y-2">
+    <dl>
       <div
         v-for="a in articles.data"
         :key="a.id"


### PR DESCRIPTION
<img width="1434" alt="image" src="https://github.com/user-attachments/assets/448988f0-9885-4be3-b04c-7ceba636fc1d">


Use 'createListResource'  to get the canned responses