### PR TITLE
fix: only apply team restrictions on the agent side

### DIFF
--- a/helpdesk/api/doc.py
+++ b/helpdesk/api/doc.py
@@ -37,7 +37,7 @@ def get_list_data(
 
     handle_at_me_support(filters)
 
-    if doctype == "HD Ticket":
+    if doctype == "HD Ticket" and not show_customer_portal_fields:
         handle_team_restrictions(filters)
 
     _list = get_controller(doctype)


### PR DESCRIPTION
**Issue:**
Ticket restrictions based on teams are currently applied to agents and the Customer Portal. As a result, customers may see incorrect or incomplete ticket data on the portal.

**Solution:**
Apply the team restrictions code only on the Agent Portal.