### PR TITLE
fix: tooltip for response and resolution time

### DIFF
--- a/desk/src/components/ticket-agent/TicketSLA.vue
+++ b/desk/src/components/ticket-agent/TicketSLA.vue
@@ -38,26 +38,38 @@
       <!-- First Response -->
       <div class="flex items-center gap-1">
         <span>First Response</span>
-        <Badge
-          :label="firstResponse.label"
-          variant="subtle"
-          :theme="firstResponse.color"
-        />
+        <Tooltip
+          :text="dateFormat(firstResponse.date, dateTooltipFormat)"
+          :hover-delay="0.25"
+          :placement="'top'"
+        >
+          <Badge
+            :label="firstResponse.label"
+            variant="subtle"
+            :theme="firstResponse.color"
+          />
+        </Tooltip>
       </div>
       <!-- divider -->
       <div class="border-l border-outline-gray-2 h-[13px]" />
       <!-- Resolution by -->
       <div class="flex items-center gap-1">
         <span>Resolution </span>
-        <Badge
-          v-if="resolutionBy"
-          :label="resolutionBy.label"
-          variant="subtle"
-          :theme="resolutionBy.color !== 'purple' && resolutionBy.color"
-          :class="
-            resolutionBy.color === 'purple' && '!text-[#6B46C1] !bg-[#F3E8FF]'
-          "
-        />
+        <Tooltip
+          :text="dateFormat(resolutionBy.date, dateTooltipFormat)"
+          :hover-delay="0.25"
+          :placement="'top'"
+        >
+          <Badge
+            v-if="resolutionBy"
+            :label="resolutionBy.label"
+            variant="subtle"
+            :theme="resolutionBy.color !== 'purple' && resolutionBy.color"
+            :class="
+              resolutionBy.color === 'purple' && '!text-[#6B46C1] !bg-[#F3E8FF]'
+            "
+          />
+        </Tooltip>
       </div>
     </div>
   </teleport>
@@ -65,15 +77,20 @@
 
 <script setup lang="ts">
 import { TicketSymbol } from "@/types";
-import { copyToClipboard } from "@/utils";
-import { dayjs } from "frappe-ui";
+import {
+  copyToClipboard,
+  dateFormat,
+  dateTooltipFormat,
+  formatTime,
+} from "@/utils";
+import { dayjs, Tooltip } from "frappe-ui";
 import Badge from "frappe-ui/src/components/Badge/Badge.vue";
 import { computed, inject } from "vue";
 
 const ticket = inject(TicketSymbol);
 
 const firstResponse = computed(() => {
-  if (ticket.value?.get?.loading) return { label: "", color: "" };
+  if (ticket.value?.get?.loading) return { label: "", color: "", date: "" };
   if (
     !ticket.value.doc.first_responded_on &&
     dayjs().isBefore(dayjs(ticket.value.doc.response_by))
@@ -82,6 +99,7 @@ const firstResponse = computed(() => {
     return {
       label: `Due in ${responseBy}`,
       color: "orange",
+      date: ticket.value.doc.response_by,
     };
   } else if (
     dayjs(ticket.value.doc.first_responded_on).isBefore(
@@ -95,6 +113,7 @@ const firstResponse = computed(() => {
     return {
       label: `Fulfilled in ${responseBy}`,
       color: "green",
+      date: ticket.value.doc.first_responded_on,
     };
   } else {
     let responseBy = formatTimeShort(
@@ -104,12 +123,13 @@ const firstResponse = computed(() => {
     return {
       label: `Failed by ${responseBy}`,
       color: "red",
+      date: ticket.value.doc.response_by,
     };
   }
 });
 
 const resolutionBy = computed(() => {
-  if (ticket.value?.get?.loading) return { label: "", color: "" };
+  if (ticket.value?.get?.loading) return { label: "", color: "", date: "" };
 
   if (
     ticket.value.doc?.status_category === "Paused" &&
@@ -118,9 +138,11 @@ const resolutionBy = computed(() => {
       dayjs(ticket.value.doc?.on_hold_since)
     )
   ) {
+    let timeLeft = dayjs(ticket.value.doc?.resolution_by).diff(dayjs(), "s");
     return {
-      label: `On Hold`,
+      label: `${formatTime(timeLeft)} left (On Hold)`,
       color: "blue",
+      date: ticket.value.doc?.on_hold_since,
     };
   } else if (
     !ticket.value.doc?.resolution_date &&
@@ -130,6 +152,7 @@ const resolutionBy = computed(() => {
     return {
       label: `Due in ${resolutionBy}`,
       color: "purple",
+      date: ticket.value.doc?.resolution_by,
     };
   } else if (
     dayjs(ticket.value.doc?.resolution_date).isBefore(
@@ -143,6 +166,7 @@ const resolutionBy = computed(() => {
     return {
       label: `Fulfilled in ${resolutionBy}`,
       color: "green",
+      date: ticket.value.doc?.resolution_date,
     };
   } else {
     let resolutionBy = formatTimeShort(
@@ -152,6 +176,7 @@ const resolutionBy = computed(() => {
     return {
       label: `Failed by ${resolutionBy}`,
       color: "red",
+      date: ticket.value.doc?.resolution_by,
     };
   }
 });

--- a/desk/src/components/ticket/TicketAgentDetails.vue
+++ b/desk/src/components/ticket/TicketAgentDetails.vue
@@ -65,6 +65,7 @@ const firstResponseBadge = computed(() => {
     firstResponse = {
       label: `Due in ${formatTime(firstResponseSeconds.value)}`,
       color: "orange",
+      date: props.ticket.response_by,
     };
   } else if (
     dayjs(props.ticket.first_responded_on).isBefore(
@@ -79,11 +80,13 @@ const firstResponseBadge = computed(() => {
         )
       )}`,
       color: "green",
+      date: props.ticket.first_responded_on,
     };
   } else {
     firstResponse = {
       label: "Failed",
       color: "red",
+      date: props.ticket.response_by,
     };
   }
   return firstResponse;
@@ -103,6 +106,7 @@ const resolutionBadge = computed(() => {
     resolution = {
       label: `${formatTime(timeLeft)} left (On Hold)`,
       color: "blue",
+      date: props.ticket.on_hold_since,
     };
   } else if (
     !props.ticket.resolution_date &&
@@ -116,6 +120,7 @@ const resolutionBadge = computed(() => {
     resolution = {
       label: `Due in ${formatTime(resolutionSeconds.value)}`,
       color: "orange",
+      date: props.ticket.resolution_by,
     };
   } else if (props.ticket.agreement_status === "Fulfilled") {
     resolution = {
@@ -123,11 +128,13 @@ const resolutionBadge = computed(() => {
         dayjs(props.ticket.resolution_time, "s")
       )}`,
       color: "green",
+      date: props.ticket.resolution_date,
     };
   } else {
     resolution = {
       label: "Failed",
       color: "red",
+      date: props.ticket.resolution_by,
     };
   }
   return resolution;
@@ -146,16 +153,13 @@ function getCalculatedResolution() {
 const sections = computed(() => [
   {
     label: "First Response",
-    tooltipValue: dateFormat(props.ticket.response_by, dateTooltipFormat),
+    tooltipValue: dateFormat(firstResponseBadge.value.date, dateTooltipFormat),
     badgeText: firstResponseBadge.value.label,
     badgeColor: firstResponseBadge.value.color,
   },
   {
     label: "Resolution",
-    tooltipValue: dateFormat(
-      props.ticket.resolution_date || props.ticket.resolution_by,
-      dateTooltipFormat
-    ),
+    tooltipValue: dateFormat(resolutionBadge.value.date, dateTooltipFormat),
     badgeText: resolutionBadge.value.label,
     badgeColor: resolutionBadge.value.color,
   },


### PR DESCRIPTION
#### Issue:
Tooltip was not shown for response time and resolution time in ticket view

#### Fix:
<img width="1015" height="159" alt="image" src="https://github.com/user-attachments/assets/d33a2434-5fa0-4f7d-a639-764a0fb62d17" />
