### PR TITLE
chore: show app version on sidebar

### DIFF
--- a/desk/src/components/layouts/Sidebar.vue
+++ b/desk/src/components/layouts/Sidebar.vue
@@ -159,6 +159,13 @@
       :currentStep="currentStep"
     />
     <CP v-model="showCommandPalette" />
+    <span
+      v-if="appVersion"
+      class="text-sm text-gray-600 cursor-pointer"
+      @click="goToRelease"
+    >
+      v{{ appVersion }}
+    </span>
   </div>
 </template>
 
@@ -186,7 +193,7 @@ import { useNotificationStore } from "@/stores/notification";
 import { useSidebarStore } from "@/stores/sidebar";
 import { capture } from "@/telemetry";
 import { isCustomerPortal } from "@/utils";
-import { call } from "frappe-ui";
+import { call, createResource } from "frappe-ui";
 import {
   GettingStartedBanner,
   HelpModal,
@@ -242,6 +249,23 @@ const showCommandPalette = ref(false);
 const { pinnedViews, publicViews } = useView();
 
 const isFCSite = ref(window.is_fc_site);
+
+const appVersion = ref("");
+createResource({
+  url: "helpdesk.api.get_app_version",
+  auto: true,
+  onSuccess: (data) => {
+    appVersion.value = data;
+  },
+});
+
+const goToRelease = () => {
+  if (!appVersion.value) return;
+  window.open(
+    `https://github.com/frappe/helpdesk/releases/tag/v${appVersion.value}`,
+    "_blank"
+  );
+};
 
 const allViews = computed(() => {
   let items = isCustomerPortal.value

--- a/helpdesk/api/__init__.py
+++ b/helpdesk/api/__init__.py
@@ -1,0 +1,6 @@
+import frappe
+
+
+@frappe.whitelist()
+def get_app_version():
+    return frappe.get_attr("helpdesk" + ".__version__")


### PR DESCRIPTION
This  helps users quickly see their current Helpdesk app version. When they click the version number, they are taken directly to the release notes on GitHub. This is especially useful when reporting bugs, as users can easily confirm which version they are running.



https://github.com/user-attachments/assets/0fe1d4b7-1b3a-46e5-8864-0ccb1abe1bb0


