### PR TITLE
feat: make all user-facing strings translatable

### DIFF
--- a/desk/src/components/ConfirmDialog.vue
+++ b/desk/src/components/ConfirmDialog.vue
@@ -8,7 +8,7 @@
     <template #actions>
       <Button
         class="w-full"
-        label="Confirm"
+        :label="__('Confirm')"
         variant="solid"
         :loading="isLoading"
         @click="onConfirm"

--- a/desk/src/components/Settings/Agents.vue
+++ b/desk/src/components/Settings/Agents.vue
@@ -212,7 +212,7 @@ function getRoles(agent: string) {
   const agentRole = getUserRole(agent);
   const roles = [
     {
-      label: "Agent",
+      label: __("Agent"),
       component: (props) =>
         RoleOption({
           role: "Agent",
@@ -227,7 +227,7 @@ function getRoles(agent: string) {
   ];
   if (isManager) {
     roles.unshift({
-      label: "Manager",
+      label: __("Manager"),
       component: (props) =>
         RoleOption({
           role: "Manager",
@@ -286,7 +286,7 @@ function updateRole(agent: string, newRole: string) {
     new_role: newRole,
   }).then(() => {
     updateUserRoleCache(agent, newRole);
-    toast.success(__(`Role updated to ${newRole} successfully.`));
+    toast.success(__("Role updated to {0} successfully.", [newRole]));
   });
 }
 
@@ -294,7 +294,7 @@ function getOptions(agent) {
   let filters = agentStore.filters;
   return [
     {
-      label: "Disable Agent",
+      label: __("Disable Agent"),
       icon: "x-circle",
       onClick: async () => {
         await agentStore.updateAgent(agent.name, 0);
@@ -303,7 +303,7 @@ function getOptions(agent) {
       condition: () => agent.is_active,
     },
     {
-      label: "Enable Agent",
+      label: __("Enable Agent"),
       icon: "check-circle",
       onClick: async () => {
         await agentStore.updateAgent(agent.name, 1);
@@ -316,21 +316,21 @@ function getOptions(agent) {
 
 const dropdownOptions = [
   {
-    label: "All",
+    label: __("All"),
     onClick: () => {
       agentStore.filters["is_active"] = ["in", [0, 1]];
       activeFilter.value = "All";
     },
   },
   {
-    label: "Active",
+    label: __("Active"),
     onClick: () => {
       agentStore.filters["is_active"] = ["=", 1];
       activeFilter.value = "Active";
     },
   },
   {
-    label: "Inactive",
+    label: __("Inactive"),
     onClick: () => {
       agentStore.filters["is_active"] = ["=", 0];
       activeFilter.value = "Inactive";

--- a/desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue
+++ b/desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue
@@ -395,7 +395,7 @@ const getAssignmentRuleData = createResource({
       assignConditionJson = JSON.parse(data.assign_condition_json || "[]");
     } catch (error) {
       toast.error(
-        "Assignment conditions are invalid or corrupt, recreate the conditions."
+        __("Assignment conditions are invalid or corrupt, recreate the conditions.")
       );
       assignConditionJson = [];
     }
@@ -403,7 +403,7 @@ const getAssignmentRuleData = createResource({
       unassignConditionJson = JSON.parse(data.unassign_condition_json || "[]");
     } catch (error) {
       toast.error(
-        "Unassignment conditions are invalid or corrupt, recreate the conditions."
+        __("Unassignment conditions are invalid or corrupt, recreate the conditions.")
       );
       unassignConditionJson = [];
     }

--- a/desk/src/components/Settings/Holiday/HolidaysTableView.vue
+++ b/desk/src/components/Settings/Holiday/HolidaysTableView.vue
@@ -62,6 +62,7 @@ import { ConfirmDelete, getFormattedDate } from "@/utils";
 import { holidayData } from "@/stores/holidayList";
 import AddHolidayModal from "./Modals/AddHolidayModal.vue";
 import { Dropdown } from "frappe-ui";
+import { __ } from "@/translation";
 
 const isConfirmingDelete = ref(false);
 
@@ -73,7 +74,7 @@ interface Holiday {
 
 const dropdownOptions = (holiday: Holiday) => [
   {
-    label: "Edit",
+    label: __("Edit"),
     onClick: () => editHoliday(holiday),
     icon: "edit",
   },
@@ -98,11 +99,11 @@ const holidays = computed(() => {
 
 const columns = [
   {
-    label: "Date",
+    label: __("Date"),
     key: "holiday_date",
   },
   {
-    label: "Description",
+    label: __("Description"),
     key: "description",
   },
 ];

--- a/desk/src/components/Settings/Holiday/Modals/AddHolidayModal.vue
+++ b/desk/src/components/Settings/Holiday/Modals/AddHolidayModal.vue
@@ -3,14 +3,14 @@
     v-model="dialog.show"
     :options="{
       size: 'sm',
-      title: dialog.editing ? 'Edit Holiday' : 'Add Holiday',
+      title: dialog.editing ? __('Edit Holiday') : __('Add Holiday'),
     }"
     @after-leave="resetForm"
   >
     <template #body-content>
       <div class="flex flex-col gap-4 mt-4">
         <div class="flex flex-col gap-1.5">
-          <FormLabel label="Date" required />
+          <FormLabel :label="__('Date')" required />
           <DatePicker
             :value="dayjs(dialog.holiday_date).format('MM-DD-YYYY')"
             @update:model-value="dialog.holiday_date = $event"
@@ -29,8 +29,8 @@
             :type="'textarea'"
             size="sm"
             variant="subtle"
-            placeholder="National holiday, etc."
-            label="Description"
+            :placeholder="__('National holiday, etc.')"
+            :label="__('Description')"
             v-model="dialog.description"
             required
             @change="errors.description = ''"
@@ -44,13 +44,13 @@
         <Button
           variant="subtle"
           theme="gray"
-          label="Cancel"
+          :label="__('Cancel')"
           @click="dialog.show = false"
         />
         <Button
           variant="solid"
           icon-left="plus"
-          label="Add Holiday"
+          :label="__('Add Holiday')"
           @click="onSave"
         />
       </div>
@@ -60,6 +60,7 @@
 
 <script setup lang="ts">
 import { getFormattedDate } from "@/utils";
+import { __ } from "@/translation";
 import {
   Dialog,
   FormControl,
@@ -98,10 +99,10 @@ const resetForm = () => {
 
 const onSave = () => {
   if (dialog.value.description?.trim() === "") {
-    errors.value.description = "Please enter a description";
+    errors.value.description = __("Please enter a description");
   }
   if (!dialog.value.holiday_date) {
-    errors.value.holiday_date = "Please enter a valid date";
+    errors.value.holiday_date = __("Please enter a valid date");
   }
 
   if (errors.value.holiday_date || errors.value.description) {
@@ -113,10 +114,11 @@ const onSave = () => {
   const toDate = dayjs(holidayData.value.to_date).startOf("day");
 
   if (holidayDate.isBefore(fromDate) || holidayDate.isAfter(toDate)) {
-    toast.error(
-      `Holiday date must be between ${getFormattedDate(
-        holidayData.value.from_date
-      )} and ${getFormattedDate(holidayData.value.to_date)}`
+      toast.error(
+      __("Holiday date must be between {0} and {1}", [
+        getFormattedDate(holidayData.value.from_date),
+        getFormattedDate(holidayData.value.to_date),
+      ])
     );
     return;
   }
@@ -134,7 +136,7 @@ const onSave = () => {
       getFormattedDate(holidayExists.holiday_date) !==
         getFormattedDate(dialog.value.editing.holiday_date)
     ) {
-      toast.error("Holiday already exists");
+      toast.error(__("Holiday already exists"));
       return;
     }
     const holidayIndex = holidayData.value.holidays.indexOf(
@@ -151,7 +153,7 @@ const onSave = () => {
         getFormattedDate(dialog.value.holiday_date)
     );
     if (index !== -1) {
-      toast.error("Holiday already exists");
+      toast.error(__("Holiday already exists"));
       return;
     }
     holidayData.value.holidays.push({

--- a/desk/src/components/Settings/Holiday/RecurringHolidaysList.vue
+++ b/desk/src/components/Settings/Holiday/RecurringHolidaysList.vue
@@ -44,14 +44,14 @@
       <hr class="my-0.5" v-if="index !== holidays.length - 1" />
     </div>
     <div v-if="holidays?.length === 0" class="text-center p-4 text-gray-600">
-      No items in the list
+    {{ __('No items in the list') }}
     </div>
   </div>
   <Button
     variant="subtle"
     @click="addHoliday"
     class="mt-2.5"
-    label="Add Recurring Holiday"
+    :label="__('Add Recurring Holiday')"
     icon-left="plus"
   />
   <Dialog
@@ -71,7 +71,7 @@
       </div>
       <div v-else class="flex flex-col gap-4">
         <div class="flex flex-col gap-1.5">
-          <FormLabel label="Day" required />
+          <FormLabel :label="__('Day')" required />
           <Select
             :options="availableWorkDays"
             v-model="recurringHolidayData.day"
@@ -79,11 +79,11 @@
           />
         </div>
         <div class="flex flex-col gap-1.5">
-          <FormLabel label="Repetition" required />
+          <FormLabel :label="__('Repetition')" required />
           <div class="grid grid-cols-2 gap-2 mt-2">
             <Checkbox
               v-model="recurringHolidayData.repetition.all"
-              label="Every week"
+              :label="__('Every week')"
               :disabled="
                 recurringHolidayData.repetition.first ||
                 recurringHolidayData.repetition.second ||
@@ -93,27 +93,27 @@
             />
             <Checkbox
               v-model="recurringHolidayData.repetition.first"
-              label="Every first week"
+              :label="__('Every first week')"
               :disabled="recurringHolidayData.repetition.all"
             />
             <Checkbox
               v-model="recurringHolidayData.repetition.second"
-              label="Every second week"
+              :label="__('Every second week')"
               :disabled="recurringHolidayData.repetition.all"
             />
             <Checkbox
               v-model="recurringHolidayData.repetition.third"
-              label="Every third week"
+              :label="__('Every third week')"
               :disabled="recurringHolidayData.repetition.all"
             />
             <Checkbox
               v-model="recurringHolidayData.repetition.fourth"
-              label="Every fourth week"
+              :label="__('Every fourth week')"
               :disabled="recurringHolidayData.repetition.all"
             />
             <Checkbox
               v-model="recurringHolidayData.repetition.fifth"
-              label="Every fifth week"
+              :label="__('Every fifth week')"
               :disabled="recurringHolidayData.repetition.all"
             />
           </div>
@@ -127,7 +127,7 @@
         class="w-full"
         v-if="props.holidayData.from_date && props.holidayData.to_date"
         :label="
-          recurringHolidayData.isEditing ? 'Update Holiday' : 'Add Holiday'
+          recurringHolidayData.isEditing ? __('Update Holiday') : __('Add Holiday')
         "
         :icon-left="recurringHolidayData.isEditing ? 'edit-2' : 'plus'"
       />
@@ -138,6 +138,7 @@
 <script setup lang="ts">
 import { updateWeeklyOffDates } from "@/stores/holidayList";
 import { ConfirmDelete } from "@/utils";
+import { __ } from "@/translation";
 import dayjs from "dayjs";
 import isSameOrBefore from "dayjs/plugin/isSameOrBefore";
 import weekday from "dayjs/plugin/weekday";
@@ -178,49 +179,49 @@ const props = defineProps({
 
 const columns = [
   {
-    label: "Day",
+    label: __("Day"),
     key: "day",
   },
   {
-    label: "Repetition",
+    label: __("Repetition"),
     key: "repetition",
   },
 ];
 
 const workDays = ref([
   {
-    label: "Monday",
+    label: __("Monday"),
     value: "Monday",
   },
   {
-    label: "Tuesday",
+    label: __("Tuesday"),
     value: "Tuesday",
   },
   {
-    label: "Wednesday",
+    label: __("Wednesday"),
     value: "Wednesday",
   },
   {
-    label: "Thursday",
+    label: __("Thursday"),
     value: "Thursday",
   },
   {
-    label: "Friday",
+    label: __("Friday"),
     value: "Friday",
   },
   {
-    label: "Saturday",
+    label: __("Saturday"),
     value: "Saturday",
   },
   {
-    label: "Sunday",
+    label: __("Sunday"),
     value: "Sunday",
   },
 ]);
 
 const dropdownOptions = (holiday: any) => [
   {
-    label: "Edit",
+    label: __("Edit"),
     onClick: () => editHoliday(holiday),
     icon: "edit",
   },
@@ -279,14 +280,14 @@ const editHoliday = (holiday: any) => {
 
 const saveHoliday = () => {
   if (!recurringHolidayData.value.day) {
-    toast.error("Please select a day of the week");
+    toast.error(__("Please select a day of the week"));
     return;
   }
 
   const { all, first, second, third, fourth, fifth } =
     recurringHolidayData.value.repetition;
   if (!all && !first && !second && !third && !fourth && !fifth) {
-    toast.error("Please select at least one repetition option");
+    toast.error(__("Please select at least one repetition option"));
     return;
   }
 
@@ -297,7 +298,7 @@ const saveHoliday = () => {
       props.holidays[holidayData.editIndex] = { ...holidayData };
       updateWeeklyOffDates();
     } else {
-      toast.error("Error: Unable to find the holiday to update");
+      toast.error(__("Error: Unable to find the holiday to update"));
       return;
     }
   } else {
@@ -309,7 +310,7 @@ const saveHoliday = () => {
     );
 
     if (isDuplicate) {
-      toast.error("Holiday with the same day and repetition already exists");
+      toast.error(__("Holiday with the same day and repetition already exists"));
       return;
     }
 

--- a/desk/src/components/Settings/InviteAgents.vue
+++ b/desk/src/components/Settings/InviteAgents.vue
@@ -200,19 +200,19 @@ const inviteByEmailResource = createResource({
     resetInputValues();
     let emailsStr = emailsToStr(data.invited_emails);
     if (emailsStr.trim() !== "") {
-      toast.success(`${emailsStr} invited successfully`);
+      toast.success(__("{0} invited successfully", [emailsStr]));
     }
     emailsStr = emailsToStr(data.disabled_user_emails);
     if (emailsStr.trim() !== "") {
-      toast.info(`${emailsStr} already present and disabled`);
+      toast.info(__("{0} already present and disabled", [emailsStr]));
     }
     emailsStr = emailsToStr(data.pending_invite_emails);
     if (emailsStr.trim() !== "") {
-      toast.info(`${emailsStr} already invited`);
+      toast.info(__("{0} already invited", [emailsStr]));
     }
     emailsStr = emailsToStr(data.accepted_invite_emails);
     if (emailsStr.trim() !== "") {
-      toast.info(`${emailsStr} already present`);
+      toast.info(__("{0} already present", [emailsStr]));
     }
     pendingInvitesResource.reload();
     updateOnboardingStep("invite_your_team");
@@ -235,7 +235,7 @@ const cancelInviteResource = createResource({
   url: "frappe.core.api.user_invitation.cancel_invitation",
   method: "PATCH",
   onSuccess() {
-    toast.success("Invitation cancelled successfully");
+    toast.success(__("Invitation cancelled successfully"));
     pendingInvitesResource.fetch();
   },
 });

--- a/desk/src/components/Settings/Sla/Modals/EditResponseResolutionModal.vue
+++ b/desk/src/components/Settings/Sla/Modals/EditResponseResolutionModal.vue
@@ -2,7 +2,7 @@
   <Dialog
     v-model="dialog"
     :options="{
-      title: 'Edit response and resolution',
+      title: __('Edit response and resolution'),
     }"
   >
     <template #body-content>
@@ -11,14 +11,14 @@
           :type="'select'"
           size="sm"
           variant="subtle"
-          placeholder="Select Priority"
-          label="Priority"
+          :placeholder="__('Select Priority')"
+          :label="__('Priority')"
           v-model="priorityData.priority"
           :options="priorityOptions"
           required
         />
         <div>
-          <FormLabel label="Response time" required />
+          <FormLabel :label="__('Response time')" required />
           <Popover class="mt-2">
             <template #target="{ togglePopover }" class="w-max">
               <div
@@ -28,7 +28,7 @@
                 <div v-if="priorityData.response_time">
                   {{ formatTimeHMS(priorityData.response_time) }}
                 </div>
-                <div v-else class="text-gray-500">Select time</div>
+                <div v-else class="text-gray-500">{{ __('Select time') }}</div>
               </div>
             </template>
             <template #body>
@@ -42,7 +42,7 @@
           </Popover>
         </div>
         <div>
-          <FormLabel label="Resolution time" required />
+          <FormLabel :label="__('Resolution time')" required />
           <Popover class="mt-2">
             <template #target="{ togglePopover }" class="w-max">
               <div
@@ -52,7 +52,7 @@
                 <div v-if="priorityData.resolution_time">
                   {{ formatTimeHMS(priorityData.resolution_time) }}
                 </div>
-                <div v-else class="text-gray-500">Select time</div>
+                <div v-else class="text-gray-500">{{ __('Select time') }}</div>
               </div>
             </template>
             <template #body>
@@ -67,7 +67,7 @@
         </div>
         <Checkbox
           v-model="priorityData.default_priority"
-          label="Set default priority"
+          :label="__('Set default priority')"
         />
       </div>
     </template>
@@ -110,6 +110,7 @@ import { inject, ref } from "vue";
 import { formatTimeHMS } from "../utils";
 import DurationPicker from "@/components/frappe-ui/DurationPicker.vue";
 import { slaData } from "@/stores/sla";
+import { __ } from "@/translation";
 
 const dialog = defineModel<boolean>();
 const emit = defineEmits(["onDefaultPriorityChange"]);
@@ -133,19 +134,19 @@ const priorityData = ref({
 
 const validateForm = () => {
   if (!priorityData.value.priority) {
-    toast.error("Please select a priority");
+    toast.error(__("Please select a priority"));
     return false;
   }
 
   const resolutionTime = parseInt(priorityData.value.resolution_time);
   if (isNaN(resolutionTime) || resolutionTime <= 0) {
-    toast.error("Resolution time must be a positive number");
+    toast.error(__("Resolution time must be a positive number"));
     return false;
   }
 
   const responseTime = parseInt(priorityData.value.response_time);
   if (isNaN(responseTime) || responseTime <= 0) {
-    toast.error("Response time must be a positive number");
+    toast.error(__("Response time must be a positive number"));
     return false;
   }
 

--- a/desk/src/components/Settings/Sla/Modals/WorkDayModal.vue
+++ b/desk/src/components/Settings/Sla/Modals/WorkDayModal.vue
@@ -2,7 +2,7 @@
   <Dialog
     v-model="dialog.show"
     @after-leave="resetForm"
-    :options="{ title: dialog.isEditing ? 'Edit workday' : 'Add workday' }"
+    :options="{ title: dialog.isEditing ? __('Edit workday') : __('Add workday') }"
   >
     <template #body-content>
       <div class="flex flex-col gap-4">
@@ -11,36 +11,36 @@
             :type="'select'"
             size="sm"
             variant="subtle"
-            placeholder="Select Workday"
-            label="Workday"
+            :placeholder="__('Select Workday')"
+            :label="__('Workday')"
             v-model="workDayData.workday"
             :options="[
               {
-                label: 'Monday',
+                label: __('Monday'),
                 value: 'Monday',
               },
               {
-                label: 'Tuesday',
+                label: __('Tuesday'),
                 value: 'Tuesday',
               },
               {
-                label: 'Wednesday',
+                label: __('Wednesday'),
                 value: 'Wednesday',
               },
               {
-                label: 'Thursday',
+                label: __('Thursday'),
                 value: 'Thursday',
               },
               {
-                label: 'Friday',
+                label: __('Friday'),
                 value: 'Friday',
               },
               {
-                label: 'Saturday',
+                label: __('Saturday'),
                 value: 'Saturday',
               },
               {
-                label: 'Sunday',
+                label: __('Sunday'),
                 value: 'Sunday',
               },
             ]"
@@ -55,8 +55,8 @@
             :type="'time'"
             size="sm"
             variant="subtle"
-            placeholder="Start Time"
-            label="Start Time"
+            :placeholder="__('Start Time')"
+            :label="__('Start Time')"
             v-model="workDayData.start_time"
             :class="{ 'border-red-500': errors.start_time }"
             @blur="validateField('start_time')"
@@ -69,8 +69,8 @@
             :type="'time'"
             size="sm"
             variant="subtle"
-            placeholder="End Time"
-            label="End Time"
+            :placeholder="__('End Time')"
+            :label="__('End Time')"
             v-model="workDayData.end_time"
             :class="{ 'border-red-500': errors.end_time }"
             @blur="validateTimeRange"
@@ -91,7 +91,7 @@
           <Button
             variant="subtle"
             :theme="isConfirmingDelete ? 'red' : 'gray'"
-            :label="isConfirmingDelete ? 'Confirm Delete' : 'Delete'"
+            :label="isConfirmingDelete ? __('Confirm Delete') : __('Delete')"
             @click="deleteWorkDay"
             icon-left="trash-2"
           />
@@ -101,9 +101,9 @@
             variant="subtle"
             theme="gray"
             @click="dialog.show = false"
-            label="Cancel"
+            :label="__('Cancel')"
           />
-          <Button variant="solid" @click="onSave" label="Save" />
+          <Button variant="solid" @click="onSave" :label="__('Save')" />
         </div>
       </div>
     </template>
@@ -200,7 +200,7 @@ function resetForm() {
 
 const validateField = (field: string) => {
   if (!workDayData[field as keyof typeof workDayData]) {
-    errors[field as keyof typeof errors] = "This field is required";
+    errors[field as keyof typeof errors] = __("This field is required");
     return false;
   }
   errors[field as keyof typeof errors] = "";
@@ -209,8 +209,8 @@ const validateField = (field: string) => {
 
 const validateTimeRange = () => {
   if (!workDayData.start_time || !workDayData.end_time) {
-    if (!workDayData.start_time) errors.start_time = "Start time is required";
-    if (!workDayData.end_time) errors.end_time = "End time is required";
+    if (!workDayData.start_time) errors.start_time = __("Start time is required");
+    if (!workDayData.end_time) errors.end_time = __("End time is required");
     return false;
   }
 
@@ -223,7 +223,7 @@ const validateTimeRange = () => {
     endHours < startHours ||
     (endHours === startHours && endMinutes <= startMinutes)
   ) {
-    errors.end_time = "End time must be after start time";
+    errors.end_time = __("End time must be after start time");
     return false;
   }
 
@@ -264,7 +264,7 @@ const onSave = () => {
       );
 
       if (isDuplicate) {
-        errors.workday = "This workday already exists";
+        errors.workday = __("This workday already exists");
         toast.error(__("A workday with this name already exists"));
         return;
       }
@@ -275,7 +275,7 @@ const onSave = () => {
     }
     dialog.value.show = false;
   } catch (error) {
-    toast.error(__(`Failed to save workday: ${error}`));
+    toast.error(__("Failed to save workday: {0}", [error]));
   }
 };
 

--- a/desk/src/components/Settings/Sla/SlaPolicyView.vue
+++ b/desk/src/components/Settings/Sla/SlaPolicyView.vue
@@ -331,7 +331,7 @@ const getSlaData = createResource({
       condition_json = JSON.parse(data.condition_json || "[]");
     } catch (error) {
       toast.error(
-        "Assignment conditions are invalid or corrupt, recreate the conditions."
+        __("Assignment conditions are invalid or corrupt, recreate the conditions.")
       );
       condition_json = [];
     }

--- a/desk/src/components/Settings/Sla/SlaPriorityList.vue
+++ b/desk/src/components/Settings/Sla/SlaPriorityList.vue
@@ -72,6 +72,7 @@ import {
 } from "@/stores/sla";
 import { watchDebounced } from "@vueuse/core";
 import { getGridTemplateColumnsForTable } from "@/utils";
+import { __ } from "@/translation";
 
 createResource({
   url: "frappe.client.get_list",
@@ -114,7 +115,7 @@ const addRow = () => {
   );
 
   if (availablePriorities.length === 0) {
-    toast.error("All available priorities have already been added");
+    toast.error(__("All available priorities have already been added"));
     return;
   }
 
@@ -130,22 +131,22 @@ const addRow = () => {
 
 const columns = computed(() => [
   {
-    label: "Priority",
+    label: __("Priority"),
     key: "priority",
     isRequired: true,
   },
   {
-    label: "Default priority",
+    label: __("Default priority"),
     key: "default_priority",
     isRequired: true,
   },
   {
-    label: "First response time",
+    label: __("First response time"),
     key: "response_time",
     isRequired: true,
   },
   {
-    label: "Resolution time",
+    label: __("Resolution time"),
     key: "resolution_time",
     isRequired: true,
   },

--- a/desk/src/components/Settings/Sla/SlaPriorityListItem.vue
+++ b/desk/src/components/Settings/Sla/SlaPriorityListItem.vue
@@ -74,6 +74,7 @@ import { Button, Checkbox, Dropdown, Popover } from "frappe-ui";
 import { inject, ref } from "vue";
 import EditResponseResolutionModal from "./Modals/EditResponseResolutionModal.vue";
 import { formatTimeHMS } from "./utils";
+import { __ } from "@/translation";
 
 const props = defineProps({
   columns: {
@@ -103,7 +104,7 @@ const priorityOptions = inject<Array<any>>("priorityOptions");
 
 const dropdownOptions = [
   {
-    label: "Edit",
+    label: __("Edit"),
     onClick: () => editItem(),
     icon: "edit",
   },

--- a/desk/src/components/Settings/Sla/SlaWorkDaysList.vue
+++ b/desk/src/components/Settings/Sla/SlaWorkDaysList.vue
@@ -51,6 +51,7 @@ import { Button } from "frappe-ui";
 import SlaWorkDaysListItem from "./SlaWorkDaysListItem.vue";
 import { slaData, slaDataErrors } from "@/stores/sla";
 import { getGridTemplateColumnsForTable } from "@/utils";
+import { __ } from "@/translation";
 
 interface Column {
   key: string;
@@ -84,17 +85,17 @@ const addWorkDay = () => {
 
 const columns: Column[] = [
   {
-    label: "Day",
+    label: __("Day"),
     key: "workday",
     isRequired: true,
   },
   {
-    label: "Start time",
+    label: __("Start time"),
     key: "start_time",
     isRequired: true,
   },
   {
-    label: "End time",
+    label: __("End time"),
     key: "end_time",
     isRequired: true,
   },

--- a/desk/src/components/Settings/Sla/SlaWorkDaysListItem.vue
+++ b/desk/src/components/Settings/Sla/SlaWorkDaysListItem.vue
@@ -51,6 +51,7 @@ import { Button, Dropdown } from "frappe-ui";
 import WorkDayModal from "./Modals/WorkDayModal.vue";
 import { ConfirmDelete, getGridTemplateColumnsForTable } from "@/utils";
 import { slaData } from "@/stores/sla";
+import { __ } from "@/translation";
 
 interface Column {
   key: string;
@@ -72,13 +73,13 @@ const props = defineProps<{
 }>();
 
 const workDayOptions = [
-  { label: "Monday", value: "Monday" },
-  { label: "Tuesday", value: "Tuesday" },
-  { label: "Wednesday", value: "Wednesday" },
-  { label: "Thursday", value: "Thursday" },
-  { label: "Friday", value: "Friday" },
-  { label: "Saturday", value: "Saturday" },
-  { label: "Sunday", value: "Sunday" },
+  { label: __("Monday"), value: "Monday" },
+  { label: __("Tuesday"), value: "Tuesday" },
+  { label: __("Wednesday"), value: "Wednesday" },
+  { label: __("Thursday"), value: "Thursday" },
+  { label: __("Friday"), value: "Friday" },
+  { label: __("Saturday"), value: "Saturday" },
+  { label: __("Sunday"), value: "Sunday" },
 ];
 
 const dialog = ref({
@@ -91,7 +92,7 @@ const isConfirmingDelete = ref(false);
 
 const dropdownOptions = [
   {
-    label: "Edit",
+    label: __("Edit"),
     onClick: () => editWorkDay(),
     icon: "edit",
   },

--- a/desk/src/components/Settings/Telephony/ExotelSettings.vue
+++ b/desk/src/components/Settings/Telephony/ExotelSettings.vue
@@ -271,7 +271,7 @@ async function save() {
   if (isDirty.value.twilio) {
     promises.push(
       twilio.save.submit().catch((er) => {
-        const error = __(`Twilio error: {0}`, er?.messages?.[0]);
+        const error = __("Twilio error: {0}", er?.messages?.[0]);
         toast.error(error || __("Failed to save Twilio settings"));
       })
     );
@@ -279,7 +279,7 @@ async function save() {
   if (isDirty.value.exotel) {
     promises.push(
       exotel.save.submit().catch((er) => {
-        const error = __(`Exotel error: {0}`, er?.messages?.[0]);
+        const error = __("Exotel error: {0}", er?.messages?.[0]);
         toast.error(error || __("Failed to save Exotel settings"));
       })
     );

--- a/desk/src/components/Settings/Telephony/Telephony.vue
+++ b/desk/src/components/Settings/Telephony/Telephony.vue
@@ -200,8 +200,8 @@ const twilioAppsResource = createResource({
 });
 
 const telephonyProviders = [
-  { label: "Twilio", value: "Twilio" },
-  { label: "Exotel", value: "Exotel" },
+  { label: __("Twilio"), value: "Twilio" },
+  { label: __("Exotel"), value: "Exotel" },
 ];
 
 async function save() {
@@ -222,7 +222,7 @@ async function save() {
   if (isDirty.value.twilio) {
     promises.push(
       twilio.save.submit().catch((er) => {
-        const error = __(`Twilio error: {0}`, er?.messages?.[0]);
+        const error = __("Twilio error: {0}", er?.messages?.[0]);
         toast.error(error || __("Failed to save Twilio settings"));
       })
     );
@@ -230,7 +230,7 @@ async function save() {
   if (isDirty.value.exotel) {
     promises.push(
       exotel.save.submit().catch((er) => {
-        const error = __(`Exotel error: {0}`, er?.messages?.[0]);
+        const error = __("Exotel error: {0}", er?.messages?.[0]);
         toast.error(error || __("Failed to save Exotel settings"));
       })
     );

--- a/desk/src/components/Settings/Telephony/TwilioSettings.vue
+++ b/desk/src/components/Settings/Telephony/TwilioSettings.vue
@@ -225,7 +225,7 @@ async function save() {
   if (isDirty.value.twilio) {
     promises.push(
       twilio.save.submit().catch((er) => {
-        const error = __(`Twilio error: {0}`, er?.messages?.[0]);
+        const error = __("Twilio error: {0}", er?.messages?.[0]);
         toast.error(error || __("Failed to save Twilio settings"));
       })
     );

--- a/desk/src/components/Settings/emailConfig.ts
+++ b/desk/src/components/Settings/emailConfig.ts
@@ -192,48 +192,42 @@ export const services: EmailService[] = [
   {
     name: "GMail",
     icon: LogoGmail,
-    info: __(`Setting up GMail requires you to enable two factor authentication
-		  and app specific passwords. Read more`),
+    info: __("Setting up GMail requires you to enable two factor authentication and app specific passwords. Read more"),
     link: "https://support.google.com/accounts/answer/185833",
     custom: false,
   },
   {
     name: "Outlook",
     icon: LogoOutlook,
-    info: __(`Setting up Outlook requires you to enable two factor authentication
-		  and app specific passwords. Read more`),
+    info: __("Setting up Outlook requires you to enable two factor authentication and app specific passwords. Read more"),
     link: "https://support.microsoft.com/en-us/account-billing/how-to-get-and-use-app-passwords-5896ed9b-4263-e681-128a-a6f2979a7944",
     custom: false,
   },
   {
     name: "Sendgrid",
     icon: LogoSendgrid,
-    info: __(`Setting up Sendgrid requires you to enable two factor authentication
-		  and app specific passwords. Read more`),
+    info: __("Setting up Sendgrid requires you to enable two factor authentication and app specific passwords. Read more"),
     link: "https://sendgrid.com/docs/ui/account-and-settings/two-factor-authentication/",
     custom: false,
   },
   {
     name: "SparkPost",
     icon: LogoSparkpost,
-    info: __(`Setting up SparkPost requires you to enable two factor authentication
-		  and app specific passwords. Read more`),
+    info: __("Setting up SparkPost requires you to enable two factor authentication and app specific passwords. Read more"),
     link: "https://support.sparkpost.com/docs/my-account-and-profile/enabling-two-factor-authentication",
     custom: false,
   },
   {
     name: "Yahoo",
     icon: LogoYahoo,
-    info: __(`Setting up Yahoo requires you to enable two factor authentication
-		  and app specific passwords. Read more`),
+    info: __("Setting up Yahoo requires you to enable two factor authentication and app specific passwords. Read more"),
     link: "https://help.yahoo.com/kb/SLN15241.html",
     custom: false,
   },
   {
     name: "Yandex",
     icon: LogoYandex,
-    info: __(`Setting up Yandex requires you to enable two factor authentication
-		  and app specific passwords. Read more`),
+    info: __("Setting up Yandex requires you to enable two factor authentication and app specific passwords. Read more"),
     link: "https://yandex.com/support/id/authorization/app-passwords.html",
     custom: false,
   },
@@ -241,7 +235,7 @@ export const services: EmailService[] = [
     name: "Frappe Mail",
     icon: LogoFrappeMail,
     info: __(
-      `Setting up Frappe Mail requires you to have an API key and API Secret of your email account. Read more`
+      "Setting up Frappe Mail requires you to have an API key and API Secret of your email account. Read more"
     ),
     link: "https://github.com/frappe/mail",
     custom: true,
@@ -249,7 +243,7 @@ export const services: EmailService[] = [
   {
     name: "Custom",
     icon: "",
-    info: __(`Use your own IMAP/SMTP settings. Open in Desk`),
+    info: __("Use your own IMAP/SMTP settings. Open in Desk"),
     link: "/desk/email-account/new-email-account",
     custom: true,
   },

--- a/desk/src/components/conditions-filter/CFCondition.vue
+++ b/desk/src/components/conditions-filter/CFCondition.vue
@@ -35,7 +35,7 @@
           <Autocomplete
             :options="filterableFields.data"
             v-model="props.condition[0]"
-            :placeholder="'Field'"
+            :placeholder="__('Field')"
             @update:modelValue="updateField"
           />
         </div>
@@ -44,7 +44,7 @@
             v-if="!props.condition[0]"
             disabled
             type="text"
-            :placeholder="'operator'"
+            :placeholder="__('operator')"
             class="w-[100px]"
           />
           <FormControl
@@ -62,7 +62,7 @@
             v-if="!props.condition[0]"
             disabled
             type="text"
-            :placeholder="'condition'"
+            :placeholder="__('condition')"
             class="w-full"
           />
           <component
@@ -70,7 +70,7 @@
             :is="getValueControl()"
             v-model="props.condition[2]"
             @change="updateValue"
-            :placeholder="'condition'"
+            :placeholder="__('condition')"
           />
         </div>
       </div>
@@ -85,7 +85,7 @@
         variant="outline"
         v-if="props.isGroup && (props.level == 2 || props.level == 4)"
         @click="show = true"
-        label="Open nested conditions"
+        :label="__('Open nested conditions')"
       />
     </div>
     <div :class="'w-max'">
@@ -94,7 +94,7 @@
       </Dropdown>
     </div>
   </div>
-  <Dialog v-model="show" :options="{ size: '3xl', title: 'Nested conditions' }">
+  <Dialog v-model="show" :options="{ size: '3xl', title: __('Nested conditions') }">
     <template #body-content>
       <CFConditions
         :conditions="props.condition"
@@ -124,6 +124,7 @@ import GroupIcon from "~icons/lucide/group";
 import UnGroupIcon from "~icons/lucide/ungroup";
 import CFConditions from "./CFConditions.vue";
 import { filterableFields } from "./filterableFields";
+import { __ } from "@/translation";
 
 const show = ref(false);
 const emit = defineEmits([
@@ -167,7 +168,7 @@ const dropdownOptions = computed(() => {
 
   if (!props.isGroup && props.level < 4) {
     options.push({
-      label: "Turn into a group",
+      label: __("Turn into a group"),
       icon: () => h(GroupIcon),
       onClick: () => {
         emit("turnIntoGroup");
@@ -177,7 +178,7 @@ const dropdownOptions = computed(() => {
 
   if (props.isGroup) {
     options.push({
-      label: "Ungroup conditions",
+      label: __("Ungroup conditions"),
       icon: () => h(UnGroupIcon),
       onClick: () => {
         emit("unGroupConditions");
@@ -186,10 +187,10 @@ const dropdownOptions = computed(() => {
   }
 
   options.push({
-    label: "Remove",
+    label: __("Remove"),
     component: (props) =>
       TemplateOption({
-        option: "Remove",
+        option: __("Remove"),
         icon: "trash-2",
         active: props.active,
         variant: "danger",
@@ -201,10 +202,10 @@ const dropdownOptions = computed(() => {
   });
 
   options.push({
-    label: "Remove group",
+    label: __("Remove group"),
     component: (props) =>
       TemplateOption({
-        option: "Remove group",
+        option: __("Remove group"),
         icon: "trash-2",
         active: props.active,
         variant: "danger",
@@ -250,11 +251,11 @@ function getValueControl() {
       type: "select",
       options: [
         {
-          label: "Set",
+          label: __("Set"),
           value: "set",
         },
         {
-          label: "Not Set",
+          label: __("Not Set"),
           value: "not set",
         },
       ],
@@ -334,33 +335,33 @@ function getOperators() {
   if (typeString.includes(fieldtype)) {
     options.push(
       ...[
-        { label: "Equals", value: "==" },
-        { label: "Not Equals", value: "!=" },
-        { label: "Like", value: "like" },
-        { label: "Not Like", value: "not like" },
-        { label: "In", value: "in" },
-        { label: "Not In", value: "not in" },
-        { label: "Is", value: "is" },
+        { label: __("Equals"), value: "==" },
+        { label: __("Not Equals"), value: "!=" },
+        { label: __("Like"), value: "like" },
+        { label: __("Not Like"), value: "not like" },
+        { label: __("In"), value: "in" },
+        { label: __("Not In"), value: "not in" },
+        { label: __("Is"), value: "is" },
       ]
     );
   }
   if (fieldname === "_assign") {
     options = [
-      { label: "Like", value: "like" },
-      { label: "Not Like", value: "not like" },
-      { label: "Is", value: "is" },
+      { label: __("Like"), value: "like" },
+      { label: __("Not Like"), value: "not like" },
+      { label: __("Is"), value: "is" },
     ];
   }
   if (typeNumber.includes(fieldtype)) {
     options.push(
       ...[
-        { label: "Equals", value: "==" },
-        { label: "Not Equals", value: "!=" },
-        { label: "Like", value: "like" },
-        { label: "Not Like", value: "not like" },
-        { label: "In", value: "in" },
-        { label: "Not In", value: "not in" },
-        { label: "Is", value: "is" },
+        { label: __("Equals"), value: "==" },
+        { label: __("Not Equals"), value: "!=" },
+        { label: __("Like"), value: "like" },
+        { label: __("Not Like"), value: "not like" },
+        { label: __("In"), value: "in" },
+        { label: __("Not In"), value: "not in" },
+        { label: __("Is"), value: "is" },
         { label: "<", value: "<" },
         { label: ">", value: ">" },
         { label: "<=", value: "<=" },
@@ -371,61 +372,61 @@ function getOperators() {
   if (typeSelect.includes(fieldtype)) {
     options.push(
       ...[
-        { label: "Equals", value: "==" },
-        { label: "Not Equals", value: "!=" },
-        { label: "In", value: "in" },
-        { label: "Not In", value: "not in" },
-        { label: "Is", value: "is" },
+        { label: __("Equals"), value: "==" },
+        { label: __("Not Equals"), value: "!=" },
+        { label: __("In"), value: "in" },
+        { label: __("Not In"), value: "not in" },
+        { label: __("Is"), value: "is" },
       ]
     );
   }
   if (typeLink.includes(fieldtype)) {
     options.push(
       ...[
-        { label: "Equals", value: "==" },
-        { label: "Not Equals", value: "!=" },
-        { label: "Like", value: "like" },
-        { label: "Not Like", value: "not like" },
-        { label: "In", value: "in" },
-        { label: "Not In", value: "not in" },
-        { label: "Is", value: "is" },
+        { label: __("Equals"), value: "==" },
+        { label: __("Not Equals"), value: "!=" },
+        { label: __("Like"), value: "like" },
+        { label: __("Not Like"), value: "not like" },
+        { label: __("In"), value: "in" },
+        { label: __("Not In"), value: "not in" },
+        { label: __("Is"), value: "is" },
       ]
     );
   }
   if (typeCheck.includes(fieldtype)) {
-    options.push(...[{ label: "Equals", value: "==" }]);
+    options.push(...[{ label: __("Equals"), value: "==" }]);
   }
   if (["Duration"].includes(fieldtype)) {
     options.push(
       ...[
-        { label: "Like", value: "like" },
-        { label: "Not Like", value: "not like" },
-        { label: "In", value: "in" },
-        { label: "Not In", value: "not in" },
-        { label: "Is", value: "is" },
+        { label: __("Like"), value: "like" },
+        { label: __("Not Like"), value: "not like" },
+        { label: __("In"), value: "in" },
+        { label: __("Not In"), value: "not in" },
+        { label: __("Is"), value: "is" },
       ]
     );
   }
   if (typeDate.includes(fieldtype)) {
     options.push(
       ...[
-        { label: "Equals", value: "==" },
-        { label: "Not Equals", value: "!=" },
-        { label: "Is", value: "is" },
+        { label: __("Equals"), value: "==" },
+        { label: __("Not Equals"), value: "!=" },
+        { label: __("Is"), value: "is" },
         { label: ">", value: ">" },
         { label: "<", value: "<" },
         { label: ">=", value: ">=" },
         { label: "<=", value: "<=" },
-        { label: "Between", value: "between" },
+        { label: __("Between"), value: "between" },
       ]
     );
   }
   if (typeRating.includes(fieldtype)) {
     options.push(
       ...[
-        { label: "Equals", value: "==" },
-        { label: "Not Equals", value: "!=" },
-        { label: "Is", value: "is" },
+        { label: __("Equals"), value: "==" },
+        { label: __("Not Equals"), value: "!=" },
+        { label: __("Is"), value: "is" },
         { label: ">", value: ">" },
         { label: "<", value: "<" },
         { label: ">=", value: ">=" },

--- a/desk/src/components/conditions-filter/CFConditions.vue
+++ b/desk/src/components/conditions-filter/CFConditions.vue
@@ -20,7 +20,7 @@
       <Dropdown v-slot="{ open }" :options="dropdownOptions">
         <Button
           :disabled="props.disableAddCondition"
-          label="Add condition"
+          :label="__('Add condition')"
           icon-left="plus"
           :icon-right="open ? 'chevron-up' : 'chevron-down'"
         />
@@ -32,6 +32,7 @@
 <script setup lang="ts">
 import { Button, Dropdown } from "frappe-ui";
 import { computed, onMounted } from "vue";
+import { __ } from "@/translation";
 import CFCondition from "./CFCondition.vue";
 import { filterableFields } from "./filterableFields";
 
@@ -75,7 +76,7 @@ const isGroupCondition = (condition) => {
 const dropdownOptions = computed(() => {
   const options = [
     {
-      label: "Add condition",
+    { label: __("Add condition"),
       onClick: () => {
         const conjunction = getConjunction();
         props.conditions.push(conjunction, ["", "", ""]);
@@ -84,7 +85,7 @@ const dropdownOptions = computed(() => {
   ];
   if (props.level < 3) {
     options.push({
-      label: "Add condition group",
+      label: __("Add condition group"),
       onClick: () => {
         const conjunction = getConjunction();
         props.conditions.push(conjunction, [[]]);

--- a/desk/src/components/desk/global/AddNewAgentsDialog.vue
+++ b/desk/src/components/desk/global/AddNewAgentsDialog.vue
@@ -80,6 +80,7 @@ import { useAuthStore } from "@/stores/auth";
 import { createResource, Dialog, FeatherIcon, Input, toast } from "frappe-ui";
 import { useOnboarding } from "frappe-ui/frappe";
 import { ref } from "vue";
+import { __ } from "@/translation";
 
 const props = defineProps({
   show: Boolean,
@@ -177,7 +178,7 @@ const sentInvitesResource = createResource({
       updateOnboardingStep("invite_agents");
     }
 
-    toast.success("Invites sent successfully!");
+    toast.success(__("Invites sent successfully!"));
 
     close();
   },

--- a/desk/src/components/desk/global/NewCustomerDialog.vue
+++ b/desk/src/components/desk/global/NewCustomerDialog.vue
@@ -72,7 +72,7 @@ const customerResource = createResource({
 
 function addCustomer() {
   if (!state.customer) {
-    toast.error("Customer name is required");
+    toast.error(__("Customer name is required"));
     return;
   }
   customerResource.submit({

--- a/desk/src/components/frappe-ui/Autocomplete.vue
+++ b/desk/src/components/frappe-ui/Autocomplete.vue
@@ -54,7 +54,7 @@
                 "
                 :value="query"
                 autocomplete="off"
-                placeholder="Search"
+                :placeholder="__('Search')"
               />
               <button
                 class="absolute right-1.5 inline-flex h-7 w-7 items-center justify-center"
@@ -109,7 +109,7 @@
                 v-if="groups.length == 0"
                 class="mt-1.5 rounded-md px-2.5 py-1.5 text-base text-gray-600"
               >
-                No results found
+                {{ __('No results found') }}
               </li>
             </ComboboxOptions>
             <div v-if="slots.footer" class="border-t p-1.5 pb-0.5">

--- a/desk/src/components/frappe-ui/Dropdown.vue
+++ b/desk/src/components/frappe-ui/Dropdown.vue
@@ -9,7 +9,7 @@
         <MenuButton as="template">
           <slot v-if="$slots.default" v-bind="{ open, togglePopover }" />
           <Button v-else :active="open" v-bind="button">
-            {{ button ? button?.label || null : "Options" }}
+            {{ button ? button?.label || null : __('Options') }}
           </Button>
         </MenuButton>
       </template>

--- a/desk/src/components/frappe-ui/Link.vue
+++ b/desk/src/components/frappe-ui/Link.vue
@@ -50,7 +50,7 @@
           <Button
             variant="ghost"
             class="w-full !justify-start"
-            :label="'Create New'"
+            :label="__('Create New')"
             @click="attrs.onCreate(value, close)"
           >
             <template #prefix>
@@ -62,7 +62,7 @@
           <Button
             variant="ghost"
             class="w-full !justify-start"
-            :label="'Clear'"
+            :label="__('Clear')"
             @click="() => clearValue(close)"
           >
             <template #prefix>

--- a/desk/src/components/frappe-ui/MultiSelectCombobox.vue
+++ b/desk/src/components/frappe-ui/MultiSelectCombobox.vue
@@ -83,7 +83,7 @@
                   :value="query"
                   @change="query = $event.target.value"
                   autocomplete="off"
-                  placeholder="Search"
+                  :placeholder="__('Search')"
                 />
                 <button
                   class="absolute right-0 inline-flex h-7 w-7 items-center justify-center"
@@ -167,7 +167,7 @@
                 v-if="groups.length == 0"
                 class="rounded-md px-2.5 py-1.5 text-base text-gray-600"
               >
-                No results found
+                {{ __('No results found') }}
               </li>
             </ComboboxOptions>
 
@@ -182,12 +182,12 @@
                 >
                   <Button
                     v-if="!areAllOptionsSelected"
-                    label="Select All"
+                    :label="__('Select All')"
                     @click.stop="selectAll"
                   />
                 </div>
                 <div v-else class="flex items-center justify-end">
-                  <Button label="Clear" @click.stop="selectedValue = null" />
+                  <Button :label="__('Clear')" @click.stop="selectedValue = null" />
                 </div>
               </slot>
             </div>
@@ -353,7 +353,7 @@ export default {
     },
     getLabel(option) {
       if (typeof option !== "object") return option;
-      return option?.label || option?.value || "No label";
+      return option?.label || option?.value || this.__("No label");
     },
     sanitizeOptions(options) {
       if (!options) return [];

--- a/desk/src/components/telephony/CallUI.vue
+++ b/desk/src/components/telephony/CallUI.vue
@@ -47,6 +47,7 @@ import TwilioCallUI from "./TwilioCallUI.vue";
 import ExotelCallUI from "./ExotelCallUI.vue";
 import { useTelephonyStore } from "@/stores/telephony";
 import { storeToRefs } from "pinia";
+import { __ } from "@/translation";
 
 const telephonyStore = useTelephonyStore();
 const { defaultCallingMedium, isExotelEnabled, isTwilioEnabled } =
@@ -117,7 +118,7 @@ async function setCallingMedium() {
   telephonyStore.setDefaultCallingMedium(callMedium.value);
   telephonyStore.fetchCallIntegrationStatus();
   toast.success(
-    `Default calling medium set successfully to ${callMedium.value}`
+    __("Default calling medium set successfully to {0}", [callMedium.value])
   );
 }
 

--- a/desk/src/components/telephony/TwilioCallUI.vue
+++ b/desk/src/components/telephony/TwilioCallUI.vue
@@ -180,6 +180,7 @@ import { inject, ref, watch } from "vue";
 import LucidePhone from "~icons/lucide/phone";
 import CountUpTimer from "./CountUpTimer.vue";
 import MinimizeIcon from "./Icons/MinimizeIcon.vue";
+import { __ } from "@/translation";
 
 const telephonyStore = useTelephonyStore();
 
@@ -420,7 +421,7 @@ async function makeOutgoingCall(number) {
   } else {
     onCallFailed && onCallFailed();
     log.value = "Unable to make call.";
-    toast.error("Unable to make call.");
+    toast.error(__("Unable to make call."));
   }
 }
 

--- a/desk/src/components/ticket-agent/TicketHeader.vue
+++ b/desk/src/components/ticket-agent/TicketHeader.vue
@@ -200,7 +200,7 @@ function updateField(fieldname: string, value: string, callback = () => {}) {
 
 function handleDeleteTicket() {
   $dialog({
-    title: __(`Delete ticket #${ticket?.value?.name}`),
+    title: __("Delete ticket #{0}", [ticket?.value?.name]),
     message: __(
       "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
     ),

--- a/desk/src/components/ticket-agent/TicketNavigation.vue
+++ b/desk/src/components/ticket-agent/TicketNavigation.vue
@@ -3,7 +3,7 @@
     <Tooltip
       :text="
         getPreviousTicket()
-          ? __(`Go to previous ticket (Shift + <)`)
+          ? __("Go to previous ticket (Shift + <)")
           : __('No previous ticket')
       "
       :disabled="disableLeftCondition"
@@ -18,7 +18,7 @@
     <Tooltip
       :text="
         getNextTicket()
-          ? __(`Go to next ticket (Shift + >)`)
+          ? __("Go to next ticket (Shift + >)")
           : __('No next ticket')
       "
       :disabled="disableRightCondition"

--- a/desk/src/components/ticket/TicketAgentFields.vue
+++ b/desk/src/components/ticket/TicketAgentFields.vue
@@ -15,6 +15,7 @@ import { Field, FieldValue } from "@/types";
 import { toast } from "frappe-ui";
 import { computed } from "vue";
 import TicketField from "../TicketField.vue";
+import { __ } from "@/translation";
 const emit = defineEmits(["update"]);
 
 const props = defineProps({
@@ -30,7 +31,7 @@ const fields = computed(() => {
 
 function update(field: Field["fieldname"], value: FieldValue, event = null) {
   if (field === "subject" && value === "") {
-    toast.error("Subject is required");
+    toast.error(__("Subject is required"));
     event.target.value = props.ticket.subject;
     return;
   }

--- a/desk/src/components/ticket/TicketMergeModal.vue
+++ b/desk/src/components/ticket/TicketMergeModal.vue
@@ -113,6 +113,7 @@ import {
 import { ref, watch } from "vue";
 import LucideMerge from "~icons/lucide/merge";
 import TriangleAlert from "~icons/lucide/triangle-alert";
+import { __ } from "@/translation";
 // interface P
 interface Props {
   ticket: HDTicket;
@@ -168,7 +169,7 @@ const mergeTicket = createResource({
     if (!target) throw { message: "Ticket to merged with is required" };
   },
   onSuccess: () => {
-    toast.success("Ticket merged successfully.");
+    toast.success(__("Ticket merged successfully."));
     emit("update");
 
     showDialog.value = false;

--- a/desk/src/composables/fc.ts
+++ b/desk/src/composables/fc.ts
@@ -1,6 +1,7 @@
 import { globalStore } from "@/stores/globalStore";
 import { createResource } from "frappe-ui";
 import { ref } from "vue";
+import { __ } from "@/translation";
 
 const baseEndpoint = ref("https://frappecloud.com");
 const siteName = ref("");
@@ -20,11 +21,11 @@ export const confirmLoginToFrappeCloud = () => {
   const { $dialog } = globalStore();
 
   $dialog({
-    title: "Login to Frappe Cloud?",
-    message: "Are you sure you want to login to your Frappe Cloud dashboard?",
+    title: __("Login to Frappe Cloud?"),
+    message: __("Are you sure you want to login to your Frappe Cloud dashboard?"),
     actions: [
       {
-        label: "Confirm",
+        label: __("Confirm"),
         variant: "solid",
         onClick(close: Function) {
           loginToFrappeCloud();

--- a/desk/src/composables/useView.ts
+++ b/desk/src/composables/useView.ts
@@ -5,6 +5,7 @@ import { useDebounceFn } from "@vueuse/core";
 import { call, createListResource, createResource } from "frappe-ui";
 import { computed, ref, watch } from "vue";
 import { useRouter } from "vue-router";
+import { __ } from "@/translation";
 
 const debouncedSetValue = useDebounceFn(
   (doctype: string, name: string, fieldname: any, cb?: Function) => {
@@ -30,7 +31,7 @@ export const views = createListResource({
 });
 
 export const currentView = ref({
-  label: "List",
+  label: __("List"),
   icon: LucideAlignJustify,
 });
 

--- a/desk/src/pages/desk/contact/Contacts.vue
+++ b/desk/src/pages/desk/contact/Contacts.vue
@@ -98,7 +98,7 @@ function openContact(id: string): void {
 }
 
 function handleContactUpdated(): void {
-  toast.success("Contact updated successfully.");
+  toast.success(__("Contact updated successfully."));
   listViewRef.value?.reload();
 }
 usePageMeta(() => {

--- a/desk/src/pages/knowledge-base/Article.vue
+++ b/desk/src/pages/knowledge-base/Article.vue
@@ -431,8 +431,8 @@ const toggleStatus = debounce(() => {
     {
       onSuccess: () => {
         if (status === "Published")
-          toast.success("Article published successfully.");
-        else toast.success("Article unpublished successfully.");
+          toast.success(__("Article published successfully."));
+        else toast.success(__("Article unpublished successfully."));
         article.reload();
       },
     }
@@ -452,7 +452,7 @@ function handleMoveToCategory(category: string) {
       onSuccess: () => {
         article.reload();
         moveToModal.value = false;
-        toast.success(__(`Article has been successfully moved.`));
+        toast.success(__("Article has been successfully moved."));
       },
       onError: (error: Error) => {
         let msg = error?.messages?.[0] || error.message;

--- a/desk/src/pages/ticket/TicketAgent.vue
+++ b/desk/src/pages/ticket/TicketAgent.vue
@@ -71,6 +71,7 @@ import { computed, onBeforeUnmount, onMounted, provide, ref, watch } from "vue";
 import { useRoute } from "vue-router";
 import { showCommentBox, showEmailBox } from "./modalStates";
 import TicketIcon from "@/components/icons/TicketIcon.vue";
+import { __ } from "@/translation";
 
 const telephonyStore = useTelephonyStore();
 const { $socket } = globalStore();
@@ -168,7 +169,7 @@ onMounted(() => {
   $socket.on("ticket_update", (data: TicketUpdateData) => {
     if (data.ticket_id === ticket.value?.name) {
       // Notify the user about the update
-      toast.info(`User ${data.user} updated ${data.field} to ${data.value}`);
+      toast.info(__("{0} updated {1} to {2}", [data.user, data.field, data.value]));
     }
   });
 

--- a/desk/src/pages/ticket/TicketTextEditor.vue
+++ b/desk/src/pages/ticket/TicketTextEditor.vue
@@ -43,7 +43,7 @@
           @success="
             (f: File) => $emit('update:attachments', [...attachments, f])
           "
-          @failure="() => toast.error('Error uploading file')"
+          @failure="() => toast.error(__('Error uploading file'))"
         >
           <template #default="{ openFileSelector }">
             <Button theme="gray" variant="ghost" @click="openFileSelector()">
@@ -91,6 +91,7 @@ import { File } from "@/types";
 import { removeAttachmentFromServer } from "@/utils";
 import { FileUploader, toast } from "frappe-ui";
 import { computed, ref } from "vue";
+import { __ } from "@/translation";
 
 interface P {
   content: string;

--- a/desk/src/stores/knowledgeBase.ts
+++ b/desk/src/stores/knowledgeBase.ts
@@ -1,4 +1,5 @@
 import { createResource } from "frappe-ui";
+import { __ } from "@/translation";
 
 // Title
 export const newArticle = createResource({
@@ -14,8 +15,8 @@ export const newArticle = createResource({
     };
   },
   validate({ doc }) {
-    if (!doc.title) throw "Title is required";
-    if (!doc.content) throw "Content is required";
+    if (!doc.title) throw __("Title is required");
+    if (!doc.content) throw __("Content is required");
   },
 });
 
@@ -35,7 +36,7 @@ export const deleteArticles = createResource({
     };
   },
   validate({ articles }) {
-    if (!articles) throw "Articles are required";
+    if (!articles) throw __("Articles are required");
   },
 });
 
@@ -48,7 +49,7 @@ export const newCategory = createResource({
     };
   },
   validate({ title }) {
-    if (!title) throw "Title is required";
+    if (!title) throw __("Title is required");
   },
 });
 
@@ -68,8 +69,8 @@ export const moveToCategory = createResource({
     };
   },
   validate({ category, articles }) {
-    if (!category) throw { message: "Category is required" };
-    if (!articles) throw { message: "Articles are required" };
+    if (!category) throw { message: __("Category is required") };
+    if (!articles) throw { message: __("Articles are required") };
   },
 });
 
@@ -82,8 +83,8 @@ export const mergeCategory = createResource({
     };
   },
   validate({ source, target }) {
-    if (!source) throw { message: "Category is required" };
-    if (!target) throw { message: "Target is required" };
+    if (!source) throw { message: __("Category is required") };
+    if (!target) throw { message: __("Target is required") };
   },
 });
 

--- a/desk/src/utils.ts
+++ b/desk/src/utils.ts
@@ -671,7 +671,7 @@ export function getFieldDependencyLabel(name: string) {
 export function ConfirmDelete({ isConfirmingDelete, onConfirmDelete }) {
   return [
     {
-      label: "Delete",
+      label: __("Delete"),
       component: (props) =>
         TemplateOption({
           option: "Delete",
@@ -687,7 +687,7 @@ export function ConfirmDelete({ isConfirmingDelete, onConfirmDelete }) {
       condition: () => !isConfirmingDelete.value,
     },
     {
-      label: "Confirm Delete",
+      label: __("Confirm Delete"),
       component: (props) =>
         TemplateOption({
           option: "Confirm Delete",

--- a/helpdesk/auth.py
+++ b/helpdesk/auth.py
@@ -1,6 +1,7 @@
 import json
 
 import frappe
+from frappe import _
 
 ALLOWED_PATHS = [
     "/api/method/ping",
@@ -102,7 +103,7 @@ def authenticate():
 
     if path in ALLOWED_PATHS:
         return
-    frappe.throw(f"Access not allowed for this URL: {path}", frappe.PermissionError)
+    frappe.throw(_("Access not allowed for this URL: {0}").format(path), frappe.PermissionError)
 
 
 def is_server_script_path(path):

--- a/helpdesk/extends/assignment_rule.py
+++ b/helpdesk/extends/assignment_rule.py
@@ -9,7 +9,7 @@ def on_assignment_rule_trash(doc, event):
         "Assignment Rule",
         filters={"document_type": "HD Ticket", "name": ["!=", doc.name]},
     ):
-        frappe.throw("There should atleast be 1 assignment rule for ticket")
+        frappe.throw(_("There should atleast be 1 assignment rule for ticket"))
 
 
 def on_assignment_rule_validate(doc, event):
@@ -17,7 +17,7 @@ def on_assignment_rule_validate(doc, event):
         frappe.throw(
             _("The Assign Condition JSON '{0}' is invalid: </br> {1}").format(
                 doc.assign_condition_json,
-                "Condition format should be like this e.g [['status','==','open']], it's recommended to use portal view to create conditions.",
+                _("Condition format should be like this e.g [['status','==','open']], it's recommended to use portal view to create conditions."),
             )
         )
 
@@ -25,6 +25,6 @@ def on_assignment_rule_validate(doc, event):
         frappe.throw(
             _("The Unassign Condition JSON '{0}' is invalid: </br> {1}").format(
                 doc.unassign_condition_json,
-                "Condition format should be like this e.g [['status','==','open']], it's recommended to use portal view to create conditions.",
+                _("Condition format should be like this e.g [['status','==','open']], it's recommended to use portal view to create conditions."),
             )
         )

--- a/helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.py
+++ b/helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe import _
 from frappe.model.document import Document
 from frappe.utils import get_url, random_string
 
@@ -35,6 +36,8 @@ class HDDeskAccountRequest(Document):
             )
         except Exception:
             frappe.throw(
-                "Either setup up Support email account or there should be a default"
-                " outgoing email account"
+                _(
+                    "Either setup up Support email account or there should be a default"
+                    " outgoing email account"
+                )
             )

--- a/helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.py
@@ -60,7 +60,9 @@ def toggle_reaction(comment: str, emoji: str):
 
     if emoji not in PRESET_EMOJIS:
         frappe.throw(
-            f"Invalid emoji. Only preset emojis are allowed: {', '.join(PRESET_EMOJIS)}"
+            _("Invalid emoji. Only preset emojis are allowed: {0}").format(
+                ", ".join(PRESET_EMOJIS)
+            )
         )
 
     if not frappe.db.exists("HD Ticket Comment", comment):

--- a/helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py
@@ -53,8 +53,8 @@ class HDTicketStatus(Document):
             if count == 0:
                 frappe.throw(
                     _(
-                        f"At least one ticket status with category '{old_category}' must exist in the system."
-                    )
+                        "At least one ticket status with category '{0}' must exist in the system."
+                    ).format(old_category)
                 )
 
     def validate_disabling_status(self):


### PR DESCRIPTION
- Python: wrap all frappe.throw() messages with _(), fix f-string anti-patterns
- Vue/TS: wrap all toast, label, placeholder, dialog strings with __()
- Fix template literal anti-patterns: convert __(template) to __('string', [var])
- Add missing import { __ } from '@/translation' across 30+ files
- Wrap operator labels, column headers, dropdown labels, validation messages
- Files updated: auth.py, assignment_rule.py, hd_ticket_comment.py, hd_ticket_status.py, hd_desk_account_request.py (Python) 40 Vue/TS components including conditions-filter, frappe-ui, Settings, telephony, ticket, knowledge-base pages