### PR TITLE
fix: handle RFC-5322 email addresses with commas in display names

### DIFF
--- a/desk/src/components/MultiSelectInput.vue
+++ b/desk/src/components/MultiSelectInput.vue
@@ -93,6 +93,7 @@ import {
   ComboboxOption,
 } from "@headlessui/vue";
 import { UserAvatar } from "@/components/";
+import { splitEmailAddresses } from "@/utils";
 import { Popover, createResource } from "frappe-ui";
 import { ref, computed, nextTick } from "vue";
 import { watchDebounced } from "@vueuse/core";
@@ -177,28 +178,29 @@ function reload(val) {
 const addValue = (value) => {
   error.value = null;
   if (value) {
-    const splitValues = value.split(",");
-    splitValues.forEach((value) => {
-      value = value.trim();
-      if (value) {
+    const splitValues = splitEmailAddresses(value);
+    splitValues.forEach((emailValue) => {
+      emailValue = emailValue.trim();
+      if (emailValue) {
         // check if value is not already in the values array
-        if (!values.value?.includes(value)) {
+        if (!values.value?.includes(emailValue)) {
           // check if value is valid
-          if (value && props.validate && !props.validate(value)) {
-            error.value = props.errorMessage(value);
+          if (emailValue && props.validate && !props.validate(emailValue)) {
+            error.value = props.errorMessage(emailValue);
             return;
           }
           // add value to values array
           if (!values.value) {
-            values.value = [value];
+            values.value = [emailValue];
           } else {
-            values.value.push(value);
+            values.value.push(emailValue);
           }
-          value = value.replace(value, "");
         }
       }
     });
-    !error.value && (value = "");
+    if (!error.value) {
+      value = "";
+    }
   }
 };
 


### PR DESCRIPTION
Fixes #2302

## Problem
Email validation was failing for RFC-5322 compliant addresses with commas in display names, like:
- `"John, Doe" <john@example.com>`

The issue occurred at multiple levels:
1. Email validation regex only validated bare addresses
2. Email splitting used naive `split(",")` which broke quoted display names

## Solution
- Add `extractEmailAddress()` to parse the actual email from RFC-5322 format
- Add `splitEmailAddresses()` that respects commas inside quotes
- Update `validateEmail()` and `validateEmailWithZod()` to extract the email before validation
- Update `MultiSelectInput.vue` to use proper email splitting

## Testing
1. Open any ticket and click Reply
2. Enter email: `"John, Doe" <john@example.com>`
3. Should be accepted without validation errors
4. Multiple emails like `"John, Doe" <john@example.com>, jane@example.com` should split correctly