### PR TITLE
add Telephony app prerequisite to README for smoother Helpdesk setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@
 
 **Customer Service, Made Simple and Effective**
 
+> **Prerequisites:** To fully use Frappe Helpdesk, you also need to install the **Telephony app**.
+> bench get-app telephony
+> bench --site site1.local install-app telephony
+
+
+
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/frappe/helpdesk)
 [![codecov](https://codecov.io/github/frappe/helpdesk/branch/develop/graph/badge.svg?token=8ZXHCY4G9U)](https://codecov.io/github/frappe/helpdesk)
 


### PR DESCRIPTION
Added a prerequisites section to the README to guide users on installing the Telephony app before Helpdesk. This helps prevent installation errors for users who don’t have Telephony installed, ensuring a smoother setup experience.