### PR TITLE
fix: Allow users to reorder fields in the `HD Ticket Template` for customizable display order

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket_template/api.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket_template/api.py
@@ -27,7 +27,7 @@ def get_one(name: str):
     fields.extend(get_fields(name, "Custom Field"))
     return {
         "about": about,
-        "fields": fields,
+        "fields": sorted(fields, key=lambda x: x["idx"]),
     }
 
 


### PR DESCRIPTION
**Before**
When additional fields were added or reordered in the HD Ticket Template, they would not appear in the same order on the Ticket Portal.


**After**
Fields are now displayed on the Ticket Portal in the exact order set by the user in the HD Ticket Template.

![Screenshot from 2024-09-30 12-45-29](https://github.com/user-attachments/assets/0093db17-f2c0-4991-9de8-8e685c8bc57a)
