### PR TITLE
fix: reply all 'To' email bug

### DIFF
--- a/desk/src/components/EmailArea.vue
+++ b/desk/src/components/EmailArea.vue
@@ -64,7 +64,7 @@
           @click="
             emit('reply', {
               content: content,
-              to: to ?? sender.name,
+              to: sender?.name ?? to,
               cc: cc ? cc : [],
               bcc: bcc ? bcc : [],
             })


### PR DESCRIPTION
#### Issue:
On clicking "Reply all", the "To" email field was getting set incorrectly. 

#### Reason:
Instead of the sender's email address, the receiver's email address was getting set in "To" field

#### Before fix
<img width="1595" height="996" alt="image" src="https://github.com/user-attachments/assets/eb77f2be-a385-4fd5-b8f3-15f7c9c62c07" />

#### After fix
<img width="1573" height="967" alt="image" src="https://github.com/user-attachments/assets/5ebb7494-b42b-47fc-8464-d6c7534c081e" />
