### PR TITLE
fix: security hardening, XSS prevention, perf fixes, and org-based KB visibility

### DIFF
--- a/desk/src/components/ConfirmDialog.vue
+++ b/desk/src/components/ConfirmDialog.vue
@@ -2,7 +2,7 @@
   <Dialog v-model="showDialog" :options="{ title }" @close="closeDialog">
     <template #body-content>
       <div class="space-y-4">
-        <p class="text-p-base text-gray-800" v-if="message" v-html="message" />
+        <p class="text-p-base text-gray-800" v-if="message">{{ message }}</p>
       </div>
     </template>
     <template #actions>

--- a/desk/src/components/SearchArticles.vue
+++ b/desk/src/components/SearchArticles.vue
@@ -37,11 +37,9 @@
           target="_blank"
         >
           <dt class="font-base">{{ a.subject }} - {{ a.headings }}</dt>
-          <!-- eslint-disable-next-line vue/no-v-html -->
           <dd
             class="font-base text-p-sm text-gray-600 line-clamp-1"
-            v-html="a.description"
-          ></dd>
+          >{{ a.description }}</dd>
         </RouterLink>
       </div>
     </dl>

--- a/desk/src/components/dialogs.jsx
+++ b/desk/src/components/dialogs.jsx
@@ -18,7 +18,7 @@ export let Dialogs = {
               dialog.message && (
                 <p class="text-p-base text-ink-gray-7">{dialog.message}</p>
               ),
-              dialog.html && <div v-html={dialog.html} />,
+              dialog.html && <p class="text-p-base text-ink-gray-7">{dialog.html}</p>,
               <ErrorMessage class="mt-2" message={dialog.error} />,
             ];
           },

--- a/desk/src/composables/realtime.ts
+++ b/desk/src/composables/realtime.ts
@@ -2,43 +2,54 @@ import { useAuthStore } from "@/stores/auth";
 import { globalStore } from "@/stores/globalStore";
 import { reactive, ref, watch } from "vue";
 
-const currentViewers = reactive<Record<string, string[]> | null>({});
+const currentViewers = reactive<Record<string, string[]>>({});
 
 export function useActiveViewers(ticketId: string) {
   const { $socket } = globalStore();
 
   const { userId } = useAuthStore();
-  $socket.on("ticket_viewers", (data: { ticket_id: string; users: string }) => {
-    if (data.ticket_id === ticketId) {
-      const viewers = JSON.parse(data.users).filter(
-        (u: string) => u !== userId
-      );
-      currentViewers[ticketId] = viewers;
-    }
-  });
 
-  const handleBeforeUnload = (_ticketId: string) => {
-    $socket.emit("stop_view_ticket", _ticketId);
+  const onTicketViewers = (data: { ticket_id: string; users: string }) => {
+    if (data.ticket_id === ticketId) {
+      try {
+        const viewers = JSON.parse(data.users).filter(
+          (u: string) => u !== userId
+        );
+        currentViewers[ticketId] = viewers;
+      } catch {
+        currentViewers[ticketId] = [];
+      }
+    }
   };
+
+  $socket.on("ticket_viewers", onTicketViewers);
+
+  const beforeUnloadHandler = () => {
+    $socket.emit("stop_view_ticket", ticketId);
+  };
+
   const startViewing = (_ticketId: string) => {
     $socket.emit("view_ticket", _ticketId);
-    window.addEventListener("beforeunload", () =>
-      handleBeforeUnload(_ticketId)
-    );
+    window.addEventListener("beforeunload", beforeUnloadHandler);
   };
 
   const stopViewing = (_ticketId: string) => {
     $socket.emit("stop_view_ticket", _ticketId);
+    window.removeEventListener("beforeunload", beforeUnloadHandler);
+    delete currentViewers[_ticketId];
+  };
 
-    window.removeEventListener("beforeunload", () =>
-      handleBeforeUnload(_ticketId)
-    );
+  const cleanup = () => {
+    $socket.off("ticket_viewers", onTicketViewers);
+    window.removeEventListener("beforeunload", beforeUnloadHandler);
+    delete currentViewers[ticketId];
   };
 
   return {
     currentViewers,
     startViewing,
     stopViewing,
+    cleanup,
   };
 }
 
@@ -47,7 +58,6 @@ export function useNotifyTicketUpdate(ticketId: string) {
   const notifyTicketUpdate = (field: string, value: string) => {
     $socket.emit("notify_ticket_update", ticketId, field, value);
   };
-  // how to check if $socket is already listening to avoid multiple listeners
   return { notifyTicketUpdate };
 }
 
@@ -60,32 +70,26 @@ export function useTyping(ticketId: string) {
   const typingUsers = reactive<string[]>([]);
   let timeout: any = null;
 
-  // Listen for typing events from other users
-  $socket.on(
-    "helpdesk_ticket_typing",
-    (data: { ticket_id: string; user: string }) => {
-      if (data.ticket_id === ticketId && data.user !== userId) {
-        // Add user to typing list if not already present
-        if (!typingUsers.includes(data.user)) {
-          typingUsers.push(data.user);
-        }
+  const onTyping = (data: { ticket_id: string; user: string }) => {
+    if (data.ticket_id === ticketId && data.user !== userId) {
+      if (!typingUsers.includes(data.user)) {
+        typingUsers.push(data.user);
       }
     }
-  );
+  };
 
-  // Listen for typing stopped events
-  $socket.on(
-    "helpdesk_ticket_typing_stopped",
-    (data: { ticket_id: string; user: string }) => {
-      if (data.ticket_id === ticketId) {
-        // Remove user from typing list
-        const index = typingUsers.indexOf(data.user);
-        if (index > -1) {
-          typingUsers.splice(index, 1);
-        }
+  const onTypingStopped = (data: { ticket_id: string; user: string }) => {
+    if (data.ticket_id === ticketId) {
+      const index = typingUsers.indexOf(data.user);
+      if (index > -1) {
+        typingUsers.splice(index, 1);
       }
     }
-  );
+  };
+
+  // Listen for typing events from other users
+  $socket.on("helpdesk_ticket_typing", onTyping);
+  $socket.on("helpdesk_ticket_typing_stopped", onTypingStopped);
 
   const emitStartTyping = () => {
     $socket?.emit("helpdesk_ticket_typing", ticketId);
@@ -104,7 +108,6 @@ export function useTyping(ticketId: string) {
   };
 
   // Reset the typing state after 10 seconds of inactivity
-  // If agent is not typing for 10 seconds, we assume they have stopped typing
   watch(typingCounter, (newVal) => {
     if (timeout) {
       clearTimeout(timeout);
@@ -133,9 +136,9 @@ export function useTyping(ticketId: string) {
     if (timeout) {
       clearTimeout(timeout);
     }
-    // Remove socket listeners
-    $socket.off("helpdesk_ticket_typing");
-    $socket.off("helpdesk_ticket_typing_stopped");
+    // Remove specific socket listeners to avoid removing others
+    $socket.off("helpdesk_ticket_typing", onTyping);
+    $socket.off("helpdesk_ticket_typing_stopped", onTypingStopped);
   };
 
   return {

--- a/desk/src/composables/useTicket.ts
+++ b/desk/src/composables/useTicket.ts
@@ -49,10 +49,14 @@ export const useTicket = (ticketId: string): MapValue => {
         params: { ticket: ticketId },
         auto: true,
         transform: (data: string) => {
-          return JSON.parse(data).map((name: string) => ({ name })) as Record<
-            "name",
-            string
-          >[];
+          try {
+            return JSON.parse(data).map((name: string) => ({ name })) as Record<
+              "name",
+              string
+            >[];
+          } catch {
+            return [];
+          }
         },
       }),
       contact: createResource({

--- a/desk/src/composables/useView.ts
+++ b/desk/src/composables/useView.ts
@@ -26,7 +26,7 @@ export const views = createListResource({
       view.rows = JSON.parse(view.rows) || [];
     });
   },
-  pageLength: 1000,
+  pageLength: 100,
 });
 
 export const currentView = ref({

--- a/desk/src/main.js
+++ b/desk/src/main.js
@@ -43,7 +43,11 @@ setConfig("serverMessagesHandler", (msgs) => {
     return;
   }
   msgs.forEach((msg) => {
-    msg = JSON.parse(msg);
+    try {
+      msg = JSON.parse(msg);
+    } catch {
+      return;
+    }
     if (msg && msg.message == "Feedback email has been sent to the customer.") {
       toast.success(msg.message);
       return;
@@ -81,8 +85,11 @@ if (import.meta.env.DEV) {
   frappeRequest({
     url: "/api/method/helpdesk.www.helpdesk.index.get_context_for_dev",
   }).then((values) => {
-    for (let key in values) {
-      window[key] = values[key];
+    const allowedKeys = ["site_name", "csrf_token", "socketio_port"];
+    for (let key of allowedKeys) {
+      if (key in values) {
+        window[key] = values[key];
+      }
     }
     socket = initSocket();
     app.config.globalProperties.$socket = socket;

--- a/desk/src/pages/SearchAgent.vue
+++ b/desk/src/pages/SearchAgent.vue
@@ -172,8 +172,7 @@
                   <div
                     v-if="item.title"
                     class="text-base font-medium truncate max-w-[60%]"
-                    v-html="item.title"
-                  />
+                  >{{ stripHtml(item.title) }}</div>
                   <div class="text-base font-medium" v-else>
                     {{ item.name }}
                   </div>
@@ -195,8 +194,7 @@
                 <div
                   v-if="item.content"
                   class="mt-1 text-p-base text-ink-gray-6"
-                  v-html="item.content"
-                ></div>
+                >{{ stripHtml(item.content) }}</div>
               </div>
             </router-link>
             <div class="border-b mx-2"></div>
@@ -276,6 +274,13 @@ interface FilterOptions {
   statuses: Record<string, number>;
   priorities: Record<string, number>;
   doctypes: Record<string, number>;
+}
+
+// Helpers
+function stripHtml(html: string): string {
+  if (!html) return "";
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  return doc.body.textContent || "";
 }
 
 // Constants and Configuration

--- a/desk/src/router/index.ts
+++ b/desk/src/router/index.ts
@@ -209,6 +209,7 @@ router.beforeEach(async (to, _, next) => {
     window.location.href =
       LOGIN_PAGE +
       (redirectURL ? `?redirect-to=/helpdesk${redirectURL}` : "/helpdesk");
+    return;
   } else if (!to.meta.public && !authStore.hasDeskAccess) {
     next({ name: "TicketsCustomer" });
   } else if (to.name === "TicketAgent" && !authStore.isAgent) {

--- a/desk/src/stores/meta.ts
+++ b/desk/src/stores/meta.ts
@@ -19,7 +19,11 @@ export function getMeta(doctype: string) {
         doctypeMeta[dtMeta.name] = dtMeta;
       }
 
-      userSettings[doctype] = JSON.parse(res.user_settings);
+      try {
+        userSettings[doctype] = JSON.parse(res.user_settings);
+      } catch {
+        userSettings[doctype] = {};
+      }
     },
   });
   if (!doctypeMeta[doctype] && !meta.loading) {

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,4 +1,5 @@
-#!bin/bash
+#!/bin/bash
+set -e
 
 if [ -d "/home/frappe/frappe-bench/apps/frappe" ]; then
     echo "Bench already exists, skipping init"

--- a/helpdesk/api/agent.py
+++ b/helpdesk/api/agent.py
@@ -1,4 +1,6 @@
 import frappe
+from frappe import _
+from frappe.utils import validate_email_address
 
 from helpdesk.utils import agent_only
 
@@ -6,12 +8,23 @@ from helpdesk.utils import agent_only
 @frappe.whitelist()
 @agent_only
 def sent_invites(emails: list[str], send_welcome_mail_to_user: bool = True):
+    """Send agent invitations to the given email addresses."""
+    if not emails:
+        frappe.throw(_("Please provide at least one email address"))
+
     for email in emails:
+        if not validate_email_address(email, throw=False):
+            frappe.throw(_("Invalid email address: {0}").format(email))
+
+        if frappe.db.exists("HD Agent", {"user": email}):
+            continue
+
         if frappe.db.exists("User", email):
             user = frappe.get_doc("User", email)
         else:
+            first_name = email.split("@")[0] if "@" in email else email
             user = frappe.get_doc(
-                {"doctype": "User", "email": email, "first_name": email.split("@")[0]}
+                {"doctype": "User", "email": email, "first_name": first_name}
             ).insert()
 
             if send_welcome_mail_to_user:

--- a/helpdesk/api/auth.py
+++ b/helpdesk/api/auth.py
@@ -25,7 +25,8 @@ def get_user():
     )
 
     is_agent = _is_agent()
-    is_admin = ("System Manager" or "Admistrator") in frappe.get_roles(current_user)
+    roles = frappe.get_roles(current_user)
+    is_admin = "System Manager" in roles or "Administrator" in roles
     has_desk_access = is_agent or is_admin
     user_image = user.user_image
     user_first_name = user.first_name

--- a/helpdesk/api/doc.py
+++ b/helpdesk/api/doc.py
@@ -163,19 +163,28 @@ def get_list_data(
                 return [option for option in options.split("\n")]
             else:
                 has_empty_values = any([not d.get(group_by_field) for d in data])
-                options = list(set([d.get(group_by_field) for d in data]))
-                options = [u for u in options if u]
-                options = [category_name for category_name in options if category_name]
+                option_values = list(set([d.get(group_by_field) for d in data]))
+                option_values = [o for o in option_values if o]
+
+                # Batch fetch labels to avoid N+1 queries
+                target_doc = label_doc if label_doc else doctype
+                target_field = label_field if label_field else group_by_field
+                if option_values:
+                    label_records = frappe.get_all(
+                        target_doc,
+                        filters={"name": ["in", option_values]},
+                        fields=["name", target_field],
+                    )
+                    label_map = {r["name"]: r[target_field] for r in label_records}
+                else:
+                    label_map = {}
+
                 options = [
                     {
-                        "label": frappe.db.get_value(
-                            label_doc if label_doc else doctype,
-                            option,
-                            label_field if label_field else group_by_field,
-                        ),
+                        "label": label_map.get(option, option),
                         "value": option,
                     }
-                    for option in options
+                    for option in option_values
                     if option
                 ]
                 if has_empty_values:
@@ -222,9 +231,9 @@ def get_list_data(
         "columns": columns,
         "rows": rows,
         "fields": fields if doctype == "HD Ticket" else [],
-        "total_count": frappe.get_list(doctype, fields=[COUNT_NAME], filters=filters)[
-            0
-        ].get("count", 0),
+        "total_count": (
+            frappe.get_list(doctype, fields=[COUNT_NAME], filters=filters) or [{}]
+        )[0].get("count", 0),
         "row_count": len(data),
         "group_by_field": group_by_field,
         "view_type": view_type,

--- a/helpdesk/api/knowledge_base.py
+++ b/helpdesk/api/knowledge_base.py
@@ -7,11 +7,97 @@ from frappe.utils import get_user_info_for_avatar
 from helpdesk.utils import is_agent
 
 
+def get_user_organizations():
+    """Get HD Organizations the current user belongs to.
+
+    Resolution paths:
+        Path 1: user email -> Contact Email -> Contact -> HD Org Contact Item -> HD Organization
+        Path 2: user email -> Contact Email -> Contact -> Dynamic Link -> HD Customer -> organization -> HD Organization
+
+    Returns:
+        None   -- agent (see all articles)
+        []     -- no organization (see only Public articles)
+        [str]  -- list of HD Organization names
+    """
+    if is_agent():
+        return None
+
+    user_email = frappe.session.user
+    contacts = frappe.get_all(
+        "Contact Email",
+        filters={"email_id": user_email, "parenttype": "Contact"},
+        pluck="parent",
+    )
+    if not contacts:
+        return []
+
+    orgs = set()
+
+    # Path 1: Contact -> HD Organization (via contacts child table)
+    direct_orgs = frappe.get_all(
+        "HD Organization",
+        filters=[["HD Organization Contact Item", "contact", "in", contacts]],
+        pluck="name",
+    )
+    orgs.update(direct_orgs)
+
+    # Path 2: Contact -> HD Customer -> HD Organization
+    customers = frappe.get_all(
+        "Dynamic Link",
+        filters={
+            "parenttype": "Contact",
+            "parent": ["in", contacts],
+            "link_doctype": "HD Customer",
+        },
+        pluck="link_name",
+    )
+    if customers:
+        customer_orgs = frappe.get_all(
+            "HD Customer",
+            filters={"name": ["in", customers], "organization": ["is", "set"]},
+            pluck="organization",
+        )
+        orgs.update(customer_orgs)
+
+    return list(orgs)
+
+
+def is_article_visible(article_name, user_orgs):
+    """Check if an article is visible to the current user.
+
+    Args:
+        article_name: HD Article name
+        user_orgs: result from get_user_organizations()
+    """
+    if user_orgs is None:
+        return True
+
+    visibility = frappe.db.get_value("HD Article", article_name, "visibility")
+    if visibility != "Restricted":
+        return True
+
+    if not user_orgs:
+        return False
+
+    allowed_orgs = frappe.get_all(
+        "HD Article Organization",
+        filters={"parent": article_name, "parenttype": "HD Article"},
+        pluck="organization",
+    )
+    return bool(set(user_orgs) & set(allowed_orgs))
+
+
 @frappe.whitelist(allow_guest=True)
 def get_article(name: str):
     article = frappe.get_doc("HD Article", name).as_dict()
 
-    if not is_agent() and article["status"] != "Published":
+    user_orgs = get_user_organizations()
+
+    # user_orgs is None for agents -- they see everything
+    if user_orgs is not None and article["status"] != "Published":
+        frappe.throw(_("Access denied"), frappe.PermissionError)
+
+    if not is_article_visible(name, user_orgs):
         frappe.throw(_("Access denied"), frappe.PermissionError)
 
     author = get_user_info_for_avatar(article["author"])
@@ -40,8 +126,6 @@ def get_article(name: str):
         "feedback": int(feedback),
     }
 
-    return article
-
 
 @frappe.whitelist()
 def delete_articles(articles: list[str]):
@@ -69,21 +153,17 @@ def move_to_category(category: str, articles: list[str]):
     frappe.has_permission("HD Article", "write", throw=True)
 
     for article in articles:
-        try:
-            article_category = frappe.db.get_value("HD Article", article, "category")
-            category_existing_articles = frappe.db.count(
-                "HD Article", {"category": article_category}
-            )
-            if category_existing_articles == 1:
-                frappe.throw(_("Category must have atleast one article"))
-                return
-            else:
-                frappe.db.set_value(
-                    "HD Article", article, "category", category, update_modified=False
-                )
-        except Exception as e:
-            frappe.db.rollback()
-            frappe.throw(_("Error moving article to category"))
+        article_category = frappe.db.get_value("HD Article", article, "category")
+        if not article_category:
+            frappe.throw(_("Article {0} not found").format(article))
+        category_existing_articles = frappe.db.count(
+            "HD Article", {"category": article_category}
+        )
+        if category_existing_articles == 1:
+            frappe.throw(_("Category must have at least one article"))
+        frappe.db.set_value(
+            "HD Article", article, "category", category, update_modified=False
+        )
 
 
 @frappe.whitelist()
@@ -92,10 +172,34 @@ def get_categories():
         "HD Article Category",
         fields=["name", "category_name", "modified"],
     )
+    user_orgs = get_user_organizations()
+
     for c in categories:
-        c["article_count"] = frappe.db.count(
-            "HD Article", filters={"category": c.name, "status": "Published"}
-        )
+        if user_orgs is None:
+            # Agent: count all published articles
+            c["article_count"] = frappe.db.count(
+                "HD Article", filters={"category": c.name, "status": "Published"}
+            )
+        else:
+            # Non-agent: count only visible articles
+            public_count = frappe.db.count(
+                "HD Article",
+                filters={"category": c.name, "status": "Published", "visibility": ["in", ["Public", ""]]},
+            )
+            if not user_orgs:
+                c["article_count"] = public_count
+            else:
+                restricted_count = frappe.db.sql("""
+                    SELECT COUNT(DISTINCT a.name)
+                    FROM `tabHD Article` a
+                    INNER JOIN `tabHD Article Organization` ao
+                        ON ao.parent = a.name AND ao.parenttype = 'HD Article'
+                    WHERE a.category = %s
+                        AND a.status = 'Published'
+                        AND a.visibility = 'Restricted'
+                        AND ao.organization IN %s
+                """, (c.name, user_orgs))[0][0]
+                c["article_count"] = public_count + restricted_count
 
     categories.sort(key=lambda c: c["article_count"], reverse=True)
     categories = [c for c in categories if c["article_count"] > 0]
@@ -104,11 +208,39 @@ def get_categories():
 
 @frappe.whitelist()
 def get_category_articles(category: str):
-    articles = frappe.get_all(
-        "HD Article",
-        filters={"category": category, "status": "Published"},
-        fields=["name", "title", "published_on", "modified", "author", "content"],
-    )
+    user_orgs = get_user_organizations()
+
+    if user_orgs is None:
+        # Agent: all published articles
+        articles = frappe.get_all(
+            "HD Article",
+            filters={"category": category, "status": "Published"},
+            fields=["name", "title", "published_on", "modified", "author", "content"],
+        )
+    else:
+        # Non-agent: Public + visible Restricted articles
+        articles = frappe.get_all(
+            "HD Article",
+            filters={
+                "category": category,
+                "status": "Published",
+                "visibility": ["in", ["Public", ""]],
+            },
+            fields=["name", "title", "published_on", "modified", "author", "content"],
+        )
+        if user_orgs:
+            restricted = frappe.db.sql("""
+                SELECT DISTINCT a.name, a.title, a.published_on, a.modified, a.author, a.content
+                FROM `tabHD Article` a
+                INNER JOIN `tabHD Article Organization` ao
+                    ON ao.parent = a.name AND ao.parenttype = 'HD Article'
+                WHERE a.category = %s
+                    AND a.status = 'Published'
+                    AND a.visibility = 'Restricted'
+                    AND ao.organization IN %s
+            """, (category, user_orgs), as_dict=True)
+            articles.extend(restricted)
+
     for article in articles:
         article["author"] = get_user_info_for_avatar(article["author"])
         soup = BeautifulSoup(article["content"], "html.parser")

--- a/helpdesk/api/permission.py
+++ b/helpdesk/api/permission.py
@@ -7,9 +7,12 @@ def has_app_permission():
         return True
 
     roles = frappe.get_roles()
-    helpdesk_roles = ["Agent"]
-    if any(role in roles for role in helpdesk_roles):
+    allowed_roles = ["Agent", "System Manager"]
+    if any(role in roles for role in allowed_roles):
         return True
 
-    # TODO: Check for Customer permission once the role is added
-    return True
+    # Customers can access the portal but not the agent desk
+    if frappe.db.exists("HD Customer", {"email_id": frappe.session.user}):
+        return True
+
+    return False

--- a/helpdesk/api/saved_replies.py
+++ b/helpdesk/api/saved_replies.py
@@ -9,6 +9,7 @@ from helpdesk.utils import agent_only
 def get_rendered_saved_reply(ticket_id: str | int, saved_reply_id: str | None = None):
     if not saved_reply_id:
         frappe.throw(_("Please provide saved_reply_id"))
+    frappe.has_permission("HD Ticket", "read", ticket_id, throw=True)
     saved_reply = frappe.get_doc("HD Saved Reply", saved_reply_id).message
     ticket = frappe.get_doc("HD Ticket", ticket_id).as_dict()
     user = frappe.get_doc("User", frappe.session.user).as_dict()

--- a/helpdesk/api/session.py
+++ b/helpdesk/api/session.py
@@ -5,13 +5,17 @@ from helpdesk.utils import agent_only
 
 @frappe.whitelist()
 @agent_only
-def get_users():
+def get_users(page_length: int = 100, start: int = 0):
+    """Get list of users with their helpdesk roles."""
+    page_length = min(int(page_length or 100), 500)
+    start = max(int(start or 0), 0)
+
     users = frappe.qb.get_query(
         "User",
         fields=["name", "email", "enabled", "user_image", "full_name", "user_type"],
         order_by="full_name asc",
         distinct=True,
-    ).run(as_dict=1)
+    ).limit(page_length).offset(start).run(as_dict=1)
 
     for user in users:
         roles = frappe.get_roles(user.name)

--- a/helpdesk/api/settings/field_dependency.py
+++ b/helpdesk/api/settings/field_dependency.py
@@ -1,3 +1,4 @@
+import json
 import re
 
 import frappe
@@ -96,12 +97,13 @@ def generate_on_change_function(parent_child_mapping, parent_field, child_field)
     script = f"function update_{child_field}(value){{\n"
     first = True
     for parent, children in parent_child_mapping.items():
-        options = ",".join([f'"{child}"' for child in children])
+        options = ",".join([json.dumps(child) for child in children])
+        escaped_parent = json.dumps(parent)
         if first:
-            script += f'        if(value=="{parent}") {{\n'
+            script += f"        if(value=={escaped_parent}) {{\n"
             first = False
         else:
-            script += f'        else if(value=="{parent}") {{\n'
+            script += f"        else if(value=={escaped_parent}) {{\n"
 
         script += f"            options = [{options}]\n"
         script += f'            applyFilters("{child_field}",options)\n'

--- a/helpdesk/auth.py
+++ b/helpdesk/auth.py
@@ -127,6 +127,6 @@ def is_custom_app_endpoint(path):
             allowed_custom_endpoints = [allowed_custom_endpoints]
 
     for endpoint in allowed_custom_endpoints:  # noqa: SIM110
-        if endpoint in path:
+        if path == endpoint or path.startswith(endpoint + "/"):
             return True
     return False

--- a/helpdesk/helpdesk/doctype/hd_article/hd_article.json
+++ b/helpdesk/helpdesk/doctype/hd_article/hd_article.json
@@ -8,6 +8,7 @@
  "field_order": [
   "title",
   "status",
+  "visibility",
   "published_on",
   "views",
   "column_break_7",
@@ -15,7 +16,9 @@
   "author",
   "title_slug",
   "content_section",
-  "content"
+  "content",
+  "sb_visibility",
+  "visible_to"
  ],
  "fields": [
   {
@@ -74,6 +77,14 @@
    "options": "Published\nDraft\nArchived"
   },
   {
+   "default": "Public",
+   "fieldname": "visibility",
+   "fieldtype": "Select",
+   "label": "Visibility",
+   "options": "Public\nRestricted",
+   "reqd": 1
+  },
+  {
    "fieldname": "title_slug",
    "fieldtype": "Data",
    "is_virtual": 1,
@@ -85,6 +96,18 @@
    "fieldtype": "Int",
    "label": "Views",
    "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.visibility === 'Restricted'",
+   "fieldname": "sb_visibility",
+   "fieldtype": "Section Break",
+   "label": "Visible To Organizations"
+  },
+  {
+   "fieldname": "visible_to",
+   "fieldtype": "Table",
+   "label": "Visible To",
+   "options": "HD Article Organization"
   }
  ],
  "links": [],

--- a/helpdesk/helpdesk/doctype/hd_article/hd_article.py
+++ b/helpdesk/helpdesk/doctype/hd_article/hd_article.py
@@ -13,6 +13,7 @@ class HDArticle(Document):
     def validate(self):
         self.validate_article_category()
         self.validate_published_content()
+        self.validate_visibility()
 
     def validate_article_category(self):
         if self.has_value_changed("category") and not self.is_new():
@@ -22,6 +23,12 @@ class HDArticle(Document):
     def validate_published_content(self):
         if self.status == "Published" and not self.content:
             frappe.throw(_("Published articles must have content."))
+
+    def validate_visibility(self):
+        if self.visibility == "Restricted" and not self.visible_to:
+            frappe.throw(
+                _("Please specify at least one organization when visibility is set to Restricted")
+            )
 
     def before_insert(self):
         self.author = frappe.session.user

--- a/helpdesk/helpdesk/doctype/hd_article_organization/hd_article_organization.json
+++ b/helpdesk/helpdesk/doctype/hd_article_organization/hd_article_organization.json
@@ -1,0 +1,33 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-04-03 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "organization"
+ ],
+ "fields": [
+  {
+   "fieldname": "organization",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Organization",
+   "options": "HD Organization",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-04-03 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Helpdesk",
+ "name": "HD Article Organization",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/helpdesk/helpdesk/doctype/hd_article_organization/hd_article_organization.py
+++ b/helpdesk/helpdesk/doctype/hd_article_organization/hd_article_organization.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class HDArticleOrganization(Document):
+	pass

--- a/helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+++ b/helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -10,6 +10,7 @@
   "image",
   "customer_name",
   "domain",
+  "organization",
   "references_tab",
   "contact_html"
  ],
@@ -31,6 +32,12 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Domain"
+  },
+  {
+   "fieldname": "organization",
+   "fieldtype": "Link",
+   "label": "Organization",
+   "options": "HD Organization"
   },
   {
    "fieldname": "references_tab",

--- a/helpdesk/helpdesk/doctype/hd_ticket/api.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/api.py
@@ -30,11 +30,17 @@ from helpdesk.utils import (
 
 
 @frappe.whitelist()
-# flake8: noqa
 def new(doc: dict, attachments: list[dict] = []):
+    """Create a new HD Ticket."""
     doc["doctype"] = "HD Ticket"
-    doc["via_customer_portal"] = bool(frappe.session.user)
+
+    # Detect if the user is a customer (not an agent) to set portal flag
+    doc["via_customer_portal"] = not is_agent()
     doc["attachments"] = attachments
+
+    if not doc.get("subject"):
+        frappe.throw(_("Subject is required"))
+
     d = frappe.get_doc(doc).insert()
     return d
 

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -84,7 +84,7 @@ class HDTicket(Document):
         self.set_feedback_values()
         self.set_default_status()
         self.set_status_category()
-        # self.apply_escalation_rule()
+        # TODO: Re-enable escalation rules once the feature is complete
         self.set_sla()
 
         self.set_contact()
@@ -1216,7 +1216,7 @@ def has_permission(doc, user=None):
             assignees = json.loads(doc._assign)
             if user in assignees:
                 return True
-        except:
+        except (json.JSONDecodeError, TypeError):
             return False
 
     teams = get_agents_team()
@@ -1277,9 +1277,7 @@ def permission_query(user):
         if not all_teams:
             return query
         all_teams = ", ".join(f"'{team}'" for team in all_teams)
-        query += f" OR (`tabHD Ticket`.agent_group in ({all_teams}))".format(
-            all_teams=all_teams
-        )
+        query += f" OR (`tabHD Ticket`.agent_group in ({all_teams}))"
         if not show_tickets_without_team:
             query += " OR (`tabHD Ticket`.agent_group is null)"
         return query
@@ -1297,9 +1295,7 @@ def permission_query(user):
 
     # Here we will apply the restriction based on the teams the agent belongs to.
     team_names = ", ".join(f"'{team}'" for team in team_names)
-    query += f" OR (`tabHD Ticket`.agent_group in ({team_names}))".format(
-        team_names=team_names
-    )
+    query += f" OR (`tabHD Ticket`.agent_group in ({team_names}))"
     return query
 
 

--- a/helpdesk/patches/add_fulltext_index.py
+++ b/helpdesk/patches/add_fulltext_index.py
@@ -2,5 +2,4 @@ from helpdesk.setup.install import add_fts_index
 
 
 def execute():
-    print("Adding FULLTEXT Index")
     add_fts_index()

--- a/helpdesk/patches/remove_agents_teams_default_views.py
+++ b/helpdesk/patches/remove_agents_teams_default_views.py
@@ -2,10 +2,5 @@ import frappe
 
 
 def execute():
-    print("Removing default views of agents")
     frappe.db.delete("HD View", {"dt": "HD Agent"})
-    print("Removed default views of agents")
-    print("--------------------")
-    print("Removing default views of teams")
     frappe.db.delete("HD View", {"dt": "HD Team"})
-    print("Removed default views of teams")

--- a/helpdesk/patches/rename_canned_response_to_saved_reply.py
+++ b/helpdesk/patches/rename_canned_response_to_saved_reply.py
@@ -12,4 +12,3 @@ def execute():
         return
 
     frappe.rename_doc("DocType", old, new, ignore_if_exists=True)
-    print("Migrated", old, "to", new)

--- a/helpdesk/patches/rename_doctypes_prefix_with_hd.py
+++ b/helpdesk/patches/rename_doctypes_prefix_with_hd.py
@@ -53,4 +53,3 @@ def execute():
             continue
 
         frappe.rename_doc("DocType", old, new)
-        print("Migrated", old, "to", new)

--- a/helpdesk/patches/update_hd_team_users.py
+++ b/helpdesk/patches/update_hd_team_users.py
@@ -14,9 +14,6 @@ def execute():
         for agent in existing_agents:
             is_agent_active = frappe.get_value("HD Agent", agent, "is_active")
             if is_agent_active and agent not in team_users:
-                team_doc = (
-                    frappe.get_doc("HD Team", team)
-                    .append("users", {"user": agent})
-                    .save()
-                )
-                print("Agent Added")
+                frappe.get_doc("HD Team", team).append(
+                    "users", {"user": agent}
+                ).save()

--- a/helpdesk/setup/welcome_ticket.py
+++ b/helpdesk/setup/welcome_ticket.py
@@ -1,7 +1,7 @@
 import frappe
 from frappe.desk.form.assign_to import add as add_assign
 
-AUTHOR_EMAIl = "john@example.com"
+AUTHOR_EMAIL = "john@example.com"
 AUTHOR_NAME = "John Doe"
 CONTENT = """
 <div style="font-family: 'Segoe UI', sans-serif; font-size: 15px; line-height: 1.8; color: #374151; max-width: 560px; margin: 0 auto;">
@@ -77,7 +77,7 @@ def create_ticket():
     d = frappe.new_doc("HD Ticket")
     d.subject = "Welcome to Helpdesk"
     d.description = rendered_content
-    d.raised_by = AUTHOR_EMAIl
+    d.raised_by = AUTHOR_EMAIL
     d.contact = AUTHOR_NAME
     d.via_customer_portal = True
     d.insert()
@@ -95,6 +95,6 @@ def create_contact():
         {
             "doctype": "Contact",
             "first_name": AUTHOR_NAME,
-            "email_ids": [{"email_id": AUTHOR_EMAIl, "is_primary": 1}],
+            "email_ids": [{"email_id": AUTHOR_EMAIL, "is_primary": 1}],
         }
     ).insert()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ authors = [
     { name = "Frappe Technologies Pvt Ltd", email = "hello@frappe.io"}
 ]
 description = "Open Source Customer Service Software"
-requires-python = ">=3.11"
+requires-python = ">=3.14"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ authors = [
     { name = "Frappe Technologies Pvt Ltd", email = "hello@frappe.io"}
 ]
 description = "Open Source Customer Service Software"
-requires-python = ">=3.14"
+requires-python = ">=3.11"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [

--- a/realtime/handlers.js
+++ b/realtime/handlers.js
@@ -4,7 +4,7 @@ function helpdesk_handlers(socket) {
   });
 
   socket.on("view_ticket", (ticket_id) => {
-    if (!ticket_id) return;
+    if (!ticket_id || !socket.user) return;
     const room = open_doc_room("HD Ticket", ticket_id);
     socket.join(room);
 
@@ -16,7 +16,7 @@ function helpdesk_handlers(socket) {
   });
 
   socket.on("stop_view_ticket", (ticket_id) => {
-    if (!ticket_id) return;
+    if (!ticket_id || !socket.user) return;
     const room = open_doc_room("HD Ticket", ticket_id);
     socket.leave(room);
 
@@ -28,18 +28,23 @@ function helpdesk_handlers(socket) {
   });
 
   socket.on("ticket_get_viewers", (ticket_id) => {
-    if (!ticket_id) return;
+    if (!ticket_id || !socket.user) return;
     // Send current viewers list to the requesting user only
     notify_ticket_viewers({
       socket: socket,
       ticket_id: ticket_id,
-      toUser: true, // saying that whenever we ask for viewers, send only to the user who asked
+      toUser: true,
     });
   });
 
   socket.on("notify_ticket_update", (ticket_id, field, value) => {
-    if (!(ticket_id && field)) return;
+    if (!(ticket_id && field && socket.user)) return;
+
+    // Only broadcast if the user is actually in the ticket room
     const ticket_room = open_doc_room("HD Ticket", ticket_id);
+    const rooms = socket.rooms;
+    if (!rooms.has(ticket_room)) return;
+
     socket.to(ticket_room).emit("ticket_update", {
       ticket_id,
       user: socket.user,
@@ -50,10 +55,12 @@ function helpdesk_handlers(socket) {
 
   // Typing indicators
   socket.on("helpdesk_ticket_typing", (ticket_id) => {
-    if (!ticket_id) return;
+    if (!ticket_id || !socket.user) return;
     const ticket_room = open_doc_room("HD Ticket", ticket_id);
 
-    // Broadcast to all other users in the ticket room that this user is typing
+    // Only broadcast if the user is in the ticket room
+    if (!socket.rooms.has(ticket_room)) return;
+
     socket.to(ticket_room).emit("helpdesk_ticket_typing", {
       ticket_id,
       user: socket.user,
@@ -61,10 +68,12 @@ function helpdesk_handlers(socket) {
   });
 
   socket.on("helpdesk_ticket_typing_stopped", (ticket_id) => {
-    if (!ticket_id) return;
+    if (!ticket_id || !socket.user) return;
     const ticket_room = open_doc_room("HD Ticket", ticket_id);
 
-    // Broadcast to all other users in the ticket room that this user stopped typing
+    // Only broadcast if the user is in the ticket room
+    if (!socket.rooms.has(ticket_room)) return;
+
     socket.to(ticket_room).emit("helpdesk_ticket_typing_stopped", {
       ticket_id,
       user: socket.user,
@@ -86,10 +95,12 @@ function notify_ticket_viewers(args) {
 
   // Extract user information for each socket in the room
   socket.nsp.sockets.forEach((sock) => {
-    if (clients.includes(sock.id)) {
+    if (clients.includes(sock.id) && sock.user) {
       users.push(sock.user);
     }
   });
+
+  const uniqueUsers = Array.from(new Set(users));
 
   const target_room = args.toUser
     ? user_room(args.socket.user) // Send to specific user only
@@ -98,8 +109,8 @@ function notify_ticket_viewers(args) {
   // Emit the notification with current viewers list
   socket.nsp.to(target_room).emit("ticket_viewers", {
     ticket_id,
-    users: JSON.stringify(Array.from(new Set(users))), // Remove duplicate users
-    total_viewers: Array.from(new Set(users)).length,
+    users: JSON.stringify(uniqueUsers),
+    total_viewers: uniqueUsers.length,
   });
 }
 
@@ -107,6 +118,5 @@ function notify_ticket_viewers(args) {
 const open_doc_room = (doctype, docname) =>
   "open_doc:" + doctype + "/" + docname;
 const user_room = (user) => "user:" + user;
-const ticket_response_room = (ticket_id) => "ticket_response:" + ticket_id;
 
 module.exports = helpdesk_handlers;


### PR DESCRIPTION
## Summary

Comprehensive code review fixes covering security vulnerabilities, frontend XSS prevention, performance improvements, and a new organization-based knowledge base visibility feature.

### Security Fixes
- **Auth logic bug**: Fixed admin check that always evaluated truthy + "Admistrator" typo (`api/auth.py`)
- **Auth bypass**: Changed substring path matching to exact prefix matching (`auth.py`)
- **Permission bypass**: `has_app_permission()` no longer returns `True` for everyone (`api/permission.py`)
- **IDOR prevention**: Added `frappe.has_permission()` check in saved replies API
- **Script injection**: Escape values with `json.dumps()` in generated JS (`field_dependency.py`)
- **Socket.IO**: Added `socket.user` validation and room membership checks on all events
- **Window globals**: Restricted to allowlist instead of accepting arbitrary API response keys

### XSS Prevention (Frontend)
- Replaced all `v-html` with text interpolation or `stripHtml()` in SearchAgent, SearchArticles, ConfirmDialog, dialogs.jsx

### Performance & Stability
- Fixed N+1 query in `doc.py` group_by options (batch fetch labels)
- Fixed event listener memory leak in `realtime.ts` (stored handler refs + cleanup)
- Added `try-catch` around `JSON.parse` calls in frontend composables
- Reduced view `pageLength` from 1000 to 100
- Added missing `return` after redirect in router guard
- Guarded empty count query result in `doc.py`

### Feature: Organization-Based KB Article Visibility
- Added `visibility` field (Public/Restricted) to HD Article
- New `HD Article Organization` child doctype for org assignment
- Added `organization` Link field to HD Customer
- KB API filters articles by user's organization membership
- Agents see all articles; customers see Public + their org's Restricted articles

### Code Quality
- Fixed docker `init.sh` shebang and added `set -e`
- Fixed `AUTHOR_EMAIl` typo in `welcome_ticket.py`
- Removed debug `print()` from 5 patch files
- Added email validation and duplicate check in agent invites
- Added pagination to `get_users()` API
- Fixed unreachable code and generic error swallowing in `knowledge_base.py`
- Fixed redundant f-string+format in `hd_ticket.py` permission_query
- Fixed `via_customer_portal` detection in ticket creation

## Test Plan
- [ ] Verify agent login works correctly (admin check fix)
- [ ] Verify portal users can only access allowed endpoints (auth.py fix)
- [ ] Verify saved replies require ticket read permission
- [ ] Verify search results display without XSS (text-only rendering)
- [ ] Verify Socket.IO events only broadcast to room members
- [ ] Verify group-by views load efficiently (no N+1)
- [ ] Test KB visibility: agents see all, customers see Public + their org's Restricted
- [ ] Test restricted article direct URL access returns 403 for unauthorized users
- [ ] Verify `bench start` runs cleanly
- [ ] Run `bench --site <site> migrate` to apply doctype changes