### PR TITLE
feat: auto close tickets after n number of days

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+++ b/helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -30,6 +30,9 @@
   "allow_anyone_to_create_tickets",
   "is_feedback_mandatory",
   "auto_update_status",
+  "column_break_iarl",
+  "auto_close_tickets",
+  "auto_close_after_days",
   "workflow_tab",
   "skip_email_workflow",
   "instantly_send_email",
@@ -309,11 +312,29 @@
    "fieldname": "is_feedback_mandatory",
    "fieldtype": "Check",
    "label": "Make feedback mandatory"
+  },
+  {
+   "fieldname": "column_break_iarl",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "auto_close_tickets",
+   "fieldtype": "Check",
+   "label": "Enable auto closing tickets"
+  },
+  {
+   "depends_on": "auto_close_tickets",
+   "fieldname": "auto_close_after_days",
+   "fieldtype": "Int",
+   "label": "Auto-close after (Days)",
+   "mandatory_depends_on": "auto_close_tickets"
   }
  ],
+ "grid_page_length": 50,
  "issingle": 1,
  "links": [],
- "modified": "2024-12-10 14:46:08.764944",
+ "modified": "2025-03-06 17:37:01.084240",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Settings",
@@ -338,6 +359,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+++ b/helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -321,9 +321,10 @@
    "default": "0",
    "fieldname": "auto_close_tickets",
    "fieldtype": "Check",
-   "label": "Enable auto closing tickets"
+   "label": "Automatically Close Tickets"
   },
   {
+   "default": "14",
    "depends_on": "auto_close_tickets",
    "fieldname": "auto_close_after_days",
    "fieldtype": "Int",
@@ -334,7 +335,7 @@
  "grid_page_length": 50,
  "issingle": 1,
  "links": [],
- "modified": "2025-03-06 17:37:01.084240",
+ "modified": "2025-03-06 21:32:47.307901",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Settings",

--- a/helpdesk/helpdesk/doctype/hd_settings/hd_settings.py
+++ b/helpdesk/helpdesk/doctype/hd_settings/hd_settings.py
@@ -5,6 +5,7 @@
 from __future__ import unicode_literals
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists
 from frappe.realtime import get_website_room
@@ -16,6 +17,13 @@ from helpdesk.helpdesk.doctype.hd_ticket.hd_ticket import (
 
 
 class HDSettings(Document):
+    def validate(self):
+        self.validate_auto_close_days()
+
+    def validate_auto_close_days(self):
+        if self.auto_close_tickets and self.auto_close_after_days <= 0:
+            frappe.throw(_("Auto Close Days cannot be negative or zero"))
+
     def get_base_support_rotation(self):
         """Returns the base support rotation rule if it exists, else creats once and returns it"""
 

--- a/helpdesk/helpdesk/doctype/hd_settings/hd_settings.py
+++ b/helpdesk/helpdesk/doctype/hd_settings/hd_settings.py
@@ -22,7 +22,9 @@ class HDSettings(Document):
 
     def validate_auto_close_days(self):
         if self.auto_close_tickets and self.auto_close_after_days <= 0:
-            frappe.throw(_("Auto Close Days cannot be negative or zero"))
+            frappe.throw(
+                _("Day count for auto closing tickets cannot be negative or zero")
+            )
 
     def get_base_support_rotation(self):
         """Returns the base support rotation rule if it exists, else creats once and returns it"""

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -893,7 +893,7 @@ def close_tickets_after_n_days():
         pluck="name",
     )
 
-    frappe.log_error(f"Tickets to close: {tickets_to_close}")
+    frappe.log("Tickets to close: ", tickets_to_close)
 
     # cant do set_value because SLA will not be applied as setting directly to db and doc is not running.
     for ticket in tickets_to_close:

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -893,8 +893,6 @@ def close_tickets_after_n_days():
         pluck="name",
     )
 
-    frappe.log("Tickets to close: ", tickets_to_close)
-
     # cant do set_value because SLA will not be applied as setting directly to db and doc is not running.
     for ticket in tickets_to_close:
         doc = frappe.get_doc("HD Ticket", ticket)

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -872,3 +872,31 @@ def remove_guest_ticket_creation_permission():
 
 
 customer_not_allowed_fields = ["customer"]
+
+
+def close_tickets_after_n_days():
+    if frappe.db.get_single_value("HD Settings", "auto_close_tickets") == 0:
+        return
+
+    days_threshold = frappe.db.get_single_value("HD Settings", "auto_close_after_days")
+
+    tickets_to_close = frappe.get_list(
+        "HD Ticket",
+        filters=[
+            ["status", "=", "Replied"],
+            [
+                "modified",
+                "<",
+                frappe.utils.add_days(frappe.utils.now_datetime(), -days_threshold),
+            ],
+        ],
+        pluck="name",
+    )
+
+    frappe.log_error(f"Tickets to close: {tickets_to_close}")
+
+    # cant do set_value because SLA will not be applied as setting directly to db and doc is not running.
+    for ticket in tickets_to_close:
+        doc = frappe.get_doc("HD Ticket", ticket)
+        doc.status = "Closed"
+        doc.save(ignore_permissions=True)

--- a/helpdesk/hooks.py
+++ b/helpdesk/hooks.py
@@ -23,10 +23,7 @@ after_migrate = [
 ]
 
 scheduler_events = {
-    "all": [
-        "helpdesk.search.build_index_if_not_exists",
-        "helpdesk.helpdesk.doctype.hd_ticket.hd_ticket.close_tickets_after_n_days",
-    ],
+    "all": ["helpdesk.search.build_index_if_not_exists"],
     "daily": [
         "helpdesk.helpdesk.doctype.hd_ticket.hd_ticket.close_tickets_after_n_days"
     ],

--- a/helpdesk/hooks.py
+++ b/helpdesk/hooks.py
@@ -23,7 +23,13 @@ after_migrate = [
 ]
 
 scheduler_events = {
-    "all": ["helpdesk.search.build_index_if_not_exists"],
+    "all": [
+        "helpdesk.search.build_index_if_not_exists",
+        "helpdesk.helpdesk.doctype.hd_ticket.hd_ticket.close_tickets_after_n_days",
+    ],
+    "daily": [
+        "helpdesk.helpdesk.doctype.hd_ticket.hd_ticket.close_tickets_after_n_days"
+    ],
 }
 
 


### PR DESCRIPTION
Scheduler Job which runs every day at midnight and closes all the tickets that are in replied status for more than "n" number of days.

The number of days threshold is taken from HD Settings doctype.

To enable this feature, go to HD Settings > Ticket Tab > click on "Automatically Close Tickets"
Once you click on the setting, the days threshold field (Auto-close after) field will be visible. Here, you can specify the number of days, the default is set to 14 (Days)

![image](https://github.com/user-attachments/assets/25528345-1638-4037-8b9d-2cfd66fad565)


closes: https://github.com/frappe/helpdesk/issues/2210

