### PR TITLE
fix: stop duplicate communication in HD Ticket

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/api.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/api.py
@@ -16,7 +16,6 @@ def new(doc, attachments=[]):
     doc["doctype"] = "HD Ticket"
     doc["via_customer_portal"] = bool(frappe.session.user)
     d = frappe.get_doc(doc).insert()
-    d.create_communication_via_contact(d.description, attachments)
     return d
 
 

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -191,7 +191,6 @@ class HDTicket(Document):
         log_ticket_activity(self.name, "created this ticket")
         capture_event("ticket_created")
         publish_event("helpdesk:new-ticket", {"name": self.name})
-
         if self.get("description"):
             self.create_communication_via_contact(self.description)
 


### PR DESCRIPTION
Double communication was being created when a ticket is created. This PR fixes the issue