### PR TITLE
fix: include all recipients when using 'reply all' feature

### DIFF
--- a/desk/src/components/EmailArea.vue
+++ b/desk/src/components/EmailArea.vue
@@ -53,7 +53,7 @@
           @click="
             emit('reply', {
               content: content,
-              to: sender?.name ?? to,
+              to: to ?? sender.name,
               cc: cc,
               bcc: bcc,
             })


### PR DESCRIPTION
Resolves one issue associated with [this](https://support.frappe.io/helpdesk/tickets/44082) ticket.

When using the 'Reply All' feature on an activity, all of the recipients in that activity should be added as recipients of the email in the email text editor. Currently, only the sender of the activity is added as a recipient (This PR fixes that).


https://github.com/user-attachments/assets/295b423b-402d-4292-8906-c0abfb1d37b2

