### PR TITLE
fix: don't use message-id to send mails

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -462,7 +462,6 @@ class HDTicket(Document):
         )
         if last_communication and last_communication.message_id:
             communication.in_reply_to = last_communication.name
-            communication.message_id = last_communication.message_id
 
         communication.insert(ignore_permissions=True)
         capture_event("agent_replied")
@@ -523,7 +522,6 @@ class HDTicket(Document):
                 template=template,
                 with_container=False,
                 in_reply_to=last_communication.name,
-                message_id=last_communication.message_id,
             )
         except Exception as e:
             frappe.throw(_(e))


### PR DESCRIPTION
**Issue:**
When an agent replies to a ticket, we use `frappe.sendmail`, and to initiate the threading we set the `message_id` in the communication document, which is a wrong thing to do since it is unique and is generated automatically. 

**Solution:**
Don't send `message_id` in the params, only send the `in_reply_to` param in `frappe.sendmail`


Related: https://github.com/frappe/frappe/pull/32651