### PR TITLE
fix: email send button bug and null value appearing in saved replies

### DIFF
--- a/desk/src/components/CommentTextEditor.vue
+++ b/desk/src/components/CommentTextEditor.vue
@@ -14,7 +14,7 @@
     :editable="editable"
     :mentions="dropdown"
     @change="editable ? (newComment = $event) : null"
-    :extensions="[PreserveVideoControls]"
+    :extensions="[ComponentUtils]"
     :uploadFunction="(file:any)=>uploadFunction(file, doctype, ticketId)"
   >
     <template #bottom>
@@ -113,7 +113,7 @@ import { AttachmentIcon } from "@/components/icons/";
 import { useTyping } from "@/composables/realtime";
 import { useAgentStore } from "@/stores/agent";
 import { useAuthStore } from "@/stores/auth";
-import { PreserveVideoControls } from "@/tiptap-extensions";
+import { ComponentUtils } from "@/tiptap-extensions";
 import {
   getFontFamily,
   isContentEmpty,

--- a/desk/src/components/EmailEditor.vue
+++ b/desk/src/components/EmailEditor.vue
@@ -248,10 +248,10 @@ const { onUserType, cleanup } = useTyping(props.ticketId);
 
 const attachments = ref([]);
 const isUploading = ref(false);
+const contentEmpty = computed(() => isContentEmpty(newEmail.value));
+
 const isDisabled = computed(() => {
-  return (
-    isContentEmpty(newEmail.value) || sendMail.loading || isUploading.value
-  );
+  return contentEmpty.value || sendMail.loading || isUploading.value;
 });
 
 // Watch for changes in email content to trigger typing events

--- a/desk/src/components/EmailEditor.vue
+++ b/desk/src/components/EmailEditor.vue
@@ -6,13 +6,14 @@
       'min-h-[7rem]',
       getFontFamily(newEmail),
       editable && '!max-h-[35vh] overflow-y-auto',
+      '[&_p.reply-to-content]:hidden',
     ]"
     :content="newEmail"
     :starterkit-options="{ heading: { levels: [2, 3, 4, 5, 6] } }"
     :placeholder="placeholder"
     :editable="editable"
     @change="editable ? (newEmail = $event) : null"
-    :extensions="[PreserveVideoControls]"
+    :extensions="[ComponentUtils]"
     :uploadFunction="(file:any)=>uploadFunction(file, doctype, ticketId)"
   >
     <template #top>
@@ -170,7 +171,7 @@ import {
 import { AttachmentIcon } from "@/components/icons";
 import { useTyping } from "@/composables/realtime";
 import { useAuthStore } from "@/stores/auth";
-import { PreserveVideoControls } from "@/tiptap-extensions";
+import { ComponentUtils } from "@/tiptap-extensions";
 import {
   getFontFamily,
   isContentEmpty,
@@ -248,10 +249,11 @@ const { onUserType, cleanup } = useTyping(props.ticketId);
 
 const attachments = ref([]);
 const isUploading = ref(false);
-const contentEmpty = computed(() => isContentEmpty(newEmail.value));
 
 const isDisabled = computed(() => {
-  return contentEmpty.value || sendMail.loading || isUploading.value;
+  return (
+    isContentEmpty(newEmail.value) || sendMail.loading || isUploading.value
+  );
 });
 
 // Watch for changes in email content to trigger typing events
@@ -352,15 +354,18 @@ function addToReply(
   toEmailsClone.value = toEmails;
   ccEmailsClone.value = ccEmails;
   bccEmailsClone.value = bccEmails;
+  const repliedMessage = `<p class="reply-to-content"><p><blockquote>${body}</blockquote>`;
   editorRef.value.editor
     .chain()
     .clearContent()
-    .insertContent(body)
+    .insertContent(repliedMessage)
     .focus("all")
-    .setBlockquote()
     .insertContentAt(0, { type: "paragraph" })
     .focus("start")
     .run();
+  nextTick(() => {
+    newEmail.value = editorRef.value.editor.getHTML();
+  });
 }
 
 function resetState() {

--- a/desk/src/components/TextEditor.vue
+++ b/desk/src/components/TextEditor.vue
@@ -2,7 +2,7 @@
   <div class="rounded p-3 shadow w-full">
     <FTextEditor
       ref="e"
-      :extensions="[PreserveVideoControls]"
+      :extensions="[ComponentUtils]"
       v-bind="$attrs"
       :editor-class="[
         'prose-f max-h-64 max-w-none  overflow-auto my-4 min-h-[5rem]',
@@ -59,7 +59,7 @@
 <script setup lang="ts">
 import { UserAvatar } from "@/components";
 import { useAuthStore } from "@/stores/auth";
-import { PreserveVideoControls } from "@/tiptap-extensions";
+import { ComponentUtils } from "@/tiptap-extensions";
 import { getFontFamily } from "@/utils";
 import { TextEditor as FTextEditor, TextEditorFixedMenu } from "frappe-ui";
 import { computed, nextTick, ref } from "vue";

--- a/desk/src/pages/knowledge-base/Article.vue
+++ b/desk/src/pages/knowledge-base/Article.vue
@@ -89,7 +89,7 @@
           ref="editorRef"
           :editor-class="editorClass"
           :content="textEditorContentWithIDs"
-          :extensions="[PreserveIds]"
+          :extensions="[ComponentUtils]"
           :editable="editable"
           @change="(event:string) => {
 			      content = event;
@@ -127,7 +127,7 @@ import {
   updateRes as updateArticle,
 } from "@/stores/knowledgeBase";
 import { capture } from "@/telemetry";
-import { PreserveIds } from "@/tiptap-extensions";
+import { ComponentUtils } from "@/tiptap-extensions";
 import { Article, Breadcrumb, Error, FeedbackAction, Resource } from "@/types";
 import {
   copyToClipboard,

--- a/desk/src/tiptap-extensions.ts
+++ b/desk/src/tiptap-extensions.ts
@@ -72,8 +72,8 @@ export const FieldAutocomplete = createSuggestionExtension<FieldItem>({
   component: FieldAutocompleteList,
 });
 
-export const PreserveVideoControls: Extension = Extension.create({
-  name: "preserveVideoControls",
+export const ComponentUtils: Extension = Extension.create({
+  name: "ComponentUtils",
   addGlobalAttributes() {
     return [
       {
@@ -88,15 +88,7 @@ export const PreserveVideoControls: Extension = Extension.create({
           },
         },
       },
-    ];
-  },
-});
-
-export const PreserveIds: Extension = Extension.create({
-  name: "preserveIds",
-  addGlobalAttributes() {
-    return [
-      {
+           {
         types: ["heading"],
         attributes: {
           id: {
@@ -107,6 +99,19 @@ export const PreserveIds: Extension = Extension.create({
                 return {};
               }
               return { id: attributes.id };
+            },
+          },
+        },
+      },
+            {
+        types: ["paragraph"],
+        attributes: {
+          class: {
+            default: null,
+            parseHTML: (element) => element.getAttribute('class'),
+            renderHTML: (attributes) => {
+              if (!attributes.class) return {}
+              return { class: attributes.class }
             },
           },
         },

--- a/desk/src/utils.ts
+++ b/desk/src/utils.ts
@@ -174,9 +174,15 @@ export const textEditorMenuButtons = [
 ];
 
 export function isContentEmpty(content: string) {
+  if (!content || content === null || content === undefined) {
+    return true;
+  }
   const parser = new DOMParser();
   const doc = parser.parseFromString(content, "text/html");
-  return doc.body.textContent === "";
+  if (doc.body.textContent === null) {
+    return true;
+  }
+  return doc.body.textContent.trim() === "";
 }
 
 export function isTouchScreenDevice() {


### PR DESCRIPTION
<img width="836" height="152" alt="image" src="https://github.com/user-attachments/assets/1f7b5058-81c0-42e0-ab0a-f97a9021b900" />

in Email Area, occasionally cache  would store an object null thus allowing send button to be enabled even when empty also when using saved replies garbage value was added

<img width="652" height="119" alt="image" src="https://github.com/user-attachments/assets/869aac09-2719-4351-81f6-16e26a7120a3" />

also a bug where replied content doesn't come under collapsed
<img width="860" height="398" alt="image" src="https://github.com/user-attachments/assets/6dd87361-bcf9-4d64-adb3-d2d34fc7415d" />

fix:
<img width="860" height="285" alt="image" src="https://github.com/user-attachments/assets/7743471f-f46e-4819-a364-d28d7d498e73" />


one more bug where on reply the send button is still disabled or has garbage value at times

https://github.com/user-attachments/assets/56cc2aa0-33fd-4f4b-820e-bc0949fd8680





this fixes all of these issues