### PR TITLE
fix: ignore duplicate while installing HD

### DIFF
--- a/helpdesk/setup/default_template.py
+++ b/helpdesk/setup/default_template.py
@@ -4,6 +4,8 @@ from helpdesk.consts import DEFAULT_TICKET_TEMPLATE
 
 
 def create_default_template():
+    if frappe.db.exists("HD Ticket Template", DEFAULT_TICKET_TEMPLATE):
+        return
     doc = {
         "doctype": "HD Ticket Template",
         "template_name": DEFAULT_TICKET_TEMPLATE,

--- a/helpdesk/setup/install.py
+++ b/helpdesk/setup/install.py
@@ -56,7 +56,8 @@ def add_default_sla():
     add_default_ticket_priorities()
     add_default_holiday_list()
     enable_track_service_level_agreement_in_support_settings()
-
+    if frappe.db.exists("HD Service Level Agreement", "Default"):
+        return
     sla_doc = frappe.new_doc("HD Service Level Agreement")
 
     sla_doc.service_level = "Default"


### PR DESCRIPTION
1. Dont create default SLA & HD Ticket Template, if they already exists while installing Helpdesk