### PR TITLE
fix: on ticket reload customActions disapper

### DIFF
--- a/desk/src/composables/formCustomisation.ts
+++ b/desk/src/composables/formCustomisation.ts
@@ -1,6 +1,8 @@
 import { Field } from "@/types";
 
-export async function setupCustomizations(data, obj) {
+export async function setupCustomizations(doc, obj) {
+  let data = doc?.data;
+  if (!data) return;
   if (!data._form_script) return [];
   let actions = [];
   let onChangeFieldMap = {};

--- a/desk/src/pages/ticket/TicketAgent.vue
+++ b/desk/src/pages/ticket/TicketAgent.vue
@@ -222,16 +222,17 @@ const ticket = createResource({
     }
     renameSubject.value = data.subject;
   },
-  onSuccess: (ticket) => {
-    document.title = ticket.subject;
+  onSuccess: (data) => {
+    document.title = data.subject;
     setupCustomizations(ticket, {
-      doc: ticket,
+      doc: data,
       call,
       router,
       $dialog,
       updateField,
       createToast,
     });
+    // console.log(ticket._customActions);
   },
 });
 function updateField(name: string, value: string, callback = () => {}) {
@@ -277,6 +278,15 @@ const dropdownOptions = computed(() =>
       }),
   }))
 );
+
+// watch(
+//   () => ticket.data,
+//   (val) => {
+//     console.log("CUSTOM ACTIONSSS");
+//     // console.log(val._customActions);
+//   },
+//   { deep: true }
+// );
 
 const tabIndex = ref(0);
 const tabs: TabObject[] = [

--- a/desk/src/pages/ticket/TicketCustomer.vue
+++ b/desk/src/pages/ticket/TicketCustomer.vue
@@ -95,7 +95,7 @@ const ticket = useTicket(
   true,
   null,
   (data) => {
-    setupCustomizations(data, {
+    setupCustomizations(ticket, {
       doc: data,
       call,
       router,

--- a/desk/src/pages/ticket/TicketNew.vue
+++ b/desk/src/pages/ticket/TicketNew.vue
@@ -162,19 +162,17 @@ const template = createResource({
     name: props.templateId || "Default",
   }),
   auto: true,
-  transform: (doc) => {
-    setupCustomizations(doc, {
+  onSuccess: (data) => {
+    description.value = data.description_template || "";
+    oldFields = window.structuredClone(data.fields || []);
+    setupCustomizations(template, {
       doc: templateFields,
       call,
       router,
       $dialog,
       applyFilters,
     });
-    setupTemplateFields(doc.fields);
-  },
-  onSuccess: (data) => {
-    description.value = data.description_template || "";
-    oldFields = window.structuredClone(data.fields || []);
+    setupTemplateFields(data.fields);
   },
 });
 


### PR DESCRIPTION
Whenever the ticket reloads, the CustomActions disappear automatically. 

The object reference wasn't being passed properly.