### PR TITLE
fix: handle email ticket reopen and default status

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -852,8 +852,21 @@ class HDTicket(Document):
     def on_communication_update(self, c):
         # If communication is incoming, then it is a reply from customer, and ticket must
         # be reopened.
-        # if c.sent_or_received == "Received":
-        #     self.status = self.ticket_reopen_status if self.status_category == "Paused" else self.default_open_status
+        # handle re opening tickets for email
+        if c.sent_or_received == "Received" and not self.via_customer_portal:
+            # check if agent has replied
+            has_agent_replied = frappe.db.exists(
+                "Communication",
+                {
+                    "reference_doctype": "HD Ticket",
+                    "reference_name": self.name,
+                    "sent_or_received": "Sent",
+                },
+            )
+            if has_agent_replied:
+                self.status = self.ticket_reopen_status
+            else:
+                self.status = self.default_open_status
         # If communication is outgoing, it must be a reply from agent
         if c.sent_or_received == "Sent":
             # Set first response date if not set already

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -56,7 +56,6 @@ class HDTicket(Document):
             self.sla,
             "ticket_reopen_status",
         ) or frappe.db.get_single_value("HD Settings", "ticket_reopen_status")
-        pass
 
     def publish_update(self):
         publish_event("helpdesk:ticket-update", self.name)
@@ -853,17 +852,10 @@ class HDTicket(Document):
         # If communication is incoming, then it is a reply from customer, and ticket must
         # be reopened.
         # handle re opening tickets for email
-        if c.sent_or_received == "Received" and not self.via_customer_portal:
+        if c.sent_or_received == "Received":
             # check if agent has replied
-            has_agent_replied = frappe.db.exists(
-                "Communication",
-                {
-                    "reference_doctype": "HD Ticket",
-                    "reference_name": self.name,
-                    "sent_or_received": "Sent",
-                },
-            )
-            if has_agent_replied:
+
+            if self.has_agent_replied:
                 self.status = self.ticket_reopen_status
             else:
                 self.status = self.default_open_status

--- a/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
@@ -495,7 +495,9 @@ class TestHDTicket(IntegrationTestCase):
         ticket2.create_communication_via_contact("Testing reply")
         ticket2.reload()
         # reopen the ticket
-        self.assertEqual(ticket2.status, "Open")
+
+        # status remains default one unless agent replies
+        self.assertEqual(ticket2.status, "New")
 
     def test_hold_time_resolution_time_with_holiday_with_custom_status(self):
         """
@@ -577,3 +579,4 @@ class TestHDTicket(IntegrationTestCase):
     def tearDown(self):
         remove_holidays()
         frappe.db.set_single_value("HD Settings", "default_ticket_status", "Open")
+        frappe.delete_doc("HD Ticket Status", "New", force=True)


### PR DESCRIPTION
**Issue:**
When a ticket is received via email, the status of the ticket remains unaffected. If the agent has marked the ticket on "Replied" the ticket will remain in "Replied" status, even after we receive a response from the customer.

**Solution:**
On receiving a response, reopen the ticket's status