### PR TITLE
fix(hdticket): get_list_data returns only the frappe.session.user's tickets

### DIFF
--- a/helpdesk/api/doc.py
+++ b/helpdesk/api/doc.py
@@ -486,7 +486,7 @@ def handle_at_me_support(filters):
             elif "%@me%" in value:
                 index = [i for i, v in enumerate(value) if v == "%@me%"]
                 for i in index:
-                    value[i] = "%" + frappe.session.user + "%"
+                    value[i] = frappe.session.user
         elif value == "@me":
             filters[key] = frappe.session.user
 


### PR DESCRIPTION
get_list_data returns only the frappe.session.user's ticket and not all matching users.
Eg: Now i can see tarun@frappe.io tickets while i am arun@frappe.io
![image](https://github.com/user-attachments/assets/a71c7dd6-5dcd-4162-9d8c-a1d033d574a4)
