### PR TITLE
docs: add missing migration and build steps to local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ To setup the repository locally follow the steps mentioned below:
 1. Map your site to localhost with the command `bench --site helpdesk.test add-to-hosts`
 1. Get the Helpdesk app. Run `bench get-app https://github.com/frappe/helpdesk`
 1. Run `bench --site helpdesk.test install-app helpdesk`.
+1. Run `bench --site helpdesk.test migrate`
+1. Run `bench build --app helpdesk`
 1. Now open the URL `http://helpdesk.test:8000/helpdesk` in your browser, you should see the app running
 
 


### PR DESCRIPTION
## Problem
The current local setup instructions in the README are missing critical steps that cause the helpdesk to show a blank page after installation. Users following the current steps will encounter:
- Blank page when accessing http://helpdesk.test:8000/helpdesk
- Missing frontend assets
- Database migrations not applied

## Solution
Added two missing steps to the local setup instructions:
- `bench --site helpdesk.test migrate` - Applies database migrations
- `bench build --app helpdesk` - Builds frontend assets

## Testing
I experienced this issue firsthand and confirmed these steps resolve the blank page problem.

## Checklist
- [x] Tested the solution personally
- [x] Updated documentation with clear, actionable steps
- [x] Follows conventional commit format
- [x] No breaking changes