### PR TITLE
feat: Display outside working hours alert on New Ticket page

### DIFF
--- a/desk/src/components/OutsideHoursAlert.vue
+++ b/desk/src/components/OutsideHoursAlert.vue
@@ -1,0 +1,55 @@
+<template>
+  <div
+    v-if="showAlert && alertMessage"
+    class="flex gap-4 justify-start p-4 bg-orange-50 text-orange-800 rounded-lg border border-orange-200"
+  >
+    <Clock class="size-5" />
+
+    <div class="flex-1 flex flex-col gap-1 text-sm">
+      <h4 class="font-semibold">Outside Business Hours</h4>
+      <p>{{ alertMessage }}</p>
+    </div>
+
+    <button
+      @click="dismissAlert"
+      class="hover:text-orange-900"
+      aria-label="Dismiss alert"
+    >
+      <X class="size-4" />
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { createResource } from "frappe-ui";
+import { ref } from "vue";
+import Clock from "~icons/lucide/clock";
+import X from "~icons/lucide/x";
+
+const showAlert = ref(false);
+const alertMessage = ref("");
+const isDismissed = ref(false);
+
+const workingHours = createResource({
+  url: "helpdesk.helpdesk.doctype.hd_settings.hd_settings.check_working_hours",
+  auto: true,
+  onSuccess: (data) => {
+    if (data && data.show_message && !isDismissed.value) {
+      showAlert.value = true;
+      alertMessage.value = data.message;
+    }
+  },
+  onError: (error) => {
+    console.error("Error checking working hours:", error);
+  },
+});
+
+function dismissAlert() {
+  isDismissed.value = true;
+  showAlert.value = false;
+}
+
+defineExpose({
+  reload: () => workingHours.reload(),
+});
+</script>

--- a/desk/src/pages/ticket/TicketNew.vue
+++ b/desk/src/pages/ticket/TicketNew.vue
@@ -15,6 +15,8 @@
     <div
       class="flex flex-col gap-5 py-6 h-full flex-1 self-center overflow-auto mx-auto w-full max-w-4xl px-5"
     >
+      <!-- outside working hours alert -->
+      <OutsideHoursAlert />
       <!-- custom fields descriptions -->
       <div v-if="Boolean(template.data?.about)" class="">
         <div class="prose-f" v-html="sanitize(template.data.about)" />
@@ -140,6 +142,7 @@ import { computed, onMounted, reactive, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import SearchArticles from "../../components/SearchArticles.vue";
 import TicketTextEditor from "./TicketTextEditor.vue";
+import OutsideHoursAlert from "../../components/OutsideHoursAlert.vue";
 
 interface P {
   templateId?: string;

--- a/helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+++ b/helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -69,7 +69,22 @@
   "reply_email_to_agent_content",
   "reply_from_agent_section",
   "enable_reply_email_via_agent",
-  "reply_via_agent_email_content"
+  "reply_via_agent_email_content",
+  "work_tab",
+  "work_duration_section",
+  "sunday",
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+  "column_break_ydtb",
+  "work_start_time",
+  "work_end_time",
+  "notification_section",
+  "show_message_outside_working_hours",
+  "outside_hours_message"
  ],
  "fields": [
   {
@@ -449,12 +464,95 @@
    "link_filters": "[[\"HD Ticket Status\",\"category\",\"in\",[\"Paused\",\"Resolved\",null]]]",
    "mandatory_depends_on": "eval: doc.auto_close_tickets",
    "options": "HD Ticket Status"
+  },
+  {
+   "fieldname": "work_tab",
+   "fieldtype": "Tab Break",
+   "label": "Work Duration"
+  },
+  {
+   "fieldname": "work_duration_section",
+   "fieldtype": "Section Break",
+   "label": "Working days and hours"
+  },
+  {
+   "default": "0",
+   "fieldname": "sunday",
+   "fieldtype": "Check",
+   "label": "Sunday"
+  },
+  {
+   "default": "0",
+   "fieldname": "monday",
+   "fieldtype": "Check",
+   "label": "Monday"
+  },
+  {
+   "default": "0",
+   "fieldname": "tuesday",
+   "fieldtype": "Check",
+   "label": "Tuesday"
+  },
+  {
+   "default": "0",
+   "fieldname": "wednesday",
+   "fieldtype": "Check",
+   "label": "Wednesday"
+  },
+  {
+   "default": "0",
+   "fieldname": "thursday",
+   "fieldtype": "Check",
+   "label": "Thursday"
+  },
+  {
+   "default": "0",
+   "fieldname": "friday",
+   "fieldtype": "Check",
+   "label": "Friday"
+  },
+  {
+   "fieldname": "column_break_ydtb",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "work_start_time",
+   "fieldtype": "Time",
+   "label": "Work start time"
+  },
+  {
+   "fieldname": "work_end_time",
+   "fieldtype": "Time",
+   "label": "Work end time"
+  },
+  {
+   "fieldname": "notification_section",
+   "fieldtype": "Section Break",
+   "label": "Notification"
+  },
+  {
+   "fieldname": "outside_hours_message",
+   "fieldtype": "Text",
+   "label": "Outside hours message"
+  },
+  {
+   "default": "0",
+   "fieldname": "saturday",
+   "fieldtype": "Check",
+   "label": "Saturday"
+  },
+  {
+   "default": "0",
+   "description": "Enable this to show a notification to users who create a ticket outside of work hours.\n\nYou must configure the 'Work Duration' section and set a message in 'Outside hours notification message' for this to work.",
+   "fieldname": "show_message_outside_working_hours",
+   "fieldtype": "Check",
+   "label": "Show message outside working hours"
   }
  ],
  "grid_page_length": 50,
  "issingle": 1,
  "links": [],
- "modified": "2025-08-29 13:34:17.018321",
+ "modified": "2025-10-20 01:44:08.616238",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Settings",

--- a/helpdesk/helpdesk/doctype/hd_settings/test_hd_settings.py
+++ b/helpdesk/helpdesk/doctype/hd_settings/test_hd_settings.py
@@ -4,7 +4,134 @@
 from __future__ import unicode_literals
 
 import unittest
+from datetime import datetime
+
+import frappe
 
 
-class TestHDSettings(unittest.TestCase):
-    pass
+class TestHDSettingsWorkingHours(unittest.TestCase):
+    """
+    Testing for outside working hours notification functionality
+    """
+
+    def setup_standard_work_week(self):
+        self.settings = frappe.get_doc("HD Settings")
+        self.settings.update(
+            {
+                "show_message_outside_working_hours": 1,
+                "outside_hours_message": "We are currently closed. We will get back to you during business hours.",
+                "monday": 1,
+                "tuesday": 1,
+                "wednesday": 1,
+                "thursday": 1,
+                "friday": 1,
+                "saturday": 0,
+                "sunday": 0,
+                "work_start_time": "09:00:00",
+                "work_end_time": "17:00:00",
+            }
+        )
+        self.settings.save()
+
+    def run_check_working_hours_at(self, mock_time: datetime):
+        """
+        Mocks the time and calls the check_working_hours API.
+        """
+        patch_target = "helpdesk.helpdesk.doctype.hd_settings.hd_settings.now_datetime"
+
+        with unittest.mock.patch(patch_target, return_value=mock_time):
+            response = frappe.call(
+                "helpdesk.helpdesk.doctype.hd_settings.hd_settings.check_working_hours"
+            )
+            return response
+
+    def test_feature_disabled(self):
+        """
+        Test that no message is shown if the feature is disabled, even if it's outside working hours.
+        """
+        self.setup_standard_work_week()
+        self.settings.show_message_outside_working_hours = 0
+        self.settings.save()
+
+        mock_time = datetime(2025, 10, 19, 12, 0, 0)
+
+        response = self.run_check_working_hours_at(mock_time)
+
+        self.assertFalse(response.get("show_message"))
+
+    def test_outside_working_day(self):
+        """
+        Test that the message is shown on a non-working day (e.g., Sunday).
+        """
+        self.setup_standard_work_week()
+        mock_time = datetime(2025, 10, 19, 14, 0, 0)
+
+        response = self.run_check_working_hours_at(mock_time)
+
+        self.assertTrue(response.get("show_message"))
+        self.assertEqual(response.get("message"), self.settings.outside_hours_message)
+
+    def test_inside_working_day_before_hours(self):
+        """
+        Test that the message is shown on a working day but before work starts.
+        """
+        self.setup_standard_work_week()
+        mock_time = datetime(2025, 10, 20, 8, 0, 0)
+
+        response = self.run_check_working_hours_at(mock_time)
+
+        self.assertTrue(response.get("show_message"))
+        self.assertEqual(response.get("message"), self.settings.outside_hours_message)
+
+    def test_inside_working_day_after_hours(self):
+        """
+        Test that the message is shown on a working day but after work ends.
+        """
+        self.setup_standard_work_week()
+        mock_time = datetime(2025, 10, 20, 18, 0, 0)
+
+        response = self.run_check_working_hours_at(mock_time)
+
+        self.assertTrue(response.get("show_message"))
+
+    def test_inside_working_hours(self):
+        """
+        Test that no message is shown when raising a ticket during working days and hours.
+        """
+        self.setup_standard_work_week()
+        mock_time = datetime(2025, 10, 20, 12, 0, 0)
+
+        response = self.run_check_working_hours_at(mock_time)
+
+        self.assertFalse(response.get("show_message"))
+
+    def test_working_day_with_no_times_set(self):
+        """
+        Test edge case: If a day is a working day but no start/end times
+        are set, it should be considered "always on" for that day.
+        """
+        self.setup_standard_work_week()
+        self.settings.work_start_time = None
+        self.settings.work_end_time = None
+        self.settings.save()
+
+        mock_time = datetime(2025, 10, 20, 2, 0, 0)
+
+        response = self.run_check_working_hours_at(mock_time)
+
+        self.assertFalse(response.get("show_message"))
+
+    def test_empty_message(self):
+        """
+        Test that the message is an empty string if it's not set in settings.
+        """
+        self.setup_standard_work_week()
+        self.settings.outside_hours_message = ""
+        self.settings.save()
+
+        mock_time = datetime(2025, 10, 19, 14, 0, 0)
+
+        response = self.run_check_working_hours_at(mock_time)
+
+        self.assertTrue(response.get("show_message"))
+        self.assertEqual(response.get("message"), "")


### PR DESCRIPTION
Implements a feature to inform customers when they are creating a new ticket outside of defined business hours.

**Changes:**
- Added necessary fields to HD Settings to enter working hours
- Implemented check_working_hours API (hd_settings.py)
- Created the OutsideHoursAlert.vue component and integrated it into TicketNew.vue.
- Added tests in HD Settings checking various scenarios

**Demonstration:** 
When I change working hours to include the current hour, the notification disappears:

![screenshot-gif-github-issue](https://github.com/user-attachments/assets/c526a90d-89c6-4b51-89ea-4446486fc177)