### PR TITLE
fix: iframe click does not close popover

### DIFF
--- a/desk/src/components/EmailContent.vue
+++ b/desk/src/components/EmailContent.vue
@@ -205,6 +205,13 @@ watch(iframeRef, (iframe) => {
 
       iframe.style.height = parent.offsetHeight + 1 + "px";
 
+      // Clicks inside the iframe don't bubble to the parent document, popovers/dropdowns that close on outside-click never fire.
+      iframe.contentDocument?.addEventListener("pointerdown", () => {
+        document.dispatchEvent(
+          new PointerEvent("pointerdown", { bubbles: true })
+        );
+      });
+
       const replyCollapsers = emailContent.querySelectorAll(".replyCollapser");
       if (replyCollapsers.length) {
         replyCollapsers.forEach((replyCollapser) => {


### PR DESCRIPTION
When a popover is opened and then if we click on an "EmailBox", the popover does not close.
Reason is, the "EmailContent" is an iframe, and the click event does not bubble hence not closing any popover (which is automatically closed when we click outside).
