### PR TITLE
fix: filter out null/undefined values in apiOptions

### DIFF
--- a/desk/src/components/TicketField.vue
+++ b/desk/src/components/TicketField.vue
@@ -74,22 +74,24 @@ const apiOptions = createResource({
   auto: !!props.field.url_method,
   transform: (data) => {
     if (!data?.length) return [];
-    return data
-      .filter((o) => Boolean(o))
-      .map((o) => {
-        if (
-          typeof o === "object" &&
-          o.hasOwnProperty("label") &&
-          o.hasOwnProperty("value")
-        ) {
-          return o;
-        } else {
-          return {
-            label: o?.toString(),
-            value: o,
-          };
-        }
-      });
+    return (
+      data
+        .filter((o) => Boolean(o))
+        .map((o) => {
+          if (
+            typeof o === "object" &&
+            o.hasOwnProperty("label") &&
+            o.hasOwnProperty("value")
+          ) {
+            return o;
+          } else {
+            return {
+              label: o?.toString(),
+              value: o,
+            };
+          }
+        }) || []
+    );
   },
 });
 


### PR DESCRIPTION
**Issue**
Bug introduced by: https://github.com/frappe/helpdesk/pull/2715

While fetching the options from API, for each option we are checking if the `typeof option === object`. 

Type of `null` is also an `object` so we get an error "label is undefined".

**Solution**
To fix the issue, we should first filter out the undefined / null values, then only transform the data

