### PR TITLE
fix: timezone bug of datetime in ticket activities

### DIFF
--- a/desk/src/utils.ts
+++ b/desk/src/utils.ts
@@ -47,11 +47,12 @@ export function validateEmailWithZod(email: string) {
 
 export function dateFormat(date, format?: string) {
   const _format = format || "DD-MM-YYYY HH:mm:ss";
-  return useDateFormat(date, _format).value;
+  const _date = date ? dayjs.tz(date).toDate() : date;
+  return useDateFormat(_date, _format).value;
 }
 
 export function timeAgo(date) {
-  return useTimeAgo(date).value;
+  return useTimeAgo(dayjs.tz(date).toDate()).value;
 }
 
 export const dateTooltipFormat = "ddd, MMM D, YYYY h:mm A";


### PR DESCRIPTION
### Issue
The time displayed for the activities of the tickets is wrong and is not displayed with respect to the timezone

### Fix 
Fix date utility functions to correctly display time

---

Here is an example where the timezone is set to Dubai - Asia/Riyadh
## Before Fix
<img width="850" height="465" alt="time-before-fix" src="https://github.com/user-attachments/assets/1aed68ce-4937-45d8-a884-ec7664dd64d1" />

## After Fix
<img width="863" height="485" alt="time-after-fix" src="https://github.com/user-attachments/assets/da5cb96a-af24-49ad-8895-970a97270aeb" />