### PR TITLE
fix: new submodule setup

### DIFF
--- a/desk/vite-helpers.ts
+++ b/desk/vite-helpers.ts
@@ -1,0 +1,86 @@
+import { existsSync } from "node:fs";
+import path from "path";
+import type { PluginOption } from "vite";
+
+interface LocalFrappeUIDevConfigParams {
+  mode: string;
+  rootDir: string;
+}
+
+interface LocalFrappeUIDevConfig {
+  useLocalFrappeUI: boolean;
+  localFrappeUIPath: string;
+  localFrappeUIAliases: Record<string, string>;
+}
+
+interface ImportFrappeUIPluginParams {
+  useLocalFrappeUI: boolean;
+}
+
+type FrappeUIPluginFactory = (...args: any[]) => PluginOption;
+type FrappeUIPluginModule = { default: FrappeUIPluginFactory };
+
+async function loadFrappeUIPluginModule(
+  modulePath: string
+): Promise<FrappeUIPluginModule> {
+  return (await import(modulePath)) as FrappeUIPluginModule;
+}
+
+export function getLocalFrappeUIDevConfig({
+  mode,
+  rootDir,
+}: LocalFrappeUIDevConfigParams): LocalFrappeUIDevConfig {
+  const isDev = mode === "development";
+  const localFrappeUIPath = path.resolve(rootDir, "../frappe-ui");
+  const useLocalFrappeUI =
+    isDev && existsSync(path.join(localFrappeUIPath, "node_modules"));
+
+  if (isDev && existsSync(localFrappeUIPath) && !useLocalFrappeUI) {
+    console.warn("⚠️  Local frappe-ui found but dependencies not installed.");
+    console.warn("   Run: cd ../frappe-ui && yarn install");
+  }
+
+  const localFrappeUIAliases: Record<string, string> = useLocalFrappeUI
+    ? {
+        "frappe-ui/style.css": path.resolve(
+          localFrappeUIPath,
+          "src",
+          "style.css"
+        ),
+        "frappe-ui": localFrappeUIPath,
+      }
+    : {};
+
+  return {
+    useLocalFrappeUI,
+    localFrappeUIPath,
+    localFrappeUIAliases,
+  };
+}
+
+export async function importFrappeUIPlugin({
+  useLocalFrappeUI,
+}: ImportFrappeUIPluginParams): Promise<FrappeUIPluginFactory> {
+  const npmModulePath = "frappe-ui/vite";
+  const modulePath = useLocalFrappeUI
+    ? "../frappe-ui/vite/index.js"
+    : npmModulePath;
+
+  try {
+    const module = await loadFrappeUIPluginModule(modulePath);
+    return module.default as FrappeUIPluginFactory;
+  } catch (error) {
+    if (useLocalFrappeUI) {
+      console.warn(
+        "⚠️  Failed to import local frappe-ui plugin, falling back to npm package"
+      );
+      console.warn(
+        "   Error:",
+        error instanceof Error ? error.message : String(error)
+      );
+      const fallbackModule = await loadFrappeUIPluginModule(npmModulePath);
+      return fallbackModule.default as FrappeUIPluginFactory;
+    }
+    throw error;
+  }
+}

--- a/desk/vite.config.js
+++ b/desk/vite.config.js
@@ -1,102 +1,118 @@
 import vue from "@vitejs/plugin-vue";
 import vueJsx from "@vitejs/plugin-vue-jsx";
-import frappeui from "frappe-ui/vite";
 import path from "path";
 import { defineConfig } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
+import {
+  getLocalFrappeUIDevConfig,
+  importFrappeUIPlugin,
+} from "./vite-helpers";
 
-export default defineConfig({
-  plugins: [
-    frappeui({
-      frappeProxy: true,
-      lucideIcons: true,
-      jinjaBootData: true,
-      buildConfig: {
-        outDir: `../helpdesk/public/desk`,
-        emptyOutDir: true,
-        indexHtmlPath: "../helpdesk/www/helpdesk/index.html",
-      },
-      frappeTypes: {
-        input: {
-          helpdesk: [
-            "hd_ticket_status",
-            "hd_ticket",
-            "hd_service_holiday_list",
-            "hd_service_level_agreement",
-            "hd_agent",
-          ],
-          frappe: ["assignment_rule"],
+export default defineConfig(async ({ mode }) => {
+  const { useLocalFrappeUI, localFrappeUIAliases } = getLocalFrappeUIDevConfig({
+    mode,
+    rootDir: __dirname,
+  });
+
+  const frappeui = await importFrappeUIPlugin({ useLocalFrappeUI });
+  const config = {
+    plugins: [
+      frappeui({
+        frappeProxy: true,
+        lucideIcons: true,
+        jinjaBootData: true,
+        buildConfig: {
+          outDir: `../helpdesk/public/desk`,
+          emptyOutDir: true,
+          indexHtmlPath: "../helpdesk/www/helpdesk/index.html",
         },
-      },
-    }),
+        frappeTypes: {
+          input: {
+            helpdesk: [
+              "hd_ticket_status",
+              "hd_ticket",
+              "hd_service_holiday_list",
+              "hd_service_level_agreement",
+              "hd_agent",
+            ],
+            frappe: ["assignment_rule"],
+          },
+        },
+      }),
 
-    vue(),
-    vueJsx(),
-    VitePWA({
-      registerType: "autoUpdate",
-      devOptions: {
-        enabled: true,
-      },
-      workbox: {
-        cleanupOutdatedCaches: true,
-        maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
-      },
-      manifest: {
-        display: "standalone",
-        name: "Frappe Helpdesk",
-        short_name: "Helpdesk",
-        start_url: "/helpdesk",
-        description:
-          "Modern, Streamlined, Free and Open Source Customer Service Software",
-        icons: [
-          {
-            src: "/assets/helpdesk/desk/manifest/manifest-icon-192.maskable.png",
-            sizes: "192x192",
-            type: "image/png",
-            purpose: "any",
-          },
-          {
-            src: "/assets/helpdesk/desk/manifest/manifest-icon-192.maskable.png",
-            sizes: "192x192",
-            type: "image/png",
-            purpose: "maskable",
-          },
-          {
-            src: "/assets/helpdesk/desk/manifest/manifest-icon-512.maskable.png",
-            sizes: "512x512",
-            type: "image/png",
-            purpose: "any",
-          },
-          {
-            src: "/assets/helpdesk/desk/manifest/manifest-icon-512.maskable.png",
-            sizes: "512x512",
-            type: "image/png",
-            purpose: "maskable",
-          },
-        ],
-      },
-    }),
-  ],
-  server: {
-    allowedHosts: true,
-  },
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "src"),
-      "tailwind.config.js": path.resolve(__dirname, "tailwind.config.js"),
-    },
-  },
-  optimizeDeps: {
-    include: [
-      "feather-icons",
-      "tailwind.config.js",
-      "prosemirror-state",
-      "prosemirror-view",
-      "prosemirror-gapcursor",
-      "prosemirror-tables",
-      "lowlight",
-      "interactjs",
+      vue(),
+      vueJsx(),
+      VitePWA({
+        registerType: "autoUpdate",
+        devOptions: {
+          enabled: true,
+        },
+        workbox: {
+          cleanupOutdatedCaches: true,
+          maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
+        },
+        manifest: {
+          display: "standalone",
+          name: "Frappe Helpdesk",
+          short_name: "Helpdesk",
+          start_url: "/helpdesk",
+          description:
+            "Modern, Streamlined, Free and Open Source Customer Service Software",
+          icons: [
+            {
+              src: "/assets/helpdesk/desk/manifest/manifest-icon-192.maskable.png",
+              sizes: "192x192",
+              type: "image/png",
+              purpose: "any",
+            },
+            {
+              src: "/assets/helpdesk/desk/manifest/manifest-icon-192.maskable.png",
+              sizes: "192x192",
+              type: "image/png",
+              purpose: "maskable",
+            },
+            {
+              src: "/assets/helpdesk/desk/manifest/manifest-icon-512.maskable.png",
+              sizes: "512x512",
+              type: "image/png",
+              purpose: "any",
+            },
+            {
+              src: "/assets/helpdesk/desk/manifest/manifest-icon-512.maskable.png",
+              sizes: "512x512",
+              type: "image/png",
+              purpose: "maskable",
+            },
+          ],
+        },
+      }),
     ],
-    exclude: ["frappe-ui"],
-  },
+    server: {
+      allowedHosts: true,
+      fs: {
+        allow: [".."],
+      },
+    },
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "src"),
+        "tailwind.config.js": path.resolve(__dirname, "tailwind.config.js"),
+        ...localFrappeUIAliases,
+      },
+    },
+    optimizeDeps: {
+      include: [
+        "feather-icons",
+        "tailwind.config.js",
+        "prosemirror-state",
+        "prosemirror-view",
+        "prosemirror-gapcursor",
+        "prosemirror-tables",
+        "lowlight",
+        "interactjs",
+      ],
+      exclude: ["frappe-ui"],
+    },
+  };
+  return config;
 });

--- a/package.json
+++ b/package.json
@@ -3,14 +3,8 @@
 	"scripts": {
 		"postinstall": "cd desk && yarn install",
 		"dev": "cd desk && yarn dev",
-		"build": "cd desk && yarn build",
-		"disable-workspaces": "sed -i '' 's/\"workspaces\"/\"aworkspaces\"/g' package.json",
-		"enable-workspaces": "sed -i '' 's/\"aworkspaces\"/\"workspaces\"/g' package.json && rm -rf node_modules ./desk/node_modules/ frappe-ui/node_modules/ && yarn install"
+		"build": "cd desk && yarn build"
 	},
-	"workspaces": [
-		"desk",
-		"frappe-ui"
-	],
 	"resolutions": {
 		"cheerio": "1.0.0-rc.12",
 		"prosemirror-model": "1.25.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2632,14 +2632,6 @@ agent-base@6:
   dependencies:
     debug "4"
 
-aggregate-error@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
-  integrity sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==
-  dependencies:
-    clean-stack "^2.0.0"
-    indent-string "^4.0.0"
-
 ajv@^8.6.0:
   version "8.18.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.18.0.tgz#8864186b6738d003eb3a933172bb3833e10cefbc"
@@ -2736,11 +2728,6 @@ arraybuffer.prototype.slice@^1.0.4:
     es-errors "^1.3.0"
     get-intrinsic "^1.2.6"
     is-array-buffer "^3.0.4"
-
-assert-plus@1.0.0, assert-plus@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
-  integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
 
 assertion-error@^2.0.1:
   version "2.0.1"
@@ -3049,11 +3036,6 @@ classnames@^2.2.5:
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
   integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
 
-clean-stack@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
-  integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
-
 cli-cursor@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
@@ -3206,11 +3188,6 @@ core-js@^3.1.3:
   version "3.49.0"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.49.0.tgz#8b4d520ac034311fa21aa616f017ada0e0dbbddd"
   integrity sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==
-
-core-util-is@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-  integrity sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==
 
 crelt@^1.0.0, crelt@^1.0.5, crelt@^1.0.6:
   version "1.0.6"
@@ -3794,16 +3771,6 @@ extend-shallow@^2.0.1:
   dependencies:
     is-extendable "^0.1.0"
 
-extsprintf@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
-  integrity sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==
-
-extsprintf@^1.2.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07"
-  integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
-
 fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -4338,11 +4305,6 @@ ignore@^5.2.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
-indent-string@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
-  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
-
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -4717,7 +4679,7 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
-json-schema@0.4.0, json-schema@^0.4.0:
+json-schema@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
   integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
@@ -5573,7 +5535,7 @@ prosemirror-menu@^1.2.4:
     prosemirror-history "^1.0.0"
     prosemirror-state "^1.0.0"
 
-prosemirror-model@1.25.4, prosemirror-model@^1.0.0, prosemirror-model@^1.20.0, prosemirror-model@^1.21.0, prosemirror-model@^1.24.1, prosemirror-model@^1.25.0, prosemirror-model@^1.25.4:
+prosemirror-model@1.25.4, prosemirror-model@^1.0.0, prosemirror-model@^1.20.0, prosemirror-model@^1.21.0, prosemirror-model@^1.23.0, prosemirror-model@^1.24.1, prosemirror-model@^1.25.0, prosemirror-model@^1.25.4:
   version "1.25.4"
   resolved "https://registry.yarnpkg.com/prosemirror-model/-/prosemirror-model-1.25.4.tgz#8ebfbe29ecbee9e5e2e4048c4fe8e363fcd56e7c"
   integrity sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==
@@ -5587,7 +5549,7 @@ prosemirror-schema-basic@^1.2.3:
   dependencies:
     prosemirror-model "^1.25.0"
 
-prosemirror-schema-list@^1.5.0:
+prosemirror-schema-list@^1.4.1, prosemirror-schema-list@^1.5.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz#5869c8f749e8745c394548bb11820b0feb1e32f5"
   integrity sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==
@@ -6050,6 +6012,11 @@ set-proto@^1.0.0:
     dunder-proto "^1.0.1"
     es-errors "^1.3.0"
     es-object-atoms "^1.0.0"
+
+shell-quote@^1.8.3:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.3.tgz#55e40ef33cf5c689902353a3d8cd1a6725f08b4b"
+  integrity sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==
 
 shiki-es@^0.2.0:
   version "0.2.0"
@@ -6882,15 +6849,6 @@ vee-validate@4.15.1:
   dependencies:
     "@vue/devtools-api" "^7.5.2"
     type-fest "^4.8.3"
-
-verror@1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
-  integrity sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==
-  dependencies:
-    assert-plus "^1.0.0"
-    core-util-is "1.0.2"
-    extsprintf "^1.2.0"
 
 vite-node@2.1.9:
   version "2.1.9"


### PR DESCRIPTION
Remove workspaces setup & use vite as alias to the submodule.



If frappe-ui submodule is installed, the codebase will refer to the submodule directly without the workspaces setup.

To toggle between node_modules reference and submodule reference, comment this line in vite.config.js
<img width="878" height="705" alt="image" src="https://github.com/user-attachments/assets/a6222b9f-4c53-4c5e-b0da-97e5e61ba59a" />

