### PR TITLE
fix: add type hints

### DIFF
--- a/helpdesk/api/assignment_rule.py
+++ b/helpdesk/api/assignment_rule.py
@@ -9,7 +9,7 @@ def get_assignment_rules_list():
             frappe.PermissionError,
         )
 
-    assignment_rules = frappe.get_all(
+    assignment_rules = frappe.get_list(
         "Assignment Rule",
         fields=["name", "description", "disabled", "priority"],
         order_by="modified desc",

--- a/helpdesk/api/saved_replies.py
+++ b/helpdesk/api/saved_replies.py
@@ -6,7 +6,7 @@ from helpdesk.utils import agent_only
 
 @frappe.whitelist()
 @agent_only
-def get_rendered_saved_reply(ticket_id, saved_reply_id=None):
+def get_rendered_saved_reply(ticket_id: str, saved_reply_id: str | None = None):
     if not saved_reply_id:
         frappe.throw(_("Please provide saved_reply_id"))
     saved_reply = frappe.get_doc("HD Saved Reply", saved_reply_id).message

--- a/helpdesk/helpdesk/doctype/hd_ticket/api.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/api.py
@@ -40,7 +40,7 @@ def new(doc, attachments=[]):
 
 
 @frappe.whitelist()
-def get_one(name, is_customer_portal=False):
+def get_one(name: str, is_customer_portal: bool = False):
     frappe.has_permission("HD Ticket", "read", name, throw=True)
     QBContact = frappe.qb.DocType("Contact")
     QBTicket = frappe.qb.DocType("HD Ticket")


### PR DESCRIPTION
Add type hints to APIs as pydantic enforces it