### PR TITLE
fix: truncate text for translations in settings menu

### DIFF
--- a/desk/src/components/Settings/SettingsModal.vue
+++ b/desk/src/components/Settings/SettingsModal.vue
@@ -10,7 +10,7 @@
           class="flex w-52 shrink-0 flex-col bg-gray-50 p-1 overflow-y-auto hide-scrollbar"
         >
           <h1
-            class="h-7.5 px-2 py-[7px] my-[3px] flex cursor-pointer gap-1.5 text-base text-ink-gray-5 transition-all duration-300 ease-in-out"
+            class="h-7.5 px-2 py-[7px] my-[3px] flex cursor-pointer gap-1.5 text-base text-ink-gray-5 transition-all duration-300 ease-in-out truncate"
           >
             {{ __("My Settings") }}
           </h1>
@@ -21,7 +21,9 @@
               v-if="!tab.hideLabel"
               class="h-7.5 px-2 py-[7px] my-[3px] flex cursor-pointer gap-1.5 text-base text-ink-gray-5 transition-all duration-300 ease-in-out"
             >
-              <span>{{ __(tab.label) }}</span>
+              <Tooltip :text="tab.label">
+                <span class="truncate">{{ __(tab.label) }}</span>
+              </Tooltip>
             </div>
 
             <nav class="space-y-[3px] px-1">
@@ -37,9 +39,11 @@
                 @click="() => onTabChange(item)"
               >
                 <component :is="item.icon" class="h-4 w-4 text-gray-700" />
-                <span class="text-p-sm text-gray-800">
-                  {{ item.label }}
-                </span>
+                <Tooltip :text="item.label">
+                  <span class="text-p-sm text-gray-800 truncate">
+                    {{ item.label }}
+                  </span>
+                </Tooltip>
               </button>
             </nav>
           </div>

--- a/desk/src/components/Settings/SettingsModal.vue
+++ b/desk/src/components/Settings/SettingsModal.vue
@@ -21,7 +21,7 @@
               v-if="!tab.hideLabel"
               class="h-7.5 px-2 py-[7px] my-[3px] flex cursor-pointer gap-1.5 text-base text-ink-gray-5 transition-all duration-300 ease-in-out"
             >
-              <Tooltip :text="tab.label" placement="right">
+              <Tooltip :text="__(tab.label)" placement="right">
                 <span class="truncate">{{ __(tab.label) }}</span>
               </Tooltip>
             </div>
@@ -42,9 +42,9 @@
                   :is="item.icon"
                   class="h-4 w-4 text-gray-700 shrink-0"
                 />
-                <Tooltip :text="item.label" placement="right">
+                <Tooltip :text="__(item.label)" placement="right">
                   <span class="text-p-sm text-gray-800 truncate">
-                    {{ item.label }}
+                    {{ __(item.label) }}
                   </span>
                 </Tooltip>
               </button>

--- a/desk/src/components/Settings/SettingsModal.vue
+++ b/desk/src/components/Settings/SettingsModal.vue
@@ -21,7 +21,7 @@
               v-if="!tab.hideLabel"
               class="h-7.5 px-2 py-[7px] my-[3px] flex cursor-pointer gap-1.5 text-base text-ink-gray-5 transition-all duration-300 ease-in-out"
             >
-              <Tooltip :text="tab.label">
+              <Tooltip :text="tab.label" placement="right">
                 <span class="truncate">{{ __(tab.label) }}</span>
               </Tooltip>
             </div>
@@ -38,8 +38,11 @@
                 ]"
                 @click="() => onTabChange(item)"
               >
-                <component :is="item.icon" class="h-4 w-4 text-gray-700" />
-                <Tooltip :text="item.label">
+                <component
+                  :is="item.icon"
+                  class="h-4 w-4 text-gray-700 shrink-0"
+                />
+                <Tooltip :text="item.label" placement="right">
                   <span class="text-p-sm text-gray-800 truncate">
                     {{ item.label }}
                   </span>
@@ -82,7 +85,7 @@
   />
 </template>
 <script setup lang="ts">
-import { Dialog } from "frappe-ui";
+import { Dialog, Tooltip } from "frappe-ui";
 import { ModelRef, ref, watch } from "vue";
 import ConfirmDialog from "@/components/ConfirmDialog.vue";
 import {

--- a/desk/src/components/SidebarLink.vue
+++ b/desk/src/components/SidebarLink.vue
@@ -33,7 +33,7 @@
     </span>
 
     <div
-      class="-all ml-2 flex shrink-0 grow items-center justify-between text-sm duration-300 ease-in-out"
+      class="-all ml-2 flex shrink-0 grow items-center justify-between text-sm duration-300 ease-in-out truncate"
       :class="{
         'opacity-100': isExpanded,
         'opacity-0': !isExpanded,

--- a/desk/src/components/SidebarLink.vue
+++ b/desk/src/components/SidebarLink.vue
@@ -33,14 +33,16 @@
     </span>
 
     <div
-      class="-all ml-2 flex shrink-0 grow items-center justify-between text-sm duration-300 ease-in-out truncate"
+      class="-all ml-2 flex min-w-0 items-center justify-between text-sm duration-300 ease-in-out w-full"
       :class="{
         'opacity-100': isExpanded,
         'opacity-0': !isExpanded,
         '-z-50': !isExpanded,
       }"
     >
-      {{ __(label) }}
+      <Tooltip :text="__(label)" placement="right">
+        <span class="truncate"> {{ __(label) }}</span>
+      </Tooltip>
       <slot name="right" />
     </div>
   </div>

--- a/desk/src/components/ViewBreadcrumbs.vue
+++ b/desk/src/components/ViewBreadcrumbs.vue
@@ -11,7 +11,7 @@
       <template #default="{ open }">
         <Button
           variant="ghost"
-          class="text-lg font-medium text-nowrap"
+          class="text-lg font-medium text-nowrap truncate max-w-[200px] sm:max-w-none"
           :label="currentView.label"
         >
           <template #prefix>


### PR DESCRIPTION
Fixes text overflow in the settings menu when translated strings are longer than their English equivalents, which is common in languages like spanish, arabic, etc

**Changes:**

Added truncate class to settings menu label elements to prevent text overflow

Ensures translated labels are clipped cleanly with an ellipsis rather than breaking layout

also add tooltip to show truncated text

<img width="1058" height="225" alt="Screenshot 2026-04-06 at 3 51 19 PM" src="https://github.com/user-attachments/assets/c952e420-3cad-4683-afa0-9782b7f3d48f" />
<img width="1058" height="225" alt="Screenshot 2026-04-06 at 3 52 40 PM" src="https://github.com/user-attachments/assets/13463e44-d998-45ea-87db-ab0067c4431b" />

proper truncation for mobile view
<img width="289" height="203" alt="Screenshot 2026-04-06 at 3 54 09 PM" src="https://github.com/user-attachments/assets/553fd262-dde7-4204-9bc0-a955a99b9102" />


closes: https://github.com/frappe/helpdesk/issues/3135