### PR TITLE
fix: assign history message

### DIFF
--- a/desk/src/components/ticket-agent/AssignTo.vue
+++ b/desk/src/components/ticket-agent/AssignTo.vue
@@ -49,7 +49,7 @@
 </template>
 
 <script setup lang="ts">
-import { AssigneeSymbol, TicketSymbol } from "@/types";
+import { ActivitiesSymbol, AssigneeSymbol, TicketSymbol } from "@/types";
 import { Popover } from "frappe-ui";
 import { inject } from "vue";
 import LucideChevronDown from "~icons/lucide/chevron-down";
@@ -57,7 +57,7 @@ import MultipleAvatar from "../MultipleAvatar.vue";
 import AssignToBody from "./AssignToBody.vue";
 const ticket = inject(TicketSymbol);
 const assignees = inject(AssigneeSymbol);
-
+const activities = inject(ActivitiesSymbol);
 async function saveAssignees(
   addedAssignees,
   removedAssignees,
@@ -66,6 +66,7 @@ async function saveAssignees(
 ) {
   removedAssignees.length && (await removeAssignees.submit(removedAssignees));
   addedAssignees.length && (await addAssignees.submit(addedAssignees));
+  activities.value.reload();
 }
 </script>
 

--- a/desk/src/components/ticket-agent/AssignToBody.vue
+++ b/desk/src/components/ticket-agent/AssignToBody.vue
@@ -173,7 +173,7 @@ async function updateAssignees() {
   if (addedAssignees.length || removedAssignees.length) {
     let logMessage = `${
       addedAssignees.length ? `assigned ${addedAssignees.join(", ")}` : ""
-    } ${removedAssignees.length ? " & " : ""} ${
+    } ${addedAssignees.length && removedAssignees.length ? " & " : ""} ${
       removedAssignees.length ? `unassigned ${removedAssignees.join(", ")}` : ""
     }`;
     call("frappe.client.insert", {

--- a/desk/src/components/ticket-agent/AssignToBody.vue
+++ b/desk/src/components/ticket-agent/AssignToBody.vue
@@ -173,7 +173,7 @@ async function updateAssignees() {
   if (addedAssignees.length || removedAssignees.length) {
     let logMessage = `${
       addedAssignees.length ? `assigned ${addedAssignees.join(", ")}` : ""
-    } ${removeAssignees.length ? " & " : ""} ${
+    } ${removedAssignees.length ? " & " : ""} ${
       removedAssignees.length ? `unassigned ${removedAssignees.join(", ")}` : ""
     }`;
     call("frappe.client.insert", {
@@ -196,7 +196,7 @@ async function updateAssignees() {
       await removeAssignees.submit(removedAssignees);
     }
     if (addedAssignees.length) {
-      addAssignees.submit(addedAssignees);
+      await addAssignees.submit(addedAssignees);
     }
   }
 }

--- a/desk/src/components/ticket-agent/TicketDetailsTab.vue
+++ b/desk/src/components/ticket-agent/TicketDetailsTab.vue
@@ -64,6 +64,7 @@ import { parseField } from "@/composables/formCustomisation";
 import { useNotifyTicketUpdate } from "@/composables/realtime";
 import { getMeta } from "@/stores/meta";
 import {
+  ActivitiesSymbol,
   AssigneeSymbol,
   CustomizationSymbol,
   FieldValue,
@@ -77,6 +78,7 @@ import TicketContact from "./TicketContact.vue";
 const ticket = inject(TicketSymbol);
 const assignees = inject(AssigneeSymbol);
 const customizations = inject(CustomizationSymbol);
+const activities = inject(ActivitiesSymbol);
 const { getFields, getField } = getMeta("HD Ticket");
 const { notifyTicketUpdate } = useNotifyTicketUpdate(ticket.value?.name);
 
@@ -174,6 +176,7 @@ function handleFieldUpdate(
         if (fieldname === "agent_group") {
           assignees.value.reload();
         }
+        activities.value.reload();
       },
     }
 


### PR DESCRIPTION
**Issue:**
The assign message in HD ticket history doctype was not recorded properly

**Reason:**
We were checking "resource" length instead of the "Array" length.

