### PR TITLE
fix: cc email

### DIFF
--- a/desk/src/components/EmailArea.vue
+++ b/desk/src/components/EmailArea.vue
@@ -3,7 +3,10 @@
     v-bind="$attrs"
     class="grow cursor-pointer border-transparent bg-white rounded-md shadow text-base leading-6 transition-all duration-300 ease-in-out"
   >
-    <div class="flex items-center justify-between gap-2">
+    <div
+      class="flex items-center justify-between gap-2"
+      :class="isMobileView && 'items-start'"
+    >
       <!-- email design for mobile -->
       <div v-if="isMobileView" class="flex items-center gap-2 text-sm">
         <div class="leading-tight">
@@ -27,6 +30,13 @@
       </div>
 
       <div class="flex gap-0.5 items-center">
+        <Badge
+          v-if="status.label"
+          :label="__(status.label)"
+          variant="subtle"
+          :theme="status.color"
+          class="mr-1.5"
+        />
         <Tooltip
           :text="dateFormat(creation, dateTooltipFormat)"
           v-if="!isMobileView"
@@ -118,7 +128,7 @@ import { AttachmentItem } from "@/components";
 import { useScreenSize } from "@/composables/screen";
 import { dateFormat, dateTooltipFormat, timeAgo } from "@/utils";
 import { Dropdown } from "frappe-ui";
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import LucideSplit from "~icons/lucide/split";
 import { ReplyAllIcon, ReplyIcon } from "./icons";
 import TicketSplitModal from "./ticket/TicketSplitModal.vue";
@@ -133,14 +143,39 @@ const props = defineProps({
   },
 });
 
-const { sender, to, cc, bcc, creation, subject, attachments, content, name } =
-  props.activity;
-
+const {
+  sender,
+  to,
+  cc,
+  bcc,
+  creation,
+  subject,
+  attachments,
+  content,
+  name,
+  deliveryStatus,
+} = props.activity;
+console.log(deliveryStatus);
 const emit = defineEmits(["reply"]);
 
 const { isMobileView } = useScreenSize();
 
 const showSplitModal = ref(false);
+
+const status = computed(() => {
+  let _status = deliveryStatus;
+  let indicator_color = "red";
+  if (["Sent", "Clicked"].includes(_status)) {
+    indicator_color = "green";
+  } else if (["Sending", "Scheduled"].includes(_status)) {
+    indicator_color = "orange";
+  } else if (["Opened", "Read"].includes(_status)) {
+    indicator_color = "blue";
+  } else if (_status == "Error") {
+    indicator_color = "red";
+  }
+  return { label: _status, color: indicator_color };
+});
 
 // TODO: Implement reply functionality using this way instead of emit drillup
 // function reply(email, reply_all = false) {

--- a/desk/src/pages/ticket/MobileTicketAgent.vue
+++ b/desk/src/pages/ticket/MobileTicketAgent.vue
@@ -333,6 +333,7 @@ const activities = computed(() => {
       creation: email.communication_date || email.creation,
       attachments: email.attachments,
       name: email.name,
+      deliveryStatus: email.delivery_status,
       isFirstEmail: idx === 0,
     };
   });

--- a/desk/src/pages/ticket/TicketAgent.vue
+++ b/desk/src/pages/ticket/TicketAgent.vue
@@ -322,6 +322,7 @@ const activities = computed(() => {
       creation: email.communication_date || email.creation,
       attachments: email.attachments,
       name: email.name,
+      deliveryStatus: email.delivery_status,
       isFirstEmail: idx === 0,
     };
   });

--- a/helpdesk/helpdesk/doctype/hd_ticket/api.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/api.py
@@ -135,6 +135,7 @@ def get_communications(ticket: str):
             QBCommunication.sender,
             QBCommunication.recipients,
             QBCommunication.subject,
+            QBCommunication.delivery_status,
         )
         .where(QBCommunication.reference_doctype == "HD Ticket")
         .where(QBCommunication.reference_name == ticket)

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -498,11 +498,6 @@ class HDTicket(Document):
         sender = frappe.session.user
         recipients = to or self.raised_by
         sender_email = None if skip_email_workflow else self.sender_email()
-        last_communication = self.get_last_communication()
-
-        if last_communication:
-            cc = cc or last_communication.cc
-            bcc = bcc or last_communication.bcc
 
         if recipients == "Administrator":
             admin_email = frappe.get_value("User", "Administrator", "email")
@@ -527,6 +522,8 @@ class HDTicket(Document):
                 "subject": subject,
             }
         )
+
+        last_communication = self.get_last_communication()
         if last_communication and last_communication.message_id:
             communication.in_reply_to = last_communication.name
 

--- a/helpdesk/www/helpdesk/index.py
+++ b/helpdesk/www/helpdesk/index.py
@@ -34,6 +34,7 @@ def get_boot():
             "favicon": get_favicon(),
             "setup_complete": cint(frappe.get_system_settings("setup_complete")),
             "is_fc_site": is_fc_site(),
+            "session_user": frappe.session.user,
         }
     )
 


### PR DESCRIPTION
**Issue:**
Currently, when a user replies to a customer email that includes a CC recipient, the reply is being sent to both the customer and the CC'd address. This occurs even when using the standard 'Reply' (single arrow) or 'New > Email' options, which are expected to send the response only to the original sender.


**Solution:**
1. Only send to the CC email when "Reply All" is clicked.
2. Adds Communication delivery status to the UI
<img width="795" height="144" alt="image" src="https://github.com/user-attachments/assets/cc678f4a-824c-4e12-a834-612f52118ae6" />
3. Add session_user to window object


Closes: https://github.com/frappe/helpdesk/issues/2435
