### PR TITLE
fix: Correct redis search import from indexDefinition to index_definition

### DIFF
--- a/helpdesk/search.py
+++ b/helpdesk/search.py
@@ -16,7 +16,7 @@ from frappe.utils import cstr, strip_html_tags, update_progress_bar
 from frappe.utils.caching import redis_cache
 from frappe.utils.synchronization import filelock
 from redis.commands.search.field import TagField, TextField
-from redis.commands.search.index_definition import IndexDefinition
+from redis.commands.search.indexDefinition import IndexDefinition
 from redis.commands.search.query import Query
 from redis.exceptions import ResponseError
 


### PR DESCRIPTION
## Problem
The helpdesk app had a typo in the redis search import statement:
```python
from redis.commands.search.indexDefinition import IndexDefinition  # Wrong
```

This caused import errors during migration because the correct module name uses snake_case.
```
Updating DocTypes for frappe        : [========================================] 100%
Updating DocTypes for helpdesk      : [========================================] 100%
helpdesk.search.build_index_if_not_exists is not a valid method: No module named 'redis.commands.search.index_definition'
helpdesk.search.download_corpus is not a valid method: No module named 'redis.commands.search.index_definition'
helpdesk.helpdesk.doctype.hd_ticket.hd_ticket.close_tickets_after_n_days is not a valid method: No module named 'redis.commands.search.index_definition'
Updating Dashboard for frappe
Updating Dashboard for helpdesk
Orphaned DocType(s) found: HD Settings, HD Ticket
Deleting orphaned DocTypes          : [========================================] 100%
Executing `after_migrate` hooks...
Queued rebuilding of search index for help15.localhost

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/workspace/development/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 114, in <module>
    main()
  File "/workspace/development/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 20, in main
    click.Group(commands=commands)(prog_name="bench")
  File "/workspace/development/frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/development/frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/workspace/development/frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/development/frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/development/frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/development/frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/development/frappe-bench/env/lib/python3.11/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/development/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 29, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/development/frappe-bench/apps/frappe/frappe/commands/site.py", line 684, in migrate
    ).run(site=site)
      ^^^^^^^^^^^^^^
  File "/workspace/development/frappe-bench/apps/frappe/frappe/migrate.py", line 189, in run
    self.post_schema_updates()
  File "/workspace/development/frappe-bench/apps/frappe/frappe/migrate.py", line 52, in wrapper
    raise e
  File "/workspace/development/frappe-bench/apps/frappe/frappe/migrate.py", line 44, in wrapper
    ret = method(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/development/frappe-bench/apps/frappe/frappe/migrate.py", line 154, in post_schema_updates
    frappe.get_attr(fn)()
    ^^^^^^^^^^^^^^^^^^^
  File "/workspace/development/frappe-bench/apps/frappe/frappe/__init__.py", line 1744, in get_attr
    return getattr(get_module(modulename), methodname)
                   ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/development/frappe-bench/apps/frappe/frappe/__init__.py", line 1454, in get_module
    return importlib.import_module(modulename)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/.pyenv/versions/3.11.6/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/workspace/development/frappe-bench/apps/helpdesk/helpdesk/search.py", line 19, in <module>
    from redis.commands.search.index_definition import IndexDefinition
ModuleNotFoundError: No module named 'redis.commands.search.index_definition'
```

## Solution
Fixed the import to use the correct module name:
```python
from redis.commands.search.index_definition import IndexDefinition  # Correct
```

fixes:
https://github.com/frappe/helpdesk/issues/2327
https://github.com/frappe/helpdesk/issues/2344
https://github.com/frappe/helpdesk/issues/2326
https://github.com/frappe/helpdesk/issues/2384
