### PR TITLE
fix: hide quick filter select's placeholder when a value is selected

### DIFF
--- a/desk/src/components/view-controls/QuickFilterField.vue
+++ b/desk/src/components/view-controls/QuickFilterField.vue
@@ -11,7 +11,7 @@
     v-else-if="filter.type === 'Select'"
     class="form-control cursor-pointer [&_select]:cursor-pointer w-44"
     type="select"
-    :value="props.value"
+    :model-value="props.value"
     :options="filter.options"
     :placeholder="filter.label"
     @change.stop="updateFilter(filter, $event.target.value)"


### PR DESCRIPTION
Currently, the quick filter select doesn't hide the placeholder text when a value is selected, which is incorrect.

<img width="186" height="39" alt="Screenshot 2025-08-28 at 4 01 40 PM" src="https://github.com/user-attachments/assets/24922760-1d91-41ba-8bf7-24365e5cd4c5" />

This PR fixes the issue.

<img width="183" height="43" alt="Screenshot 2025-08-28 at 4 03 54 PM" src="https://github.com/user-attachments/assets/2a3c227b-ddcd-4f37-b2f6-1b69348c062f" />
