### PR TITLE
fix: attachments

### DIFF
--- a/desk/src/pages/TicketAgent.vue
+++ b/desk/src/pages/TicketAgent.vue
@@ -361,7 +361,6 @@ function updateTicket(fieldname: string, value: string) {
     auto: true,
     onSuccess: () => {
       isLoading.value = false;
-      ticket.reload();
       createToast({
         title: "Ticket updated",
         icon: "check",

--- a/helpdesk/helpdesk/doctype/hd_ticket/api.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/api.py
@@ -15,6 +15,7 @@ from helpdesk.utils import check_permissions, get_customer, is_agent
 def new(doc, attachments=[]):
     doc["doctype"] = "HD Ticket"
     doc["via_customer_portal"] = bool(frappe.session.user)
+    doc['attachments'] = attachments
     d = frappe.get_doc(doc).insert()
     return d
 

--- a/helpdesk/helpdesk/doctype/hd_ticket/api.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/api.py
@@ -15,7 +15,7 @@ from helpdesk.utils import check_permissions, get_customer, is_agent
 def new(doc, attachments=[]):
     doc["doctype"] = "HD Ticket"
     doc["via_customer_portal"] = bool(frappe.session.user)
-    doc['attachments'] = attachments
+    doc["attachments"] = attachments
     d = frappe.get_doc(doc).insert()
     return d
 

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -571,7 +571,7 @@ class HDTicket(Document):
             file_doc.attached_to_name = communication.name
             file_doc.attached_to_doctype = "Communication"
             file_doc.save(ignore_permissions=True)
-            self.attach_ticket_with_file(file_doc.file_url)
+            self.attach_file_with_ticket(file_doc.file_url)
 
             _attachments.append({"file_url": file_doc.file_url})
 
@@ -653,7 +653,7 @@ class HDTicket(Document):
             "File", filters={"attached_to_name": c.name}, pluck="file_url"
         )
         for url in file_urls:
-            self.attach_ticket_with_file(url)
+            self.attach_file_with_ticket(url)
 
     @frappe.whitelist()
     def mark_seen(self):
@@ -760,7 +760,7 @@ class HDTicket(Document):
         # Save the ticket, allowing for hooks to run.
         self.save()
 
-    def attach_ticket_with_file(self, file_url):
+    def attach_file_with_ticket(self, file_url):
         file_doc = frappe.new_doc("File")
         file_doc.attached_to_name = self.name
         file_doc.attached_to_doctype = "HD Ticket"

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -639,9 +639,7 @@ class HDTicket(Document):
         c.ignore_permissions = True
         c.ignore_mandatory = True
         c.save(ignore_permissions=True)
-
-        _attachments = self.get("attachments", attachments)
-
+        _attachments = self.get("attachments") or attachments or []
         if not len(_attachments):
             return
         QBFile = frappe.qb.DocType("File")

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -646,7 +646,7 @@ class HDTicket(Document):
         condition_name = [QBFile.name == i["name"] for i in _attachments]
         frappe.qb.update(QBFile).set(QBFile.attached_to_name, c.name).set(
             QBFile.attached_to_doctype, "Communication"
-        ).where(Criterion.any(condition_name)).run(debug=True)
+        ).where(Criterion.any(condition_name)).run()
 
         # attach files to ticket
         file_urls = frappe.get_all(

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -638,11 +638,12 @@ class HDTicket(Document):
         c.ignore_mandatory = True
         c.save(ignore_permissions=True)
 
-        attachments = self.get("attachments", [])
-        if not len(attachments):
+        _attachments = self.get("attachments", attachments)
+
+        if not len(_attachments):
             return
         QBFile = frappe.qb.DocType("File")
-        condition_name = [QBFile.name == i["name"] for i in attachments]
+        condition_name = [QBFile.name == i["name"] for i in _attachments]
         frappe.qb.update(QBFile).set(QBFile.attached_to_name, c.name).set(
             QBFile.attached_to_doctype, "Communication"
         ).where(Criterion.any(condition_name)).run()

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -617,6 +617,7 @@ class HDTicket(Document):
     @frappe.whitelist()
     # flake8: noqa
     def create_communication_via_contact(self, message, attachments=[]):
+
         if self.status == "Replied":
             self.status = "Open"
             log_ticket_activity(self.name, "set status to Open")
@@ -637,6 +638,7 @@ class HDTicket(Document):
         c.ignore_mandatory = True
         c.save(ignore_permissions=True)
 
+        attachments = self.get("attachments", [])
         if not len(attachments):
             return
         QBFile = frappe.qb.DocType("File")

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -571,6 +571,8 @@ class HDTicket(Document):
             file_doc.attached_to_name = communication.name
             file_doc.attached_to_doctype = "Communication"
             file_doc.save(ignore_permissions=True)
+            self.attach_ticket_with_file(file_doc.content_hash, file_doc.file_url)
+
             _attachments.append({"file_url": file_doc.file_url})
 
         reply_to_email = sender_email.email_id
@@ -752,6 +754,14 @@ class HDTicket(Document):
         self.description = self.description or c.content
         # Save the ticket, allowing for hooks to run.
         self.save()
+
+    def attach_ticket_with_file(self, content_hash, file_url):
+        file_doc = frappe.new_doc("File")
+        file_doc.attached_to_name = self.name
+        file_doc.attached_to_doctype = "HD Ticket"
+        file_doc.content_hash = content_hash
+        file_doc.file_url = file_url
+        file_doc.save(ignore_permissions=True)
 
     @staticmethod
     def default_list_data(show_customer_portal_fields=False):


### PR DESCRIPTION
**Issue:**

1. When a ticket was created users attachment were not showing, this is because attachments object was not being passed.
2. When an agent attached a file that file becomes private and the customer is not able to access it. 


**Solution:**
1. Attach tickets object while creating ticket.
2. Attach the file uploaded to the ticket, to share its access with the customers having access to the tickets.

