### PR TITLE
feat: ticket description template

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install and Run Pre-commit
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.1
 
       - name: Download Semgrep rules
         run: git clone --depth 1 https://github.com/frappe/semgrep-rules.git frappe-semgrep-rules

--- a/desk/src/components/SearchPopover.vue
+++ b/desk/src/components/SearchPopover.vue
@@ -1,0 +1,63 @@
+<template>
+  <Popover
+    :popover-class="popoverClass.length > 0 ? popoverClass : ''"
+    class="flex w-full"
+  >
+    <template #target="{ open, close }">
+      <div class="flex flex-col gap-1 w-full">
+        <slot name="label"></slot>
+        <FormControl
+          type="text"
+          class="w-full focus:outline-none outline-none border-inherit shadow-none"
+          v-bind="$attrs"
+          v-model="query"
+          @update:model-value="
+				(e:string) => {
+				  if (e.length >= 3) {
+					open();
+				  } else {
+					close();
+				  }
+				}
+			  "
+        >
+          <template #prefix>
+            <Icon icon="lucide:search" class="h-4 w-4 text-gray-500" />
+          </template>
+        </FormControl>
+      </div>
+    </template>
+    <template #body-main>
+      <!-- Searched Articles -->
+      <div class="max-h-[320px] md:max-h-[420px] overflow-scroll flex flex-col">
+        <SearchArticles
+          :query="query"
+          :hideViewAll="true"
+          class="p-3 py-2 border-0 pt-2"
+        />
+      </div>
+    </template>
+  </Popover>
+</template>
+
+<script setup lang="ts">
+import { FormControl, Popover } from "frappe-ui";
+import SearchArticles from "./SearchArticles.vue";
+import { ModelRef } from "vue";
+import { Icon } from "@iconify/vue";
+
+interface P {
+  popoverClass: Array<string>;
+  inputOptions?: Record<string, unknown>;
+}
+
+//   with defaults defineProps []
+const props = withDefaults(defineProps<P>(), {
+  popoverClass: () => [],
+  inputOptions: () => ({}),
+});
+
+const query: ModelRef<string> = defineModel();
+</script>
+
+<style scoped></style>

--- a/desk/src/components/SearchPopover.vue
+++ b/desk/src/components/SearchPopover.vue
@@ -11,15 +11,13 @@
           class="w-full focus:outline-none outline-none border-inherit shadow-none"
           v-bind="$attrs"
           v-model="query"
-          @update:model-value="
-				(e:string) => {
-				  if (e.length >= 3) {
-					open();
-				  } else {
-					close();
-				  }
-				}
-			  "
+          @update:model-value="(e:string)=>{
+            if (e.length >= 3) {
+              open();
+            } else {
+            close();
+            }
+          }"
         >
           <template #prefix>
             <Icon icon="lucide:search" class="h-4 w-4 text-gray-500" />

--- a/desk/src/pages/knowledge-base/KnowledgeBaseCustomer.vue
+++ b/desk/src/pages/knowledge-base/KnowledgeBaseCustomer.vue
@@ -8,48 +8,13 @@
     <div
       class="max-w-4xl 2xl:max-w-5xl pt-4 sm:px-5 w-full flex flex-col gap-4"
     >
-      <Popover
-        :popover-class="['max-w-[310px] md:max-w-[842px] !top-1 ']"
-        class="flex w-full"
-      >
-        <template #target="{ open, close }">
-          <FormControl
-            ref="searchInputRef"
-            type="text"
-            class="w-full focus:outline-none outline-none border-inherit shadow-none"
-            placeholder="Ask a question..."
-            size="md"
-            autofocus
-            autocomplete="off"
-            v-model="query"
-            @update:model-value="
-              (e:string) => {
-                if (e.length >= 3) {
-                  open();
-                } else {
-                  close();
-                }
-              }
-            "
-          >
-            <template #prefix>
-              <Icon icon="lucide:search" class="h-4 w-4 text-gray-500" />
-            </template>
-          </FormControl>
-        </template>
-        <template #body-main>
-          <!-- Searched Articles -->
-          <div
-            class="max-h-[320px] md:max-h-[420px] overflow-scroll flex flex-col"
-          >
-            <SearchArticles
-              :query="query"
-              :hideViewAll="true"
-              class="p-3 py-2 border-0 pt-2"
-            />
-          </div>
-        </template>
-      </Popover>
+      <SearchPopover
+        :popoverClass="['max-w-[310px] md:max-w-[842px] !top-1']"
+        v-model="query"
+        placeholder="Ask a question..."
+        size="md"
+        :autofocus="true"
+      />
 
       <!-- Categories Folder -->
       <section class="flex flex-col gap-3">
@@ -63,15 +28,14 @@
 
 <script setup lang="ts">
 import { ref, onMounted } from "vue";
-import { FormControl, usePageMeta, Popover } from "frappe-ui";
-import { Icon } from "@iconify/vue";
+import { usePageMeta } from "frappe-ui";
+
 import { LayoutHeader } from "@/components";
 import CategoryFolderContainer from "@/components/knowledge-base/CategoryFolderContainer.vue";
-import SearchArticles from "../../components/SearchArticles.vue";
+import SearchPopover from "@/components/SearchPopover.vue";
 import { capture } from "@/telemetry";
 
 const query = ref("");
-const searchInputRef = ref(null);
 
 onMounted(() => {
   capture("kb_customer_page_viewed");

--- a/desk/src/pages/ticket/TicketNew.vue
+++ b/desk/src/pages/ticket/TicketNew.vue
@@ -170,6 +170,8 @@ const template = createResource({
     setupTemplateFields(doc.fields);
   },
   onSuccess: (data) => {
+    console.log(data);
+    description.value = data.description_template || "";
     oldFields = window.structuredClone(data.fields || []);
   },
 });

--- a/desk/src/pages/ticket/TicketNew.vue
+++ b/desk/src/pages/ticket/TicketNew.vue
@@ -173,7 +173,6 @@ const template = createResource({
     setupTemplateFields(doc.fields);
   },
   onSuccess: (data) => {
-    console.log(data);
     description.value = data.description_template || "";
     oldFields = window.structuredClone(data.fields || []);
   },

--- a/desk/src/pages/ticket/TicketNew.vue
+++ b/desk/src/pages/ticket/TicketNew.vue
@@ -35,7 +35,10 @@
         />
       </div>
       <!-- existing fields -->
-      <div class="flex flex-col" :class="subject.length >= 2 && 'gap-5'">
+      <div
+        class="flex flex-col"
+        :class="(subject.length >= 2 || description.length) && 'gap-5'"
+      >
         <div class="flex flex-col gap-2">
           <span class="block text-sm text-gray-700">
             Subject

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -540,6 +540,9 @@ class HDTicket(Document):
         c.ignore_permissions = True
         c.ignore_mandatory = True
         c.save(ignore_permissions=True)
+
+        self.send_email_to_agent(message)
+
         _attachments = self.get("attachments") or attachments or []
         if not len(_attachments):
             return
@@ -555,6 +558,38 @@ class HDTicket(Document):
         )
         for url in file_urls:
             self.attach_file_with_doc("HD Ticket", self.name, url)
+
+        # send email to assigned agents
+
+    def send_email_to_agent(self, message):
+        assigned_agents = self.get_assigned_agents()
+        if not assigned_agents:
+            return
+
+        recipients = [a.get("name") for a in self.get_assigned_agents()]
+
+        args = {
+            "ticket_id": self.name,
+            "ticket_subject": self.subject,
+            "message": message,
+            "priority": self.priority,
+            "raised_by": self.raised_by,
+            "ticket_url": frappe.utils.get_url("/helpdesk/tickets/" + str(self.name)),
+        }
+
+        try:
+            frappe.sendmail(
+                recipients=recipients,
+                subject="Re: " + self.subject,
+                message=message,
+                reference_doctype="HD Ticket",
+                reference_name=self.name,
+                template="new_reply_to_agent",
+                args=args,
+                now=True,
+            )
+        except Exception as e:
+            frappe.throw(_(e))
 
     @frappe.whitelist()
     def mark_seen(self):

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -541,6 +541,7 @@ class HDTicket(Document):
         c.ignore_mandatory = True
         c.save(ignore_permissions=True)
 
+        # send email to assigned agents
         self.send_email_to_agent(message)
 
         _attachments = self.get("attachments") or attachments or []
@@ -558,8 +559,6 @@ class HDTicket(Document):
         )
         for url in file_urls:
             self.attach_file_with_doc("HD Ticket", self.name, url)
-
-        # send email to assigned agents
 
     def send_email_to_agent(self, message):
         assigned_agents = self.get_assigned_agents()

--- a/helpdesk/helpdesk/doctype/hd_ticket_template/api.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket_template/api.py
@@ -16,10 +16,9 @@ DOCTYPE_TICKET = "HD Ticket"
 @frappe.whitelist()
 def get_one(name: str):
     check_permissions(DOCTYPE_TEMPLATE, None)
-    found, about = frappe.get_value(DOCTYPE_TEMPLATE, name, ["name", "about"]) or [
-        None,
-        None,
-    ]
+    found, about, description_template = frappe.get_value(
+        DOCTYPE_TEMPLATE, name, ["name", "about", "description_template"]
+    ) or [None, None, None]
     if not found:
         return {"about": None, "fields": []}
 
@@ -28,6 +27,7 @@ def get_one(name: str):
     return {
         "about": about,
         "fields": fields,
+        "description_template": description_template,
         "_form_script": get_form_script(
             "HD Ticket", apply_on_new_page=True, is_customer_portal=False
         ),

--- a/helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+++ b/helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
@@ -10,7 +10,8 @@
  "field_order": [
   "template_name",
   "about",
-  "fields"
+  "fields",
+  "description_template"
  ],
  "fields": [
   {
@@ -22,7 +23,7 @@
   {
    "fieldname": "about",
    "fieldtype": "Code",
-   "label": "About",
+   "label": "Additional Information",
    "options": "HTML"
   },
   {
@@ -30,11 +31,17 @@
    "fieldtype": "Table",
    "label": "Fields",
    "options": "HD Ticket Template Field"
+  },
+  {
+   "fieldname": "description_template",
+   "fieldtype": "Text Editor",
+   "label": "Description Template"
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-08-02 15:56:25.602767",
+ "modified": "2025-04-16 13:05:11.916581",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Ticket Template",
@@ -75,6 +82,7 @@
    "share": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/helpdesk/templates/emails/new_reply_to_agent.html
+++ b/helpdesk/templates/emails/new_reply_to_agent.html
@@ -1,0 +1,14 @@
+<div>
+  <p>Hello,</p>
+  <p>You have a new reply on the ticket <strong>#{{ ticket_id }}</strong>.</p>
+  <p><strong>Subject:</strong> {{ticket_subject}}</p>
+  <p><strong>Raised By:</strong> {{raised_by}}</p>
+  <p><strong>Priority:</strong> {{priority}}</p>
+
+  <br />
+  <p>
+    You can view and respond to this ticket by
+    <a href="{{ ticket_url }}">clicking here</a>.
+  </p>
+  <p>Regards,<br />Support Team</p>
+</div>


### PR DESCRIPTION
1. Pre-fill description while raising tickets.

In the "HD Ticket Template" doctype a new field is introduced called "description_template".

Here user can write a markdown and this template will be shown while raising the ticket.

Whatever the agent writes here:
<img width="1231" alt="image" src="https://github.com/user-attachments/assets/f7d89f14-d612-4814-9935-8a99c41eb958" />


Gets displayed in the portal while raising the ticket:
<img width="1269" alt="image" src="https://github.com/user-attachments/assets/27e4f30a-be1d-42a4-bccc-46789a65d578" />




2. Send email to the agent when a ticket received a reply