### PR TITLE
fix: fetch correct recipient emails when using reply all in ticket

### DIFF
--- a/desk/src/components/EmailArea.vue
+++ b/desk/src/components/EmailArea.vue
@@ -46,7 +46,7 @@
           @click="
             emit('reply', {
               content: content,
-              to: to ?? sender.name,
+              to: sender?.name ?? to,
               cc: cc,
               bcc: bcc,
             })


### PR DESCRIPTION
Fetch correct recipient emails when using reply all in ticket.

Before:

![image](https://github.com/user-attachments/assets/24cf173a-2503-4517-b52c-f05104d93c61)

After:

![image](https://github.com/user-attachments/assets/90331277-2271-43bc-9e8c-6b1b5fa5079a)
