### PR TITLE
fix: dont delete src tag

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -655,7 +655,7 @@ class HDTicket(Document):
         if self.instantly_send_email():
             send_delayed = False
             send_now = True
-
+        print("\n\n", message, "\n\n")
         try:
             frappe.sendmail(
                 attachments=_attachments,
@@ -1168,10 +1168,8 @@ class HDTicket(Document):
                 tag["embed"] = tag.get("src")
                 tag["width"] = "80%"
                 tag["height"] = "80%"
-                del tag["src"]
             elif tag.name == "video":
                 tag["embed"] = tag.get("src")
-                del tag["src"]
 
         return str(soup)
 

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -655,7 +655,7 @@ class HDTicket(Document):
         if self.instantly_send_email():
             send_delayed = False
             send_now = True
-        print("\n\n", message, "\n\n")
+
         try:
             frappe.sendmail(
                 attachments=_attachments,


### PR DESCRIPTION
**Issue:**

Don't delete src tag while adding embed tags.

Reason:  the images starting with "https" like publicly uploaded the content which we receive is empty 

Ref: https://github.com/frappe/frappe/blob/develop/frappe/email/email_body.py#L607 


Hence the image content is never shown in the email