### PR TITLE
fix: show fields on agent portal creation

### DIFF
--- a/desk/src/pages/ticket/TicketNew.vue
+++ b/desk/src/pages/ticket/TicketNew.vue
@@ -201,7 +201,7 @@ const customOnChange = computed(() => template.data?._customOnChange);
 
 const visibleFields = computed(() => {
   let _fields = template.data?.fields?.filter(
-    (f) => route.meta.agent || !f.hide_from_customer
+    (f) => !isCustomerPortal.value || !f.hide_from_customer
   );
   if (!_fields) return [];
   return _fields.map((field) => parseField(field, templateFields));


### PR DESCRIPTION
While raising ticket from the Agent portal, agents were not able to see the fields which were hidden from the customers.
