### PR TITLE
fix(dashboard): include today's date & change feedback value logic

### DIFF
--- a/desk/src/pages/dashboard/Dashboard.vue
+++ b/desk/src/pages/dashboard/Dashboard.vue
@@ -84,12 +84,16 @@
           class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4"
           v-if="!numberCards.loading"
         >
-          <NumberChart
+          <Tooltip
             v-for="(config, index) in numberCards.data"
-            :key="index"
-            class="border rounded-md"
-            :config="config"
-          />
+            :text="config.tooltip"
+          >
+            <NumberChart
+              :key="index"
+              class="border rounded-md"
+              :config="config"
+            />
+          </Tooltip>
         </div>
         <!-- Trend Charts -->
         <div
@@ -140,6 +144,7 @@ import {
   DonutChart,
   Dropdown,
   NumberChart,
+  Tooltip,
   usePageMeta,
 } from "frappe-ui";
 import { computed, h, onMounted, reactive, ref, watch } from "vue";

--- a/helpdesk/api/dashboard.py
+++ b/helpdesk/api/dashboard.py
@@ -7,8 +7,6 @@ from helpdesk.utils import agent_only
 @frappe.whitelist()
 @agent_only
 def get_dashboard_data(dashboard_type, filters=None):
-    # TODO:
-    #   3. Tooltip
     """
     Get dashboard data based on the type and date range.
     """
@@ -498,17 +496,17 @@ def get_ticket_trend_data(from_date, to_date, conds=""):
     """
     result = frappe.db.sql(
         f"""
-        SELECT 
-            DATE(creation) as date,
-            COUNT(CASE WHEN status = 'Open' THEN name END) as open,
-            COUNT(CASE WHEN status IN ('Resolved', 'Closed') THEN name END) as closed,
-            COUNT(CASE WHEN agreement_status = 'Fulfilled' THEN name END) as SLA_fulfilled
-        FROM `tabHD Ticket`
-        WHERE creation > %(from_date)s AND creation < DATE_ADD(%(to_date)s, INTERVAL 1 DAY)
-        {conds}
-        GROUP BY DATE(creation)
-        ORDER BY DATE(creation)
-    """,
+            SELECT 
+                DATE(creation) as date,
+                COUNT(CASE WHEN status = 'Open' THEN name END) as open,
+                COUNT(CASE WHEN status IN ('Resolved', 'Closed') THEN name END) as closed,
+                COUNT(CASE WHEN agreement_status = 'Fulfilled' THEN name END) as SLA_fulfilled
+            FROM `tabHD Ticket`
+            WHERE creation > %(from_date)s AND creation < DATE_ADD(%(to_date)s, INTERVAL 1 DAY)
+            {conds}
+            GROUP BY DATE(creation)
+            ORDER BY DATE(creation)
+        """,
         {
             "from_date": from_date,
             "to_date": to_date,

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -161,12 +161,12 @@ class HDTicket(Document):
         old_status = (
             self.get_doc_before_save().status if self.get_doc_before_save() else None
         )
-        is_closed_or_resoled = old_status == "Open" and self.status in [
+        is_closed_or_resolved = old_status == "Open" and self.status in [
             "Resolved",
             "Closed",
         ]
 
-        if self.status == "Replied" or is_closed_or_resoled:
+        if self.status == "Replied" or is_closed_or_resolved:
             self.first_responded_on = (
                 self.first_responded_on or frappe.utils.now_datetime()
             )
@@ -519,7 +519,9 @@ class HDTicket(Document):
                 subject=subject,
                 template=template,
                 with_container=False,
-                in_reply_to=last_communication.name,
+                in_reply_to=last_communication.name
+                if last_communication.name
+                else None,
             )
         except Exception as e:
             frappe.throw(_(e))


### PR DESCRIPTION
1. Use `feedback_rating > 0` instead of `IS NOT NULL` since default is 0.  
2. Add tooltip in the frontend for better UX.  
3. To include today’s tickets, increment `to_date` by 1 (e.g., "18-06-2025" → "19-06-2025") as SQL excludes today's entries by default (created before 00:00 hrs).
