### PR TITLE
fix: handle routes properly

### DIFF
--- a/desk/src/App.vue
+++ b/desk/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <RouterView class="antialiased" :key="$route.fullPath" />
+  <RouterView class="antialiased" />
   <Toasts />
   <KeymapDialog />
   <Dialogs />

--- a/desk/src/components/SidebarLink.vue
+++ b/desk/src/components/SidebarLink.vue
@@ -8,7 +8,7 @@
       [bgColor]: isActive,
       [hvColor]: !isActive,
     }"
-    @click="handle"
+    @click="handleNavigation"
   >
     <span
       class="shrink-0 text-gray-700"
@@ -57,12 +57,12 @@ const props = withDefaults(defineProps<P>(), {
 });
 const router = useRouter();
 
-function handle() {
+function handleNavigation() {
   props.onClick();
-  if (props.to) {
-    router.push({
-      name: props.to,
-    });
-  }
+  if (!props.to) return;
+  if (props.to === router.currentRoute.value.name) return;
+  router.push({
+    name: props.to,
+  });
 }
 </script>

--- a/desk/src/pages/TicketAgent.vue
+++ b/desk/src/pages/TicketAgent.vue
@@ -169,7 +169,12 @@ const props = defineProps({
     required: true,
   },
 });
-
+watch(
+  () => props.ticketId,
+  () => {
+    ticket.reload();
+  }
+);
 provide("communicationArea", communicationAreaRef);
 
 let storage = useStorage("ticket_agent", {
@@ -184,9 +189,9 @@ const ticket = createResource({
   url: "helpdesk.helpdesk.doctype.hd_ticket.api.get_one",
   cache: ["Ticket", props.ticketId],
   auto: true,
-  params: {
+  makeParams: () => ({
     name: props.ticketId,
-  },
+  }),
   transform: (data) => {
     if (data._assign) {
       data.assignees = JSON.parse(data._assign).map((assignee) => {

--- a/desk/src/pages/knowledge-base/KnowledgeBaseArticleTopPublic.vue
+++ b/desk/src/pages/knowledge-base/KnowledgeBaseArticleTopPublic.vue
@@ -12,7 +12,7 @@
     </div>
   </div>
   <div class="border-b pb-3">
-    <div class="text-3xl font-semibold text-gray-900">
+    <div class="text-2xl font-semibold text-gray-900">
       {{ title }}
     </div>
   </div>

--- a/desk/src/pages/knowledge-base/KnowledgeBaseArticleTopView.vue
+++ b/desk/src/pages/knowledge-base/KnowledgeBaseArticleTopView.vue
@@ -23,7 +23,7 @@
     </div>
   </div>
   <div class="border-b pb-3">
-    <div class="text-3xl font-semibold text-gray-900">
+    <div class="text-2xl font-semibold text-gray-900">
       {{ title }}
     </div>
   </div>

--- a/desk/src/pages/ticket/TicketTextEditor.vue
+++ b/desk/src/pages/ticket/TicketTextEditor.vue
@@ -37,6 +37,14 @@
             private: true,
           }"
           @success="(f: File) => $emit('update:attachments', [...attachments, f])"
+          @failure="
+            () =>
+              createToast({
+                title: 'Error Uploading File',
+                icon: 'x',
+                iconClasses: 'text-red-600',
+              })
+          "
         >
           <template #default="{ openFileSelector }">
             <Button theme="gray" variant="ghost" @click="openFileSelector()">
@@ -85,6 +93,7 @@ import {
   UserAvatar,
 } from "@/components";
 import { File } from "@/types";
+import { createToast } from "@/utils";
 
 interface P {
   content: string;

--- a/desk/src/router/index.ts
+++ b/desk/src/router/index.ts
@@ -233,11 +233,9 @@ export const router = createRouter({
 
 router.beforeEach(async (to, _, next) => {
   const authStore = useAuthStore();
-  const userStore = useUserStore();
 
   if (authStore.isLoggedIn) {
     await authStore.init();
-    await userStore.users.fetch();
   }
 
   if (!authStore.isLoggedIn) {
@@ -245,4 +243,11 @@ router.beforeEach(async (to, _, next) => {
   } else {
     next();
   }
+});
+
+router.afterEach(async (to) => {
+  const isCustomerPortal = to.meta.public ?? false;
+  if (isCustomerPortal) return;
+  const userStore = useUserStore();
+  await userStore.users.fetch();
 });


### PR DESCRIPTION
1. On customer portal we were calling api to get all_users. So basically anyone with access to Customer Portal would be able to see the user database along with images.
![image](https://github.com/user-attachments/assets/0226b472-8f9d-4c92-9b6b-255584ef411a)

2. Because we get all_users before_route the page load becomes slow, to improve it we will get all_users after routing, to increase performance.
