### PR TITLE
fix: only agents can access users api

### DIFF
--- a/desk/src/components/ticket/TicketsListView.vue
+++ b/desk/src/components/ticket/TicketsListView.vue
@@ -72,7 +72,7 @@
             </Tooltip>
           </div>
           <div v-else-if="column.key === 'agent_group'" class="truncate">
-            {{ item || "-" }}
+            {{ item }}
           </div>
           <div v-else-if="column.key === 'resolution_by'">
             <Badge

--- a/helpdesk/api/session.py
+++ b/helpdesk/api/session.py
@@ -1,8 +1,14 @@
 import frappe
+from frappe import _
+
+from helpdesk.utils import is_agent
 
 
 @frappe.whitelist()
 def get_users():
+    if not is_agent():
+        frappe.throw(_("Access denied"), exc=frappe.PermissionError)
+
     if frappe.session.user == "Guest":
         frappe.throw(frappe._("Authentication failed"), exc=frappe.AuthenticationError)
 

--- a/helpdesk/helpdesk/doctype/hd_team/hd_team.json
+++ b/helpdesk/helpdesk/doctype/hd_team/hd_team.json
@@ -48,7 +48,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-12-07 14:03:15.382072",
+ "modified": "2024-12-23 23:02:36.015099",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Team",
@@ -90,6 +90,10 @@
    "role": "Administrator",
    "share": 1,
    "write": 1
+  },
+  {
+   "read": 1,
+   "role": "All"
   }
  ],
  "quick_entry": 1,


### PR DESCRIPTION
Currently: all users who are logged into the system can access the users api and get all users, which is a very high security breach.
![User List](https://github.com/user-attachments/assets/edb4e71f-8c91-4a1d-891c-b2f424413770)


This PR fixes the issue: Only Agents will be allowed to access the get_users API.