### PR TITLE
fix: fix saved replies scope filtering

### DIFF
--- a/desk/src/components/SavedRepliesSelectorModal.vue
+++ b/desk/src/components/SavedRepliesSelectorModal.vue
@@ -201,7 +201,7 @@ const selectedTemplate = ref({
 });
 
 const scope = computed(() => {
-  return filters.value.find((f) => f.label === activeFilter.value)?.value;
+  return filters.value.find((f) => f.value === activeFilter.value)?.value;
 });
 
 const savedReplyListResource = createListResource({


### PR DESCRIPTION
<img width="1082" height="167" alt="image" src="https://github.com/user-attachments/assets/8089f4b1-8f10-4d8d-82cc-a31e05c8d7da" />

filter was being compared with translated labels thus causing an issue for saved replies to appear for users which have different langauages set


This pr fixes this issue and closes https://github.com/frappe/helpdesk/issues/3084