### PR TITLE
fix(patch): rename canned response

### DIFF
--- a/helpdesk/patches/rename_canned_response_to_saved_reply.py
+++ b/helpdesk/patches/rename_canned_response_to_saved_reply.py
@@ -11,5 +11,5 @@ def execute():
     if not frappe.db.exists("DocType", old):
         return
 
-    frappe.rename_doc("DocType", old, new)
+    frappe.rename_doc("DocType", old, new, ignore_if_exists=True)
     print("Migrated", old, "to", new)


### PR DESCRIPTION
#### Issue
There is an edge case where, after restoring the site the patch runs into bug where `HD Saved reply` already exists

#### Fix
Pass `ignore_if_exists` flag in `rename_doctype` function