### PR TITLE
refactor: update apiOptions transform to map object labels and values

### DIFF
--- a/desk/src/components/TicketField.vue
+++ b/desk/src/components/TicketField.vue
@@ -75,10 +75,14 @@ const apiOptions = createResource({
   transform: (data) => {
     if (!data?.length) return [];
     return (
-      data?.map((o) => ({
-        label: o,
-        value: o,
-      })) || []
+      data?.map((o) =>
+        typeof o === "object" && o.label && o.value
+          ? o
+          : {
+              label: o?.toString(),
+              value: o,
+            }
+      ) || []
     );
   },
 });

--- a/desk/src/components/UniInput.vue
+++ b/desk/src/components/UniInput.vue
@@ -91,10 +91,14 @@ const apiOptions = createResource({
   url: props.field.url_method,
   auto: !!props.field.url_method,
   transform: (data) =>
-    data?.map((o) => ({
-      label: o,
-      value: o,
-    })) || [],
+    data?.map((o) =>
+      typeof o === "object" && o.label && o.value
+        ? o
+        : {
+            label: o?.toString(),
+            value: o,
+          }
+    ) || [],
 });
 
 const transValue = computed(() => {


### PR DESCRIPTION
Closes: #2714 

---

After this PR is merged, you can return data in the following format from server side using the `url_method` field in the **Fields** child table of the **HD Ticket Template**:

```python
[
    {"label": "Support Category", "value": "HD-CAT-0001"},
    {"label": "Billing Category", "value": "HD-CAT-0002"}
]
```

The `transform` function in `apiOptions` within the `UniInput` component will now correctly map these objects into dropdown options.
