### PR TITLE
fix: avoid converting yes-no select filter values to boolean

### DIFF
--- a/desk/src/components/view-controls/Filter.vue
+++ b/desk/src/components/view-controls/Filter.vue
@@ -520,30 +520,32 @@ function isSameTypeOperator(oldOperator, newOperator) {
 }
 
 function apply() {
-  let _filters = [];
+  const _filters = [];
   filters.value.forEach((f) => {
     _filters.push({
       fieldname: f.fieldname,
       operator: f.operator,
       value: f.value,
+      toBoolean: f.field.fieldtype === "Check",
     });
   });
   listViewActions.applyFilters(parseFilters(_filters));
 }
 
 function parseFilters(filters) {
-  const filtersArray = Array.from(filters);
-  const obj = filtersArray.map(transformIn).reduce((p, c) => {
+  return filters.map(transformIn).reduce((p, c) => {
     if (["equals", "="].includes(c.operator)) {
-      p[c.fieldname] =
-        c.value == "Yes" ? true : c.value == "No" ? false : c.value;
+      if (c.toBoolean) {
+        p[c.fieldname] =
+          c.value === "Yes" ? true : c.value === "No" ? false : c.value;
+      } else {
+        p[c.fieldname] = c.value;
+      }
     } else {
       p[c.fieldname] = [operatorMap[c.operator.toLowerCase()], c.value];
     }
     return p;
   }, {});
-  const merged = { ...obj };
-  return merged;
 }
 
 function transformIn(f) {


### PR DESCRIPTION
Resolves the issue associated with [this](https://support.frappe.io/helpdesk/tickets/39853?view=VIEW-HD+Ticket-003) ticket.

All of the `Yes` and `No` values of the filters are converted to `boolean`. This is required for `Check` fieldtype filters, but it breaks `Select` fieldtype filters that have `Yes` and `No` as options. The fix is to just convert `Check` fieldtype filter values.


https://github.com/user-attachments/assets/046a0d5b-216f-4fac-8698-e2f5a712740f

 