### PR TITLE
refactor: comment box 

### DIFF
--- a/desk/src/components/CommentBox.vue
+++ b/desk/src/components/CommentBox.vue
@@ -58,7 +58,7 @@
       >
         <template #bottom v-if="editable">
           <div class="flex flex-row-reverse gap-2">
-            <Button label="Save" @click="handleSave" variant="solid" />
+            <Button label="Save" @click="handleSaveComment" variant="solid" />
             <Button label="Discard" @click="handleDiscard" />
           </div>
         </template>
@@ -124,6 +124,16 @@ const _content = ref(content);
 const commentBoxRef = ref(null);
 const editorRef = ref(null);
 
+function handleEditMode() {
+  editable.value = true;
+  editorRef.value.editor.chain().focus("start");
+}
+
+function handleDiscard() {
+  _content.value = content;
+  editable.value = false;
+}
+
 const deleteComment = createResource({
   url: "frappe.client.delete",
   makeParams: () => ({
@@ -140,17 +150,7 @@ const deleteComment = createResource({
   },
 });
 
-function handleEditMode() {
-  editable.value = true;
-  editorRef.value.editor.chain().focus("start");
-}
-
-function handleDiscard() {
-  _content.value = content;
-  editable.value = false;
-}
-
-function handleSave() {
+function handleSaveComment() {
   if (content === _content.value) {
     editable.value = false;
     return;

--- a/desk/src/components/CommentBox.vue
+++ b/desk/src/components/CommentBox.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex-col text-base">
+  <div class="flex-col text-base flex-1" ref="commentBoxRef">
     <div class="mb-1 ml-0.5 flex items-center justify-between">
       <div class="text-gray-600 flex items-center gap-2">
         <Avatar
@@ -36,10 +36,33 @@
         </div>
       </div>
     </div>
-    <div
+    <TextEditor
+      ref="editorRef"
+      :editor-class="'prose-f shrink rounded bg-gray-50 px-4 py-3 text-p-sm transition-all duration-300 ease-in-out block w-full '"
+      :content="content"
+      :editable="false"
+      @change="(event:string) => {content = event}"
+    >
+      <template #bottom v-if="false">
+        <TextEditorFixedMenu
+          class="-ml-1 overflow-x-auto w-full"
+          :buttons="textEditorMenuButtons"
+        />
+      </template>
+    </TextEditor>
+    <!-- <div
       class="prose-f grow cursor-pointer rounded bg-gray-50 px-4 py-3 text-base leading-6 transition-all duration-300 ease-in-out"
-      v-html="content"
-    />
+    >
+      <iframe :srcdoc="content" class="prose-f block w-full h-fit" />
+    </div> -->
+    <!-- <div class="flex flex-wrap gap-2">
+      <AttachmentItem
+        v-for="a in attachments"
+        :key="a.file_url"
+        :label="a.file_name"
+        :url="a.file_url"
+      />
+    </div> -->
   </div>
   <Dialog
     v-model="showDialog"
@@ -59,16 +82,31 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
-import { Dropdown, createResource, Dialog, Avatar } from "frappe-ui";
-import { dateFormat, timeAgo, dateTooltipFormat, createToast } from "@/utils";
+import { ref, PropType } from "vue";
+import {
+  Dropdown,
+  createResource,
+  Dialog,
+  Avatar,
+  TextEditor,
+  TextEditorFixedMenu,
+} from "frappe-ui";
+// import { EmailContent } from "@/components/EmailContent.vue";
+import {
+  dateFormat,
+  timeAgo,
+  dateTooltipFormat,
+  createToast,
+  textEditorMenuButtons,
+} from "@/utils";
 import { useAuthStore } from "@/stores/auth";
 import { useUserStore } from "@/stores/user";
-
+import { CommentActivity } from "@/types";
+import { onMounted } from "vue";
 const authStore = useAuthStore();
 const props = defineProps({
   activity: {
-    type: Object,
+    type: Object as PropType<CommentActivity>,
     required: true,
   },
 });
@@ -78,6 +116,11 @@ const { name, creation, content, commenter, commentedBy } = props.activity;
 
 const emit = defineEmits(["update"]);
 const showDialog = ref(false);
+const commentBoxRef = ref(null);
+
+onMounted(() => {
+  commentBoxRef.value.style.width = "0px";
+});
 
 const deleteComment = createResource({
   url: "frappe.client.delete",

--- a/desk/src/components/CommentBox.vue
+++ b/desk/src/components/CommentBox.vue
@@ -63,6 +63,14 @@
           </div>
         </template>
       </TextEditor>
+      <div class="flex flex-wrap gap-2">
+        <AttachmentItem
+          v-for="a in attachments"
+          :key="a.file_url"
+          :label="a.file_name"
+          :url="a.file_url"
+        />
+      </div>
     </div>
   </div>
   <Dialog
@@ -83,7 +91,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, PropType } from "vue";
+import { ref, PropType, onMounted } from "vue";
 import {
   Dropdown,
   createResource,
@@ -99,10 +107,10 @@ import {
   textEditorMenuButtons,
   isContentEmpty,
 } from "@/utils";
+import { AttachmentItem } from "@/components";
 import { useAuthStore } from "@/stores/auth";
 import { useUserStore } from "@/stores/user";
 import { CommentActivity } from "@/types";
-import { onMounted } from "vue";
 import { updateRes as updateComment } from "@/stores/knowledgeBase";
 const authStore = useAuthStore();
 const props = defineProps({
@@ -113,7 +121,8 @@ const props = defineProps({
 });
 const { getUser } = useUserStore();
 
-const { name, creation, content, commenter, commentedBy } = props.activity;
+const { name, creation, content, commenter, commentedBy, attachments } =
+  props.activity;
 
 const emit = defineEmits(["update"]);
 const showDialog = ref(false);

--- a/desk/src/components/CommentBox.vue
+++ b/desk/src/components/CommentBox.vue
@@ -23,12 +23,12 @@
             {{ timeAgo(creation) }}
           </span>
         </Tooltip>
-        <div v-if="authStore.userId === commentedBy">
+        <div v-if="authStore.userId === commentedBy && !editable">
           <Dropdown
             :options="[
               {
                 label: 'Edit',
-                onClick: () => (editable = true),
+                onClick: () => handleEditMode(),
                 icon: 'edit-2',
               },
               {
@@ -117,9 +117,12 @@ const { name, creation, content, commenter, commentedBy } = props.activity;
 
 const emit = defineEmits(["update"]);
 const showDialog = ref(false);
-const commentBoxRef = ref(null);
 const editable = ref(false);
 const _content = ref(content);
+
+// HTML refs
+const commentBoxRef = ref(null);
+const editorRef = ref(null);
 
 const deleteComment = createResource({
   url: "frappe.client.delete",
@@ -136,6 +139,11 @@ const deleteComment = createResource({
     });
   },
 });
+
+function handleEditMode() {
+  editable.value = true;
+  editorRef.value.editor.chain().focus("start");
+}
 
 function handleDiscard() {
   _content.value = content;

--- a/desk/src/components/CommentBox.vue
+++ b/desk/src/components/CommentBox.vue
@@ -63,7 +63,7 @@
           </div>
         </template>
       </TextEditor>
-      <div class="flex flex-wrap gap-2">
+      <div class="flex flex-wrap gap-2" v-if="!editable">
         <AttachmentItem
           v-for="a in attachments"
           :key="a.file_url"

--- a/desk/src/components/CommentTextEditor.vue
+++ b/desk/src/components/CommentTextEditor.vue
@@ -154,10 +154,14 @@ async function submitComment() {
       method: "new_comment",
       args: {
         content: newComment.value,
+        attachments: attachments.value,
       },
     }),
     onSuccess: () => {
       emit("submit");
+      loading.value = false;
+    },
+    onError: () => {
       loading.value = false;
     },
   });

--- a/desk/src/components/EmailArea.vue
+++ b/desk/src/components/EmailArea.vue
@@ -102,7 +102,6 @@ const { sender, to, cc, bcc, creation, subject, attachments, content } =
 
 const emit = defineEmits(["reply"]);
 
-let emailBox = inject("communicationArea");
 const { isMobileView } = useScreenSize();
 
 // TODO: Implement reply functionality using this way instead of emit drillup

--- a/desk/src/components/EmailArea.vue
+++ b/desk/src/components/EmailArea.vue
@@ -84,11 +84,10 @@
 </template>
 
 <script setup lang="ts">
-import { UserAvatar, AttachmentItem } from "@/components";
+import { AttachmentItem } from "@/components";
 import { dateFormat, timeAgo, dateTooltipFormat } from "@/utils";
 import { ReplyIcon, ReplyAllIcon } from "./icons";
 import { useScreenSize } from "@/composables/screen";
-import { inject } from "vue";
 
 const props = defineProps({
   activity: {

--- a/desk/src/components/EmailArea.vue
+++ b/desk/src/components/EmailArea.vue
@@ -71,11 +71,7 @@
       </span>
       <span v-if="bcc">{{ bcc }}</span>
     </div>
-    <!-- <div
-      class="email-content prose-f max-h-[500px] overflow-y-auto"
-      v-html="content"
-    /> -->
-    <EmailContent :content="content" :emailBox="emailBox" />
+    <EmailContent :content="content" />
     <div class="flex flex-wrap gap-2">
       <AttachmentItem
         v-for="a in attachments"

--- a/desk/src/components/EmailEditor.vue
+++ b/desk/src/components/EmailEditor.vue
@@ -165,7 +165,6 @@ import {
 } from "@/components";
 import { AttachmentIcon, EmailIcon } from "@/components/icons";
 import { PreserveVideoControls } from "@/tiptap-extensions";
-import { useError } from "@/composables/error";
 
 const editorRef = ref(null);
 const showCannedResponseSelectorModal = ref(false);

--- a/desk/src/components/HistoryBox.vue
+++ b/desk/src/components/HistoryBox.vue
@@ -1,52 +1,56 @@
 <template>
-  <div class="mt-1.5 flex justify-between text-base">
-    <div class="text-gray-600">
-      <span class="font-medium text-gray-800">
-        {{ user }}
-      </span>
-      <span> {{ content }}</span>
-    </div>
-    <Tooltip :text="dateFormat(creation, dateTooltipFormat)">
-      <div class="text-gray-600">
-        {{ timeAgo(creation) }}
-      </div>
-    </Tooltip>
-  </div>
-  <div v-if="show_others && content !== 'created this ticket'">
-    <div
-      v-for="relatedActivity in relatedActivities"
-      :key="relatedActivity.creation"
-      class="mt-2 flex justify-between text-base"
-    >
+  <div class="flex-1">
+    <div class="mt-1.5 flex justify-between text-base items-center">
       <div class="text-gray-600">
         <span class="font-medium text-gray-800">
-          {{ relatedActivity.user }}
+          {{ user }}
         </span>
-        <span> {{ relatedActivity.content }}</span>
+        <span> {{ content }}</span>
       </div>
-      <Tooltip :text="dateFormat(relatedActivity.creation, dateTooltipFormat)">
-        <div class="text-gray-600">
-          {{ timeAgo(relatedActivity.creation) }}
+      <Tooltip :text="dateFormat(creation, dateTooltipFormat)">
+        <div class="text-gray-600 text-sm">
+          {{ timeAgo(creation) }}
         </div>
       </Tooltip>
     </div>
+    <div v-if="show_others && content !== 'created this ticket'">
+      <div
+        v-for="relatedActivity in relatedActivities"
+        :key="relatedActivity.creation"
+        class="mt-2 flex justify-between text-base"
+      >
+        <div class="text-gray-600">
+          <span class="font-medium text-gray-800">
+            {{ relatedActivity.user }}
+          </span>
+          <span> {{ relatedActivity.content }}</span>
+        </div>
+        <Tooltip
+          :text="dateFormat(relatedActivity.creation, dateTooltipFormat)"
+        >
+          <div class="text-gray-600 text-sm">
+            {{ timeAgo(relatedActivity.creation) }}
+          </div>
+        </Tooltip>
+      </div>
+    </div>
+    <Button
+      v-if="relatedActivities.length && content !== 'created this ticket'"
+      :label="
+        show_others ? 'Hide' : `${relatedActivities.length} other activities`
+      "
+      variant="outline"
+      class="mt-2"
+      @click="show_others = !show_others"
+    >
+      <template #suffix>
+        <FeatherIcon
+          :name="show_others ? 'chevron-up' : 'chevron-down'"
+          class="h-4 text-gray-600"
+        />
+      </template>
+    </Button>
   </div>
-  <Button
-    v-if="relatedActivities.length && content !== 'created this ticket'"
-    :label="
-      show_others ? 'Hide' : `${relatedActivities.length} other activities`
-    "
-    variant="outline"
-    class="mt-2"
-    @click="show_others = !show_others"
-  >
-    <template #suffix>
-      <FeatherIcon
-        :name="show_others ? 'chevron-up' : 'chevron-down'"
-        class="h-4 text-gray-600"
-      />
-    </template>
-  </Button>
 </template>
 
 <script setup lang="ts">

--- a/desk/src/components/layouts/MobileSidebar.vue
+++ b/desk/src/components/layouts/MobileSidebar.vue
@@ -16,7 +16,7 @@
           <!-- user dropwdown -->
           <div><UserMenu class="p-2 mb-2" :options="profileSettings" /></div>
           <!-- notifications -->
-          <div class="overflow-y-auto px-2">
+          <div class="overflow-y-auto px-2" v-if="!isCustomerPortal">
             <div class="mb-3 flex flex-col">
               <SidebarLink
                 class="relative"

--- a/desk/src/components/layouts/Sidebar.vue
+++ b/desk/src/components/layouts/Sidebar.vue
@@ -39,7 +39,9 @@
         <template #right>
           <Badge
             v-if="isExpanded && notificationStore.unread"
-            :label="notificationStore.unread"
+            :label="
+              notificationStore.unread > 9 ? '9+' : notificationStore.unread
+            "
             theme="gray"
             variant="subtle"
           />

--- a/desk/src/components/ticket/TicketAgentActivities.vue
+++ b/desk/src/components/ticket/TicketAgentActivities.vue
@@ -36,7 +36,7 @@
               <DotIcon v-else class="text-gray-600" />
             </div>
           </div>
-          <div class="mb-4 w-full">
+          <div class="mb-4 flex flex-1">
             <EmailArea
               v-if="activity.type === 'email'"
               :activity="activity"
@@ -74,7 +74,7 @@
 </template>
 
 <script setup lang="ts">
-import { Ref, inject, h, computed, onMounted, watch } from "vue";
+import { Ref, inject, h, computed, onMounted, watch, PropType } from "vue";
 import { useElementVisibility } from "@vueuse/core";
 import {
   DotIcon,
@@ -86,10 +86,10 @@ import {
 import { EmailArea, CommentBox, HistoryBox } from "@/components";
 import { useUserStore } from "@/stores/user";
 import { Avatar } from "frappe-ui";
-
+import { TicketActivity } from "@/types";
 const props = defineProps({
   activities: {
-    type: Array,
+    type: Array as PropType<TicketActivity[]>,
     required: true,
   },
   title: {

--- a/desk/src/components/ticket/TicketAgentSidebar.vue
+++ b/desk/src/components/ticket/TicketAgentSidebar.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex w-[382px] flex-col justify-between border-l">
-    <div class="h-10.5 flex items-center justify-between border-b px-5 py-2.5">
+    <div class="h-[2.83rem] flex items-center justify-between border-b px-5">
       <span
         class="cursor-copy text-lg font-semibold"
         @click="copyToClipboard(ticket.name, ticket.name)"

--- a/desk/src/pages/TicketAgent.vue
+++ b/desk/src/pages/TicketAgent.vue
@@ -296,6 +296,7 @@ const activities = computed(() => {
       commenter: comment.user.name,
       creation: comment.creation,
       content: comment.content,
+      attachments: comment.attachments,
     };
   });
 

--- a/desk/src/pages/ticket/TicketCustomerTemplateFields.vue
+++ b/desk/src/pages/ticket/TicketCustomerTemplateFields.vue
@@ -1,5 +1,5 @@
 <template>
-  <span class="grid grid-cols-1 gap-4 border-b px-5 py-2.5 sm:grid-cols-3">
+  <div class="grid grid-cols-1 gap-4 border-b px-5 py-2.5 sm:grid-cols-3">
     <div class="space-y-1.5">
       <span class="block text-sm text-gray-700"> Status </span>
       <span class="block break-words text-base font-medium text-gray-900">
@@ -40,7 +40,7 @@
         {{ ticket.data[field.fieldname] }}
       </span>
     </div>
-  </span>
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/desk/src/types.ts
+++ b/desk/src/types.ts
@@ -275,3 +275,35 @@ export interface Breadcrumb {
     params?: Record<string, string>;
   };
 }
+
+interface BaseActivity {
+  type: string;
+  key: string;
+  creation: string;
+  content: string;
+}
+
+interface HistoryActivity extends BaseActivity {
+  type: "history";
+  user: string;
+  relatedActivities: HistoryActivity[];
+}
+
+interface EmailActivity extends BaseActivity {
+  type: "email";
+  attachments: Array<{ key: string; name: any }>;
+  bcc: string;
+  cc: string;
+  sender: { full_name: string; name: string };
+  subject: string;
+  to: string;
+}
+
+export interface CommentActivity extends BaseActivity {
+  type: "comment";
+  name: string;
+  commenter: string;
+  commentedBy: string;
+}
+
+export type TicketActivity = HistoryActivity | EmailActivity | CommentActivity;

--- a/desk/src/types.ts
+++ b/desk/src/types.ts
@@ -276,6 +276,7 @@ export interface Breadcrumb {
   };
 }
 
+// Activity Types
 interface BaseActivity {
   type: string;
   key: string;
@@ -289,9 +290,9 @@ interface HistoryActivity extends BaseActivity {
   relatedActivities: HistoryActivity[];
 }
 
-interface EmailActivity extends BaseActivity {
+export interface EmailActivity extends BaseActivity {
   type: "email";
-  attachments: Array<{ key: string; name: any }>;
+  attachments: FileAttachment;
   bcc: string;
   cc: string;
   sender: { full_name: string; name: string };
@@ -304,6 +305,13 @@ export interface CommentActivity extends BaseActivity {
   name: string;
   commenter: string;
   commentedBy: string;
+  attachments: FileAttachment[];
 }
 
 export type TicketActivity = HistoryActivity | EmailActivity | CommentActivity;
+
+interface FileAttachment {
+  name: string;
+  file_name: string;
+  file_url: string;
+}

--- a/desk/src/utils.ts
+++ b/desk/src/utils.ts
@@ -177,3 +177,9 @@ export const textEditorMenuButtons = [
     "DeleteTable",
   ],
 ];
+
+export function isContentEmpty(content: string) {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(content, "text/html");
+  return doc.body.textContent === "";
+}

--- a/helpdesk/api/doc.py
+++ b/helpdesk/api/doc.py
@@ -289,12 +289,13 @@ def get_list_data(
                     "type": field.get("type"),
                     "options": options,
                 }
-
     return {
         "data": data,
         "columns": columns,
         "fields": fields if doctype == "HD Ticket" else [],
-        "total_count": len(frappe.get_list(doctype, filters=filters)),
+        "total_count": frappe.get_list(
+            doctype, filters=filters, fields="count(*) as count"
+        )[0].count,
         "row_count": len(data),
         "group_by_field": group_by_field,
         "view_type": view_type,

--- a/helpdesk/helpdesk/doctype/hd_notification/utils.py
+++ b/helpdesk/helpdesk/doctype/hd_notification/utils.py
@@ -16,7 +16,7 @@ def clear(user: str = None, ticket: str | int = None, comment: str = None):
         filters["reference_ticket"] = ticket
     if comment:
         filters["reference_comment"] = comment
-    for n in frappe.get_all("HD Notification", filters=filters):
-        d = frappe.get_doc("HD Notification", n.name)
-        d.read = True
-        d.save()
+    for notification in frappe.get_all(
+        "HD Notification", filters=filters, pluck="name"
+    ):
+        frappe.db.set_value("HD Notification", notification, "read", 1)

--- a/helpdesk/helpdesk/doctype/hd_ticket/api.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/api.py
@@ -143,6 +143,7 @@ def get_comments(ticket: str):
     )
     for c in comments:
         c.user = get_user_info_for_avatar(c.commented_by)
+        c.attachments = get_attachments("HD Ticket Comment", c.name)
     return comments
 
 


### PR DESCRIPTION
**Issue:**
1. Currently, we use `v-html` for the content box, resulting in an overflow of the ticket like this.
<img width="1384" alt="Screenshot 2025-01-23 at 6 28 59 PM" src="https://github.com/user-attachments/assets/fef7bb27-3aec-43dd-a7c6-b16d50d0d709" />

2. Because of this we can't edit the comment.
3. No attachments are shown in the UI.
4. Make Ticket agent activities typesafe.