### PR TITLE
fix: sync standard and quick list filters

### DIFF
--- a/desk/src/components/ListViewBuilder.vue
+++ b/desk/src/components/ListViewBuilder.vue
@@ -521,7 +521,7 @@ const showViewControls = computed(() => {
     filterableFields.data &&
     sortableFields.data &&
     quickFilters.data &&
-    list.data?.data.length > 0
+    list.data?.data?.length > 0
   );
 });
 

--- a/desk/src/components/ListViewBuilder.vue
+++ b/desk/src/components/ListViewBuilder.vue
@@ -99,6 +99,13 @@
       "
     />
   </div>
+  <!-- Loading State -->
+  <div
+    v-else-if="list.loading"
+    class="w-full h-full flex items-center justify-center -mt-48"
+  >
+    <LoadingIndicator :scale="10" />
+  </div>
   <!-- Empty State -->
   <EmptyState
     v-else
@@ -141,6 +148,7 @@ import {
   ListRowItem,
   ListSelectBanner,
   ListView,
+  LoadingIndicator,
   toast,
 } from "frappe-ui";
 import {
@@ -512,7 +520,8 @@ const showViewControls = computed(() => {
     !options.value.hideViewControls &&
     filterableFields.data &&
     sortableFields.data &&
-    quickFilters.data
+    quickFilters.data &&
+    list.data?.data.length > 0
   );
 });
 

--- a/desk/src/components/view-controls/Filter.vue
+++ b/desk/src/components/view-controls/Filter.vue
@@ -75,7 +75,7 @@
               </div>
             </div>
             <div v-else class="flex items-center justify-between gap-2">
-              <div class="flex items-center gap-2">
+              <div class="flex items-center gap-2 flex-1">
                 <div class="w-13 pl-2 text-end text-base text-gray-600">
                   {{ i == 0 ? "Where" : "And" }}
                 </div>
@@ -98,7 +98,7 @@
                     :placeholder="'Equals'"
                   />
                 </div>
-                <div id="value" class="!min-w-[140px]">
+                <div id="value" class="!min-w-[140px] flex-1">
                   <component
                     :is="getValueControl(f)"
                     v-model="f.value"

--- a/desk/src/components/view-controls/QuickFilterField.vue
+++ b/desk/src/components/view-controls/QuickFilterField.vue
@@ -3,7 +3,7 @@
     v-if="filter.type == 'Check'"
     :label="filter.label"
     type="checkbox"
-    v-model="filter.value"
+    :checked="props.value"
     @change.stop="updateFilter(filter, $event.target.checked)"
     class="w-44"
   />
@@ -11,14 +11,14 @@
     v-else-if="filter.type === 'Select'"
     class="form-control cursor-pointer [&_select]:cursor-pointer w-44"
     type="select"
-    v-model="filter.value"
+    :value="props.value"
     :options="filter.options"
     :placeholder="filter.label"
     @change.stop="updateFilter(filter, $event.target.value)"
   />
   <Link
     v-else-if="filter.type === 'Link'"
-    :value="filter.value"
+    :value="props.value"
     :doctype="filter.options"
     :placeholder="filter.label"
     @change="(data) => updateFilter(filter, data)"
@@ -28,13 +28,13 @@
     v-else-if="['Date', 'Datetime'].includes(filter.type)"
     class="border-none w-44"
     :is="filter.type === 'Date' ? DatePicker : DateTimePicker"
-    :value="filter.value"
+    :value="props.value"
     @change="(v) => updateFilter(filter, v)"
     :placeholder="filter.label"
   />
   <TextInput
     v-else
-    v-model="filter.value"
+    :value="props.value"
     type="text"
     :placeholder="filter.label"
     @input.stop="debouncedFn(filter, $event.target.value)"
@@ -48,6 +48,10 @@ import { DatePicker, DateTimePicker, FormControl, TextInput } from "frappe-ui";
 const props = defineProps({
   filter: {
     type: Object,
+    required: true,
+  },
+  value: {
+    type: [String, Boolean],
     required: true,
   },
 });


### PR DESCRIPTION
Closes #2419

> We will have to come up with a better way to sync the filters (or not sync them at all) once we work on [this](https://github.com/frappe/helpdesk/issues/2256) issue.

There are 2 types of filters

<img width="1275" height="254" alt="filter-types" src="https://github.com/user-attachments/assets/18a00401-f7f0-43c8-8853-8483013361ae" />

Until now, updating quick filters has automatically updated the standard filters, but this update was partial (see [this](https://github.com/frappe/helpdesk/issues/2419) issue). This PR fully syncs the quick filters with the standard filters whenever it makes sense.

https://github.com/user-attachments/assets/a804c464-36e5-470b-a62b-2eb005f47ce3

