### PR TITLE
feat(customisation): filters in link field

### DIFF
--- a/desk/src/components/UniInput.vue
+++ b/desk/src/components/UniInput.vue
@@ -43,18 +43,12 @@ const props = defineProps<P>();
 const emit = defineEmits<E>();
 
 const component = computed(() => {
-  if (props.field.fieldname === "priority") {
-    debugger;
-  }
   if (props.field.url_method) {
     return h(Autocomplete, {
       options: apiOptions.data,
     });
   } else if (props.field.fieldtype === "Link" && props.field.options) {
-    console.log(props.field.fieldname);
-    debugger;
     let filters = null;
-
     if (!props.field.link_filters) {
       filters = null;
     }

--- a/desk/src/components/UniInput.vue
+++ b/desk/src/components/UniInput.vue
@@ -19,10 +19,9 @@
 
 <script setup lang="ts">
 import { computed, h } from "vue";
-import { Autocomplete } from "@/components";
+import { Autocomplete, Link } from "@/components";
 import { createResource, FormControl } from "frappe-ui";
 import { Field } from "@/types";
-import SearchComplete from "./SearchComplete.vue";
 
 type Value = string | number | boolean;
 
@@ -44,13 +43,29 @@ const props = defineProps<P>();
 const emit = defineEmits<E>();
 
 const component = computed(() => {
+  if (props.field.fieldname === "priority") {
+    debugger;
+  }
   if (props.field.url_method) {
     return h(Autocomplete, {
       options: apiOptions.data,
     });
   } else if (props.field.fieldtype === "Link" && props.field.options) {
-    return h(SearchComplete, {
+    console.log(props.field.fieldname);
+    debugger;
+    let filters = null;
+
+    if (!props.field.link_filters) {
+      filters = null;
+    }
+    try {
+      filters = JSON.parse(props.field.link_filters);
+    } catch (error) {
+      filters = null;
+    }
+    return h(Link, {
       doctype: props.field.options,
+      filters,
     });
   } else if (props.field.fieldtype === "Select") {
     return h(Autocomplete, {

--- a/desk/src/components/UniInput.vue
+++ b/desk/src/components/UniInput.vue
@@ -54,7 +54,6 @@ const component = computed(() => {
     } catch (error) {
       filters = null;
     }
-    console.log(filters);
     return h(Link, {
       doctype: props.field.options,
       filters,

--- a/desk/src/components/UniInput.vue
+++ b/desk/src/components/UniInput.vue
@@ -49,14 +49,12 @@ const component = computed(() => {
     });
   } else if (props.field.fieldtype === "Link" && props.field.options) {
     let filters = null;
-    if (!props.field.link_filters) {
-      filters = null;
-    }
     try {
       filters = JSON.parse(props.field.link_filters);
     } catch (error) {
       filters = null;
     }
+    console.log(filters);
     return h(Link, {
       doctype: props.field.options,
       filters,

--- a/desk/src/components/ticket/TicketAgentFields.vue
+++ b/desk/src/components/ticket/TicketAgentFields.vue
@@ -29,7 +29,6 @@
           :doctype="o.options"
           :placeholder="o.placeholder"
           @change="update(o.field, $event)"
-          :filters="{ domain: ['!=', 'iftas.io'] }"
         />
         <Autocomplete
           v-else

--- a/desk/src/components/ticket/TicketAgentFields.vue
+++ b/desk/src/components/ticket/TicketAgentFields.vue
@@ -29,6 +29,7 @@
           :doctype="o.options"
           :placeholder="o.placeholder"
           @change="update(o.field, $event)"
+          :filters="{ domain: ['!=', 'iftas.io'] }"
         />
         <Autocomplete
           v-else

--- a/desk/src/types.ts
+++ b/desk/src/types.ts
@@ -133,6 +133,7 @@ export interface Field {
   required: 0 | 1;
   description?: null;
   url_method?: string;
+  link_filters?: string;
 }
 
 export type FieldValue = string | number | boolean;


### PR DESCRIPTION
Apply filters to link field from property setter and custom fields.


https://github.com/user-attachments/assets/c0274778-b34a-4081-837f-a0aad95727de


When we apply a filter in the desk, it gets stored in link_filters docfield.

We can use this field and fetch it in the frontend to apply filters.
