### PR TITLE
fix: email reply all bug

### DIFF
--- a/desk/src/components/CommunicationArea.vue
+++ b/desk/src/components/CommunicationArea.vue
@@ -135,13 +135,21 @@ function submitComment() {
   }
 }
 
+function splitIfString(str: string | string[]) {
+  if (typeof str === "string") {
+    return str.split(",");
+  }
+  return str;
+}
+
 function replyToEmail(data: object) {
   showEmailBox.value = true;
+
   emailEditorRef.value.addToReply(
     data.content,
-    data.to?.split(","),
-    data.cc?.split(","),
-    data.bcc?.split(",")
+    splitIfString(data.to),
+    splitIfString(data.cc),
+    splitIfString(data.bcc)
   );
 }
 


### PR DESCRIPTION
Fix a bug in email "reply all" button where "quote", "CC", "BCC" emails were not loading 

***Before***
<img width="1738" height="335" alt="image" src="https://github.com/user-attachments/assets/3de09cb5-faff-4ac3-92ab-82bda43406b8" />

***After***
<img width="1973" height="419" alt="image" src="https://github.com/user-attachments/assets/ef9861d8-4680-4685-8983-6619d3a9fbb5" />
