### PR TITLE
feat: setting to auto update status on reply

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+++ b/helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -28,6 +28,8 @@
   "column_break_zxek",
   "ticket_restrictions_section",
   "allow_anyone_to_create_tickets",
+  "section_break_duow",
+  "auto_update_status",
   "workflow_tab",
   "skip_email_workflow",
   "instantly_send_email",
@@ -294,11 +296,22 @@
    "fieldname": "allow_anyone_to_create_tickets",
    "fieldtype": "Check",
    "label": "Allow anyone to create tickets"
+  },
+  {
+   "fieldname": "section_break_duow",
+   "fieldtype": "Section Break"
+  },
+  {
+   "default": "0",
+   "description": "When enabled, the ticket status will automatically change to \"Replied\" whenever the agent responds to a ticket.\n",
+   "fieldname": "auto_update_status",
+   "fieldtype": "Check",
+   "label": "Auto Update Status"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2024-10-22 02:14:33.360809",
+ "modified": "2024-11-22 16:50:02.831137",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Settings",

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -738,6 +738,10 @@ class HDTicket(Document):
             self.first_responded_on = (
                 self.first_responded_on or frappe.utils.now_datetime()
             )
+
+            if frappe.db.get_single_value("HD Settings", "auto_update_status"):
+                self.status = "Replied"
+
         # Fetch description from communication if not set already. This might not be needed
         # anymore as a communication is created when a ticket is created.
         self.description = self.description or c.content


### PR DESCRIPTION
Setting to auto update ticket status to an agent replies on a ticket.

<img width="1063" alt="image" src="https://github.com/user-attachments/assets/df0f4008-1613-4ea2-a501-a99a376ccacf">

