### PR TITLE
fix: docker bash file

### DIFF
--- a/docker/init.sh
+++ b/docker/init.sh
@@ -22,7 +22,7 @@ bench set-redis-socketio-host redis://redis:6379
 sed -i '/redis/d' ./Procfile
 sed -i '/watch/d' ./Procfile
 
-bench get-app telephony --branch main
+bench get-app telephony
 bench get-app helpdesk --branch main
 
 bench new-site helpdesk.localhost \


### PR DESCRIPTION
#### Issue:
Docker development setup script was failing

#### Reason:
The script was using the incorrect branch for telephony