### PR TITLE
feat: restrict assignment of tickets to the selected team

### DIFF
--- a/desk/src/components/AssignmentModal.vue
+++ b/desk/src/components/AssignmentModal.vue
@@ -8,7 +8,7 @@
   >
     <template #body-content>
       <AutocompleteNew
-        v-if="teamRestrictionApplied && assignWithinTeam"
+        v-if="showRestrictedMembers"
         placeholder="Search agents"
         :model-value="search"
         :options="members"
@@ -189,8 +189,12 @@ async function getMembers() {
   });
 }
 
+const showRestrictedMembers = computed(() => {
+  return teamRestrictionApplied && assignWithinTeam && props.team;
+});
+
 onMounted(() => {
-  if (teamRestrictionApplied && assignWithinTeam) {
+  if (showRestrictedMembers.value) {
     getMembers();
   }
 });

--- a/desk/src/components/AssignmentModal.vue
+++ b/desk/src/components/AssignmentModal.vue
@@ -7,7 +7,29 @@
     }"
   >
     <template #body-content>
+      <AutocompleteNew
+        v-if="teamRestrictionApplied && assignWithinTeam"
+        placeholder="Search agents"
+        :model-value="search"
+        :options="members"
+        @update:model-value="
+          ({ _, value }) => {
+            addAssignee(value);
+          }
+        "
+      >
+        <template #item-prefix="{ option }">
+          <UserAvatar class="mr-2" :name="option.value" size="sm" />
+        </template>
+        <template #item-label="{ option }">
+          <Tooltip :text="option.value">
+            {{ getUser(option.value).full_name }}
+          </Tooltip>
+        </template>
+      </AutocompleteNew>
+
       <SearchComplete
+        v-else
         class="form-control"
         doctype="HD Agent"
         :custom-filters="customFilters"
@@ -27,6 +49,7 @@
           </Tooltip>
         </template>
       </SearchComplete>
+
       <div class="mt-3 flex flex-wrap items-center gap-2">
         <Tooltip
           v-for="currentAssignee in assignees"
@@ -57,18 +80,15 @@
 </template>
 
 <script setup lang="ts">
-import { SearchComplete, UserAvatar } from "@/components";
+import { AutocompleteNew, SearchComplete, UserAvatar } from "@/components";
 import { useAuthStore } from "@/stores/auth";
+import { useConfigStore } from "@/stores/config";
 import { useUserStore } from "@/stores/user";
-import { createResource } from "frappe-ui";
+import { call, createResource } from "frappe-ui";
 import { useOnboarding } from "frappe-ui/frappe";
-import { computed, ref } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 
 const props = defineProps({
-  assignees: {
-    type: Array,
-    required: true,
-  },
   doctype: {
     type: String,
     required: true,
@@ -76,6 +96,14 @@ const props = defineProps({
   docname: {
     type: String,
     required: true,
+  },
+  assignees: {
+    type: Array,
+    required: true,
+  },
+  team: {
+    type: String,
+    default: "",
   },
 });
 
@@ -86,6 +114,7 @@ const emit = defineEmits(["update"]);
 const { getUser } = useUserStore();
 const { updateOnboardingStep } = useOnboarding("helpdesk");
 const { isManager } = useAuthStore();
+const { teamRestrictionApplied, assignWithinTeam } = useConfigStore();
 
 const error = ref("");
 
@@ -104,6 +133,7 @@ const addAssignee = (value) => {
       if (isManager) {
         updateOnboardingStep("assign_to_agent");
       }
+      members.value = members.value.filter((m) => m.value !== value);
     },
   });
   emit("update");
@@ -120,6 +150,10 @@ const removeCurrentAssignee = (value) => {
     },
     onSuccess: () => {
       emit("update");
+      members.value.push({
+        label: value,
+        value: value,
+      });
     },
   });
 };
@@ -131,5 +165,33 @@ const customFilters = computed(() => {
     filters["name"] = ["not in", [...props.assignees.map((a) => a.name)]];
   }
   return filters;
+});
+
+const search = ref("");
+const members = ref([]);
+async function getMembers() {
+  let teamMembers = await call(
+    "helpdesk.helpdesk.doctype.hd_team.hd_team.get_team_members",
+    {
+      team: props.team,
+    }
+  );
+  let assignedMembers = props.assignees.map((a) => a.name);
+  teamMembers = teamMembers.filter((member: string) => {
+    return !assignedMembers.includes(member);
+  });
+
+  members.value = teamMembers.map((member: string) => {
+    return {
+      label: member,
+      value: member,
+    };
+  });
+}
+
+onMounted(() => {
+  if (teamRestrictionApplied && assignWithinTeam) {
+    getMembers();
+  }
 });
 </script>

--- a/desk/src/pages/ticket/TicketAgent.vue
+++ b/desk/src/pages/ticket/TicketAgent.vue
@@ -100,10 +100,11 @@
       />
     </div>
     <AssignmentModal
-      v-if="ticket.data"
+      v-if="ticket.data && showAssignmentModal"
       v-model="showAssignmentModal"
       :assignees="ticket.data.assignees"
       :docname="ticketId"
+      :team="ticket.data?.agent_group"
       doctype="HD Ticket"
       @update="
         () => {

--- a/desk/src/stores/config.ts
+++ b/desk/src/stores/config.ts
@@ -14,6 +14,9 @@ export const useConfigStore = defineStore("config", () => {
   const teamRestrictionApplied = computed(
     () => !!parseInt(config.value.restrict_tickets_by_agent_group)
   );
+  const assignWithinTeam = computed(
+    () => !!parseInt(config.value.assign_within_team)
+  );
   const skipEmailWorkflow: ComputedRef<boolean> = computed(
     () => !!parseInt(config.value.skip_email_workflow)
   );
@@ -33,5 +36,6 @@ export const useConfigStore = defineStore("config", () => {
     skipEmailWorkflow,
     isFeedbackMandatory,
     teamRestrictionApplied,
+    assignWithinTeam,
   };
 });

--- a/helpdesk/api/config.py
+++ b/helpdesk/api/config.py
@@ -10,6 +10,7 @@ def get_config():
         "skip_email_workflow",
         "is_feedback_mandatory",
         "restrict_tickets_by_agent_group",
+        "assign_within_team",
     ]
     res = frappe.get_value(doctype="HD Settings", fieldname=fields, as_dict=True)
     return res

--- a/helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+++ b/helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -11,6 +11,7 @@
   "agent_groups_section",
   "restrict_tickets_by_agent_group",
   "do_not_restrict_tickets_without_an_agent_group",
+  "assign_within_team",
   "column_break_dxlq",
   "assignment_rules_section",
   "base_support_rotation",
@@ -317,12 +318,19 @@
    "fieldname": "enable_email_ticket_feedback",
    "fieldtype": "Check",
    "label": "Enable feedback for Email Tickets"
+  },
+  {
+   "default": "0",
+   "depends_on": "restrict_tickets_by_agent_group",
+   "fieldname": "assign_within_team",
+   "fieldtype": "Check",
+   "label": "Restrict agent assignment to selected Team"
   }
  ],
  "grid_page_length": 50,
  "issingle": 1,
  "links": [],
- "modified": "2025-07-08 13:46:21.260686",
+ "modified": "2025-07-30 21:45:58.873574",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Settings",


### PR DESCRIPTION
If team restrictions are enabled, tickets can still be assigned to agents outside the assigned team. This feature ensures that tickets can only be assigned to agents within the team specified on the ticket.

To enable it, go to HD Settings and click on "Restrict agent assignment to selected Team"
Note: We need to enable "Restrict tickets by Team" for this setting to work.

<img width="1440" height="813" alt="Screenshot 2025-07-30 at 10 13 00 PM" src="https://github.com/user-attachments/assets/fc2d4934-ee64-4173-984e-d7876054485f" />
