### PR TITLE
fix: handle excel pasting in email editor

### DIFF
--- a/desk/src/components/CommentTextEditor.vue
+++ b/desk/src/components/CommentTextEditor.vue
@@ -14,7 +14,7 @@
     :editable="editable"
     :mentions="dropdown"
     @change="editable ? (newComment = $event) : null"
-    :extensions="[ComponentUtils]"
+    :extensions="[ComponentUtils, HandleExcelPaste]"
     :uploadFunction="(file:any)=>uploadFunction(file, doctype, ticketId)"
   >
     <template #bottom>
@@ -113,7 +113,7 @@ import { AttachmentIcon } from "@/components/icons/";
 import { useTyping } from "@/composables/realtime";
 import { useAgentStore } from "@/stores/agent";
 import { useAuthStore } from "@/stores/auth";
-import { ComponentUtils } from "@/tiptap-extensions";
+import { ComponentUtils, HandleExcelPaste } from "@/tiptap-extensions";
 import {
   getFontFamily,
   isContentEmpty,

--- a/desk/src/components/EmailEditor.vue
+++ b/desk/src/components/EmailEditor.vue
@@ -13,7 +13,7 @@
     :placeholder="placeholder"
     :editable="editable"
     @change="editable ? (newEmail = $event) : null"
-    :extensions="[ComponentUtils]"
+    :extensions="[ComponentUtils, HandleExcelPaste]"
     :uploadFunction="(file:any)=>uploadFunction(file, doctype, ticketId)"
   >
     <template #top>
@@ -171,7 +171,7 @@ import {
 import { AttachmentIcon } from "@/components/icons";
 import { useTyping } from "@/composables/realtime";
 import { useAuthStore } from "@/stores/auth";
-import { ComponentUtils } from "@/tiptap-extensions";
+import { ComponentUtils, HandleExcelPaste } from "@/tiptap-extensions";
 import {
   getFontFamily,
   isContentEmpty,

--- a/desk/src/components/TextEditor.vue
+++ b/desk/src/components/TextEditor.vue
@@ -2,7 +2,7 @@
   <div class="rounded p-3 shadow w-full">
     <FTextEditor
       ref="e"
-      :extensions="[ComponentUtils]"
+      :extensions="[ComponentUtils, HandleExcelPaste]"
       v-bind="$attrs"
       :editor-class="[
         'prose-f max-h-64 max-w-none  overflow-auto my-4 min-h-[5rem]',
@@ -59,7 +59,7 @@
 <script setup lang="ts">
 import { UserAvatar } from "@/components";
 import { useAuthStore } from "@/stores/auth";
-import { ComponentUtils } from "@/tiptap-extensions";
+import { ComponentUtils, HandleExcelPaste } from "@/tiptap-extensions";
 import { getFontFamily } from "@/utils";
 import { TextEditor as FTextEditor, TextEditorFixedMenu } from "frappe-ui";
 import { computed, nextTick, ref } from "vue";

--- a/desk/src/tiptap-extensions.ts
+++ b/desk/src/tiptap-extensions.ts
@@ -1,6 +1,6 @@
 import { Extension } from "@tiptap/core";
 import { createSuggestionExtension } from "frappe-ui";
-import { PluginKey } from "@tiptap/pm/state";
+import { PluginKey, Plugin } from "@tiptap/pm/state";
 import { getMeta } from "./stores/meta";
 import { userFields } from "./components/Settings/SavedReplies/savedReplies";
 import FieldAutocompleteList from "./components/Settings/SavedReplies/components/FieldAutocompleteList.vue";
@@ -116,6 +116,47 @@ export const ComponentUtils: Extension = Extension.create({
           },
         },
       },
+    ];
+  },
+});
+
+// fix for excel pasting issue
+export const HandleExcelPaste = Extension.create({
+  name: "handleExcelPaste",
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey("excelPasteFix"),
+        props: {
+          handlePaste(view, event) {
+            const clipboardData = event.clipboardData;
+            if (!clipboardData) return false;
+
+            const types = Array.from(clipboardData.types);
+            const hasFile = types.includes("Files");
+            const hasHtml = types.includes("text/html");
+            const hasText = types.includes("text/plain");
+            const hasRtf = types.includes("text/rtf")
+
+
+            if (hasFile && hasHtml && hasText && hasRtf) {
+              event.preventDefault()
+              const html = clipboardData.getData("text/html");
+              const text = clipboardData.getData("text/plain");
+
+              if (html) {
+                view.pasteHTML(html);
+              } else {
+                view.pasteText(text);
+              }
+              return true;
+            }
+
+            return false;
+          },
+        },
+      }),
     ];
   },
 });

--- a/desk/src/tiptap-extensions.ts
+++ b/desk/src/tiptap-extensions.ts
@@ -120,14 +120,14 @@ export const ComponentUtils: Extension = Extension.create({
   },
 });
 
-// fix for excel pasting issue
+// Handle pasting from excel properly
 export const HandleExcelPaste = Extension.create({
   name: "handleExcelPaste",
 
   addProseMirrorPlugins() {
     return [
       new Plugin({
-        key: new PluginKey("excelPasteFix"),
+        key: new PluginKey("handleExcelPaste"),
         props: {
           handlePaste(view, event) {
             const clipboardData = event.clipboardData;


### PR DESCRIPTION
When users copy content from Microsoft Excel and paste it into the editor, the content is being inserted as an image instead of structured/tabular data.

As a result, the pasted content is embedded as an image attachment and every reply in the thread re-attaches the same image causing the file size to increase per reply.

This pr handles that use case

before:

https://github.com/user-attachments/assets/efcae85a-5b59-4ae9-8e72-1f7764d578c2

after:

https://github.com/user-attachments/assets/2f20a3ac-f298-4f37-84b2-5e43ebf0ecd4

