### PR TITLE
fix: fetch contacts autocomplete from custom api

### DIFF
--- a/desk/src/components/MultiSelectInput.vue
+++ b/desk/src/components/MultiSelectInput.vue
@@ -147,9 +147,9 @@ const filterOptions = createResource({
     txt: text.value,
   },
   transform: (data: Record<"full_name" | "name" | "email_id", string>[]) => {
-    return data.map((option) => ({
-      label: option.full_name,
-      value: option.email_id,
+    return data.map(({ full_name, email_id, name }) => ({
+      label: full_name || name || email_id,
+      value: email_id,
     }));
   },
 });

--- a/desk/src/components/MultiSelectInput.vue
+++ b/desk/src/components/MultiSelectInput.vue
@@ -140,26 +140,17 @@ watchDebounced(
 );
 
 const filterOptions = createResource({
-  url: "frappe.desk.search.search_link",
-  method: "POST",
-  cache: [text.value, "Contact"],
+  url: "helpdesk.api.contact.search_contacts",
+  method: "GET",
+  cache: ["Contact", text.value],
   params: {
     txt: text.value,
-    doctype: "Contact",
   },
-  transform: (data) => {
-    let allData = data
-      .filter((c) => {
-        return c.description.split(", ")[1];
-      })
-      .map((option) => {
-        let email = option.description.split(", ")[1];
-        return {
-          label: option.label || email,
-          value: email,
-        };
-      });
-    return allData;
+  transform: (data: Record<"full_name" | "name" | "email_id", string>[]) => {
+    return data.map((option) => ({
+      label: option.full_name,
+      value: option.email_id,
+    }));
   },
 });
 
@@ -178,7 +169,6 @@ function reload(val) {
   filterOptions.update({
     params: {
       txt: val,
-      doctype: "Contact",
     },
   });
   filterOptions.reload();

--- a/helpdesk/api/contact.py
+++ b/helpdesk/api/contact.py
@@ -1,0 +1,26 @@
+from typing import Literal
+
+import frappe
+
+
+@frappe.whitelist(methods=["GET"])
+def search_contacts(
+    txt: str,
+) -> list[dict[Literal["full_name", "name", "email_id"], str]]:
+    doctype = "Contact"
+    or_filters: list[list[str]] = []
+    search_fields = ["full_name", "email_id", "name"]
+    if txt:
+        for field in search_fields:
+            or_filters.append([doctype, field, "like", f"%{txt}%"])
+    return frappe.get_list(
+        doctype,
+        filters=[[doctype, "email_id", "is", "set"]],
+        fields=search_fields,
+        or_filters=or_filters,
+        limit_start=0,
+        limit_page_length=10,
+        order_by="email_id, full_name, name",
+        ignore_permissions=False,
+        strict=False,
+    )


### PR DESCRIPTION
It is better to use a custom api to reliably generate a list of contacts for the autocomplete feature in the email editor. The logic is very similar to [Frappe CRM](https://github.com/frappe/crm/blob/c64dcb43b4a2f4063060eb79fda5a2336cb5b341/crm/api/contact.py#L116). 