### PR TITLE
refactor: update user timezone retrieval in get_user function

### DIFF
--- a/helpdesk/api/auth.py
+++ b/helpdesk/api/auth.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe.utils import get_system_timezone
 
 from helpdesk.utils import is_agent as _is_agent
 
@@ -13,7 +14,6 @@ def get_user():
         "name",
         "user_image",
         "username",
-        "time_zone",
     ]
     user = frappe.get_value(
         doctype="User",
@@ -42,7 +42,7 @@ def get_user():
         "user_first_name": user_first_name,
         "user_name": user_name,
         "username": username,
-        "time_zone": user.time_zone,
+        "time_zone": get_system_timezone(),
     }
 
 


### PR DESCRIPTION
# Problem

When creating a helpdesk ticket the users sees it as a action in the past but its happend recently. This is because the frontend is using timezone from the user. In this case timezone of the user is same as the system timezone as well but still this occoured. Ideally this should should show the same x minutes ago in all timezone but it is not working that way. Since the document creation and other time is based on the system time instead of the user time its better to use system's time itself in all place to fix that issue


https://github.com/user-attachments/assets/795e775c-be77-49e6-8574-8338be7a7e18

# Changelog 
This pull request updates how the user's time zone is handled in the `get_user` function in `helpdesk/api/auth.py`. Instead of retrieving the user's individual time zone from the database, the system-wide time zone is now used.

User time zone handling:

* Removed retrieval of the user's personal `time_zone` field from the `User` doctype and replaced it with the system-wide time zone using `get_system_timezone()` in the returned user dictionary. [[1]](diffhunk://#diff-b68bdb14f3e989d28f2101555c3976974a0cf9a9c49f18e46a3a934d3afbc7bdL16) [[2]](diffhunk://#diff-b68bdb14f3e989d28f2101555c3976974a0cf9a9c49f18e46a3a934d3afbc7bdL45-R45)
* Added an import for `get_system_timezone` from `frappe.utils` to support the new time zone logic.