### PR TITLE
fix: sqlite support

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py
+++ b/helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py
@@ -205,7 +205,7 @@ class HDServiceLevelAgreement(Document):
             doc.resolution_date = None
             doc.resolution_time = None
             return
-        doc.resolution_date = now_datetime()
+        doc.resolution_date = frappe.utils.nowdate()
         start_at = doc.service_level_agreement_creation
         end_at = doc.resolution_date
         time_took = self.calc_elapsed_time(start_at, end_at)
@@ -355,11 +355,21 @@ class HDServiceLevelAgreement(Document):
                 current_datetime, current_date
             )
             start_time = max(
-                current_workday_doc.start_time.total_seconds(), current_time_in_seconds
+                timedelta(
+                    hours=current_workday_doc.start_time.hour,
+                    minutes=current_workday_doc.start_time.minute,
+                    seconds=current_workday_doc.start_time.second,
+                ).total_seconds(),
+                current_time_in_seconds,
             )
             till_start_time = max(start_time - current_time_in_seconds, 0)
             end_time = max(
-                current_workday_doc.end_time.total_seconds(), current_time_in_seconds
+                timedelta(
+                    hours=current_workday_doc.end_time.hour,
+                    minutes=current_workday_doc.end_time.minute,
+                    seconds=current_workday_doc.end_time.second,
+                ).total_seconds(),
+                current_time_in_seconds,
             )
             time_left = max(end_time - start_time, 0)
             if not time_left:

--- a/helpdesk/setup/install.py
+++ b/helpdesk/setup/install.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date
 
 import frappe
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
@@ -132,14 +132,14 @@ def add_default_sla():
 def add_default_holiday_list():
     if frappe.db.exists("HD Service Holiday List", "Default"):
         return
+
+    year = date.today().year
     frappe.get_doc(
         {
             "doctype": "HD Service Holiday List",
             "holiday_list_name": "Default",
-            "from_date": datetime.strptime(f"Jan 1 {datetime.now().year}", "%b %d %Y"),
-            "to_date": datetime.strptime(
-                f"Jan 1 {datetime.now().year + 1}", "%b %d %Y"
-            ),
+            "from_date": date(year, 1, 1),
+            "to_date": date(year + 1, 1, 1),
         }
     ).insert()
 


### PR DESCRIPTION
    Basically involves setting the correct types here.

    Some date fields had datetime values set, which MariaDB "accepts",
    but won't work with the way we have setup some types for SQLite.