### PR TITLE
fix(search): Update search args for redis 6.x

### DIFF
--- a/helpdesk/hooks.py
+++ b/helpdesk/hooks.py
@@ -24,8 +24,10 @@ after_migrate = [
 ]
 
 scheduler_events = {
-    "all": ["helpdesk.search.build_index_if_not_exists"],
-    "hourly": ["helpdesk.search.download_corpus"],
+    "all": [
+        "helpdesk.search.build_index_if_not_exists",
+        "helpdesk.search.download_corpus",
+    ],
     "daily": [
         "helpdesk.helpdesk.doctype.hd_ticket.hd_ticket.close_tickets_after_n_days"
     ],

--- a/helpdesk/search.py
+++ b/helpdesk/search.py
@@ -161,6 +161,7 @@ class Search:
         query.summarize(fields=["description"])
         query.scorer("DISMAX")
         query.with_scores()
+        query.dialect(None)
 
         try:
             result = self.redis.ft(self.index_name).search(query)

--- a/helpdesk/search.py
+++ b/helpdesk/search.py
@@ -379,7 +379,7 @@ def search(query, only_articles=False) -> list[dict[str, list[dict]]]:
 
 
 @frappe.whitelist()
-@filelock("helpdesk_search_indexing", timeout=60)
+@filelock("helpdesk_search_indexing", timeout=1)
 def build_index():
     frappe.cache().set_value("helpdesk_search_indexing_in_progress", True)
     search = HelpdeskSearch()
@@ -398,7 +398,7 @@ def build_index_if_not_exists():
         build_index()
 
 
-@filelock("helpdesk_corpus_download", timeout=60)
+@filelock("helpdesk_corpus_download", timeout=1, is_global=True)
 def download_corpus():
     from nltk import data, download
 


### PR DESCRIPTION
- **fix(search): Better filelock args**
- **fix(search): Set dialect to None so arg is not passed to search**
