### PR TITLE
fix: read permission on communication for attachments

### DIFF
--- a/helpdesk/patches.txt
+++ b/helpdesk/patches.txt
@@ -19,3 +19,4 @@ helpdesk.helpdesk.doctype.hd_ticket.patches.feedback_in_master
 helpdesk.helpdesk.doctype.hd_ticket.patches.first_responded_on
 helpdesk.patches.update_hd_team_users
 helpdesk.patches.default_article_category #v2
+helpdesk.patches.communication_read_perm_agent

--- a/helpdesk/patches/communication_read_perm_agent.py
+++ b/helpdesk/patches/communication_read_perm_agent.py
@@ -1,0 +1,7 @@
+import frappe
+from frappe.permissions import add_permission
+
+
+def execute():
+    if frappe.db.exists("Role", "Agent"):
+        add_permission("Communication", "Agent", 0)

--- a/helpdesk/setup/install.py
+++ b/helpdesk/setup/install.py
@@ -215,6 +215,7 @@ def update_agent_role_permissions():
         add_permission("File", "Agent", 0)
         add_permission("Contact", "Agent", 0)
         add_permission("Email Account", "Agent", 0)
+        add_permission("Communication", "Agent", 0)
 
 
 def add_default_assignment_rule():


### PR DESCRIPTION
**Issue:**
If a customer attaches file with there email, sometimes the agents are not able to see the attachments

**Reason:**
Agent role does not have read permission on the communication doctype.

**Solution:**
Add perm to read communication while installing Helpdesk, also wrote a patch for the same.