### PR TITLE
fix: return agent name instead of agent doc while finding assigned agents

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -319,10 +319,7 @@ class HDTicket(Document):
         assignees = get_assignees({"doctype": "HD Ticket", "name": self.name})
         if len(assignees) > 0:
             # TODO: temporary fix, remove this when only agents can be assigned to ticket
-            exists = frappe.db.exists("HD Agent", assignees[0].owner)
-            if exists:
-                agent_doc = frappe.get_doc("HD Agent", assignees[0].owner)
-                return agent_doc
+            return frappe.db.exists("HD Agent", assignees[0].owner)
 
         return None
 


### PR DESCRIPTION
We return the Agent doc instead of the agent name while getting the current assigned agents of the "agent_group".

This causes an error because

```
frappe.db.exists(
            "HD Team Member",
            {
                "parent": team,
                "user": agent,
            },
        )
```
this code takes `agent` name instead of agent doc, hence if agent doc is passed we get an SQL error operation

