### PR TITLE
perf: update ticket elapsed time method to use minutes instead of seconds

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py
+++ b/helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py
@@ -326,12 +326,11 @@ class HDServiceLevelAgreement(Document):
                 or not_in_working_day_list
                 or not self.is_working_time(current_time, working_hours)
             ):
-                current_time += timedelta(seconds=1)
+                current_time += timedelta(minutes=1)
                 continue
             total_seconds += 1
-            current_time += timedelta(seconds=1)
-
-        return total_seconds
+            current_time += timedelta(minutes=1)
+        return total_seconds * 60
 
     def get_holidays(self):
         res = []


### PR DESCRIPTION
**Issue**
While calculating the total elapsed time of the ticket, i.e from the time ticket was created to the time ticket was closed, we calculated the time in seconds, which resulted in timeouts in alot of scenarios.

**Solution**
To enhance the performance use minutes instead of seconds.



