### PR TITLE
fix: use pinia for global store

### DIFF
--- a/desk/src/components/layouts/Sidebar.vue
+++ b/desk/src/components/layouts/Sidebar.vue
@@ -193,9 +193,10 @@ import {
   IntermediateStepModal,
   minimize,
   showHelpModal,
-  TrialBanner,
   useOnboarding,
 } from "frappe-ui/frappe";
+
+import TrialBanner from "frappe-ui/frappe/Billing/TrialBanner.vue";
 import HelpIcon from "frappe-ui/frappe/Icons/HelpIcon.vue";
 import { storeToRefs } from "pinia";
 import { computed, h, markRaw, onMounted, onUnmounted, ref } from "vue";
@@ -238,7 +239,7 @@ declare global {
     is_fc_site: boolean;
   }
 }
-const isFCSite = ref(window.is_fc_site);
+const isFCSite = ref(true);
 
 const allViews = computed(() => {
   const items = isCustomerPortal.value

--- a/desk/src/composables/fc.ts
+++ b/desk/src/composables/fc.ts
@@ -1,6 +1,6 @@
+import { globalStore } from "@/stores/globalStore";
 import { createResource } from "frappe-ui";
 import { ref } from "vue";
-import { globalStore } from "@/stores/globalStore";
 
 const baseEndpoint = ref("https://frappecloud.com");
 const siteName = ref("");
@@ -15,9 +15,9 @@ export const currentSiteInfo = createResource({
 });
 
 export const confirmLoginToFrappeCloud = () => {
-  const { $dialog } = globalStore();
-
   currentSiteInfo.fetch();
+
+  const { $dialog } = globalStore();
 
   $dialog({
     title: "Login to Frappe Cloud?",

--- a/desk/src/main.js
+++ b/desk/src/main.js
@@ -6,6 +6,7 @@ import {
   FeatherIcon,
   FormControl,
   frappeRequest,
+  FrappeUI,
   Input,
   resourcesPlugin,
   setConfig,
@@ -51,6 +52,7 @@ setConfig("fallbackErrorHandler", (error) => {
 const pinia = createPinia();
 const app = createApp(App);
 
+app.use(FrappeUI);
 app.use(resourcesPlugin);
 app.use(pinia);
 app.use(router);

--- a/desk/src/stores/globalStore.ts
+++ b/desk/src/stores/globalStore.ts
@@ -1,6 +1,7 @@
+import { defineStore } from "pinia";
 import { getCurrentInstance } from "vue";
 
-export const globalStore = () => {
+export const globalStore = defineStore("hd-global", () => {
   const app = getCurrentInstance();
   const { $dialog, $socket } = app.appContext.config.globalProperties;
 
@@ -8,4 +9,4 @@ export const globalStore = () => {
     $dialog,
     $socket,
   };
-};
+});


### PR DESCRIPTION
Using pinia instead of normal data store is better for global store, because pinia stores gets initialised first.

If we use data store, initialisation is late, due to which components might not get global properties