### PR TITLE
fix: use make method for mail tickets

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -5,6 +5,7 @@ from typing import List
 
 import frappe
 from frappe import _
+from frappe.core.doctype.communication.email import make as make_email
 from frappe.core.page.permission_manager.permission_manager import remove
 from frappe.desk.form.assign_to import add as assign
 from frappe.desk.form.assign_to import clear as clear_all_assignments
@@ -438,6 +439,23 @@ class HDTicket(Document):
         if recipients == "Administrator":
             admin_email = frappe.get_value("User", "Administrator", "email")
             recipients = admin_email
+
+        if not self.via_customer_portal:
+            make_email(
+                recipients=recipients,
+                attachments=attachments,
+                bcc=bcc,
+                cc=cc,
+                subject=subject,
+                content=message,
+                doctype="HD Ticket",
+                name=self.name,
+                send_email=True,
+                sender=sender,
+                has_attachments=1 if attachments else 0,
+            )
+            capture_event("agent_replied_to_email_ticket")
+            return
 
         communication = frappe.get_doc(
             {


### PR DESCRIPTION
**Issue:**
When the source of the ticket is Email, the images sent by the agent are not shown in the email.
This is because the images are directly sent in base64 encoding in the markdown syntax.

**Solution**
Using `make` function from the "Communication" doctype to handle tickets created via emails