### PR TITLE
fix: add modelValue to data fields

### DIFF
--- a/desk/src/components/UniInput2.vue
+++ b/desk/src/components/UniInput2.vue
@@ -14,7 +14,7 @@
         :key="field.fieldname"
         class="form-control"
         :placeholder="`Add ${field.label}`"
-        :value="transValue"
+        :model-value="transValue"
         autocomplete="off"
         v-on="
           textFields.includes(field.fieldtype)
@@ -38,10 +38,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, h } from "vue";
 import { Autocomplete, Link } from "@/components";
-import { createResource, FormControl, Tooltip } from "frappe-ui";
 import { Field, FieldValue } from "@/types";
+import { createResource, FormControl, Tooltip } from "frappe-ui";
+import { computed, h } from "vue";
 
 interface P {
   field: Field;

--- a/desk/src/components/ticket/TicketAgentSidebar.vue
+++ b/desk/src/components/ticket/TicketAgentSidebar.vue
@@ -3,7 +3,9 @@
     <div
       class="flex h-10.5 items-center border-b px-5 py-2.5 text-lg font-medium text-ink-gray-9 justify-between"
     >
-      <span class="cursor-copy text-lg font-semibold" @click="copyToClipboard()"
+      <span
+        class="cursor-copy text-lg font-semibold"
+        @click="copyToClipboard(`'${ticket.name}' copied to clipboard`)"
         >#{{ ticket.name }}
       </span>
       <Dropdown

--- a/desk/src/utils.ts
+++ b/desk/src/utils.ts
@@ -85,8 +85,8 @@ export function formatTime(seconds) {
 
 export const isCustomerPortal = ref(false);
 
-export async function copyToClipboard() {
-  let text = "Copied to clipboard";
+export async function copyToClipboard(msg: string = "") {
+  let text = msg || "Copied to clipboard";
   if (navigator.clipboard && window.isSecureContext) {
     await navigator.clipboard.writeText(text);
   } else {


### PR DESCRIPTION
After updating frappe-ui to 0.1.150,
all the data fields requires "modelValue" instead of "value" because "v-model" was introduced in this PR 
https://github.com/frappe/frappe-ui/pull/305/files

Changed ":value" prop to ":model-value"