### PR TITLE
fix: display only date & datetime fields in date format in Ticket SIdebar

### DIFF
--- a/desk/src/components/ticket/TicketCustomerSidebar.vue
+++ b/desk/src/components/ticket/TicketCustomerSidebar.vue
@@ -260,7 +260,6 @@ const ticketAdditionalInfo = computed(() => {
       }
       return option;
     });
-  console.log("this is", custom_fields);
 
   return [...fields, ...custom_fields];
 });

--- a/desk/src/components/ticket/TicketCustomerSidebar.vue
+++ b/desk/src/components/ticket/TicketCustomerSidebar.vue
@@ -94,7 +94,13 @@
           class="text-base text-gray-800 flex-1"
           :class="!field.value && 'text-ink-gray-4'"
         >
-          <template v-if="field.value && dayjs(field.value).isValid()">
+          <template
+            v-if="
+              field.value &&
+              dayjs(field.value).isValid() &&
+              (field.fieldtype === 'Date' || field.fieldtype === 'Datetime')
+            "
+          >
             {{ dateFormat(field.value, dateTooltipFormat) }}
           </template>
           <template v-else>
@@ -254,6 +260,7 @@ const ticketAdditionalInfo = computed(() => {
       }
       return option;
     });
+  console.log("this is", custom_fields);
 
   return [...fields, ...custom_fields];
 });

--- a/desk/src/components/ticket/TicketCustomerSidebar.vue
+++ b/desk/src/components/ticket/TicketCustomerSidebar.vue
@@ -97,8 +97,8 @@
           <template
             v-if="
               field.value &&
-              dayjs(field.value).isValid() &&
-              (field.fieldtype === 'Date' || field.fieldtype === 'Datetime')
+              (field.fieldtype === 'Date' || field.fieldtype === 'Datetime') &&
+              dayjs(field.value).isValid()
             "
           >
             {{ dateFormat(field.value, dateTooltipFormat) }}


### PR DESCRIPTION
Fixes a bug in the customer sidebar where number fields added through customization were bypassing the [dayjs isValid() ](https://day.js.org/docs/en/parse/is-valid) check and being incorrectly converted to date-time. This fix ensures proper validation is enforced and conversion is only for date and datetime fields.