### PR TITLE
fix: remove unnecessary validation while giving feedback for email tickets

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -304,12 +304,7 @@ class HDTicket(Document):
         )
 
     def validate_feedback(self):
-        if (
-            self.feedback
-            or self.status_category != "Resolved"
-            or is_agent()
-            or not self.has_agent_replied
-        ):
+        if self.feedback or is_agent() or not self.has_agent_replied:
             return
 
         frappe.throw(
@@ -317,7 +312,7 @@ class HDTicket(Document):
         )
 
     def check_update_perms(self):
-        if self.is_new() or is_agent():
+        if self.is_new() or is_agent() or not self.via_customer_portal:
             return
         old_doc = self.get_doc_before_save()
         is_closed = old_doc.status == "Closed"


### PR DESCRIPTION
Remove validation of 

`self.status!=Resolved` while validating feedback.

Ticket can be in any state, the end user should be able to close it regardless.