### PR TITLE
fix: disable command palette when text editor is enabled

### DIFF
--- a/desk/src/components/command-palette/CP.vue
+++ b/desk/src/components/command-palette/CP.vue
@@ -64,6 +64,7 @@ import { computed, h, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import LucideBookOpen from "~icons/lucide/book-open";
 
+import { showCommentBox, showEmailBox } from "@/pages/ticket/modalStates";
 import LucideTicket from "~icons/lucide/ticket";
 import CPGroup from "./CPGroup.vue";
 const router = useRouter();
@@ -147,6 +148,7 @@ const onSelection = (value) => {
 const addKeyboardShortcut = () => {
   window.addEventListener("keydown", (e) => {
     if (e.key === "k" && (e.ctrlKey || e.metaKey)) {
+      if (showEmailBox.value || showCommentBox.value) return;
       e.preventDefault();
       toggleCommandPalette();
     }

--- a/desk/src/pages/ticket/TicketAgent.vue
+++ b/desk/src/pages/ticket/TicketAgent.vue
@@ -34,6 +34,7 @@ import {
 import { createResource, toast } from "frappe-ui";
 import { computed, onBeforeUnmount, onMounted, provide, watch } from "vue";
 import { useRoute } from "vue-router";
+import { showCommentBox, showEmailBox } from "./modalStates";
 const { $socket } = globalStore();
 
 const props = defineProps({
@@ -120,6 +121,8 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   stopViewing(props.ticketId);
+  showEmailBox.value = false;
+  showCommentBox.value = false;
 });
 </script>
 


### PR DESCRIPTION
<img width="1024" height="605" alt="image" src="https://github.com/user-attachments/assets/3fb78e29-de00-426d-a39c-56fb4d30d904" />

**Issue:**
Both the command palette and "adding link to a text" (TextEditor) have the same shortcuts which is "cmnd / ctrl+ k"

Neither of them works when we try to add link to a text in the text editor.


**Solution:**
When text editor is enabled disable the command palette