### PR TITLE
fix: Strict permissions on HD Ticket

### DIFF
--- a/desk/src/main.js
+++ b/desk/src/main.js
@@ -21,6 +21,7 @@ import "./index.css";
 import { router } from "./router";
 import { socket } from "./socket";
 import { posthogPlugin } from "./telemetry";
+import { isCustomerPortal } from "@/utils";
 import { translationPlugin } from "./translation";
 
 const globalComponents = {
@@ -37,6 +38,9 @@ const globalComponents = {
 
 setConfig("resourceFetcher", frappeRequest);
 setConfig("serverMessagesHandler", (msgs) => {
+  if (isCustomerPortal.value) {
+    return;
+  }
   msgs.forEach((msg) => {
     msg = JSON.parse(msg);
     if (msg && msg.message == "Feedback email has been sent to the customer") {

--- a/desk/src/main.js
+++ b/desk/src/main.js
@@ -24,6 +24,7 @@ import { posthogPlugin } from "./telemetry";
 import { isCustomerPortal } from "@/utils";
 import { translationPlugin } from "./translation";
 import { isCustomerPortal } from "@/utils";
+import { translationPlugin } from "./translation";
 
 const globalComponents = {
   Badge,

--- a/desk/src/main.js
+++ b/desk/src/main.js
@@ -23,8 +23,6 @@ import { socket } from "./socket";
 import { posthogPlugin } from "./telemetry";
 import { isCustomerPortal } from "@/utils";
 import { translationPlugin } from "./translation";
-import { isCustomerPortal } from "@/utils";
-import { translationPlugin } from "./translation";
 
 const globalComponents = {
   Badge,

--- a/desk/src/main.js
+++ b/desk/src/main.js
@@ -23,6 +23,7 @@ import { socket } from "./socket";
 import { posthogPlugin } from "./telemetry";
 import { isCustomerPortal } from "@/utils";
 import { translationPlugin } from "./translation";
+import { isCustomerPortal } from "@/utils";
 
 const globalComponents = {
   Badge,

--- a/helpdesk/api/doc.py
+++ b/helpdesk/api/doc.py
@@ -5,7 +5,7 @@ from frappe.model.document import get_controller
 from frappe.utils.caching import redis_cache
 from pypika import Criterion
 
-from helpdesk.utils import check_permissions, contact_default_columns
+from helpdesk.utils import check_permissions, contact_default_columns, get_agents_team
 
 
 @frappe.whitelist()
@@ -36,9 +36,6 @@ def get_list_data(
     label_field = view.get("label_field") if view else None
 
     handle_at_me_support(filters)
-
-    if doctype == "HD Ticket" and not show_customer_portal_fields:
-        handle_team_restrictions(filters)
 
     _list = get_controller(doctype)
     default_rows = []
@@ -496,40 +493,3 @@ def handle_at_me_support(filters):
             filters[key] = frappe.session.user
 
     return filters
-
-
-# filters out tickets based on team restrictions
-def handle_team_restrictions(filters):
-    enable_restrictions = frappe.db.get_single_value(
-        "HD Settings", "restrict_tickets_by_agent_group"
-    )
-    if not enable_restrictions:
-        return
-    show_tickets_without_team = frappe.db.get_single_value(
-        "HD Settings", "do_not_restrict_tickets_without_an_agent_group"
-    )
-
-    QBTeam = frappe.qb.DocType("HD Team")
-    QBTeamMember = frappe.qb.DocType("HD Team Member")
-
-    teams = (
-        frappe.qb.from_(QBTeamMember)
-        .where(QBTeamMember.user == frappe.session.user)
-        .join(QBTeam)
-        .on(QBTeam.name == QBTeamMember.parent)
-        .select(QBTeam.team_name, QBTeam.ignore_restrictions)
-        .run(as_dict=True)
-    )
-
-    if any([team.get("ignore_restrictions") for team in teams]):
-        return
-
-    team_names = [t.get("team_name") for t in teams]
-
-    if show_tickets_without_team:
-        team_names = team_names + [""]
-
-    if not filters:
-        filters.append({"agent_group": ["in", team_names]})
-    else:
-        filters["agent_group"] = ["in", team_names]

--- a/helpdesk/api/doc.py
+++ b/helpdesk/api/doc.py
@@ -5,7 +5,7 @@ from frappe.model.document import get_controller
 from frappe.utils.caching import redis_cache
 from pypika import Criterion
 
-from helpdesk.utils import check_permissions, contact_default_columns, get_agents_team
+from helpdesk.utils import check_permissions, contact_default_columns
 
 
 @frappe.whitelist()

--- a/helpdesk/api/doc.py
+++ b/helpdesk/api/doc.py
@@ -466,6 +466,7 @@ def handle_default_view(doctype, _list, show_customer_portal_fields):
     if not columns:
         if doctype == "Contact":
             columns = contact_default_columns
+            rows = ["name", "email_id", "creation"]
         else:
             columns = (
                 _list.default_list_data(show_customer_portal_fields).get("columns")

--- a/helpdesk/crowdin.yml
+++ b/helpdesk/crowdin.yml
@@ -1,0 +1,8 @@
+files:
+  - source: /helpdesk/locale/main.pot
+    translation: /helpdesk/locale/%two_letters_code%.po
+pull_request_title: "chore: sync translations from crowdin"
+pull_request_labels:
+  - translation
+commit_message: "chore: %language% translations"
+append_commit_message: false

--- a/helpdesk/helpdesk/doctype/hd_ticket/api.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/api.py
@@ -24,7 +24,7 @@ def new(doc, attachments=[]):
 
 @frappe.whitelist()
 def get_one(name, is_customer_portal=False):
-    check_permissions("HD Ticket", None)
+    check_permissions("HD Ticket", None, doc=name)
     QBContact = frappe.qb.DocType("Contact")
     QBTicket = frappe.qb.DocType("HD Ticket")
 

--- a/helpdesk/utils.py
+++ b/helpdesk/utils.py
@@ -22,7 +22,9 @@ def check_permissions(doctype, parent, doc=None):
     ]
 
     if not has_select_permission and not has_read_permission:
-        frappe.throw(f"Insufficient Permission for {doctype}", frappe.PermissionError)
+        frappe.throw(
+            _("Insufficient Permission for {0}").format(doctype), frappe.PermissionError
+        )
 
 
 def is_admin(user: str = None) -> bool:

--- a/helpdesk/utils.py
+++ b/helpdesk/utils.py
@@ -12,12 +12,12 @@ from frappe.utils.telemetry import capture as _capture
 from pypika import Criterion
 
 
-def check_permissions(doctype, parent):
+def check_permissions(doctype, parent, doc=None):
     user = frappe.session.user
 
     permissions = ("select", "read")
     has_select_permission, has_read_permission = [
-        frappe.has_permission(doctype, perm, user=user, parent_doctype=parent)
+        frappe.has_permission(doctype, perm, user=user, doc=doc, parent_doctype=parent)
         for perm in permissions
     ]
 
@@ -161,6 +161,21 @@ def agent_only(fn):
         return fn(*args, **kwargs)
 
     return wrapper
+
+
+def get_agents_team():
+    QBTeam = frappe.qb.DocType("HD Team")
+    QBTeamMember = frappe.qb.DocType("HD Team Member")
+
+    teams = (
+        frappe.qb.from_(QBTeamMember)
+        .where(QBTeamMember.user == frappe.session.user)
+        .join(QBTeam)
+        .on(QBTeam.name == QBTeamMember.parent)
+        .select(QBTeam.team_name, QBTeam.ignore_restrictions)
+        .run(as_dict=True)
+    )
+    return teams
 
 
 contact_default_columns = [


### PR DESCRIPTION
## Description

This PR adds additional checks related to team permissions on the HD Ticket doctype to ensure consistent permission logic between the list and form views, restricting agents to only access tickets they are authorized to view.


continuation to https://github.com/frappe/helpdesk/pull/2294