### PR TITLE
fix: Maintain order of custom fields.

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket_template/api.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket_template/api.py
@@ -60,5 +60,6 @@ def get_fields(template: str, fetch: Literal["Custom Field", "DocField"]):
         .join(QBFetch, JoinType.inner)
         .on(QBFetch.fieldname == fields.fieldname)
         .where(where_parent)
+        .orderby(fields.idx)
         .run(as_dict=True)
     )


### PR DESCRIPTION
This fix maintains the order in which custom fields were added to the tickets and shows up in the side panel.