### PR TITLE
fix(similar-tickets): enforce document permissions in similar tickets API

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/api.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/api.py
@@ -759,6 +759,14 @@ def get_similar_tickets(ticket: str):
         },
         as_dict=1,
     )
+    
+    tickets = [
+        t for t in tickets
+        if frappe.has_permission("HD Ticket", "read", doc=t["name"])
+    ]
+    
+    if not tickets:
+        return []
 
     max_relevance = max((t["raw_relevance"] for t in tickets), default=0)
     for t in tickets:


### PR DESCRIPTION
The "Similar Tickets" sidebar was previously using a raw SQL query that bypassed Frappe's permission engine. This allowed restricted agents to see titles of private tickets  they were not authorized to access, leading to a 403 Forbidden error when clicking them

fixes #2947 

[Jam for the fix](https://jam.dev/c/084ebe5e-e0d2-4738-893b-cffd1a8320fc)

