### PR TITLE
feat: add invitation flow

### DIFF
--- a/desk/src/components/Settings/Agents.vue
+++ b/desk/src/components/Settings/Agents.vue
@@ -47,15 +47,26 @@
             </button>
           </template>
         </Dropdown>
-        <Button
-          @click="() => (showNewAgentsDialog = !showNewAgentsDialog)"
-          label="New"
-          variant="solid"
-        >
-          <template #prefix>
-            <LucidePlus class="h-4 w-4 stroke-1.5" />
-          </template>
-        </Button>
+        <Dropdown
+          :options="[
+            {
+              label: 'Add Existing Agent',
+              onClick: () => {},
+            },
+            {
+              label: 'Invite New Agent',
+              onClick: () => {
+                emits('switchToInviteAgentTab');
+              },
+            },
+          ]"
+          :button="{
+            label: 'New',
+            iconLeft: 'plus',
+            variant: 'solid',
+          }"
+          placement="right"
+        />
       </div>
     </div>
 
@@ -145,6 +156,8 @@ import LucideCheck from "~icons/lucide/check";
 import IconMoreHorizontal from "~icons/lucide/more-horizontal";
 import AgentCard from "./AgentCard.vue";
 import { activeFilter, showNewAgentsDialog, useAgents } from "./agents";
+
+const emits = defineEmits<{ switchToInviteAgentTab: [] }>();
 
 const { getUserRole, updateUserRoleCache } = useUserStore();
 const { isManager } = useAuthStore();

--- a/desk/src/components/Settings/InviteAgent/InviteAgent.vue
+++ b/desk/src/components/Settings/InviteAgent/InviteAgent.vue
@@ -1,0 +1,106 @@
+<template>
+  <!--
+    titleHeadingLvl
+    description
+    invitees
+    existingEmails
+    roles
+    roleMap
+    selectedRole
+  -->
+  <InvitationsSection
+    title="Send invites to"
+    :titleHeadingLvl="1"
+    description="Invite users to access Helpdesk. Specify their roles to control access and permissions"
+    sendInvitesBtnLabel="Send invites"
+    v-model:invitees="invitees"
+    inviteByEmailInputLabel="Invite by email"
+    :existingEmails="(users.data ?? []).map((user: Record<'email', string>) => user.email)"
+    :existingEmailInviteesMsg="
+      (emails) =>
+        `User${emails.length > 0 ? 's' : ''} with email ${emails.join(
+          ', '
+        )} already exists`
+    "
+    :pendingInviteesMsg="
+      (emails) =>
+        `User${emails.length > 0 ? 's' : ''} with email ${emails.join(
+          ', '
+        )} already invited`
+    "
+    inviteAsInputLabel="Invite as"
+    :roles="roles"
+    pendingInvitesSectionTitle="Pending Invites"
+    deleteInvitationTooltipText="Delete Invitation"
+    :roleMap="{
+      Agent: 'Agent',
+      'Agent Manager': 'Agent Manager',
+      'System Manager': 'System Manager',
+    }"
+    v-model:selectedRole="selectedRole"
+    :inviteByEmailResource="inviteByEmail"
+    :pendingInvitesResource="pendingInvites"
+  />
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { createResource, createListResource } from "frappe-ui";
+import InvitationsSection from "./InvitationsSection.vue";
+import { useUserStore } from "@/stores/user";
+
+const { users } = useUserStore();
+
+type Role = {
+  value: "Agent" | "Agent Manager" | "System Manager";
+  label: string;
+  description: string;
+};
+
+const roles: [Role, ...Role[]] = [
+  {
+    value: "Agent",
+    label: "Agent",
+    description:
+      "Can work with leads and deals and create private views (reports).",
+  },
+  {
+    value: "Agent Manager",
+    label: "Agent Manager",
+    description:
+      "Can manage and invite new users, and create public & private views (reports).",
+  },
+  {
+    value: "System Manager",
+    label: "System Manager",
+    description:
+      "Can manage all aspects of Helpdesk, including user management, customizations and settings.",
+  },
+] as const;
+
+const selectedRole = ref(roles[0].value);
+const invitees = ref<string[]>([]);
+
+const pendingInvites = createListResource({
+  type: "list",
+  doctype: "HD Invitation",
+  filters: { status: "Pending" },
+  fields: ["name", "email", "role"],
+  auto: true,
+});
+
+const inviteByEmail = createResource({
+  url: "helpdesk.api.invitation_flow.invite_by_email",
+  makeParams() {
+    return {
+      emails: invitees.value.join(","),
+      role: selectedRole.value,
+    };
+  },
+  onSuccess() {
+    invitees.value = [];
+    selectedRole.value = roles[0].value;
+    pendingInvites.reload();
+  },
+});
+</script>

--- a/desk/src/components/Settings/InviteAgent/MultiSelectInput.vue
+++ b/desk/src/components/Settings/InviteAgent/MultiSelectInput.vue
@@ -1,0 +1,222 @@
+<template>
+  <div>
+    <div class="flex flex-wrap gap-1">
+      <Button
+        ref="emailBtnRefs"
+        v-for="value in values"
+        :key="value"
+        :label="value"
+        theme="gray"
+        variant="subtle"
+        :class="{
+          'rounded bg-surface-white hover:!bg-surface-gray-1 focus-visible:ring-outline-gray-4':
+            props.variant === 'subtle',
+        }"
+        @keydown.delete.capture.stop="removeLastValue"
+      >
+        <template #suffix>
+          <FeatherIcon
+            class="h-3.5"
+            name="x"
+            @click.stop="() => removeValue(value)"
+          />
+        </template>
+      </Button>
+      <div class="flex-1">
+        <Combobox v-model="selectedOptionValue" nullable>
+          <Popover v-model:show="showOptions" class="w-full">
+            <template #target="{ togglePopover }">
+              <ComboboxInput
+                ref="queryInput"
+                type="text"
+                :id="props.inputId"
+                class="search-input form-input w-full border-none focus:border-none focus:!shadow-none focus-visible:!ring-0"
+                :class="[
+                  props.variant == 'ghost'
+                    ? 'bg-surface-white hover:bg-surface-white'
+                    : 'bg-surface-gray-2 hover:bg-surface-gray-3',
+                  inputClass,
+                ]"
+                :placeholder="props.placeholder"
+                :value="query"
+                autocomplete="off"
+                @change="onQueryInputChange"
+                @focus="togglePopover"
+                @keydown.delete.capture.stop="removeLastValue"
+              />
+            </template>
+            <template #body="{ isOpen }">
+              <div v-show="isOpen">
+                <div
+                  class="mt-1 rounded-lg bg-surface-modal shadow-2xl ring-1 ring-black ring-opacity-5 focus:outline-none"
+                >
+                  <ComboboxOptions
+                    class="p-1.5 max-h-[12rem] overflow-y-auto"
+                    static
+                  >
+                    <div
+                      v-if="computedOptions.length === 0"
+                      class="rounded px-2 py-1 text-base text-ink-gray-5"
+                    >
+                      {{ props.noOptionsFoundMsg }}
+                    </div>
+                    <ComboboxOption
+                      v-for="option in computedOptions"
+                      :key="option.value"
+                      :value="option.value"
+                      v-slot="{ active }"
+                    >
+                      <li
+                        :class="[
+                          'cursor-pointer flex items-center rounded px-2 py-1 text-base',
+                          { 'bg-surface-gray-3': active },
+                        ]"
+                      >
+                        <slot name="option" :option="option"></slot>
+                      </li>
+                    </ComboboxOption>
+                  </ComboboxOptions>
+                </div>
+              </div>
+            </template>
+          </Popover>
+        </Combobox>
+      </div>
+    </div>
+    <ErrorMessage class="mt-2 pl-2" v-if="errorMsg" :message="errorMsg" />
+    <p
+      v-if="duplicateValueMsg"
+      class="whitespace-pre-line text-sm text-ink-blue-3 mt-2 pl-2"
+    >
+      {{ duplicateValueMsg }}
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import {
+  Combobox,
+  ComboboxInput,
+  ComboboxOptions,
+  ComboboxOption,
+} from "@headlessui/vue";
+import { Button, Popover, ErrorMessage } from "frappe-ui";
+import { computed, nextTick, ref } from "vue";
+
+const props = withDefaults(
+  defineProps<{
+    inputId: string;
+    variant?: string;
+    isValidValue?: (value: string) => boolean;
+    getValidationErrorMsg?: (value: string) => string;
+    getDuplicateValueMsg: (value: string) => string;
+    options: readonly Record<"label" | "value", string>[];
+    noOptionsFoundMsg: string;
+    inputClass?: string;
+    placeholder?: string;
+    values: string[];
+  }>(),
+  {
+    variant: "subtle",
+    isValidValue: () => true,
+    inputClass: "",
+    placeholder: "",
+  }
+);
+
+const emits = defineEmits<{ "update:values": [string[]] }>();
+
+const query = ref("");
+const emailBtnRefs = ref<InstanceType<typeof Button>[]>([]);
+const showOptions = ref(false);
+const errorMsg = ref("");
+const duplicateValueMsg = ref("");
+const queryInput = ref<InstanceType<typeof ComboboxInput> | null>(null);
+
+const selectedOptionValue = computed<string | null>({
+  get() {
+    return query.value;
+  },
+  set(newEnteredValue) {
+    showOptions.value = false;
+    errorMsg.value = "";
+    duplicateValueMsg.value = "";
+    if (newEnteredValue === null) {
+      query.value = "";
+      return;
+    }
+    if (props.values.includes(newEnteredValue)) {
+      duplicateValueMsg.value =
+        props.getDuplicateValueMsg?.(newEnteredValue) ?? "";
+      query.value = "";
+      return;
+    }
+    if (!props.isValidValue(newEnteredValue)) {
+      errorMsg.value = props.getValidationErrorMsg?.(newEnteredValue) ?? "";
+      query.value = newEnteredValue;
+      return;
+    }
+    emits("update:values", [...props.values, newEnteredValue]);
+    query.value = "";
+  },
+});
+
+const computedOptions = computed(() => {
+  if (query.value === "") {
+    return [];
+  }
+  const lowerCasedQuery = query.value.toLowerCase();
+  const res = props.options.filter(
+    (option) =>
+      lowerCasedQuery.includes(option.label.toLowerCase()) ||
+      lowerCasedQuery.includes(option.value.toLowerCase())
+  );
+  if (res.length === 0) {
+    res.push({
+      label: query.value,
+      value: query.value,
+    });
+  }
+  return res;
+});
+
+function onQueryInputChange(
+  e: Event & {
+    target: HTMLInputElement;
+  }
+) {
+  query.value = e.target.value;
+  showOptions.value = true;
+}
+
+function focusQueryInput() {
+  queryInput.value?.$el.focus();
+}
+
+function removeLastValue() {
+  if (query.value !== "") {
+    return;
+  }
+  const lastEmailBtnRef =
+    emailBtnRefs.value[emailBtnRefs.value.length - 1]?.$el;
+  if (document.activeElement === lastEmailBtnRef) {
+    emits("update:values", props.values.slice(0, -1));
+    nextTick(() => {
+      if (emailBtnRefs.value.length === 0) {
+        focusQueryInput();
+      } else {
+        emailBtnRefs.value[emailBtnRefs.value.length - 1].$el.focus();
+      }
+    });
+  } else {
+    lastEmailBtnRef?.focus();
+  }
+}
+
+function removeValue(value: string) {
+  emits(
+    "update:values",
+    props.values.filter((v) => v !== value)
+  );
+}
+</script>

--- a/desk/src/components/Settings/InviteAgent/index.ts
+++ b/desk/src/components/Settings/InviteAgent/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./InviteAgent.vue";

--- a/desk/src/components/Settings/SettingsModal.vue
+++ b/desk/src/components/Settings/SettingsModal.vue
@@ -27,6 +27,7 @@
           <component
             :is="activeTab.component"
             v-if="activeTab"
+            @switchToInviteAgentTab="switchToInviteAgentTab"
             class="h-full flex flex-col w-full"
           />
         </div>
@@ -40,8 +41,10 @@ import { markRaw, ModelRef, ref, watch } from "vue";
 import ImageUp from "~icons/lucide/image-up";
 import LucideMail from "~icons/lucide/mail";
 import LucideUser from "~icons/lucide/user";
+import LucideUserPlus from "~icons/lucide/user-plus";
 import LucideUsers from "~icons/lucide/users";
 import Agents from "./Agents.vue";
+import InviteAgent from "./InviteAgent";
 import Branding from "./Branding.vue";
 import EmailConfig from "./EmailConfig.vue";
 import TeamsConfig from "./Teams/TeamsConfig.vue";
@@ -53,6 +56,16 @@ const props = withDefaults(
     defaultTab: 0,
   }
 );
+
+const InviteAgentTab = {
+  label: "Invite Agent",
+  icon: markRaw(LucideUserPlus),
+  component: markRaw(InviteAgent),
+};
+
+const switchToInviteAgentTab = () => {
+  activeTab.value = InviteAgentTab;
+};
 
 let tabs = [
   {
@@ -70,6 +83,7 @@ let tabs = [
     icon: markRaw(LucideUser),
     component: markRaw(Agents),
   },
+  InviteAgentTab,
   {
     label: "Teams",
     icon: markRaw(LucideUsers),

--- a/helpdesk/api/invitation_flow.py
+++ b/helpdesk/api/invitation_flow.py
@@ -1,0 +1,47 @@
+import frappe
+from frappe.utils import split_emails, validate_email_address
+
+@frappe.whitelist(allow_guest=True)
+def accept_invitation(key: str | None = None):
+    if not key:
+        frappe.throw("Invalid or expired key")
+    result = frappe.db.get_all("HD Invitation", filters={"key": key}, pluck="name")
+    if not result:
+        frappe.throw("Invalid or expired key")
+    invitation = frappe.get_doc("HD Invitation", result[0])
+    invitation.accept()
+    invitation.reload()
+    if invitation.status == "Accepted":
+        frappe.local.login_manager.login_as(invitation.email)
+        frappe.local.response["type"] = "redirect"
+        frappe.local.response["location"] = "/helpdesk"
+
+@frappe.whitelist()
+def invite_by_email(emails: str, role: str):
+    frappe.only_for(["System Manager", "Agent Manager"])
+    valid_roles = ["System Manager", "Agent Manager", "Agent"]
+    if role not in valid_roles:
+        frappe.throw("Cannot invite for this role")
+    if not emails:
+        return
+    email_string = validate_email_address(emails, throw=False)
+    email_list = split_emails(email_string)
+    if not email_list:
+        return
+    existing_members = frappe.db.get_all("User", filters={"email": ["in", email_list]}, pluck="email")
+    existing_invites = frappe.db.get_all(
+        "HD Invitation",
+        filters={
+            "email": ["in", email_list],
+            "role": ["in", valid_roles],
+        },
+        pluck="email",
+    )
+    to_invite = list(set(email_list) - set(existing_members) - set(existing_invites))
+    for email in to_invite:
+        frappe.get_doc(doctype="HD Invitation", email=email, role=role).insert(ignore_permissions=True)
+    return {
+        "existing_members": existing_members,
+        "existing_invites": existing_invites,
+        "to_invite": to_invite,
+    }

--- a/helpdesk/helpdesk/doctype/hd_invitation/hd_invitation.js
+++ b/helpdesk/helpdesk/doctype/hd_invitation/hd_invitation.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, Frappe Technologies and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("HD Invitation", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/helpdesk/helpdesk/doctype/hd_invitation/hd_invitation.json
+++ b/helpdesk/helpdesk/doctype/hd_invitation/hd_invitation.json
@@ -1,0 +1,109 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-07-01 11:49:00.163002",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "email",
+  "role",
+  "key",
+  "invited_by",
+  "status",
+  "email_sent_at",
+  "accepted_at"
+ ],
+ "fields": [
+  {
+   "fieldname": "email",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Email",
+   "reqd": 1
+  },
+  {
+   "fieldname": "role",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Role",
+   "options": "\nAgent\nAgent Manager\nSystem Manager",
+   "reqd": 1
+  },
+  {
+   "fieldname": "key",
+   "fieldtype": "Data",
+   "label": "Key"
+  },
+  {
+   "fieldname": "invited_by",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Invited By",
+   "options": "User"
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Status",
+   "options": "\nPending\nAccepted\nExpired"
+  },
+  {
+   "fieldname": "email_sent_at",
+   "fieldtype": "Datetime",
+   "label": "Email Sent At"
+  },
+  {
+   "fieldname": "accepted_at",
+   "fieldtype": "Datetime",
+   "label": "Accepted At"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-07-01 13:23:57.113032",
+ "modified_by": "Administrator",
+ "module": "Helpdesk",
+ "name": "HD Invitation",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Agent Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Agent",
+   "share": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/helpdesk/helpdesk/doctype/hd_invitation/hd_invitation.py
+++ b/helpdesk/helpdesk/doctype/hd_invitation/hd_invitation.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2025, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+
+class HDInvitation(Document):
+	def before_insert(self):
+		frappe.utils.validate_email_address(self.email, True)
+		self.key = frappe.generate_hash(length=12)
+		self.invited_by = frappe.session.user
+		self.status = "Pending"
+
+	def after_insert(self):
+		self.invite_via_email()
+
+	def invite_via_email(self):
+		invite_link = frappe.utils.get_url(f"/api/method/helpdesk.api.invitation_flow.accept_invitation?key={self.key}")
+		if frappe.local.dev_server:
+			print(f"Invite link for {self.email}: {invite_link}")
+		title = "Frappe Helpdesk"
+		template = "hd_invitation"
+		frappe.sendmail(
+			recipients=self.email,
+			subject=f"You have been invited to join {title}",
+			template=template,
+			args={"title": title, "invite_link": invite_link},
+			now=True,
+		)
+		self.db_set("email_sent_at", frappe.utils.now())
+
+	def accept(self):
+		if self.status == "Expired":
+			frappe.throw("Invalid or expired key")
+		user = self.create_user_if_not_exists()
+		user.append_roles(self.role)
+		if self.role == "Agent" or self.role == "Agent Manager":
+			self.restrict_modules(user, "Helpdesk")
+		user.save(ignore_permissions=True)
+		self.status = "Accepted"
+		self.accepted_at = frappe.utils.now()
+		self.save(ignore_permissions=True)
+
+	def restrict_modules(self, user, module):
+		block_modules = frappe.get_all(
+			"Module Def",
+			fields=["name as module"],
+			filters={"name": ["!=", module]},
+		)
+		if block_modules:
+			user.set("block_modules", block_modules)
+
+	def create_user_if_not_exists(self):
+		if not frappe.db.exists("User", self.email):
+			first_name = self.email.split("@")[0].title()
+			user = frappe.get_doc(
+				doctype="User",
+				user_type="System User",
+				email=self.email,
+				send_welcome_email=0,
+				first_name=first_name,
+			).insert(ignore_permissions=True)
+		else:
+			user = frappe.get_doc("User", self.email)
+		return user

--- a/helpdesk/helpdesk/doctype/hd_invitation/test_hd_invitation.py
+++ b/helpdesk/helpdesk/doctype/hd_invitation/test_hd_invitation.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2025, Frappe Technologies and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+
+class IntegrationTestHDInvitation(IntegrationTestCase):
+	"""
+	Integration tests for HDInvitation.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/helpdesk/templates/emails/hd_invitation.html
+++ b/helpdesk/templates/emails/hd_invitation.html
@@ -1,0 +1,4 @@
+<p>You have been invited to join Frappe Helpdesk</p>
+<p>
+	<a class="btn btn-primary" href="{{ invite_link }}">Accept Invitation</a>
+</p>


### PR DESCRIPTION
This PR adds the ability to invite a new agent or update the role of an existing agent using the settings modal. Since invitation flow is a feature that will be added to other Frappe apps eventually, the goal is to make the code as reusable as possible.