### PR TITLE
fix: update required_apps to include frappe/telephony

### DIFF
--- a/helpdesk/hooks.py
+++ b/helpdesk/hooks.py
@@ -6,7 +6,7 @@ app_icon = "octicon octicon-file-directory"
 app_color = "grey"
 app_email = "hello@frappe.io"
 app_license = "AGPLv3"
-required_apps = ["telephony"]
+required_apps = ["frappe/telephony"]
 
 add_to_apps_screen = [
     {


### PR DESCRIPTION
Fixes : #2592 
Could not find app "telephony" after latest update

Solution Description
changed telephony ro frappe/telephony , So that on installing it will check the dependency and get it cloned and installed.