### PR TITLE
fix: revert redis

### DIFF
--- a/helpdesk/search.py
+++ b/helpdesk/search.py
@@ -16,7 +16,7 @@ from frappe.utils import cstr, strip_html_tags, update_progress_bar
 from frappe.utils.caching import redis_cache
 from frappe.utils.synchronization import filelock
 from redis.commands.search.field import TagField, TextField
-from redis.commands.search.index_definition import IndexDefinition
+from redis.commands.search.indexDefinition import IndexDefinition
 from redis.commands.search.query import Query
 from redis.exceptions import ResponseError
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,4 +16,4 @@ requires = ["flit_core >=3.4,<4"]
 build-backend = "flit_core.buildapi"
 
 [tool.bench.frappe-dependencies]
-frappe = ">=16.0.0-dev,<17.0.0"
+frappe = ">=15.40.4,<16.0.0"


### PR DESCRIPTION
Use Redis 5.2.0 syntax and fixate frappe version in pyproject.toml