### PR TITLE
feat: support @mentioning user groups in ticket comments

### DIFF
--- a/helpdesk/mixins/mentions.py
+++ b/helpdesk/mixins/mentions.py
@@ -22,13 +22,38 @@ class HasMentions:
             ]
 
         for mention in current_mentions:
-            values = frappe._dict(
-                doctype="HD Notification",
-                user_from=self.owner,
-                user_to=mention.email,
-                notification_type="Mention",
-                message=self.content,
-            )
+            if mention.type == "group" and frappe.db.exists("User Group", mention.email):
+                users_to_notify = frappe.get_all(
+                    "User Group Member",
+                    filters={"parent": mention.email},
+                    pluck="user",
+                )
+            else:
+                users_to_notify = [mention.email]
+
+            for user_email in users_to_notify:
+                values = frappe._dict(
+                    doctype="HD Notification",
+                    user_from=self.owner,
+                    user_to=user_email,
+                    notification_type="Mention",
+                    message=self.content,
+                )
+                if values.user_from == values.user_to:
+                    continue
+                if self.doctype == "HD Ticket Comment":
+                    values.reference_comment = self.name
+                    values.reference_ticket = self.reference_ticket
+                if frappe.db.exists(
+                    "HD Notification",
+                    {
+                        "reference_comment": self.name,
+                        "user_to": user_email,
+                        "notification_type": "Mention",
+                    },
+                ):
+                    continue
+                frappe.get_doc(values).insert()
             # Why mention oneself?
             if values.user_from == values.user_to:
                 continue

--- a/helpdesk/utils.py
+++ b/helpdesk/utils.py
@@ -120,8 +120,10 @@ def extract_mentions(html):
     soup = BeautifulSoup(html, "html.parser")
     mentions = []
     for d in soup.find_all("span", attrs={"data-type": "mention"}):
+        email = d.get("data-id")
+        mention_type = "user" if "@" in email else "group"
         mentions.append(
-            frappe._dict(full_name=d.get("data-label"), email=d.get("data-id"))
+            frappe._dict(full_name=d.get("data-label"), email=email, type=mention_type)
         )
     return mentions
 


### PR DESCRIPTION
## Description
Adds support for @mentioning User Groups in ticket comments. Previously, 
only individual agents could be mentioned. Tagging a User Group now sends 
an HD Notification to all members of that group.

## Relevant Technical Choices
- `extract_mentions` in `utils.py` now returns a `type` field (`user` or `group`) by checking if `data-id` contains `@`. User emails always contain `@`, User Group names never do.
- `notify_mentions` in `mixins/mentions.py` expanded to resolve group mentions into individual member notifications via `User Group Member` doctype.
- `frappe.db.exists("User Group", mention.email)` guard ensures Agent document names without `@` are not mistakenly treated as groups.

## Testing Instructions
1. Open any ticket in Helpdesk
2. Type `@` in the comment box
3. Select a User Group and submit the comment
4. Verify HD Notification is created for each member of the group
5. Verify tagging an individual agent still works correctly


https://github.com/user-attachments/assets/36cec488-2c4a-4014-93ee-604f3ba34638
