### PR TITLE
fix: dont sent ack emails on initial sync

### DIFF
--- a/desk/package.json
+++ b/desk/package.json
@@ -24,7 +24,7 @@
     "autoprefixer": "^10.4.13",
     "dayjs": "^1.11.7",
     "echarts": "^5.4.1",
-    "frappe-ui": "^0.1.159",
+    "frappe-ui": "^0.1.160",
     "gemoji": "^8.1.0",
     "lodash": "^4.17.21",
     "lucide-static": "^0.276.0",

--- a/desk/src/components/layouts/MobileSidebar.vue
+++ b/desk/src/components/layouts/MobileSidebar.vue
@@ -17,7 +17,7 @@
           <div><UserMenu class="p-2 mb-2" :options="profileSettings" /></div>
           <!-- notifications -->
           <div class="overflow-y-auto px-2" v-if="!isCustomerPortal">
-            <div class="mb-3 flex flex-col">
+            <div class="mb-3 flex flex-col gap-1">
               <SidebarLink
                 class="relative"
                 label="Notifications"
@@ -35,6 +35,15 @@
                   />
                 </template>
               </SidebarLink>
+              <SidebarLink
+                v-if="!isCustomerPortal"
+                class="relative"
+                label="Dashboard"
+                :icon="LucideLayoutDashboard"
+                :to="'Dashboard'"
+                :is-active="isActiveTab('Dashboard')"
+                :is-expanded="true"
+              />
             </div>
           </div>
 
@@ -114,6 +123,7 @@ import { mobileSidebarOpened as sidebarOpened } from "@/composables/mobile";
 import { currentView, useView } from "@/composables/useView";
 
 import LucideBell from "~icons/lucide/bell";
+import LucideLayoutDashboard from "~icons/lucide/layout-dashboard";
 
 import { useAuthStore } from "@/stores/auth";
 import { isCustomerPortal } from "@/utils";

--- a/helpdesk/api/dashboard.py
+++ b/helpdesk/api/dashboard.py
@@ -363,6 +363,7 @@ def get_team_chart_data(from_date, to_date, filters=None):
         fields=["agent_group as team", "count(name) as count"],
         filters=filters,
         group_by="agent_group",
+        order_by="count desc",
     )
     for r in result:
         if not r.team:
@@ -396,6 +397,7 @@ def get_ticket_type_chart_data(from_date, to_date, filters=None):
         fields=["ticket_type as type", "count(name) as count"],
         filters=filters,
         group_by="ticket_type",
+        order_by="count desc",
     )
     # based on length show different chart, if len greater than 5 then show pie chart else bar chart
     if len(result) < 7:
@@ -426,6 +428,7 @@ def get_ticket_priority_chart_data(from_date, to_date, filters=None):
         fields=["priority as priority", "count(name) as count"],
         filters=filters,
         group_by="priority",
+        order_by="count desc",
     )
     # based on length show different chart, if len greater than 5 then show pie chart else bar chart
     if len(result) < 7:

--- a/helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+++ b/helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -28,6 +28,7 @@
   "column_break_iarl",
   "auto_close_tickets",
   "auto_close_after_days",
+  "send_acknowledgement_email",
   "workflow_tab",
   "skip_email_workflow",
   "instantly_send_email",
@@ -281,12 +282,18 @@
    "fieldtype": "Int",
    "label": "Auto-close after (Days)",
    "mandatory_depends_on": "auto_close_tickets"
+  },
+  {
+   "default": "0",
+   "fieldname": "send_acknowledgement_email",
+   "fieldtype": "Check",
+   "label": "Send Acknowledgement Email"
   }
  ],
  "grid_page_length": 50,
  "issingle": 1,
  "links": [],
- "modified": "2025-04-23 20:17:23.058689",
+ "modified": "2025-06-19 16:09:26.779792",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Settings",
@@ -308,6 +315,16 @@
    "read": 1,
    "role": "Agent",
    "share": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "Agent Manager",
+   "share": 1,
+   "write": 1
   }
  ],
  "quick_entry": 1,

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -78,7 +78,7 @@ class HDTicket(Document):
         if self.get("description"):
             self.create_communication_via_contact(self.description, new_ticket=True)
 
-        if not self.via_customer_portal:
+        if not self.via_customer_portal and not frappe.flags.initial_sync:
             self.send_acknowledgement_email()
 
     def on_update(self):

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -78,7 +78,14 @@ class HDTicket(Document):
         if self.get("description"):
             self.create_communication_via_contact(self.description, new_ticket=True)
 
-        if not self.via_customer_portal and not frappe.flags.initial_sync:
+        send_ack_email = frappe.db.get_single_value(
+            "HD Settings", "send_acknowledgement_email"
+        )
+        if (
+            not self.via_customer_portal
+            and not frappe.flags.initial_sync
+            and send_ack_email
+        ):
             self.send_acknowledgement_email()
 
     def on_update(self):


### PR DESCRIPTION
1. Don't send ack emails on initial sync
2. Make ack emails optional
3. Sort data in bar charts in descending order
4. bump frappe-ui


Depends on: https://github.com/frappe/frappe/pull/33006


