### PR TITLE
fix(security): private media

### DIFF
--- a/desk/package.json
+++ b/desk/package.json
@@ -24,7 +24,7 @@
     "autoprefixer": "^10.4.13",
     "dayjs": "^1.11.7",
     "echarts": "^5.4.1",
-    "frappe-ui": "^0.1.165",
+    "frappe-ui": "^0.1.168",
     "gemoji": "^8.1.0",
     "lodash": "^4.17.21",
     "lucide-static": "^0.276.0",

--- a/desk/src/components/CommentTextEditor.vue
+++ b/desk/src/components/CommentTextEditor.vue
@@ -15,6 +15,7 @@
     :mentions="agents"
     @change="editable ? (newComment = $event) : null"
     :extensions="[PreserveVideoControls]"
+    :uploadFunction="(file:any)=>uploadFunction(file, doctype, modelValue?.name)"
   >
     <template #bottom>
       <div v-if="editable" class="flex flex-col gap-2 px-6 md:pl-10 md:pr-9">
@@ -111,7 +112,12 @@ import { useAgentStore } from "@/stores/agent";
 
 import { useAuthStore } from "@/stores/auth";
 import { PreserveVideoControls } from "@/tiptap-extensions";
-import { getFontFamily, isContentEmpty, textEditorMenuButtons } from "@/utils";
+import {
+  getFontFamily,
+  isContentEmpty,
+  textEditorMenuButtons,
+  uploadFunction,
+} from "@/utils";
 import { useStorage } from "@vueuse/core";
 
 const { updateOnboardingStep } = useOnboarding("helpdesk");

--- a/desk/src/components/CommentTextEditor.vue
+++ b/desk/src/components/CommentTextEditor.vue
@@ -25,7 +25,7 @@
             v-for="a in attachments"
             :key="a.file_url"
             :label="a.file_name"
-            :url="a.file_url"
+            :url="!['MOV', 'MP4'].includes(a.file_type) ? a.file_url : null"
           >
             <template #suffix>
               <FeatherIcon
@@ -116,6 +116,7 @@ import { PreserveVideoControls } from "@/tiptap-extensions";
 import {
   getFontFamily,
   isContentEmpty,
+  removeAttachmentFromServer,
   textEditorMenuButtons,
   uploadFunction,
 } from "@/utils";
@@ -179,6 +180,7 @@ const agents = computed(() => {
 
 function removeAttachment(attachment) {
   attachments.value = attachments.value.filter((a) => a !== attachment);
+  removeAttachmentFromServer(attachment.name);
 }
 
 async function submitComment() {

--- a/desk/src/components/CommentTextEditor.vue
+++ b/desk/src/components/CommentTextEditor.vue
@@ -25,6 +25,7 @@
             v-for="a in attachments"
             :key="a.file_url"
             :label="a.file_name"
+            :url="a.file_url"
           >
             <template #suffix>
               <FeatherIcon

--- a/desk/src/components/EmailEditor.vue
+++ b/desk/src/components/EmailEditor.vue
@@ -77,13 +77,13 @@
           v-for="a in attachments"
           :key="a.file_url"
           :label="a.file_name"
-          :url="a.file_url"
+          :url="!['MOV', 'MP4'].includes(a.file_type) ? a.file_url : null"
         >
           <template #suffix>
             <FeatherIcon
               class="h-3.5"
               name="x"
-              @click.stop="removeAttachment(a)"
+              @click.self.stop="removeAttachment(a)"
             />
           </template>
         </AttachmentItem>
@@ -169,6 +169,7 @@ import { PreserveVideoControls } from "@/tiptap-extensions";
 import {
   getFontFamily,
   isContentEmpty,
+  removeAttachmentFromServer,
   textEditorMenuButtons,
   uploadFunction,
   validateEmail,
@@ -306,8 +307,9 @@ function toggleBCC() {
     });
 }
 
-function removeAttachment(attachment) {
+async function removeAttachment(attachment) {
   attachments.value = attachments.value.filter((a) => a !== attachment);
+  await removeAttachmentFromServer(attachment.name);
 }
 
 function addToReply(

--- a/desk/src/components/EmailEditor.vue
+++ b/desk/src/components/EmailEditor.vue
@@ -77,6 +77,7 @@
           v-for="a in attachments"
           :key="a.file_url"
           :label="a.file_name"
+          :url="a.file_url"
         >
           <template #suffix>
             <FeatherIcon

--- a/desk/src/components/EmailEditor.vue
+++ b/desk/src/components/EmailEditor.vue
@@ -13,6 +13,7 @@
     :editable="editable"
     @change="editable ? (newEmail = $event) : null"
     :extensions="[PreserveVideoControls]"
+    :uploadFunction="(file:any)=>uploadFunction(file, doctype, modelValue?.name)"
   >
     <template #top>
       <div class="mx-6 md:mx-10 flex items-center gap-2 border-y py-2.5">
@@ -168,6 +169,7 @@ import {
   getFontFamily,
   isContentEmpty,
   textEditorMenuButtons,
+  uploadFunction,
   validateEmail,
 } from "@/utils";
 // import { EditorContent } from "@tiptap/vue-3";

--- a/desk/src/pages/ticket/TicketCustomer.vue
+++ b/desk/src/pages/ticket/TicketCustomer.vue
@@ -43,6 +43,7 @@
             placeholder="Type a message"
             autofocus
             @clear="() => (isExpanded = false)"
+            :uploadFunction="(file:any)=>uploadFunction(file, 'HD Ticket', props.ticketId)"
           >
             <template #bottom-right>
               <Button
@@ -72,7 +73,7 @@ import { useScreenSize } from "@/composables/screen";
 import { socket } from "@/socket";
 import { useConfigStore } from "@/stores/config";
 import { globalStore } from "@/stores/globalStore";
-import { isContentEmpty } from "@/utils";
+import { isContentEmpty, uploadFunction } from "@/utils";
 import { Icon } from "@iconify/vue";
 import { Breadcrumbs, Button, call, createResource, toast } from "frappe-ui";
 import { computed, onMounted, onUnmounted, provide, ref } from "vue";

--- a/desk/src/pages/ticket/TicketNew.vue
+++ b/desk/src/pages/ticket/TicketNew.vue
@@ -69,6 +69,7 @@
             v-model:content="description"
             placeholder="Detailed explanation"
             expand
+            :uploadFunction="(file:any)=>uploadFunction(file)"
           >
             <template #bottom-right>
               <Button
@@ -123,7 +124,7 @@ import { useAuthStore } from "@/stores/auth";
 import { globalStore } from "@/stores/globalStore";
 import { capture } from "@/telemetry";
 import { Field } from "@/types";
-import { isCustomerPortal } from "@/utils";
+import { isCustomerPortal, uploadFunction } from "@/utils";
 import {
   Breadcrumbs,
   Button,

--- a/desk/src/pages/ticket/TicketTextEditor.vue
+++ b/desk/src/pages/ticket/TicketTextEditor.vue
@@ -13,6 +13,7 @@
           v-for="a in attachments"
           :key="a.file_url"
           :label="a.file_name"
+          :url="a.file_url"
         >
           <template #suffix>
             <Icon

--- a/desk/src/pages/ticket/TicketTextEditor.vue
+++ b/desk/src/pages/ticket/TicketTextEditor.vue
@@ -13,16 +13,19 @@
           v-for="a in attachments"
           :key="a.file_url"
           :label="a.file_name"
-          :url="a.file_url"
+          :url="!['MOV', 'MP4'].includes(a.file_type) ? a.file_url : null"
         >
           <template #suffix>
             <Icon
               icon="lucide:x"
               @click.stop="
-                $emit(
-                  'update:attachments',
-                  attachments.filter((b) => b.file_url !== a.file_url)
-                )
+                () => {
+                  $emit(
+                    'update:attachments',
+                    attachments.filter((b) => b.file_url !== a.file_url)
+                  );
+                  removeAttachmentFromServer(a.name);
+                }
               "
             />
           </template>
@@ -84,6 +87,7 @@ import {
 } from "@/components";
 import { useAuthStore } from "@/stores/auth";
 import { File } from "@/types";
+import { removeAttachmentFromServer } from "@/utils";
 import { Icon } from "@iconify/vue";
 import { FileUploader, toast } from "frappe-ui";
 import { computed, ref } from "vue";

--- a/desk/src/utils.ts
+++ b/desk/src/utils.ts
@@ -1,6 +1,6 @@
 import { useClipboard, useDateFormat, useTimeAgo } from "@vueuse/core";
 import dayjs from "dayjs";
-import { toast } from "frappe-ui";
+import { toast, useFileUpload } from "frappe-ui";
 import { gemoji } from "gemoji";
 import { h, markRaw, ref } from "vue";
 import zod from "zod";
@@ -218,4 +218,17 @@ export function getFontFamily(content: string) {
     lang = "arabic";
   }
   return langMap[lang];
+}
+
+export function uploadFunction(
+  file: File,
+  doctype: string = null,
+  docname: string = null
+) {
+  let fileUpload = useFileUpload();
+  return fileUpload.upload(file, {
+    private: true,
+    doctype: doctype,
+    docname: docname,
+  });
 }

--- a/desk/src/utils.ts
+++ b/desk/src/utils.ts
@@ -1,6 +1,6 @@
 import { useClipboard, useDateFormat, useTimeAgo } from "@vueuse/core";
 import dayjs from "dayjs";
-import { toast, useFileUpload } from "frappe-ui";
+import { call, toast, useFileUpload } from "frappe-ui";
 import { gemoji } from "gemoji";
 import { h, markRaw, ref } from "vue";
 import zod from "zod";
@@ -230,5 +230,12 @@ export function uploadFunction(
     private: true,
     doctype: doctype,
     docname: docname,
+  });
+}
+
+export async function removeAttachmentFromServer(attachment: string) {
+  await call("frappe.client.delete", {
+    doctype: "File",
+    name: attachment,
   });
 }

--- a/desk/yarn.lock
+++ b/desk/yarn.lock
@@ -3026,10 +3026,10 @@ fraction.js@^4.2.0:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.2.0.tgz#448e5109a313a3527f5a3ab2119ec4cf0e0e2950"
   integrity sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==
 
-frappe-ui@^0.1.165:
-  version "0.1.165"
-  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-0.1.165.tgz#12d28f176c45bc450210342a2cc1a021b480ddb3"
-  integrity sha512-rEuFFbY+Zx46ajXtAB4VcGA4LrRJysq145obvW02ONIlbm+qovNhKjolS0QWpTmhHboVCtcnUm4QoY1C8vnOAg==
+frappe-ui@^0.1.168:
+  version "0.1.168"
+  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-0.1.168.tgz#1b749507fe7d2936698c94b684f6bcb583093490"
+  integrity sha512-Tq2JS0sQWtiHZPmp2ohXLLQGwkZVpbxtVB7azX91C2+4cqCuO+kUw8atRbIimITvhl+qaeHm3rO5koQSnS7eCw==
   dependencies:
     "@floating-ui/vue" "^1.1.6"
     "@headlessui/vue" "^1.7.14"

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -637,20 +637,24 @@ class HDTicket(Document):
 
     def handle_inline_media_new_ticket(self):
         soup = BeautifulSoup(self.description, "html.parser")
-        files = []
+        files = []  # List of file URLs
         for tag in soup.find_all(["img", "video"]):
             if tag.has_attr("src"):
                 src = tag["src"]
                 files.append(src)
-
         for f in files:
-            last_doc = frappe.get_doc(
-                "File", {"file_url": f, "attached_to_doctype": ["!=", "Null"]}
+            doc = frappe.get_doc(
+                "File",
+                {
+                    "file_url": f,
+                    "attached_to_doctype": ["!=", "Null"],
+                    "owner": frappe.session.user,
+                },
             )
-            if last_doc:
-                last_doc.attached_to_doctype = "HD Ticket"
-                last_doc.attached_to_name = self.name
-                last_doc.save()
+            if doc:
+                doc.attached_to_doctype = "HD Ticket"
+                doc.attached_to_name = self.name
+                doc.save()
 
     def send_reply_email_to_agent(self, message):
         assigned_agents = self.get_assigned_agents()

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -993,7 +993,7 @@ class HDTicket(Document):
 
     def parse_content(self, content):
         """
-        Finds 'src' attribute of img/video and 'replaces' it  with embed attribute
+        Finds 'src' attribute of img/video and replaces it  with 'embed' attribute
         embed tag is important because framework replaces it with <img src="cid:content_id">
         this in turn is displayed as an image in the mail sent to the customer
         """

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -641,11 +641,10 @@ class HDTicket(Document):
         for tag in soup.find_all(["img", "video"]):
             if tag.has_attr("src"):
                 src = tag["src"]
-                # this is an inline media, we need to add it to the attachments
                 files.append(src)
 
         for f in files:
-            last_doc = frappe.get_last_doc(
+            last_doc = frappe.get_doc(
                 "File", {"file_url": f, "attached_to_doctype": ["!=", "Null"]}
             )
             if last_doc:


### PR DESCRIPTION
1. Before sending mail to the customer, add 'embed' attribute in the img/video element to handle inline content, 'embed' attribute is important because framework replaces it with `<img src="cid:content_id">` this in turn is displayed as an image in the mail sent to the customer.

2. All media are now private and are attached to the relevant document

2. Add  `uploadFunction` prop in TextEditor to attach the file to the document, basically attaching video/image to the ticket
3. All scenarios are covered to ensure privacy for user's media 
- New ticket raised via portal
- Ticket raised via email
- Reply from agent
- Reply from customer

5. Delete removed attachments from the server
6. Preview images before sending
7. Update frappe-ui to 0.1.168 and update yarn.lock file