### PR TITLE
fix: allow shift+enter by removing .stop from keydown handler

### DIFF
--- a/desk/src/components/EmailEditor.vue
+++ b/desk/src/components/EmailEditor.vue
@@ -13,7 +13,7 @@
     @change="editable ? (newEmail = $event) : null"
     :extensions="[ComponentUtils, HandleExcelPaste]"
     :uploadFunction="(file:any)=>uploadFunction(file, doctype, ticketId)"
-    @keydown.capture.stop="handleKeydown"
+    @keydown.capture="handleKeydown"
   >
     <template #top>
       <div class="mx-6 md:mx-10 flex items-center gap-2 border-y py-2.5">


### PR DESCRIPTION
The .stop modifier on the @keydown.capture handler was calling stopPropagation() on all keydown events thus causing tiptap causing issues when 
- shift+enter is pressed to go to next line
- backspace email in To section
- Keyboard accessibility in selecting mails