### PR TITLE
fix(styles): canned responses preview

### DIFF
--- a/desk/src/index.css
+++ b/desk/src/index.css
@@ -1,38 +1,3 @@
 @import "./assets/Inter/inter.css";
 @import "frappe-ui/src/style.css";
 
-@layer components {
-	.prose-f {
-		@apply
-		break-normal
-		max-w-none
-		prose
-		prose-code:break-all
-		prose-code:whitespace-pre-wrap
-		prose-img:border
-		prose-img:rounded-lg
-		prose-sm
-		prose-table:table-fixed
-		prose-td:border
-		prose-td:border-gray-300
-		prose-td:p-2
-		prose-td:relative
-		prose-th:bg-gray-100
-		prose-th:border
-		prose-th:border-gray-300
-		prose-th:p-2
-		prose-th:relative
-	}
-
-	.popover {
-		@apply
-		bg-white
-		mt-2
-		p-1
-		ring-1
-		ring-black
-		ring-opacity-5
-		rounded-lg
-		shadow-2xl
-	}
-}

--- a/desk/src/pages/CannedResponses.vue
+++ b/desk/src/pages/CannedResponses.vue
@@ -31,7 +31,7 @@
         <div
           v-for="cannedResponse in cannedResponses.data"
           :key="cannedResponse.name"
-          class="group flex h-56 cursor-pointer flex-col justify-between gap-2 rounded-lg border px-5 py-4 shadow-sm hover:bg-gray-50"
+          class="group flex h-60 cursor-pointer flex-col justify-between gap-2 rounded-lg border px-5 py-4 shadow-sm hover:bg-gray-50"
           @click="editItem(cannedResponse)"
         >
           <div class="flex items-center justify-between">
@@ -59,8 +59,8 @@
             v-if="cannedResponse.message"
             :content="cannedResponse.message"
             :editable="false"
-            editor-class="!prose-sm max-w-none !text-sm text-gray-600 focus:outline-none"
-            class="flex-1 overflow-hidden"
+            editor-class="prose-sm"
+            class="flex-1 overflow-hidden response-preview"
           />
           <div class="mt-2 flex items-center justify-between gap-2">
             <div class="flex items-center gap-2">
@@ -167,3 +167,9 @@ usePageMeta(() => {
   };
 });
 </script>
+
+<style>
+.response-preview :where(p, span, a) {
+  @apply !text-gray-600;
+}
+</style>


### PR DESCRIPTION
Improve UI for Canned Response Preview

**Before:**
<img width="1199" alt="image" src="https://github.com/user-attachments/assets/fcd6b521-2c2c-40c4-8205-4023b297339b" />


**After:**
<img width="1198" alt="image" src="https://github.com/user-attachments/assets/5fe3440d-3bc3-4a18-8fcb-61b22689063d" />
