### PR TITLE
fix: show frappe_mail_site field while creating Frappe Mail Account

### DIFF
--- a/desk/src/components/Settings/EmailAdd.vue
+++ b/desk/src/components/Settings/EmailAdd.vue
@@ -121,6 +121,7 @@ const state: Reactive<EmailAccount> = reactive({
   password: "",
   api_key: "",
   api_secret: "",
+  frappe_mail_site: "",
   enable_incoming: false,
   enable_outgoing: false,
   default_incoming: false,
@@ -157,7 +158,7 @@ const addEmailRes = createResource({
   },
 });
 
-const error = ref("");
+const error = ref<string | undefined>();
 function createEmailAccount() {
   error.value = validateInputs(state, selectedService.value.custom);
   if (error.value) return;

--- a/desk/src/components/Settings/EmailEdit.vue
+++ b/desk/src/components/Settings/EmailEdit.vue
@@ -113,6 +113,7 @@ const state = reactive({
   api_key: props.accountData?.api_key || null,
   api_secret: props.accountData?.api_secret || null,
   password: props.accountData?.password || null,
+  frappe_mail_site: props.accountData?.frappe_mail_site || "",
   enable_incoming: props.accountData.enable_incoming || false,
   enable_outgoing: props.accountData.enable_outgoing || false,
   default_outgoing: props.accountData.default_outgoing || false,
@@ -135,7 +136,7 @@ const fields = computed(() => {
   return popularProviderFields;
 });
 
-const error = ref("");
+const error = ref<string | undefined>();
 const loading = ref(false);
 async function updateAccount() {
   error.value = validateInputs(state, isCustomService.value);
@@ -189,7 +190,8 @@ const isDirty = computed(() => {
     state.enable_incoming !== props.accountData.enable_incoming ||
     state.enable_outgoing !== props.accountData.enable_outgoing ||
     state.default_outgoing !== props.accountData.default_outgoing ||
-    state.default_incoming !== props.accountData.default_incoming
+    state.default_incoming !== props.accountData.default_incoming ||
+    state.frappe_mail_site !== props.accountData.frappe_mail_site
   );
 });
 

--- a/desk/src/components/Settings/emailConfig.ts
+++ b/desk/src/components/Settings/emailConfig.ts
@@ -65,6 +65,12 @@ export const popularProviderFields = [
 export const customProviderFields = [
   ...fixedFields,
   {
+    label: "Frappe Mail Site",
+    name: "frappe_mail_site",
+    type: "text",
+    placeholder: "https://frappemail.com",
+  },
+  {
     label: "API Key",
     name: "api_key",
     type: "text",

--- a/desk/src/types.ts
+++ b/desk/src/types.ts
@@ -192,6 +192,7 @@ export interface EmailAccount {
   api_key?: string;
   api_secret?: string;
   password?: string;
+  frappe_mail_site?: string;
   enable_outgoing?: boolean;
   enable_incoming?: boolean;
   default_outgoing?: boolean;

--- a/helpdesk/api/settings.py
+++ b/helpdesk/api/settings.py
@@ -35,6 +35,7 @@ def create_email_account(data):
         if service == "Frappe Mail":
             email_doc.api_key = data.get("api_key")
             email_doc.api_secret = data.get("api_secret")
+            email_doc.frappe_mail_site = data.get("frappe_mail_site")
         else:
             email_doc.password = data.get("password")
             # validate whether the credentials are correct


### PR DESCRIPTION
<img width="885" alt="image" src="https://github.com/user-attachments/assets/0fb79f23-d925-4151-90f0-4f7132d154b5">


Show "frappe_mail_site" field in Settings Modal