### PR TITLE
feat: arabic support in font

### DIFF
--- a/desk/src/components/CommentBox.vue
+++ b/desk/src/components/CommentBox.vue
@@ -50,7 +50,10 @@
     <div class="rounded bg-gray-50 px-4 py-3">
       <TextEditor
         ref="editorRef"
-        :editor-class="'prose-f shrink  text-p-sm transition-all duration-300 ease-in-out block w-full content'"
+        :editor-class="[
+          'prose-f shrink  text-p-sm transition-all duration-300 ease-in-out block w-full content',
+          getFontFamily(_content),
+        ]"
         :content="_content"
         :editable="editable"
         :bubble-menu="textEditorMenuButtons"
@@ -106,6 +109,7 @@ import {
   createToast,
   textEditorMenuButtons,
   isContentEmpty,
+  getFontFamily,
 } from "@/utils";
 import { AttachmentItem } from "@/components";
 import { useAuthStore } from "@/stores/auth";

--- a/desk/src/components/CommentTextEditor.vue
+++ b/desk/src/components/CommentTextEditor.vue
@@ -6,6 +6,7 @@
       'prose-sm max-w-none',
       editable &&
         'min-h-[7rem] mx-10 max-h-[50vh] overflow-y-auto border-t py-3',
+      getFontFamily(newComment),
     ]"
     :content="newComment"
     :starterkit-options="{ heading: { levels: [2, 3, 4, 5, 6] } }"
@@ -107,7 +108,7 @@ import { AttachmentItem } from "@/components/";
 import { useAgentStore } from "@/stores/agent";
 import { useStorage } from "@vueuse/core";
 import { PreserveVideoControls } from "@/tiptap-extensions";
-import { isContentEmpty, textEditorMenuButtons } from "@/utils";
+import { isContentEmpty, textEditorMenuButtons, getFontFamily } from "@/utils";
 
 const { agents: agentsList } = useAgentStore();
 onMounted(() => {

--- a/desk/src/components/EmailContent.vue
+++ b/desk/src/components/EmailContent.vue
@@ -8,6 +8,7 @@
 
 <script setup>
 import { ref, watch } from "vue";
+import { getFontFamily } from "@/utils";
 
 const props = defineProps({
   content: {
@@ -230,7 +231,7 @@ watch(iframeRef, (iframe) => {
       const emailContent =
         iframe.contentWindow.document.querySelector(".email-content");
       let parent = emailContent.closest("html");
-
+      emailContent.classList.add(getFontFamily(_content.value));
       iframe.style.height = parent.offsetHeight + 1 + "px";
 
       let replyCollapsers = emailContent.querySelectorAll(".replyCollapser");

--- a/desk/src/components/EmailEditor.vue
+++ b/desk/src/components/EmailEditor.vue
@@ -4,6 +4,7 @@
     :editor-class="[
       'prose-sm max-w-none mx-10 max-h-[50vh] overflow-y-auto py-3',
       true && 'min-h-[7rem]',
+      getFontFamily(newEmail),
     ]"
     :content="newEmail"
     :starterkit-options="{ heading: { levels: [2, 3, 4, 5, 6] } }"
@@ -169,6 +170,7 @@ import {
   validateEmail,
   textEditorMenuButtons,
   isContentEmpty,
+  getFontFamily,
 } from "@/utils";
 import {
   MultiSelectInput,

--- a/desk/src/components/TextEditor.vue
+++ b/desk/src/components/TextEditor.vue
@@ -4,7 +4,10 @@
       ref="e"
       :extensions="[PreserveVideoControls]"
       v-bind="$attrs"
-      editor-class="prose-f max-h-64 max-w-none overflow-auto my-4 min-h-[5rem]"
+      :editor-class="[
+        'prose-f max-h-64 max-w-none overflow-auto my-4 min-h-[5rem',
+        getFontFamily(modelValue),
+      ]"
       bubble-menu
       :content="modelValue"
       @change="$emit('update:modelValue', $event)"
@@ -59,6 +62,7 @@ import { TextEditor as FTextEditor, TextEditorFixedMenu } from "frappe-ui";
 import { useAuthStore } from "@/stores/auth";
 import { UserAvatar } from "@/components";
 import { PreserveVideoControls } from "@/tiptap-extensions";
+import { getFontFamily } from "@/utils";
 
 interface P {
   modelValue: string;

--- a/desk/src/components/ticket/TicketAgentActivities.vue
+++ b/desk/src/components/ticket/TicketAgentActivities.vue
@@ -12,14 +12,14 @@
           class="w-full px-3 sm:px-10 grid grid-cols-[30px_minmax(auto,_1fr)] gap-2 sm:gap-4"
         >
           <div
-            class="relative flex justify-center after:absolute after:left-[50%] after:top-0 after:-z-10 after:border-l after:border-gray-200"
+            class="relative flex justify-center after:absolute after:left-[50%] after:top-1 after:-z-10 after:border-l after:border-gray-200"
             :class="[i != activities.length - 1 ? 'after:h-full' : 'after:h-4']"
           >
             <div
               class="z-10 flex h-7 w-7 items-center justify-center rounded-full bg-white"
               :class="[
                 activity.type === 'comment' ? 'mt-0.5' : '',
-                activity.type === 'email' ? 'mt-2' : '',
+                activity.type === 'history' ? 'mt-1' : '',
               ]"
             >
               <Avatar

--- a/desk/src/pages/ticket/TicketAgent.vue
+++ b/desk/src/pages/ticket/TicketAgent.vue
@@ -134,7 +134,6 @@
 <script setup lang="ts">
 import { computed, ref, h, watch, onMounted, onUnmounted, provide } from "vue";
 import { useRoute } from "vue-router";
-import { useStorage } from "@vueuse/core";
 import {
   Breadcrumbs,
   Dropdown,
@@ -192,11 +191,6 @@ const { findView } = useView("HD Ticket");
 
 provide("communicationArea", communicationAreaRef);
 
-let storage = useStorage("ticket_agent", {
-  showAllActivity: true,
-});
-
-const showFullActivity = ref(storage.value.showAllActivity);
 const showAssignmentModal = ref(false);
 const showSubjectDialog = ref(false);
 
@@ -258,13 +252,6 @@ const handleRename = () => {
   showSubjectDialog.value = false;
 };
 
-watch(
-  () => showFullActivity.value,
-  (value) => {
-    storage.value.showAllActivity = value;
-  }
-);
-
 const dropdownOptions = computed(() =>
   ticketStatusStore.options.map((o) => ({
     label: o,
@@ -324,12 +311,6 @@ const activities = computed(() => {
       attachments: comment.attachments,
     };
   });
-
-  if (!showFullActivity.value) {
-    return [...emailProps, ...commentProps].sort(
-      (a, b) => new Date(a.creation) - new Date(b.creation)
-    );
-  }
 
   const historyProps = [...ticket.data.history, ...ticket.data.views].map(
     (h) => {

--- a/desk/src/utils.ts
+++ b/desk/src/utils.ts
@@ -222,7 +222,19 @@ export function formatTimeShort(date: string) {
   return `${diffYears}Y`;
 }
 
-export function hasArabicContent(content: string) {
+function hasArabicContent(content: string) {
   const arabicRegex = /[\u0600-\u06FF]/;
   return arabicRegex.test(content);
+}
+
+export function getFontFamily(content: string) {
+  const langMap = {
+    default: "!font-[InterVar]",
+    arabic: "!font-[system-ui]",
+  };
+  let lang = "default";
+  if (hasArabicContent(content)) {
+    lang = "arabic";
+  }
+  return langMap[lang];
 }

--- a/desk/src/utils.ts
+++ b/desk/src/utils.ts
@@ -28,7 +28,7 @@ export async function copy(s: string) {
       title: "Copied to clipboard",
       icon: "check",
       iconClasses: "text-green-600",
-    }),
+    })
   );
 }
 
@@ -220,4 +220,9 @@ export function formatTimeShort(date: string) {
   if (diffWeeks < 4) return `${diffWeeks} w`;
   if (diffMonths < 12) return `${diffMonths} M`;
   return `${diffYears}Y`;
+}
+
+export function hasArabicContent(content: string) {
+  const arabicRegex = /[\u0600-\u06FF]/;
+  return arabicRegex.test(content);
 }


### PR DESCRIPTION
**Description:**
Currently, we use Inter font in frappe-ui, which doesn't support all characters in Arabic language.

For e.g

Hello in Arabic is "mrhban" which when wrote in Arabic looks like
![image](https://github.com/user-attachments/assets/b9d48274-cca8-4c23-825a-c84606652f55)


But in Inter Font, it looks like:
![image](https://github.com/user-attachments/assets/a5997d8d-0eb0-404d-9610-5649f2ab915a)


The difference is subtle (last character), it is something like: 

The first image is:
Hello

The second image is:
Hellu

We can understand the meaning, but it is incorrect.




**Solution:**

The _Arabic characters fall in the Unicode range 0600 - 06FF_.
We can do a REGEX check against the string to understand whether there is Arabic in the string or not. Using this logic, we return the font family. 



This is used in all the places where we have used the text editor


While writing anything in comments or email the editor detects whether arabic is present or not and changes the font automatically. If arabic is present we return the system's font family

https://github.com/user-attachments/assets/c1d6ca48-36ce-43f0-ad36-1ba8d3cd623d












