### PR TITLE
fix: redis requires schema for uri with bench set command

### DIFF
--- a/docker/init.sh
+++ b/docker/init.sh
@@ -14,9 +14,9 @@ cd frappe-bench
 
 # Use containers instead of localhost
 bench set-mariadb-host mariadb
-bench set-redis-cache-host redis:6379
-bench set-redis-queue-host redis:6379
-bench set-redis-socketio-host redis:6379
+bench set-redis-cache-host redis://redis:6379
+bench set-redis-queue-host redis://redis:6379
+bench set-redis-socketio-host redis://redis:6379
 
 # Remove redis, watch from Procfile
 sed -i '/redis/d' ./Procfile


### PR DESCRIPTION
Will not work unless Schema is specified