### PR TITLE
fix: remove index delete from hooks

### DIFF
--- a/helpdesk/hooks.py
+++ b/helpdesk/hooks.py
@@ -63,11 +63,6 @@ doc_events = {
         "on_trash": "helpdesk.extends.assignment_rule.on_assignment_rule_trash",
         "validate": "helpdesk.extends.assignment_rule.on_assignment_rule_validate",
     },
-    "HD Ticket": {
-        "on_trash": [
-            "helpdesk.search_sqlite.delete_doc",
-        ],
-    },
 }
 
 has_permission = {

--- a/helpdesk/search_sqlite.py
+++ b/helpdesk/search_sqlite.py
@@ -180,12 +180,6 @@ class HelpdeskSearch(SQLiteSearch):
 
 
 def build_index():
-    """Build search index - called by background job."""
+    """Build search index - can be called from console."""
     search = HelpdeskSearch()
     search.build_index()
-
-
-def delete_doc():
-    """Delete document from index - called by background job."""
-    search = HelpdeskSearch()
-    search.remove_doc()


### PR DESCRIPTION
Deleting ticket as throwing an error, because it is handled via hooks.

**Solution:**
Remove "delete_doc" hook, as it is handled by Framework's SQLite search implementation 