### PR TITLE
fix: preserve query parameters when switching tabs (#2790)

### DIFF
--- a/desk/src/composables/useActiveTabManager.ts
+++ b/desk/src/composables/useActiveTabManager.ts
@@ -12,7 +12,7 @@ export function useActiveTabManager(tabs) {
   const changeTabTo = (tab) => {
     tabIndex.value = tab;
     if (tab == 0) {
-      router.replace({ path: route.path });
+      router.replace({ path: route.path, query: route.query });
     } else {
       setActiveTabInUrl(tabs.value?.[tab]?.name || tabs.value[0].name);
     }
@@ -44,7 +44,7 @@ export function useActiveTabManager(tabs) {
     }
 
     tabIndex.value = 0;
-    router.replace({ path: route.path });
+    router.replace({ path: route.path, query: route.query });
   };
 
   // Handle when page is navigated
@@ -55,7 +55,7 @@ export function useActiveTabManager(tabs) {
       if (index === -1) index = 0;
 
       if (index == 0) {
-        router.replace({ path: route.path });
+        router.replace({ path: route.path, query: route.query });
       }
 
       tabIndex.value = index;


### PR DESCRIPTION
## Description
Fixes #2790 - Active View is removed from the query params when the page is reloaded

When navigating to a ticket from an Active View and switching between tabs, the query parameters (including view parameter) were being removed from the URL. This caused the view context to be lost, breaking the navigation flow.

## Problem
When users:
1. Navigate to a ticket from an "Active View" (with `?view=` query parameter)
2. Switch between tabs (Activity, Comments, History, etc.)

The view query parameter was being removed from the URL, causing the view context to be lost.

## Solution
Updated `router.replace()` calls in `useActiveTabManager.ts` to preserve `route.query` alongside `route.path` in three locations:
- `changeTabTo()` function (line 15)
- `setActiveTab()` function (line 47)
- Hash watch handler (line 58)

## Changes
**File:** `desk/src/composables/useActiveTabManager.ts`

**Before:**
```typescript
router.replace({ path: route.path });
```

**After:**
```typescript
router.replace({ path: route.path, query: route.query });
```

Applied to all three `router.replace()` calls in the file.

## Testing
Tested the following flow:
1. Navigate to tickets list with a view (`?view=VIEW-HD+Ticket-001`)
2. Click on a ticket (URL becomes `/tickets/1?view=VIEW-HD+Ticket-001`)
3. Switch between different tabs (Activity, Comments, etc.)
4. Navigate back to the list

**Result:** View parameter is now preserved throughout the navigation flow ✅

**Test Results:**
- ✅ View parameter maintained when switching tabs
- ✅ View parameter maintained when navigating back to list
- ✅ Proper navigation context preserved across tab operations