### PR TITLE
fix: email threading

### DIFF
--- a/desk/src/components/Settings/EmailEdit.vue
+++ b/desk/src/components/Settings/EmailEdit.vue
@@ -74,10 +74,12 @@
           :loading="loading"
         />
         <Button
+          v-if="accountData.enable_incoming"
           label="Pull Emails"
           variant="subtle"
           @click="pullEmails"
           :loading="loadingPull"
+          :disabled="loading"
         />
       </div>
     </div>

--- a/desk/src/pages/ticket/TicketNew.vue
+++ b/desk/src/pages/ticket/TicketNew.vue
@@ -244,13 +244,14 @@ const ticket = createResource({
         ticketId: data.name,
       },
     });
-    updateOnboardingStep("create_first_ticket", true, false, () =>
-      localStorage.setItem("firstTicket", data.name)
-    );
 
+    if (!isCustomerPortal.value) {
+      updateOnboardingStep("create_first_ticket", true, false, () =>
+        localStorage.setItem("firstTicket", data.name)
+      );
+      return;
+    }
     // only capture telemetry for customer portal
-    if (!isCustomerPortal.value) return;
-
     capture("new_ticket_submitted", {
       data: {
         user: userID,

--- a/desk/src/pages/ticket/Tickets.vue
+++ b/desk/src/pages/ticket/Tickets.vue
@@ -90,7 +90,7 @@ const {
   deleteView,
 } = useView("HD Ticket");
 
-const { $dialog } = globalStore();
+const { $dialog, $socket } = globalStore();
 const { isManager } = useAuthStore();
 
 const listViewRef = ref(null);
@@ -546,6 +546,9 @@ onMounted(() => {
       icon: "lucide:align-justify",
     };
   }
+  $socket.on("helpdesk:new-ticket", () => {
+    listViewRef.value?.reload();
+  });
 });
 usePageMeta(() => {
   return {

--- a/desk/src/router/index.ts
+++ b/desk/src/router/index.ts
@@ -221,7 +221,6 @@ router.beforeEach(async (to, _, next) => {
 });
 
 router.afterEach(async (to) => {
-  console.log(to.meta);
   if (to.meta.public) return;
   const userStore = useUserStore();
   await userStore.users.fetch();

--- a/desk/src/router/index.ts
+++ b/desk/src/router/index.ts
@@ -1,8 +1,8 @@
-import { createRouter, createWebHistory } from "vue-router";
+import { useScreenSize } from "@/composables/screen";
 import { useAuthStore } from "@/stores/auth";
 import { useUserStore } from "@/stores/user";
 import { isCustomerPortal } from "@/utils";
-import { useScreenSize } from "@/composables/screen";
+import { createRouter, createWebHistory } from "vue-router";
 const { isMobileView } = useScreenSize();
 
 export const AGENT_PORTAL_AGENT_LIST = "AgentList";
@@ -221,6 +221,7 @@ router.beforeEach(async (to, _, next) => {
 });
 
 router.afterEach(async (to) => {
+  console.log(to.meta);
   if (to.meta.public) return;
   const userStore = useUserStore();
   await userStore.users.fetch();

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -438,7 +438,7 @@
  "icon": "fa fa-issue",
  "idx": 61,
  "links": [],
- "modified": "2025-04-09 20:44:24.252633",
+ "modified": "2025-05-19 10:53:38.184632",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Ticket",

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -427,7 +427,7 @@ class HDTicket(Document):
     ):
         skip_email_workflow = self.skip_email_workflow()
         medium = "" if skip_email_workflow else "Email"
-        subject = f"Re:[## {self.name} ##] {self.subject}"
+        subject = f"Re: {self.subject}"
         sender = frappe.session.user
         recipients = to or self.raised_by
         sender_email = None if skip_email_workflow else self.sender_email()
@@ -548,7 +548,7 @@ class HDTicket(Document):
         c.communication_medium = "Email"
         c.sent_or_received = "Received"
         c.email_status = "Open"
-        c.subject = f"Re:[## {self.name} ##] {self.subject}"
+        c.subject = f"Re: {self.subject}"
         c.sender = frappe.session.user
         c.content = message
         c.status = "Linked"
@@ -593,7 +593,7 @@ class HDTicket(Document):
         try:
             frappe.sendmail(
                 recipients=recipients,
-                subject=f"Re:[## {self.name} ##] {self.subject}",
+                subject=f"Re: {self.subject} - #{self.name}",
                 message=message,
                 reference_doctype="HD Ticket",
                 reference_name=self.name,

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -426,6 +426,7 @@ class HDTicket(Document):
         skip_email_workflow = self.skip_email_workflow()
         medium = "" if skip_email_workflow else "Email"
         subject = f"Re:[## {self.name} ##] {self.subject}"
+        # subject = self.subject
         sender = frappe.session.user
         recipients = to or self.raised_by
         sender_email = None if skip_email_workflow else self.sender_email()
@@ -439,22 +440,30 @@ class HDTicket(Document):
             admin_email = frappe.get_value("User", "Administrator", "email")
             recipients = admin_email
 
-        if not self.via_customer_portal:
-            make_email(
-                recipients=recipients,
-                attachments=attachments,
-                bcc=bcc,
-                cc=cc,
-                subject=subject,
-                content=message,
-                doctype="HD Ticket",
-                name=self.name,
-                send_email=True,
-                sender=sender,
-                has_attachments=1 if attachments else 0,
-            )
-            capture_event("agent_replied_to_email_ticket")
-            return
+        # if not self.via_customer_portal:
+        #     frappe.sendmail(
+        #         recipients=recipients,
+        #         subject=subject,
+        #         message=message,
+        #         reference_doctype="HD Ticket",
+        #         reference_name=self.name,
+        #     )
+        #     make_email(
+        #         recipients=recipients,
+        #         attachments=attachments,
+        #         bcc=bcc,
+        #         cc=cc,
+        #         subject=subject,
+        #         content=message,
+        #         doctype="HD Ticket",
+        #         name=self.name,
+        #         send_email=True,
+        #         sender=sender,
+        #         has_attachments=1 if attachments else 0,
+        #         message_id=last_communication.name
+        #     )
+        #     capture_event("agent_replied_to_email_ticket")
+        #     return
 
         communication = frappe.get_doc(
             {
@@ -533,6 +542,7 @@ class HDTicket(Document):
                 subject=subject,
                 template=template,
                 with_container=False,
+                message_id=last_communication.name,
             )
         except Exception as e:
             frappe.throw(_(e))

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -5,7 +5,6 @@ from typing import List
 
 import frappe
 from frappe import _
-from frappe.core.doctype.communication.email import make as make_email
 from frappe.core.page.permission_manager.permission_manager import remove
 from frappe.desk.form.assign_to import add as assign
 from frappe.desk.form.assign_to import clear as clear_all_assignments
@@ -429,7 +428,6 @@ class HDTicket(Document):
         skip_email_workflow = self.skip_email_workflow()
         medium = "" if skip_email_workflow else "Email"
         subject = f"Re:[## {self.name} ##] {self.subject}"
-        # subject = self.subject
         sender = frappe.session.user
         recipients = to or self.raised_by
         sender_email = None if skip_email_workflow else self.sender_email()
@@ -442,31 +440,6 @@ class HDTicket(Document):
         if recipients == "Administrator":
             admin_email = frappe.get_value("User", "Administrator", "email")
             recipients = admin_email
-
-        # if not self.via_customer_portal:
-        #     frappe.sendmail(
-        #         recipients=recipients,
-        #         subject=subject,
-        #         message=message,
-        #         reference_doctype="HD Ticket",
-        #         reference_name=self.name,
-        #     )
-        #     make_email(
-        #         recipients=recipients,
-        #         attachments=attachments,
-        #         bcc=bcc,
-        #         cc=cc,
-        #         subject=subject,
-        #         content=message,
-        #         doctype="HD Ticket",
-        #         name=self.name,
-        #         send_email=True,
-        #         sender=sender,
-        #         has_attachments=1 if attachments else 0,
-        #         message_id=last_communication.name
-        #     )
-        #     capture_event("agent_replied_to_email_ticket")
-        #     return
 
         communication = frappe.get_doc(
             {
@@ -634,27 +607,28 @@ class HDTicket(Document):
     def send_acknowledgement_email(self):
 
         message = f"""
-            <p>Hello,</p>
+            <p>Hi,</p>
             <br />
-            <p>Thank you for reaching out to us.</p>
+            <p>Thank you for reaching out to us. We've received your request and created a support ticket.</p>
             <p>
-            We are writing to confirm that we have received your request. A support ticket has been created with the following ID: <strong>{self.name}</strong>, and the subject: <strong>{self.subject}</strong>.
-            Please reference this ID in any future correspondence related to this matter.
+            <strong>Ticket ID:</strong> {self.name}<br />
+            <strong>Subject:</strong> {self.subject}<br />
             </p>
             <p>
-            One of our support agents is currently reviewing your issue and will get back to you as soon as possible with an update or resolution.
+            Our team is reviewing it and will get back to you shortly.
             </p>
             <br />
-            <p>Best regards,<br />Support Team</p>
+            <p>Best,<br />Support Team</p>
         """
 
         frappe.sendmail(
             recipients=[self.raised_by],
-            subject=f"[## {self.name} ##] Your Ticket has been created",
+            subject=f"Ticket #{self.name}: We've received your request",
             message=message,
             reference_doctype="HD Ticket",
             reference_name=self.name,
             now=True,
+            expose_recipients="header",
         )
 
     @frappe.whitelist()

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -484,6 +484,9 @@ class HDTicket(Document):
                 "subject": subject,
             }
         )
+        if last_communication and last_communication.name:
+            communication.in_reply_to = last_communication.name
+            communication.message_id = last_communication.name
 
         communication.insert(ignore_permissions=True)
         capture_event("agent_replied")
@@ -543,6 +546,7 @@ class HDTicket(Document):
                 template=template,
                 with_container=False,
                 message_id=last_communication.name,
+                in_reply_to=last_communication.name,
             )
         except Exception as e:
             frappe.throw(_(e))

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -44,7 +44,6 @@ class HDTicket(Document):
         return "{0}: {1}".format(_(self.status), self.subject)
 
     def before_validate(self):
-        self.reply_subject = f"Re:[## {self.name} ##] {self.subject}"
         self.check_update_perms()
         self.set_ticket_type()
         self.set_raised_by()
@@ -426,7 +425,7 @@ class HDTicket(Document):
     ):
         skip_email_workflow = self.skip_email_workflow()
         medium = "" if skip_email_workflow else "Email"
-        subject = self.reply_subject
+        subject = f"Re:[## {self.name} ##] {self.subject}"
         sender = frappe.session.user
         recipients = to or self.raised_by
         sender_email = None if skip_email_workflow else self.sender_email()
@@ -558,7 +557,7 @@ class HDTicket(Document):
         c.communication_medium = "Email"
         c.sent_or_received = "Received"
         c.email_status = "Open"
-        c.subject = self.reply_subject
+        c.subject = f"Re:[## {self.name} ##] {self.subject}"
         c.sender = frappe.session.user
         c.content = message
         c.status = "Linked"
@@ -603,7 +602,7 @@ class HDTicket(Document):
         try:
             frappe.sendmail(
                 recipients=recipients,
-                subject=self.reply_subject,
+                subject=f"Re:[## {self.name} ##] {self.subject}",
                 message=message,
                 reference_doctype="HD Ticket",
                 reference_name=self.name,

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -484,9 +484,9 @@ class HDTicket(Document):
                 "subject": subject,
             }
         )
-        if last_communication and last_communication.name:
+        if last_communication and last_communication.message_id:
             communication.in_reply_to = last_communication.name
-            communication.message_id = last_communication.name
+            communication.message_id = last_communication.message_id
 
         communication.insert(ignore_permissions=True)
         capture_event("agent_replied")
@@ -545,8 +545,8 @@ class HDTicket(Document):
                 subject=subject,
                 template=template,
                 with_container=False,
-                message_id=last_communication.name,
                 in_reply_to=last_communication.name,
+                message_id=last_communication.message_id,
             )
         except Exception as e:
             frappe.throw(_(e))


### PR DESCRIPTION
**Issue:**
1. Emails are not threaded for the tickets that are created via "Mail", which causes issues in understanding the context
2. No acknowledgement email is sent to the tickets that are created via "Mail"
3. To pull the latest Emails, we have to go to the desk and click on the "Pull Emails" button to get them

**Solution:**
1. Emails are now threaded using "message id" & "in_reply_to" headers for the related emails, only for tickets created via email.
2. Acknowledgement email is sent
<img width="1194" alt="image" src="https://github.com/user-attachments/assets/529c7a74-3d34-4ee5-8ccf-e5fe6e446aaf" />


3. Pull Emails button is now present on the Frontend
<img width="1440" alt="Screenshot 2025-05-18 at 10 11 59 PM" src="https://github.com/user-attachments/assets/70cefcad-ff6d-4dae-b0f6-e0fabe41ef72" />
