### PR TITLE
fix(ui): improve toast icon color contrast (closes #2581)

### DIFF
--- a/desk/src/index.css
+++ b/desk/src/index.css
@@ -8,6 +8,13 @@
 	.prose-f {
 		@apply break-normal max-w-none prose prose-code:break-all prose-code:whitespace-pre-wrap prose-img:border prose-img:rounded-lg prose-sm prose-table:table-fixed prose-td:border prose-td:border-gray-300 prose-td:p-2 prose-td:relative prose-th:bg-gray-100 prose-th:border prose-th:border-gray-300 prose-th:p-2 prose-th:relative
 	}
+
+	/* Toast icon contrast fix for Issue #2581 */
+	.frappe-toast .icon,
+	.toast .icon,
+	.toast__icon {
+		color: var(--toast-icon-color, #111111);
+	}
 }
 
 html, body {


### PR DESCRIPTION
Closes #2581

## What changed
- Added CSS rule in index.css to improve toast icon color readability.

## Why
- Icons in toast notifications were unreadable in light mode.

## How tested
- Ran the app locally, triggered a toast.
- Verified the icon is readable in light mode.
- No regression in dark mode.
