### PR TITLE
fix: rendering @mention in comments

### DIFF
--- a/desk/src/components/CommentBox.vue
+++ b/desk/src/components/CommentBox.vue
@@ -62,6 +62,7 @@
         :content="_content"
         :editable="editable"
         :bubble-menu="textEditorMenuButtons"
+        :mentions="[]"
         @change="(event:string) => {_content = event}"
       >
         <template #bottom v-if="editable">


### PR DESCRIPTION
Fixes https://github.com/frappe/helpdesk/issues/2851

The @mention in comments were broken (the below image is from #2851):

<img width="550" height="169" alt="531230868-422ace08-9d03-49ee-9db0-c5fc60447d09" src="https://github.com/user-attachments/assets/7c9d48ea-7f8e-444a-a859-3cc1c4bda339" />

This PR fixes that by passing the `mentions` prop to the TextEditor. It results in correct rendering of @ mention span element.

<img width="1064" height="142" alt="image" src="https://github.com/user-attachments/assets/bd560de8-df68-42cd-8ebd-2cddfd19d56d" />


