### PR TITLE
feat : Add custom status to tickets

### DIFF
--- a/desk/src/stores/ticketStatus.ts
+++ b/desk/src/stores/ticketStatus.ts
@@ -1,20 +1,27 @@
 import { computed, ref } from "vue";
 import { defineStore } from "pinia";
+import { createResource } from "frappe-ui";
 
 export const useTicketStatusStore = defineStore("ticketStatus", () => {
-  const options = ref(["Open", "Replied", "Resolved", "Closed"]);
+
+
+  const options = ref([]);
+
   const dropdown = computed(() =>
     options.value.map((o) => ({
       label: o,
       value: o,
     }))
   );
+
   const colorMap = {
     Open: "red",
     Replied: "blue",
     Resolved: "green",
     Closed: "gray",
+
   };
+
   const textColorMap = {
     Open: "!text-red-600",
     Replied: "!text-blue-600",
@@ -22,9 +29,20 @@ export const useTicketStatusStore = defineStore("ticketStatus", () => {
     Resolved: "!text-green-700",
     Closed: "!text-gray-700",
   };
+
   const stateActive = ["Open", "Replied"];
   const stateInactive = ["Resolved", "Closed"];
 
+  const tickets = createResource({
+    url: "helpdesk.api.doc.get_status_options",
+    params: {
+      doctype: "HD Ticket",
+    },
+    auto: true,
+    onSuccess(Data) {
+      options.value = Data.options;
+    },
+  });
   return {
     colorMap,
     dropdown,

--- a/helpdesk/api/doc.py
+++ b/helpdesk/api/doc.py
@@ -274,3 +274,22 @@ def get_visible_custom_fields():
         {"parent": "Default", "hide_from_customer": 0},
         pluck="fieldname",
     )
+
+
+# Get HD Ticket Status Options
+@frappe.whitelist()
+def get_status_options(
+    # doctype: str,
+    # filters: dict = {},
+    # order_by: str = "modified desc",
+    # page_length=20,
+    # columns=None,
+    # rows=None,
+    # show_customer_portal_fields=False,
+):
+    meta = frappe.get_meta("HD Ticket")
+    options = meta.get_field("status").options
+    options = options.split("\n")
+    return {
+        "options": options,
+    }

--- a/helpdesk/api/doc.py
+++ b/helpdesk/api/doc.py
@@ -278,15 +278,7 @@ def get_visible_custom_fields():
 
 # Get HD Ticket Status Options
 @frappe.whitelist()
-def get_status_options(
-    # doctype: str,
-    # filters: dict = {},
-    # order_by: str = "modified desc",
-    # page_length=20,
-    # columns=None,
-    # rows=None,
-    # show_customer_portal_fields=False,
-):
+def get_status_options():
     meta = frappe.get_meta("HD Ticket")
     options = meta.get_field("status").options
     options = options.split("\n")


### PR DESCRIPTION
If extra statuses are added in the doctype, they show up in the frontend.
![Screenshot 2024-11-19 120148](https://github.com/user-attachments/assets/27ecdcc0-09d9-4ff5-b495-353a7caf28e5)
