### PR TITLE
fix: prevent emoji clipping

### DIFF
--- a/desk/src/components/ViewModal.vue
+++ b/desk/src/components/ViewModal.vue
@@ -11,7 +11,7 @@
         <IconPicker v-model="view.icon" v-slot="{ togglePopover }">
           <Button
             size="md"
-            class="flex size-8 text-2xl leading-none"
+            class="flex size-10 text-2xl leading-none"
             :label="view.icon"
             @click="togglePopover"
           />


### PR DESCRIPTION
**Before:**
<img width="1204" height="545" alt="image" src="https://github.com/user-attachments/assets/ad42d083-4068-497a-bd1a-0a60c3c01397" />

**After:**
<img width="1186" height="591" alt="image" src="https://github.com/user-attachments/assets/08f9f948-d7ae-4cbf-8882-ea36537d032c" />
