### PR TITLE
fix: ignore automated system notifications in ticket communication from automatically reopens the ticket.

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -889,6 +889,9 @@ class HDTicket(Document):
                 self.status = self.default_open_status
         # If communication is outgoing, it must be a reply from agent
         if c.sent_or_received == "Sent":
+            # Ignore system notifications
+            if c.communication_type and c.communication_type == "Automated Message":
+                return
             # Set first response date if not set already
             self.first_responded_on = (
                 self.first_responded_on or frappe.utils.now_datetime()


### PR DESCRIPTION
When configuring a Notification For HD Ticket with condition:

doc.status in ["Resolved", "Closed"]


the notification is sent correctly, but it also appears in the Activity as a new Reply, which automatically reopens the ticket and changes its status to Replied.

Expected: Ticket should remain Resolved/Closed after sending the notification.
Actual: Ticket reopens due to the notification being logged as a reply.