### PR TITLE
fix: show correct email

### DIFF
--- a/desk/src/pages/ticket/MobileTicketAgent.vue
+++ b/desk/src/pages/ticket/MobileTicketAgent.vue
@@ -120,6 +120,7 @@
             :to-emails="[ticket.data.raised_by]"
             :cc-emails="[]"
             :bcc-emails="[]"
+            :key="ticket.data?.name"
             @update="
               () => {
                 ticket.reload();

--- a/desk/src/pages/ticket/TicketAgent.vue
+++ b/desk/src/pages/ticket/TicketAgent.vue
@@ -82,6 +82,7 @@
           :to-emails="[ticket.data?.raised_by]"
           :cc-emails="[]"
           :bcc-emails="[]"
+          :key="ticket.data?.name"
           @update="
             () => {
               ticket.reload();


### PR DESCRIPTION
When we navigate to a ticket from Notifications the email shown is wrong, this PR fixes the issue