### PR TITLE
fix: prevent usermenu button overflow in sidebar

### DIFF
--- a/desk/src/components/UserMenu.vue
+++ b/desk/src/components/UserMenu.vue
@@ -7,8 +7,8 @@
           !sidebarStore.isExpanded
             ? 'w-auto px-0'
             : open
-            ? 'w-52 bg-white px-1 shadow-sm'
-            : 'w-52 px-1 hover:bg-gray-200'
+            ? 'w-full bg-white px-1 shadow-sm'
+            : 'w-full px-1 hover:bg-gray-200'
         "
       >
         <BrandLogo />


### PR DESCRIPTION
Related to https://github.com/frappe/frappe-ui/issues/298

## Steps to reproduce

1) Increase font size in your browser

https://github.com/user-attachments/assets/53a3faf2-6a20-4d03-b351-e50ad0872bde

## Solution

Dont hardcode the `w-52` width to the usermenu button, it must just take the parents element's width

https://github.com/user-attachments/assets/b4e0477d-e683-4d08-b82d-0142cc23f97e


https://github.com/user-attachments/assets/f628f96e-f2c0-4abc-9c55-eeccadf72e71

