### PR TITLE
fix: import `createApp` before frappe-ui components

### DIFF
--- a/desk/src/main.js
+++ b/desk/src/main.js
@@ -1,3 +1,4 @@
+import { createApp, h } from "vue";
 import {
   Badge,
   Button,
@@ -14,7 +15,6 @@ import {
   Tooltip,
 } from "frappe-ui";
 import { createPinia } from "pinia";
-import { createApp, h } from "vue";
 import App from "./App.vue";
 import { createDialog } from "./components/dialogs";
 import "./index.css";


### PR DESCRIPTION
I have spent hours on figuring this out. 

https://github.com/vueComponent/ant-design-vue/issues/7603