### PR TITLE
fix: posthog optional chaining added to fix delete button bug

### DIFF
--- a/desk/src/telemetry.ts
+++ b/desk/src/telemetry.ts
@@ -70,7 +70,7 @@ export function capture(
   options: CaptureOptions = { data: { user: "" } }
 ) {
   if (!isTelemetryEnabled()) return;
-  window.posthog.capture(`${APP}_${event}`, options);
+  window.posthog?.capture?.(`${APP}_${event}`, options);
 }
 
 export function recordSession() {


### PR DESCRIPTION
In support ticket #58533 the close button doesn't work because posthog isn't loaded sometimes. Added optional chaining avoid the functionality from breaking.

Issue Faced:
<img width="1905" height="898" alt="image" src="https://github.com/user-attachments/assets/019d5b7c-40be-4c0a-9a92-f8d307f4ff0f" />
