### PR TITLE
fix: mandatory feedback bug

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -308,8 +308,7 @@ class HDTicket(Document):
             "HD Settings", "HD Settings", "is_feedback_mandatory"
         )
         if (
-            self.feedback
-            or self.feedback_rating
+            self.feedback_rating
             or self.status_category != "Resolved"
             or is_agent()
             or not self.has_agent_replied


### PR DESCRIPTION
### Issue
Tickets are not able to close when is_feedback_mandatory is disabled

### Fix
Fixed **HD Ticket** doctype validation logic to correctly check for the is_feedback_mandatory flag and let tickets close when it is disabled