### PR TITLE
Refactor total_count calculation in doc.py

### DIFF
--- a/helpdesk/api/doc.py
+++ b/helpdesk/api/doc.py
@@ -217,9 +217,7 @@ def get_list_data(
         "columns": columns,
         "rows": rows,
         "fields": fields if doctype == "HD Ticket" else [],
-        "total_count": frappe.get_list(
-            doctype, filters=filters, fields="count(*) as count"
-        )[0].count,
+        "total_count": frappe.db.count(doctype, filters),
         "row_count": len(data),
         "group_by_field": group_by_field,
         "view_type": view_type,


### PR DESCRIPTION
Frappe v16 no longer allows expressions like "count(*) as count" inside frappe.get_list()