### PR TITLE
fix: prevent helpdesk SPA from loading when setup is incomplete

### DIFF
--- a/desk/src/SetupRequired.vue
+++ b/desk/src/SetupRequired.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="setup-wrapper">
+    <h2>Helpdesk Setup Required</h2>
+    <p>Please complete Helpdesk configuration before using the app.</p>
+    <a href="/app/helpdesk-settings" class="btn btn-primary">
+      Go to Setup
+    </a>
+  </div>
+</template>
+
+<style>
+.setup-wrapper {
+  text-align: center;
+  margin-top: 100px;
+}
+</style>

--- a/desk/src/main.js
+++ b/desk/src/main.js
@@ -61,35 +61,55 @@ setConfig("fallbackErrorHandler", (error) => {
   toast.error(msg);
 });
 
-const pinia = createPinia();
-const app = createApp(App);
+async function bootstrap() {
+  try {
+    const response = await frappeRequest({
+      url: "/api/method/helpdesk.helpdesk.api.setup.is_helpdesk_setup_complete",
+    });
 
-app.use(FrappeUI);
-app.use(pinia);
-app.use(router);
-// app.use(posthogPlugin);
-app.use(translationPlugin);
+    const isSetupComplete = response?.message;
 
-for (const c in globalComponents) {
-  app.component(c, globalComponents[c]);
-}
-
-app.config.globalProperties.$dialog = createDialog;
-
-let socket;
-if (import.meta.env.DEV) {
-  frappeRequest({
-    url: "/api/method/helpdesk.www.helpdesk.index.get_context_for_dev",
-  }).then((values) => {
-    for (let key in values) {
-      window[key] = values[key];
+    if (!isSetupComplete) {
+      window.location.href = "/helpdesk-setup";
+      return;
     }
-    socket = initSocket();
-    app.config.globalProperties.$socket = socket;
-    app.mount("#app");
-  });
-} else {
-  socket = initSocket();
-  app.config.globalProperties.$socket = socket;
-  app.mount("#app");
+
+    const pinia = createPinia();
+    const app = createApp(App);
+
+    app.use(FrappeUI);
+    app.use(pinia);
+    app.use(router);
+    // app.use(posthogPlugin);
+    app.use(translationPlugin);
+
+    for (const c in globalComponents) {
+      app.component(c, globalComponents[c]);
+    }
+
+    app.config.globalProperties.$dialog = createDialog;
+
+    let socket;
+
+    if (import.meta.env.DEV) {
+      frappeRequest({
+        url: "/api/method/helpdesk.www.helpdesk.index.get_context_for_dev",
+      }).then((values) => {
+        for (let key in values) {
+          window[key] = values[key];
+        }
+        socket = initSocket();
+        app.config.globalProperties.$socket = socket;
+        app.mount("#app");
+      });
+    } else {
+      socket = initSocket();
+      app.config.globalProperties.$socket = socket;
+      app.mount("#app");
+    }
+  } catch (error) {
+    console.error("Error checking Helpdesk setup:", error);
+  }
 }
+
+bootstrap();

--- a/desk/src/router/index.js
+++ b/desk/src/router/index.js
@@ -1,0 +1,9 @@
+import SetupRequired from "../views/SetupRequired.vue";
+
+const routes = [
+  {
+    path: "/helpdesk-setup",
+    name: "SetupRequired",
+    component: SetupRequired,
+  },
+];

--- a/helpdesk/api/setup.py
+++ b/helpdesk/api/setup.py
@@ -1,0 +1,21 @@
+# helpdesk/helpdesk/api/setup.py
+
+import frappe
+
+@frappe.whitelist(allow_guest=True)
+def is_helpdesk_setup_complete():
+    """
+    Returns True if Helpdesk setup is complete
+    """
+
+    # Example logic:
+    # Check if default department exists
+    department_exists = frappe.db.exists("HD Department")
+
+    # Check if default support email exists
+    support_email = frappe.db.exists("HD Settings")
+
+    if department_exists and support_email:
+        return True
+
+    return False

--- a/helpdesk/api/ticket.py
+++ b/helpdesk/api/ticket.py
@@ -2,9 +2,13 @@ import frappe
 from frappe import _
 
 from helpdesk.utils import agent_only
+from helpdesk.helpdesk.api.setup import is_helpdesk_setup_complete
 
 
 def assign_ticket_to_agent(ticket_id, agent_id=None):
+    if not is_helpdesk_setup_complete():
+        frappe.throw(_("Helpdesk setup is not complete"))
+
     if not ticket_id:
         return
 
@@ -24,6 +28,9 @@ def assign_ticket_to_agent(ticket_id, agent_id=None):
 @frappe.whitelist()
 @agent_only
 def bulk_assign_ticket_to_agent(ticket_ids, agent_id=None):
+    if not is_helpdesk_setup_complete():
+        frappe.throw(_("Helpdesk setup is not complete"))
+
     if ticket_ids:
         ticket_docs = []
         for ticket_id in ticket_ids:

--- a/helpdesk/hooks.py
+++ b/helpdesk/hooks.py
@@ -39,7 +39,6 @@ scheduler_events = {
     ],
 }
 
-
 website_route_rules = [
     {
         "from_route": "/helpdesk/<path:app_path>",
@@ -77,7 +76,7 @@ permission_query_conditions = {
 
 # DocType Class
 # ---------------
-# Override standard doctype classes
+
 override_doctype_class = {
     "Email Account": "helpdesk.overrides.email_account.CustomEmailAccount",
 }
@@ -88,10 +87,16 @@ ignore_links_on_delete = [
 ]
 
 # setup wizard
-# setup_wizard_requires = "assets/helpdesk/js/setup_wizard.js"
-# setup_wizard_stages = "helpdesk.setup.setup_wizard.get_setup_stages"
+
 setup_wizard_complete = "helpdesk.setup.setup_wizard.setup_complete"
 
+# ---------------------------
+# Setup Check API Registration
+# ---------------------------
+
+override_whitelisted_methods = {
+    "helpdesk.api.is_setup_complete": "helpdesk.helpdesk.api.setup.is_helpdesk_setup_complete"
+}
 
 # Testing
 # ---------------


### PR DESCRIPTION
This PR prevents the Helpdesk SPA from loading when setup is incomplete.

- Added backend API to check setup completion
- Added frontend bootstrap guard
- Added fallback setup page
- Added backend safety validation

This improves user experience and prevents broken UI on fresh installs.
