### PR TITLE
fix: add blur handler for text fields

### DIFF
--- a/desk/src/components/UniInput2.vue
+++ b/desk/src/components/UniInput2.vue
@@ -11,12 +11,26 @@
     >
       <component
         :is="component"
-        :key="transValue"
+        :key="field.fieldname"
         class="form-control"
         :placeholder="`Add ${field.label}`"
         :value="transValue"
-        @change="
-          emitUpdate(field.fieldname, $event.value || $event.target.value)
+        v-on="
+          textFields.includes(field.fieldtype)
+            ? {
+                blur: (event) =>
+                  emitUpdate(
+                    field.fieldname,
+                    event.value || event.target.value
+                  ),
+              }
+            : {
+                change: (event) =>
+                  emitUpdate(
+                    field.fieldname,
+                    event.value || event.target.value
+                  ),
+              }
         "
       />
     </div>
@@ -47,6 +61,8 @@ interface E {
 const props = defineProps<P>();
 const emit = defineEmits<E>();
 
+const textFields = ["Long Text", "Small Text", "Text"];
+
 const component = computed(() => {
   if (props.field.url_method) {
     return h(Autocomplete, {
@@ -75,9 +91,7 @@ const component = computed(() => {
         },
       ],
     });
-  } else if (
-    ["Long Text", "Small Text", "Text"].includes(props.field.fieldtype)
-  ) {
+  } else if (textFields.includes(props.field.fieldtype)) {
     return h(FormControl, {
       type: "textarea",
     });


### PR DESCRIPTION
<img width="662" alt="Multiple API Calls" src="https://github.com/user-attachments/assets/5b639e88-e4d5-494b-b9ce-805ec8d8c3cd" />

<img width="1436" alt="SET VALUE TWICE" src="https://github.com/user-attachments/assets/1ce78d91-1902-4ac6-9f74-bdcac00e7e6d" />



Set value was call being twice because of Form Control Text area element, so used blur event handler for Textarea component