### PR TITLE
fix: on mention comment skip email if skip_email_workflow is enabled

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_notification/hd_notification.py
+++ b/helpdesk/helpdesk/doctype/hd_notification/hd_notification.py
@@ -50,6 +50,10 @@ class HDNotification(Document):
 
     def after_insert(self):
         if self.notification_type == "Mention":
+            settings = frappe.get_single("HD Settings")
+            if settings.skip_email_workflow:
+                return
+
             frappe.sendmail(
                 recipients=self.user_to,
                 subject="New notification",


### PR DESCRIPTION
Issue: Comments where users are mentioned throw error that it needs email account configured even if skip_email_workflow is True
Fix: skip sending email when skip_email_workflow is checked