### PR TITLE
fix: add disable field to Feedback Option

### DIFF
--- a/desk/src/pages/ticket/TicketFeedback.vue
+++ b/desk/src/pages/ticket/TicketFeedback.vue
@@ -108,6 +108,7 @@ watch(rating, (r) => {
   options.update({
     filters: {
       rating: r,
+      disabled: 0,
     },
   });
   options.reload();

--- a/helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+++ b/helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
@@ -9,7 +9,8 @@
  "engine": "InnoDB",
  "field_order": [
   "rating",
-  "label"
+  "label",
+  "disabled"
  ],
  "fields": [
   {
@@ -24,11 +25,17 @@
    "in_list_view": 1,
    "label": "Label",
    "unique": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "disabled",
+   "fieldtype": "Check",
+   "label": "Disabled"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-08-11 12:28:27.963182",
+ "modified": "2025-09-26 13:51:37.909336",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Ticket Feedback Option",
@@ -70,6 +77,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.py
@@ -23,6 +23,8 @@ class HDTicketFeedbackOption(Document):
             frappe.throw(_("Rating must be between 0.2 and 1.0"))
 
     def validate_one_enabled_option(self):
+        if self.is_new():
+            return
         if not self.has_value_changed("disabled") and self.disabled == 1:
             return
 

--- a/helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.py
@@ -12,6 +12,7 @@ class HDTicketFeedbackOption(Document):
     def validate(self):
         self.validate_allowed_ratings()
         self.validate_bounds()
+        self.validate_one_enabled_option()
 
     def validate_allowed_ratings(self):
         if self.rating not in self.allowed_ratings:
@@ -20,3 +21,19 @@ class HDTicketFeedbackOption(Document):
     def validate_bounds(self):
         if not (0.2 <= self.rating <= 1.0):
             frappe.throw(_("Rating must be between 0.2 and 1.0"))
+
+    def validate_one_enabled_option(self):
+        if not self.has_value_changed("disabled") and self.disabled == 1:
+            return
+
+        rating = self.rating
+        count = frappe.db.count(
+            "HD Ticket Feedback Option",
+            filters={"rating": rating, "disabled": 0, "name": ["!=", self.name]},
+        )
+        if not count:
+            frappe.throw(
+                _("At least one feedback option must be enabled for rating {0}").format(
+                    rating
+                )
+            )


### PR DESCRIPTION
<img width="1462" height="795" alt="Screenshot 2025-09-26 at 1 58 28 PM" src="https://github.com/user-attachments/assets/f1ba0551-d9bc-4329-98bd-a557b04fb0c3" />

Add disable field in "HD Ticket Feedback Option" DocType.

**Problem:** 
When modifying feedback options in the Feedback Dialog, renaming existing options causes unintended side effects. Since ticket records reference these options by name, any rename operation automatically updates all historical ticket data, potentially compromising data integrity and audit trails.

**Solution:** 
Instead of renaming options, implement a disabled field for feedback options. While getting options in the frontend, add filters for "disabled:0"

