### PR TITLE
feat: settings to allow to create tickets without permission

### DIFF
--- a/desk/src/pages/TicketCustomer.vue
+++ b/desk/src/pages/TicketCustomer.vue
@@ -164,10 +164,9 @@ const showResolveButton = computed(() =>
   ["Open", "Replied"].includes(ticket.data.status)
 );
 
-const showEditor = computed(() =>
-  ["Open", "Replied", "Resolved"].includes(ticket.data.status)
-);
+const showEditor = computed(() => ticket.data.status !== "Closed");
 
+// this handles whether the ticket was raised and then was closed without any reply from the agent.
 const showFeedback = computed(() => {
   return ticket.data?.communications?.some((c) => {
     if (c.sender !== ticket.data.raised_by) {

--- a/desk/src/pages/TicketNew.vue
+++ b/desk/src/pages/TicketNew.vue
@@ -27,7 +27,7 @@
         />
       </div>
       <!-- existing fields -->
-      <div class="flex flex-col flex-1" :class="subject.length >= 2 && 'gap-5'">
+      <div class="flex flex-col" :class="subject.length >= 2 && 'gap-5'">
         <FormControl
           v-model="subject"
           type="text"

--- a/helpdesk/helpdesk/doctype/hd_service_level_agreement/utils.py
+++ b/helpdesk/helpdesk/doctype/hd_service_level_agreement/utils.py
@@ -16,7 +16,6 @@ def get_sla(ticket: Document) -> Document:
     :param doc: Ticket to use
     :return: Applicable SLA
     """
-    check_permissions(DOCTYPE, None)
     QBSla = frappe.qb.DocType(DOCTYPE)
     QBPriority = frappe.qb.DocType("HD Service Level Priority")
     now = now_datetime()

--- a/helpdesk/helpdesk/doctype/hd_service_level_agreement/utils.py
+++ b/helpdesk/helpdesk/doctype/hd_service_level_agreement/utils.py
@@ -4,7 +4,7 @@ from frappe.query_builder import JoinType
 from frappe.utils import now_datetime
 from pypika import Criterion
 
-from helpdesk.utils import check_permissions, get_context
+from helpdesk.utils import get_context
 
 DOCTYPE = "HD Service Level Agreement"
 

--- a/helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+++ b/helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -12,10 +12,6 @@
   "priority_section",
   "default_priority",
   "column_break_nvbf",
-  "ticket_type_section",
-  "default_ticket_type",
-  "is_ticket_type_mandatory",
-  "column_break_zxek",
   "agent_groups_section",
   "restrict_tickets_by_agent_group",
   "do_not_restrict_tickets_without_an_agent_group",
@@ -25,6 +21,13 @@
   "knowledge_base_section",
   "suggest_articles_in_new_ticket_page",
   "prefer_knowledge_base",
+  "ticket_tab",
+  "ticket_type_section",
+  "default_ticket_type",
+  "is_ticket_type_mandatory",
+  "column_break_zxek",
+  "ticket_restrictions_section",
+  "allow_anyone_to_create_tickets",
   "workflow_tab",
   "skip_email_workflow",
   "instantly_send_email",
@@ -274,11 +277,28 @@
    "fieldname": "headings_weight",
    "fieldtype": "Int",
    "label": "Headings Weight"
+  },
+  {
+   "fieldname": "ticket_tab",
+   "fieldtype": "Tab Break",
+   "label": "Ticket"
+  },
+  {
+   "fieldname": "ticket_restrictions_section",
+   "fieldtype": "Section Break",
+   "label": "Ticket Restrictions"
+  },
+  {
+   "default": "0",
+   "description": "If enabled, anyone will be able to create tickets (without any permission). \nUseful in cases where you wants users to create tickets via webforms or some external APIs without authentication.",
+   "fieldname": "allow_anyone_to_create_tickets",
+   "fieldtype": "Check",
+   "label": "Allow anyone to create tickets"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2024-09-18 00:47:04.055942",
+ "modified": "2024-10-22 02:14:33.360809",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Settings",

--- a/helpdesk/helpdesk/doctype/hd_settings/hd_settings.py
+++ b/helpdesk/helpdesk/doctype/hd_settings/hd_settings.py
@@ -9,6 +9,11 @@ from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists
 from frappe.realtime import get_website_room
 
+from helpdesk.helpdesk.doctype.hd_ticket.hd_ticket import (
+    remove_guest_ticket_creation_permission,
+    set_guest_ticket_creation_permission,
+)
+
 
 class HDSettings(Document):
     def get_base_support_rotation(self):
@@ -49,11 +54,20 @@ class HDSettings(Document):
 
         return
 
+    def before_save(self):
+        self.update_ticket_permissions()
+
     def on_update(self):
         event = "helpdesk:settings-updated"
         room = get_website_room()
 
         frappe.publish_realtime(event, room=room, after_commit=True)
+
+    def update_ticket_permissions(self):
+        if self.allow_anyone_to_create_tickets:
+            set_guest_ticket_creation_permission()
+        if not self.allow_anyone_to_create_tickets:
+            remove_guest_ticket_creation_permission()
 
     @property
     def hd_search(self):

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -410,7 +410,7 @@
  "icon": "fa fa-issue",
  "idx": 61,
  "links": [],
- "modified": "2023-11-23 13:44:59.105648",
+ "modified": "2024-10-22 01:28:37.126589",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Ticket",

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -5,10 +5,12 @@ from typing import List
 
 import frappe
 from frappe import _
+from frappe.core.page.permission_manager.permission_manager import remove
 from frappe.desk.form.assign_to import add as assign
 from frappe.desk.form.assign_to import clear as clear_all_assignments
 from frappe.desk.form.assign_to import get as get_assignees
 from frappe.model.document import Document
+from frappe.permissions import add_permission, update_permission_property
 from frappe.query_builder import Order
 from pypika.functions import Count
 from pypika.queries import Query
@@ -916,7 +918,27 @@ def permission_query(user):
         user=frappe.db.escape(user)
     )
     for c in customer:
-        res += ' OR `tabHD Ticket`.customer={customer}'.format(
+        res += " OR `tabHD Ticket`.customer={customer}".format(
             customer=frappe.db.escape(c)
         )
     return res
+
+
+def set_guest_ticket_creation_permission():
+    doctype = "HD Ticket"
+    add_permission(doctype, "Guest", 0)
+
+    role = "Guest"
+    permlevel = 0
+    ptype = ["read", "write", "create", "if_owner"]
+
+    for p in ptype:
+        # update permissions
+        update_permission_property(doctype, role, permlevel, p, 1)
+
+
+def remove_guest_ticket_creation_permission():
+    doctype = "HD Ticket"
+    role = "Guest"
+    permlevel = 0
+    remove(doctype, role, permlevel, 1)

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -916,7 +916,7 @@ def permission_query(user):
         user=frappe.db.escape(user)
     )
     for c in customer:
-        res += ' OR `tabHD Ticket`.customer="{customer}"'.format(
+        res += ' OR `tabHD Ticket`.customer={customer}'.format(
             customer=frappe.db.escape(c)
         )
     return res


### PR DESCRIPTION
Introducing a new HD Setting  called "Allow anyone to create tickets".
If enabled This setting allows anyone to create tickets on your support portal. Useful in cases where you wants users to create tickets via webforms or some external APIs without authentication.

By default the value is 0.