### PR TITLE
fix(ux): init config store from boot when possible

### DIFF
--- a/desk/src/stores/config.ts
+++ b/desk/src/stores/config.ts
@@ -6,8 +6,10 @@ import { computed, ComputedRef } from "vue";
 export const useConfigStore = defineStore("config", () => {
   const configRes = createResource({
     url: "helpdesk.api.config.get_config",
-    auto: true,
+    auto:  !window.hasOwnProperty("hd_config"),
   });
+
+  window.hd_config && configRes.setData(window.hd_config);
 
   const config = computed(() => configRes.data || {});
   const brandLogo = computed(() => config.value.brand_logo);

--- a/desk/src/types.ts
+++ b/desk/src/types.ts
@@ -524,5 +524,6 @@ declare global {
     date_format: string;
     time_format: string;
     session_user: string;
+    hd_config?: object;
   }
 }

--- a/helpdesk/www/helpdesk/index.py
+++ b/helpdesk/www/helpdesk/index.py
@@ -4,6 +4,8 @@ from frappe.integrations.frappe_providers.frappecloud_billing import is_fc_site
 from frappe.utils import cint
 from frappe.utils.telemetry import capture
 
+from helpdesk.api.config import get_config
+
 no_cache = 1
 
 
@@ -37,6 +39,7 @@ def get_boot():
             "session_user": frappe.session.user,
             "date_format": frappe.get_system_settings("date_format"),
             "time_format": frappe.get_system_settings("time_format"),
+            "hd_config": get_config(),
         }
     )
 


### PR DESCRIPTION
### Summary:
Initializes HD Config into boot context.

The reason I added this is because when the helpdesk page loads, it shows the default helpdesk logo for the first couple of seconds until `helpdesk.api.config.get_config` finishes loading, then it will switch to the branding set in settings.
This change pre loads those settings so there is no switching of the logo after the page has rendered.