### PR TITLE
fix: dont create null communication

### DIFF
--- a/helpdesk/api/settings.py
+++ b/helpdesk/api/settings.py
@@ -29,14 +29,15 @@ def create_email_account(data):
                 **service_config,
             }
         )
-        email_doc.append(
-            "imap_folder", {"append_to": "HD Ticket", "folder_name": "INBOX"}
-        )
         if service == "Frappe Mail":
             email_doc.api_key = data.get("api_key")
             email_doc.api_secret = data.get("api_secret")
             email_doc.frappe_mail_site = data.get("frappe_mail_site")
+            email_doc.append_to = "HD Ticket"
         else:
+            email_doc.append(
+                "imap_folder", {"append_to": "HD Ticket", "folder_name": "INBOX"}
+            )
             email_doc.password = data.get("password")
             # validate whether the credentials are correct
             email_doc.get_incoming_server()

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -191,9 +191,6 @@ class HDTicket(Document):
         log_ticket_activity(self.name, "created this ticket")
         capture_event("ticket_created")
         publish_event("helpdesk:new-ticket", {"name": self.name})
-        # create communication if we are not hitting the new ticket creation API
-        if not self.via_customer_portal:
-            self.create_communication_via_contact(self.description)
 
     def on_update(self):
         # flake8: noqa


### PR DESCRIPTION
Whenever a ticket was being created from Email, we were getting this null communication.
<img width="786" alt="image" src="https://github.com/user-attachments/assets/bd7d09c8-dfea-439a-a63f-aa916f0faa26">

