### PR TITLE
Enable Email Forwarding with Attachments in Conversations #2141

### DIFF
--- a/desk/src/components/CommunicationArea.vue
+++ b/desk/src/components/CommunicationArea.vue
@@ -131,6 +131,15 @@ function replyToEmail(data: object) {
   );
 }
 
+function forwardEmail(data: object) {
+  showEmailBox.value = true;
+  emailEditorRef.value.addToForward(
+    data.content,
+    data.subject,
+    data.attachments
+  );
+}
+
 const props = defineProps({
   doctype: {
     type: String,
@@ -152,6 +161,7 @@ const props = defineProps({
 
 defineExpose({
   replyToEmail,
+  forwardEmail,
   toggleEmailBox,
   toggleCommentBox,
   editor: emailEditorRef,

--- a/desk/src/components/EmailArea.vue
+++ b/desk/src/components/EmailArea.vue
@@ -69,6 +69,18 @@
               icon: LucideSplit,
               onClick: () => (showSplitModal = true),
             },
+            {
+              label: 'Forward',
+              icon: ForwardIcon,
+              onClick: () => emit('forward', {
+                content: content,
+                attachments: attachments,
+                subject: subject,
+                to: sender?.name ?? to,
+                cc: cc,
+                bcc: bcc,
+              }),
+            },
           ]"
         >
           <Button
@@ -115,8 +127,8 @@
 import { ref } from "vue";
 import { AttachmentItem } from "@/components";
 import { dateFormat, timeAgo, dateTooltipFormat } from "@/utils";
-import { ReplyIcon, ReplyAllIcon } from "./icons";
 import LucideSplit from "~icons/lucide/split";
+import { ReplyIcon, ReplyAllIcon, ForwardIcon } from "./icons";
 import { useScreenSize } from "@/composables/screen";
 import TicketSplitModal from "./ticket/TicketSplitModal.vue";
 
@@ -134,7 +146,7 @@ const props = defineProps({
 const { sender, to, cc, bcc, creation, subject, attachments, content, name } =
   props.activity;
 
-const emit = defineEmits(["reply"]);
+const emit = defineEmits(["reply","forward"]);
 
 const { isMobileView } = useScreenSize();
 

--- a/desk/src/components/EmailEditor.vue
+++ b/desk/src/components/EmailEditor.vue
@@ -297,6 +297,20 @@ function addToReply(
     .run();
 }
 
+function addToForward(body: string, subject: string, _attachments: any[]) {
+  newEmail.value = body;
+  attachments.value = _attachments;
+  editorRef.value.editor
+    .chain()
+    .clearContent()
+    .insertContent(body)
+    .focus("all")
+    // .setBlockquote()
+    .insertContentAt(0, { type: "paragraph" })
+    .focus("start")
+    .run();
+}
+
 function resetState() {
   newEmail.value = null;
   attachments.value = [];
@@ -321,6 +335,7 @@ const editor = computed(() => {
 
 defineExpose({
   addToReply,
+  addToForward,
   editor,
   submitMail,
 });

--- a/desk/src/components/icons/ForwardIcon.vue
+++ b/desk/src/components/icons/ForwardIcon.vue
@@ -1,0 +1,17 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="lucide lucide-forward"
+  >
+    <polyline points="15 17 20 12 15 7"></polyline>
+    <path d="M4 18v-2a4 4 0 0 1 4-4h12"></path>
+  </svg>
+</template>

--- a/desk/src/components/icons/index.ts
+++ b/desk/src/components/icons/index.ts
@@ -27,3 +27,4 @@ export { default as OrganizationsIcon } from "./OrganizationsIcon.vue";
 export { default as UnpinIcon } from "./UnpinIcon.vue";
 export { default as PinIcon } from "./PinIcon.vue";
 export { default as FrappeCloudIcon } from "./FrappeCloudIcon.vue";
+export { default as ForwardIcon } from './ForwardIcon.vue';

--- a/desk/src/components/ticket/TicketAgentActivities.vue
+++ b/desk/src/components/ticket/TicketAgentActivities.vue
@@ -45,6 +45,7 @@
               "
               class="py-2 px-3"
               @reply="(e) => emit('email:reply', e)"
+              @forward="(e) => emit('email:forward', e)"
             />
             <CommentBox
               v-else-if="activity.type === 'comment'"
@@ -106,7 +107,7 @@ const props = defineProps({
   },
 });
 
-const emit = defineEmits(["email:reply", "update"]);
+const emit = defineEmits(["email:reply", "email:forward", "update"]);
 
 const { getUser } = useUserStore();
 const communicationAreaRef: Ref = inject("communicationArea");

--- a/desk/src/pages/ticket/MobileTicketAgent.vue
+++ b/desk/src/pages/ticket/MobileTicketAgent.vue
@@ -103,6 +103,11 @@
                     communicationAreaRef.replyToEmail(e);
                   }
                 "
+                @email:forward="
+                  (e) => {
+                    communicationAreaRef.forwardEmail(e);
+                  }
+                "
               />
             </TabPanel>
           </Tabs>

--- a/desk/src/pages/ticket/TicketAgent.vue
+++ b/desk/src/pages/ticket/TicketAgent.vue
@@ -73,6 +73,11 @@
                     communicationAreaRef.replyToEmail(e);
                   }
                 "
+                @email:forward="
+                  (e) => {
+                    communicationAreaRef.forwardEmail(e);
+                  }
+                "
               />
             </TabPanel>
           </Tabs>


### PR DESCRIPTION
This PR adds functionality to forward email conversations along with their original attachments directly from the Helpdesk interface. It streamlines communication with external collaborators and addresses the limitations highlighted in issue #2141.​