### PR TITLE
fix: ignore validate using doc.flags

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -897,4 +897,6 @@ def close_tickets_after_n_days():
     for ticket in tickets_to_close:
         doc = frappe.get_doc("HD Ticket", ticket)
         doc.status = "Closed"
-        doc.save(ignore_permissions=True, ignore_validations=True)
+        doc.flags.ignore_validate = True
+        doc.save(ignore_permissions=True)
+        doc.flags.ignore_validate = False


### PR DESCRIPTION
Ignore validations while force closing tickets using doc.flags.ignore_validate