### PR TITLE
feat: added column type change migration

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/api.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/api.py
@@ -325,7 +325,7 @@ def get_attachments(doctype, name):
 
 @frappe.whitelist()
 @agent_only
-def merge_ticket(source: int, target: int):
+def merge_ticket(source: str, target: str):
     # check if source and target exists
     if not frappe.db.exists("HD Ticket", source):
         frappe.throw(_("Source ticket does not exist"))
@@ -386,7 +386,7 @@ def merge_ticket(source: int, target: int):
     c.save()
 
 
-def duplicate_list_retain_timestamp(doctype, activities: list, target: int, controller):
+def duplicate_list_retain_timestamp(doctype, activities: list, target: str, controller):
     for activity in activities:
         attachments = get_attachments(
             "HD Ticket Comment",
@@ -587,7 +587,7 @@ def get_navigation_tickets(ticket: str | int, current_view: str | None = None):
         )
 
         # Extract just the ticket IDs
-        ticket_ids = [int(ticket), *tickets]
+        ticket_ids = [str(ticket), *tickets]
         # print("\n\n", ticket_ids, "\n\n")
         return ticket_ids
 

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
  "allow_import": 1,
- "autoname": "autoincrement",
+ "autoname": "HD-TKT-.YYYY.-.#####",
  "creation": "2023-10-17 14:27:11.078679",
  "doctype": "DocType",
  "document_type": "Setup",
@@ -473,7 +473,7 @@
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Ticket",
- "naming_rule": "Autoincrement",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1,541 +1,541 @@
 {
- "actions": [],
- "allow_import": 1,
- "autoname": "autoincrement",
- "creation": "2023-10-17 14:27:11.078679",
- "doctype": "DocType",
- "document_type": "Setup",
- "email_append_to": 1,
- "engine": "InnoDB",
- "field_order": [
-  "subject_section",
-  "subject",
-  "raised_by",
-  "status",
-  "priority",
-  "status_category",
-  "cb00",
-  "ticket_type",
-  "agent_group",
-  "summary",
-  "sb_details",
-  "description",
-  "template",
-  "key",
-  "sla_tab",
-  "service_level_section",
-  "sla",
-  "response_by",
-  "raised_outside_working_hours",
-  "cb",
-  "agreement_status",
-  "resolution_by",
-  "service_level_agreement_creation",
-  "on_hold_since",
-  "total_hold_time",
-  "response_tab",
-  "response",
-  "first_response_time",
-  "first_responded_on",
-  "column_break_26",
-  "avg_response_time",
-  "last_agent_response",
-  "last_customer_response",
-  "resolution_tab",
-  "section_break_19",
-  "resolution_details",
-  "column_break1",
-  "opening_date",
-  "opening_time",
-  "resolution_date",
-  "resolution_time",
-  "user_resolution_time",
-  "reference_tab",
-  "additional_info",
-  "contact",
-  "customer",
-  "email_account",
-  "column_break_16",
-  "via_customer_portal",
-  "attachment",
-  "content_type",
-  "split_and_merge_section",
-  "is_merged",
-  "merged_with",
-  "ticket_split_from",
-  "feedback_tab",
-  "customer_feedback_section",
-  "feedback_rating",
-  "feedback",
-  "feedback_extra"
- ],
- "fields": [
-  {
-   "fieldname": "subject_section",
-   "fieldtype": "Section Break",
-   "options": "fa fa-flag"
-  },
-  {
-   "bold": 1,
-   "fieldname": "subject",
-   "fieldtype": "Data",
-   "in_global_search": 1,
-   "in_standard_filter": 1,
-   "label": "Subject",
-   "reqd": 1
-  },
-  {
-   "bold": 1,
-   "fieldname": "raised_by",
-   "fieldtype": "Data",
-   "in_global_search": 1,
-   "in_list_view": 1,
-   "label": "Raised By (Email)",
-   "oldfieldname": "raised_by",
-   "oldfieldtype": "Data",
-   "options": "Email"
-  },
-  {
-   "fieldname": "status",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Status",
-   "no_copy": 1,
-   "oldfieldname": "status",
-   "oldfieldtype": "Select",
-   "options": "HD Ticket Status",
-   "search_index": 1
-  },
-  {
-   "fieldname": "priority",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Priority",
-   "options": "HD Ticket Priority"
-  },
-  {
-   "fieldname": "cb00",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "ticket_type",
-   "fieldtype": "Link",
-   "label": "Ticket Type",
-   "link_filters": "[[\"HD Ticket Type\",\"disabled\",\"=\",0]]",
-   "options": "HD Ticket Type"
-  },
-  {
-   "fieldname": "agent_group",
-   "fieldtype": "Link",
-   "label": "Team",
-   "options": "HD Team"
-  },
-  {
-   "fieldname": "ticket_split_from",
-   "fieldtype": "Link",
-   "label": "Ticket Split From",
-   "options": "HD Ticket",
-   "read_only": 1
-  },
-  {
-   "collapsible": 1,
-   "collapsible_depends_on": "eval:doc.status!=\"Closed\"",
-   "fieldname": "sb_details",
-   "fieldtype": "Section Break",
-   "label": "Details"
-  },
-  {
-   "bold": 1,
-   "fieldname": "description",
-   "fieldtype": "Text Editor",
-   "in_global_search": 1,
-   "label": "Description",
-   "oldfieldname": "problem_description",
-   "oldfieldtype": "Text"
-  },
-  {
-   "fieldname": "template",
-   "fieldtype": "Link",
-   "label": "Template",
-   "options": "HD Ticket Template"
-  },
-  {
-   "collapsible": 1,
-   "fieldname": "service_level_section",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "sla",
-   "fieldtype": "Link",
-   "label": "SLA",
-   "options": "HD Service Level Agreement"
-  },
-  {
-   "depends_on": "eval: doc.status_category != 'Paused' && doc.sla;",
-   "fieldname": "response_by",
-   "fieldtype": "Datetime",
-   "label": "Response By",
-   "read_only": 1
-  },
-  {
-   "collapsible": 1,
-   "fieldname": "cb",
-   "fieldtype": "Column Break",
-   "options": "fa fa-pushpin",
-   "read_only": 1
-  },
-  {
-   "depends_on": "eval: doc.sla",
-   "fieldname": "agreement_status",
-   "fieldtype": "Select",
-   "label": "SLA Status",
-   "options": "\nFirst Response Due\nResolution Due\nFailed\nFulfilled\nPaused",
-   "read_only": 1
-  },
-  {
-   "depends_on": "eval: doc.status_category != 'Paused' && doc.sla;",
-   "fieldname": "resolution_by",
-   "fieldtype": "Datetime",
-   "label": "Resolution By",
-   "read_only": 1
-  },
-  {
-   "fieldname": "service_level_agreement_creation",
-   "fieldtype": "Datetime",
-   "hidden": 1,
-   "label": "SLA Creation",
-   "read_only": 1
-  },
-  {
-   "fieldname": "on_hold_since",
-   "fieldtype": "Datetime",
-   "label": "On Hold Since",
-   "read_only": 1
-  },
-  {
-   "fieldname": "total_hold_time",
-   "fieldtype": "Duration",
-   "label": "Total Hold Time",
-   "read_only": 1
-  },
-  {
-   "collapsible": 1,
-   "fieldname": "response",
-   "fieldtype": "Section Break"
-  },
-  {
-   "bold": 1,
-   "fieldname": "first_response_time",
-   "fieldtype": "Duration",
-   "label": "First Response Time",
-   "read_only": 1
-  },
-  {
-   "fieldname": "first_responded_on",
-   "fieldtype": "Datetime",
-   "label": "First Responded On",
-   "read_only": 1
-  },
-  {
-   "fieldname": "column_break_26",
-   "fieldtype": "Column Break"
-  },
-  {
-   "bold": 1,
-   "fieldname": "avg_response_time",
-   "fieldtype": "Duration",
-   "label": "Average Response Time",
-   "read_only": 1
-  },
-  {
-   "collapsible": 1,
-   "fieldname": "section_break_19",
-   "fieldtype": "Section Break"
-  },
-  {
-   "depends_on": "eval:!doc.__islocal",
-   "fieldname": "resolution_details",
-   "fieldtype": "Text Editor",
-   "label": "Resolution Details",
-   "no_copy": 1,
-   "oldfieldname": "resolution_details",
-   "oldfieldtype": "Text"
-  },
-  {
-   "depends_on": "eval:!doc.__islocal",
-   "fieldname": "column_break1",
-   "fieldtype": "Column Break",
-   "oldfieldtype": "Column Break",
-   "read_only": 1
-  },
-  {
-   "default": "Today",
-   "fieldname": "opening_date",
-   "fieldtype": "Date",
-   "label": "Opening Date",
-   "no_copy": 1,
-   "oldfieldname": "opening_date",
-   "oldfieldtype": "Date",
-   "read_only": 1
-  },
-  {
-   "fieldname": "opening_time",
-   "fieldtype": "Time",
-   "label": "Opening Time",
-   "no_copy": 1,
-   "oldfieldname": "opening_time",
-   "oldfieldtype": "Time",
-   "read_only": 1
-  },
-  {
-   "depends_on": "eval:!doc.__islocal",
-   "fieldname": "resolution_date",
-   "fieldtype": "Datetime",
-   "label": "Resolution Date",
-   "no_copy": 1,
-   "oldfieldname": "resolution_date",
-   "oldfieldtype": "Date",
-   "read_only": 1
-  },
-  {
-   "fieldname": "resolution_time",
-   "fieldtype": "Duration",
-   "label": "Resolution Time",
-   "read_only": 1
-  },
-  {
-   "fieldname": "user_resolution_time",
-   "fieldtype": "Duration",
-   "label": "User Resolution Time",
-   "read_only": 1
-  },
-  {
-   "collapsible": 1,
-   "fieldname": "additional_info",
-   "fieldtype": "Section Break",
-   "options": "fa fa-pushpin",
-   "read_only": 1
-  },
-  {
-   "fieldname": "contact",
-   "fieldtype": "Link",
-   "label": "Contact",
-   "options": "Contact"
-  },
-  {
-   "fieldname": "customer",
-   "fieldtype": "Link",
-   "in_standard_filter": 1,
-   "label": "Customer",
-   "options": "HD Customer"
-  },
-  {
-   "fieldname": "email_account",
-   "fieldtype": "Link",
-   "label": "Email Account",
-   "options": "Email Account"
-  },
-  {
-   "fieldname": "column_break_16",
-   "fieldtype": "Column Break"
-  },
-  {
-   "default": "0",
-   "fieldname": "via_customer_portal",
-   "fieldtype": "Check",
-   "label": "Via Customer Portal"
-  },
-  {
-   "fieldname": "attachment",
-   "fieldtype": "Attach",
-   "hidden": 1,
-   "label": "Attachment"
-  },
-  {
-   "fieldname": "content_type",
-   "fieldtype": "Data",
-   "hidden": 1,
-   "label": "Content Type"
-  },
-  {
-   "fieldname": "customer_feedback_section",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "feedback_extra",
-   "fieldtype": "Long Text",
-   "label": "Feedback (Extra)",
-   "read_only": 1
-  },
-  {
-   "fieldname": "feedback",
-   "fieldtype": "Link",
-   "label": "Feedback (Option)",
-   "options": "HD Ticket Feedback Option",
-   "read_only": 1
-  },
-  {
-   "fieldname": "feedback_rating",
-   "fieldtype": "Rating",
-   "label": "Rating",
-   "read_only": 1
-  },
-  {
-   "fieldname": "sla_tab",
-   "fieldtype": "Tab Break",
-   "label": "SLA"
-  },
-  {
-   "fieldname": "response_tab",
-   "fieldtype": "Tab Break",
-   "label": "Response"
-  },
-  {
-   "fieldname": "resolution_tab",
-   "fieldtype": "Tab Break",
-   "label": "Resolution"
-  },
-  {
-   "fieldname": "reference_tab",
-   "fieldtype": "Tab Break",
-   "label": "Reference"
-  },
-  {
-   "fieldname": "feedback_tab",
-   "fieldtype": "Tab Break",
-   "label": "Feedback"
-  },
-  {
-   "fieldname": "summary",
-   "fieldtype": "Text Editor",
-   "label": "Summary"
-  },
-  {
-   "fieldname": "split_and_merge_section",
-   "fieldtype": "Section Break",
-   "label": "Split and Merge"
-  },
-  {
-   "default": "0",
-   "fieldname": "is_merged",
-   "fieldtype": "Check",
-   "label": "Ticket Merged",
-   "read_only": 1
-  },
-  {
-   "depends_on": "eval:doc.is_merged",
-   "fieldname": "merged_with",
-   "fieldtype": "Link",
-   "label": "Merged With",
-   "options": "HD Ticket",
-   "read_only": 1
-  },
-  {
-   "fieldname": "key",
-   "fieldtype": "Data",
-   "label": "Key",
-   "read_only": 1,
-   "set_only_once": 1
-  },
-  {
-   "fetch_from": "status.category",
-   "fieldname": "status_category",
-   "fieldtype": "Data",
-   "label": "Status Category",
-   "read_only": 1
-  },
-  {
-   "fieldname": "last_agent_response",
-   "fieldtype": "Datetime",
-   "label": "Last Agent Response",
-   "read_only": 1
-  },
-  {
-   "fieldname": "last_customer_response",
-   "fieldtype": "Datetime",
-   "label": "Last Customer Response",
-   "read_only": 1
-  },
-  {
-   "default": "False",
-   "fieldname": "raised_outside_working_hours",
-   "fieldtype": "Check",
-   "label": "Ticket raised outside working hours",
-   "read_only": 1,
-   "set_only_once": 1
-  }
- ],
- "grid_page_length": 50,
- "icon": "fa fa-issue",
- "idx": 61,
- "links": [],
- "modified": "2026-02-27 16:42:43.292656",
- "modified_by": "Administrator",
- "module": "Helpdesk",
- "name": "HD Ticket",
- "naming_rule": "Autoincrement",
- "owner": "Administrator",
- "permissions": [
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "System Manager",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Agent",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "create": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "All",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Agent Manager",
-   "share": 1,
-   "write": 1
-  }
- ],
- "quick_entry": 1,
- "recipient_account_field": "email_account",
- "row_format": "Dynamic",
- "search_fields": "status,subject,raised_by",
- "sender_field": "raised_by",
- "show_title_field_in_link": 1,
- "sort_field": "modified",
- "sort_order": "DESC",
- "states": [],
- "subject_field": "subject",
- "timeline_field": "contact",
- "title_field": "subject",
- "track_changes": 1,
- "track_seen": 1
+  "actions": [],
+  "allow_import": 1,
+  "autoname": "HD-TKT-.YYYY.-.#####",
+  "creation": "2023-10-17 14:27:11.078679",
+  "doctype": "DocType",
+  "document_type": "Setup",
+  "email_append_to": 1,
+  "engine": "InnoDB",
+  "field_order": [
+    "subject_section",
+    "subject",
+    "raised_by",
+    "status",
+    "priority",
+    "status_category",
+    "cb00",
+    "ticket_type",
+    "agent_group",
+    "summary",
+    "sb_details",
+    "description",
+    "template",
+    "key",
+    "sla_tab",
+    "service_level_section",
+    "sla",
+    "response_by",
+    "raised_outside_working_hours",
+    "cb",
+    "agreement_status",
+    "resolution_by",
+    "service_level_agreement_creation",
+    "on_hold_since",
+    "total_hold_time",
+    "response_tab",
+    "response",
+    "first_response_time",
+    "first_responded_on",
+    "column_break_26",
+    "avg_response_time",
+    "last_agent_response",
+    "last_customer_response",
+    "resolution_tab",
+    "section_break_19",
+    "resolution_details",
+    "column_break1",
+    "opening_date",
+    "opening_time",
+    "resolution_date",
+    "resolution_time",
+    "user_resolution_time",
+    "reference_tab",
+    "additional_info",
+    "contact",
+    "customer",
+    "email_account",
+    "column_break_16",
+    "via_customer_portal",
+    "attachment",
+    "content_type",
+    "split_and_merge_section",
+    "is_merged",
+    "merged_with",
+    "ticket_split_from",
+    "feedback_tab",
+    "customer_feedback_section",
+    "feedback_rating",
+    "feedback",
+    "feedback_extra"
+  ],
+  "fields": [
+    {
+      "fieldname": "subject_section",
+      "fieldtype": "Section Break",
+      "options": "fa fa-flag"
+    },
+    {
+      "bold": 1,
+      "fieldname": "subject",
+      "fieldtype": "Data",
+      "in_global_search": 1,
+      "in_standard_filter": 1,
+      "label": "Subject",
+      "reqd": 1
+    },
+    {
+      "bold": 1,
+      "fieldname": "raised_by",
+      "fieldtype": "Data",
+      "in_global_search": 1,
+      "in_list_view": 1,
+      "label": "Raised By (Email)",
+      "oldfieldname": "raised_by",
+      "oldfieldtype": "Data",
+      "options": "Email"
+    },
+    {
+      "fieldname": "status",
+      "fieldtype": "Link",
+      "in_list_view": 1,
+      "label": "Status",
+      "no_copy": 1,
+      "oldfieldname": "status",
+      "oldfieldtype": "Select",
+      "options": "HD Ticket Status",
+      "search_index": 1
+    },
+    {
+      "fieldname": "priority",
+      "fieldtype": "Link",
+      "in_list_view": 1,
+      "label": "Priority",
+      "options": "HD Ticket Priority"
+    },
+    {
+      "fieldname": "cb00",
+      "fieldtype": "Column Break"
+    },
+    {
+      "fieldname": "ticket_type",
+      "fieldtype": "Link",
+      "label": "Ticket Type",
+      "link_filters": "[[\"HD Ticket Type\",\"disabled\",\"=\",0]]",
+      "options": "HD Ticket Type"
+    },
+    {
+      "fieldname": "agent_group",
+      "fieldtype": "Link",
+      "label": "Team",
+      "options": "HD Team"
+    },
+    {
+      "fieldname": "ticket_split_from",
+      "fieldtype": "Link",
+      "label": "Ticket Split From",
+      "options": "HD Ticket",
+      "read_only": 1
+    },
+    {
+      "collapsible": 1,
+      "collapsible_depends_on": "eval:doc.status!=\"Closed\"",
+      "fieldname": "sb_details",
+      "fieldtype": "Section Break",
+      "label": "Details"
+    },
+    {
+      "bold": 1,
+      "fieldname": "description",
+      "fieldtype": "Text Editor",
+      "in_global_search": 1,
+      "label": "Description",
+      "oldfieldname": "problem_description",
+      "oldfieldtype": "Text"
+    },
+    {
+      "fieldname": "template",
+      "fieldtype": "Link",
+      "label": "Template",
+      "options": "HD Ticket Template"
+    },
+    {
+      "collapsible": 1,
+      "fieldname": "service_level_section",
+      "fieldtype": "Section Break"
+    },
+    {
+      "fieldname": "sla",
+      "fieldtype": "Link",
+      "label": "SLA",
+      "options": "HD Service Level Agreement"
+    },
+    {
+      "depends_on": "eval: doc.status_category != 'Paused' && doc.sla;",
+      "fieldname": "response_by",
+      "fieldtype": "Datetime",
+      "label": "Response By",
+      "read_only": 1
+    },
+    {
+      "collapsible": 1,
+      "fieldname": "cb",
+      "fieldtype": "Column Break",
+      "options": "fa fa-pushpin",
+      "read_only": 1
+    },
+    {
+      "depends_on": "eval: doc.sla",
+      "fieldname": "agreement_status",
+      "fieldtype": "Select",
+      "label": "SLA Status",
+      "options": "\nFirst Response Due\nResolution Due\nFailed\nFulfilled\nPaused",
+      "read_only": 1
+    },
+    {
+      "depends_on": "eval: doc.status_category != 'Paused' && doc.sla;",
+      "fieldname": "resolution_by",
+      "fieldtype": "Datetime",
+      "label": "Resolution By",
+      "read_only": 1
+    },
+    {
+      "fieldname": "service_level_agreement_creation",
+      "fieldtype": "Datetime",
+      "hidden": 1,
+      "label": "SLA Creation",
+      "read_only": 1
+    },
+    {
+      "fieldname": "on_hold_since",
+      "fieldtype": "Datetime",
+      "label": "On Hold Since",
+      "read_only": 1
+    },
+    {
+      "fieldname": "total_hold_time",
+      "fieldtype": "Duration",
+      "label": "Total Hold Time",
+      "read_only": 1
+    },
+    {
+      "collapsible": 1,
+      "fieldname": "response",
+      "fieldtype": "Section Break"
+    },
+    {
+      "bold": 1,
+      "fieldname": "first_response_time",
+      "fieldtype": "Duration",
+      "label": "First Response Time",
+      "read_only": 1
+    },
+    {
+      "fieldname": "first_responded_on",
+      "fieldtype": "Datetime",
+      "label": "First Responded On",
+      "read_only": 1
+    },
+    {
+      "fieldname": "column_break_26",
+      "fieldtype": "Column Break"
+    },
+    {
+      "bold": 1,
+      "fieldname": "avg_response_time",
+      "fieldtype": "Duration",
+      "label": "Average Response Time",
+      "read_only": 1
+    },
+    {
+      "collapsible": 1,
+      "fieldname": "section_break_19",
+      "fieldtype": "Section Break"
+    },
+    {
+      "depends_on": "eval:!doc.__islocal",
+      "fieldname": "resolution_details",
+      "fieldtype": "Text Editor",
+      "label": "Resolution Details",
+      "no_copy": 1,
+      "oldfieldname": "resolution_details",
+      "oldfieldtype": "Text"
+    },
+    {
+      "depends_on": "eval:!doc.__islocal",
+      "fieldname": "column_break1",
+      "fieldtype": "Column Break",
+      "oldfieldtype": "Column Break",
+      "read_only": 1
+    },
+    {
+      "default": "Today",
+      "fieldname": "opening_date",
+      "fieldtype": "Date",
+      "label": "Opening Date",
+      "no_copy": 1,
+      "oldfieldname": "opening_date",
+      "oldfieldtype": "Date",
+      "read_only": 1
+    },
+    {
+      "fieldname": "opening_time",
+      "fieldtype": "Time",
+      "label": "Opening Time",
+      "no_copy": 1,
+      "oldfieldname": "opening_time",
+      "oldfieldtype": "Time",
+      "read_only": 1
+    },
+    {
+      "depends_on": "eval:!doc.__islocal",
+      "fieldname": "resolution_date",
+      "fieldtype": "Datetime",
+      "label": "Resolution Date",
+      "no_copy": 1,
+      "oldfieldname": "resolution_date",
+      "oldfieldtype": "Date",
+      "read_only": 1
+    },
+    {
+      "fieldname": "resolution_time",
+      "fieldtype": "Duration",
+      "label": "Resolution Time",
+      "read_only": 1
+    },
+    {
+      "fieldname": "user_resolution_time",
+      "fieldtype": "Duration",
+      "label": "User Resolution Time",
+      "read_only": 1
+    },
+    {
+      "collapsible": 1,
+      "fieldname": "additional_info",
+      "fieldtype": "Section Break",
+      "options": "fa fa-pushpin",
+      "read_only": 1
+    },
+    {
+      "fieldname": "contact",
+      "fieldtype": "Link",
+      "label": "Contact",
+      "options": "Contact"
+    },
+    {
+      "fieldname": "customer",
+      "fieldtype": "Link",
+      "in_standard_filter": 1,
+      "label": "Customer",
+      "options": "HD Customer"
+    },
+    {
+      "fieldname": "email_account",
+      "fieldtype": "Link",
+      "label": "Email Account",
+      "options": "Email Account"
+    },
+    {
+      "fieldname": "column_break_16",
+      "fieldtype": "Column Break"
+    },
+    {
+      "default": "0",
+      "fieldname": "via_customer_portal",
+      "fieldtype": "Check",
+      "label": "Via Customer Portal"
+    },
+    {
+      "fieldname": "attachment",
+      "fieldtype": "Attach",
+      "hidden": 1,
+      "label": "Attachment"
+    },
+    {
+      "fieldname": "content_type",
+      "fieldtype": "Data",
+      "hidden": 1,
+      "label": "Content Type"
+    },
+    {
+      "fieldname": "customer_feedback_section",
+      "fieldtype": "Section Break"
+    },
+    {
+      "fieldname": "feedback_extra",
+      "fieldtype": "Long Text",
+      "label": "Feedback (Extra)",
+      "read_only": 1
+    },
+    {
+      "fieldname": "feedback",
+      "fieldtype": "Link",
+      "label": "Feedback (Option)",
+      "options": "HD Ticket Feedback Option",
+      "read_only": 1
+    },
+    {
+      "fieldname": "feedback_rating",
+      "fieldtype": "Rating",
+      "label": "Rating",
+      "read_only": 1
+    },
+    {
+      "fieldname": "sla_tab",
+      "fieldtype": "Tab Break",
+      "label": "SLA"
+    },
+    {
+      "fieldname": "response_tab",
+      "fieldtype": "Tab Break",
+      "label": "Response"
+    },
+    {
+      "fieldname": "resolution_tab",
+      "fieldtype": "Tab Break",
+      "label": "Resolution"
+    },
+    {
+      "fieldname": "reference_tab",
+      "fieldtype": "Tab Break",
+      "label": "Reference"
+    },
+    {
+      "fieldname": "feedback_tab",
+      "fieldtype": "Tab Break",
+      "label": "Feedback"
+    },
+    {
+      "fieldname": "summary",
+      "fieldtype": "Text Editor",
+      "label": "Summary"
+    },
+    {
+      "fieldname": "split_and_merge_section",
+      "fieldtype": "Section Break",
+      "label": "Split and Merge"
+    },
+    {
+      "default": "0",
+      "fieldname": "is_merged",
+      "fieldtype": "Check",
+      "label": "Ticket Merged",
+      "read_only": 1
+    },
+    {
+      "depends_on": "eval:doc.is_merged",
+      "fieldname": "merged_with",
+      "fieldtype": "Link",
+      "label": "Merged With",
+      "options": "HD Ticket",
+      "read_only": 1
+    },
+    {
+      "fieldname": "key",
+      "fieldtype": "Data",
+      "label": "Key",
+      "read_only": 1,
+      "set_only_once": 1
+    },
+    {
+      "fetch_from": "status.category",
+      "fieldname": "status_category",
+      "fieldtype": "Data",
+      "label": "Status Category",
+      "read_only": 1
+    },
+    {
+      "fieldname": "last_agent_response",
+      "fieldtype": "Datetime",
+      "label": "Last Agent Response",
+      "read_only": 1
+    },
+    {
+      "fieldname": "last_customer_response",
+      "fieldtype": "Datetime",
+      "label": "Last Customer Response",
+      "read_only": 1
+    },
+    {
+      "default": "False",
+      "fieldname": "raised_outside_working_hours",
+      "fieldtype": "Check",
+      "label": "Ticket raised outside working hours",
+      "read_only": 1,
+      "set_only_once": 1
+    }
+  ],
+  "grid_page_length": 50,
+  "icon": "fa fa-issue",
+  "idx": 61,
+  "links": [],
+  "modified": "2026-02-27 16:42:43.292656",
+  "modified_by": "Administrator",
+  "module": "Helpdesk",
+  "name": "HD Ticket",
+  "naming_rule": "Expression",
+  "owner": "Administrator",
+  "permissions": [
+    {
+      "create": 1,
+      "delete": 1,
+      "email": 1,
+      "export": 1,
+      "print": 1,
+      "read": 1,
+      "report": 1,
+      "role": "System Manager",
+      "share": 1,
+      "write": 1
+    },
+    {
+      "create": 1,
+      "delete": 1,
+      "email": 1,
+      "export": 1,
+      "print": 1,
+      "read": 1,
+      "report": 1,
+      "role": "Agent",
+      "share": 1,
+      "write": 1
+    },
+    {
+      "create": 1,
+      "email": 1,
+      "export": 1,
+      "print": 1,
+      "read": 1,
+      "report": 1,
+      "role": "All",
+      "share": 1,
+      "write": 1
+    },
+    {
+      "create": 1,
+      "delete": 1,
+      "email": 1,
+      "export": 1,
+      "print": 1,
+      "read": 1,
+      "report": 1,
+      "role": "Agent Manager",
+      "share": 1,
+      "write": 1
+    }
+  ],
+  "quick_entry": 1,
+  "recipient_account_field": "email_account",
+  "row_format": "Dynamic",
+  "search_fields": "status,subject,raised_by",
+  "sender_field": "raised_by",
+  "show_title_field_in_link": 1,
+  "sort_field": "modified",
+  "sort_order": "DESC",
+  "states": [],
+  "subject_field": "subject",
+  "timeline_field": "contact",
+  "title_field": "subject",
+  "track_changes": 1,
+  "track_seen": 1
 }

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1,541 +1,541 @@
 {
-  "actions": [],
-  "allow_import": 1,
-  "autoname": "HD-TKT-.YYYY.-.#####",
-  "creation": "2023-10-17 14:27:11.078679",
-  "doctype": "DocType",
-  "document_type": "Setup",
-  "email_append_to": 1,
-  "engine": "InnoDB",
-  "field_order": [
-    "subject_section",
-    "subject",
-    "raised_by",
-    "status",
-    "priority",
-    "status_category",
-    "cb00",
-    "ticket_type",
-    "agent_group",
-    "summary",
-    "sb_details",
-    "description",
-    "template",
-    "key",
-    "sla_tab",
-    "service_level_section",
-    "sla",
-    "response_by",
-    "raised_outside_working_hours",
-    "cb",
-    "agreement_status",
-    "resolution_by",
-    "service_level_agreement_creation",
-    "on_hold_since",
-    "total_hold_time",
-    "response_tab",
-    "response",
-    "first_response_time",
-    "first_responded_on",
-    "column_break_26",
-    "avg_response_time",
-    "last_agent_response",
-    "last_customer_response",
-    "resolution_tab",
-    "section_break_19",
-    "resolution_details",
-    "column_break1",
-    "opening_date",
-    "opening_time",
-    "resolution_date",
-    "resolution_time",
-    "user_resolution_time",
-    "reference_tab",
-    "additional_info",
-    "contact",
-    "customer",
-    "email_account",
-    "column_break_16",
-    "via_customer_portal",
-    "attachment",
-    "content_type",
-    "split_and_merge_section",
-    "is_merged",
-    "merged_with",
-    "ticket_split_from",
-    "feedback_tab",
-    "customer_feedback_section",
-    "feedback_rating",
-    "feedback",
-    "feedback_extra"
-  ],
-  "fields": [
-    {
-      "fieldname": "subject_section",
-      "fieldtype": "Section Break",
-      "options": "fa fa-flag"
-    },
-    {
-      "bold": 1,
-      "fieldname": "subject",
-      "fieldtype": "Data",
-      "in_global_search": 1,
-      "in_standard_filter": 1,
-      "label": "Subject",
-      "reqd": 1
-    },
-    {
-      "bold": 1,
-      "fieldname": "raised_by",
-      "fieldtype": "Data",
-      "in_global_search": 1,
-      "in_list_view": 1,
-      "label": "Raised By (Email)",
-      "oldfieldname": "raised_by",
-      "oldfieldtype": "Data",
-      "options": "Email"
-    },
-    {
-      "fieldname": "status",
-      "fieldtype": "Link",
-      "in_list_view": 1,
-      "label": "Status",
-      "no_copy": 1,
-      "oldfieldname": "status",
-      "oldfieldtype": "Select",
-      "options": "HD Ticket Status",
-      "search_index": 1
-    },
-    {
-      "fieldname": "priority",
-      "fieldtype": "Link",
-      "in_list_view": 1,
-      "label": "Priority",
-      "options": "HD Ticket Priority"
-    },
-    {
-      "fieldname": "cb00",
-      "fieldtype": "Column Break"
-    },
-    {
-      "fieldname": "ticket_type",
-      "fieldtype": "Link",
-      "label": "Ticket Type",
-      "link_filters": "[[\"HD Ticket Type\",\"disabled\",\"=\",0]]",
-      "options": "HD Ticket Type"
-    },
-    {
-      "fieldname": "agent_group",
-      "fieldtype": "Link",
-      "label": "Team",
-      "options": "HD Team"
-    },
-    {
-      "fieldname": "ticket_split_from",
-      "fieldtype": "Link",
-      "label": "Ticket Split From",
-      "options": "HD Ticket",
-      "read_only": 1
-    },
-    {
-      "collapsible": 1,
-      "collapsible_depends_on": "eval:doc.status!=\"Closed\"",
-      "fieldname": "sb_details",
-      "fieldtype": "Section Break",
-      "label": "Details"
-    },
-    {
-      "bold": 1,
-      "fieldname": "description",
-      "fieldtype": "Text Editor",
-      "in_global_search": 1,
-      "label": "Description",
-      "oldfieldname": "problem_description",
-      "oldfieldtype": "Text"
-    },
-    {
-      "fieldname": "template",
-      "fieldtype": "Link",
-      "label": "Template",
-      "options": "HD Ticket Template"
-    },
-    {
-      "collapsible": 1,
-      "fieldname": "service_level_section",
-      "fieldtype": "Section Break"
-    },
-    {
-      "fieldname": "sla",
-      "fieldtype": "Link",
-      "label": "SLA",
-      "options": "HD Service Level Agreement"
-    },
-    {
-      "depends_on": "eval: doc.status_category != 'Paused' && doc.sla;",
-      "fieldname": "response_by",
-      "fieldtype": "Datetime",
-      "label": "Response By",
-      "read_only": 1
-    },
-    {
-      "collapsible": 1,
-      "fieldname": "cb",
-      "fieldtype": "Column Break",
-      "options": "fa fa-pushpin",
-      "read_only": 1
-    },
-    {
-      "depends_on": "eval: doc.sla",
-      "fieldname": "agreement_status",
-      "fieldtype": "Select",
-      "label": "SLA Status",
-      "options": "\nFirst Response Due\nResolution Due\nFailed\nFulfilled\nPaused",
-      "read_only": 1
-    },
-    {
-      "depends_on": "eval: doc.status_category != 'Paused' && doc.sla;",
-      "fieldname": "resolution_by",
-      "fieldtype": "Datetime",
-      "label": "Resolution By",
-      "read_only": 1
-    },
-    {
-      "fieldname": "service_level_agreement_creation",
-      "fieldtype": "Datetime",
-      "hidden": 1,
-      "label": "SLA Creation",
-      "read_only": 1
-    },
-    {
-      "fieldname": "on_hold_since",
-      "fieldtype": "Datetime",
-      "label": "On Hold Since",
-      "read_only": 1
-    },
-    {
-      "fieldname": "total_hold_time",
-      "fieldtype": "Duration",
-      "label": "Total Hold Time",
-      "read_only": 1
-    },
-    {
-      "collapsible": 1,
-      "fieldname": "response",
-      "fieldtype": "Section Break"
-    },
-    {
-      "bold": 1,
-      "fieldname": "first_response_time",
-      "fieldtype": "Duration",
-      "label": "First Response Time",
-      "read_only": 1
-    },
-    {
-      "fieldname": "first_responded_on",
-      "fieldtype": "Datetime",
-      "label": "First Responded On",
-      "read_only": 1
-    },
-    {
-      "fieldname": "column_break_26",
-      "fieldtype": "Column Break"
-    },
-    {
-      "bold": 1,
-      "fieldname": "avg_response_time",
-      "fieldtype": "Duration",
-      "label": "Average Response Time",
-      "read_only": 1
-    },
-    {
-      "collapsible": 1,
-      "fieldname": "section_break_19",
-      "fieldtype": "Section Break"
-    },
-    {
-      "depends_on": "eval:!doc.__islocal",
-      "fieldname": "resolution_details",
-      "fieldtype": "Text Editor",
-      "label": "Resolution Details",
-      "no_copy": 1,
-      "oldfieldname": "resolution_details",
-      "oldfieldtype": "Text"
-    },
-    {
-      "depends_on": "eval:!doc.__islocal",
-      "fieldname": "column_break1",
-      "fieldtype": "Column Break",
-      "oldfieldtype": "Column Break",
-      "read_only": 1
-    },
-    {
-      "default": "Today",
-      "fieldname": "opening_date",
-      "fieldtype": "Date",
-      "label": "Opening Date",
-      "no_copy": 1,
-      "oldfieldname": "opening_date",
-      "oldfieldtype": "Date",
-      "read_only": 1
-    },
-    {
-      "fieldname": "opening_time",
-      "fieldtype": "Time",
-      "label": "Opening Time",
-      "no_copy": 1,
-      "oldfieldname": "opening_time",
-      "oldfieldtype": "Time",
-      "read_only": 1
-    },
-    {
-      "depends_on": "eval:!doc.__islocal",
-      "fieldname": "resolution_date",
-      "fieldtype": "Datetime",
-      "label": "Resolution Date",
-      "no_copy": 1,
-      "oldfieldname": "resolution_date",
-      "oldfieldtype": "Date",
-      "read_only": 1
-    },
-    {
-      "fieldname": "resolution_time",
-      "fieldtype": "Duration",
-      "label": "Resolution Time",
-      "read_only": 1
-    },
-    {
-      "fieldname": "user_resolution_time",
-      "fieldtype": "Duration",
-      "label": "User Resolution Time",
-      "read_only": 1
-    },
-    {
-      "collapsible": 1,
-      "fieldname": "additional_info",
-      "fieldtype": "Section Break",
-      "options": "fa fa-pushpin",
-      "read_only": 1
-    },
-    {
-      "fieldname": "contact",
-      "fieldtype": "Link",
-      "label": "Contact",
-      "options": "Contact"
-    },
-    {
-      "fieldname": "customer",
-      "fieldtype": "Link",
-      "in_standard_filter": 1,
-      "label": "Customer",
-      "options": "HD Customer"
-    },
-    {
-      "fieldname": "email_account",
-      "fieldtype": "Link",
-      "label": "Email Account",
-      "options": "Email Account"
-    },
-    {
-      "fieldname": "column_break_16",
-      "fieldtype": "Column Break"
-    },
-    {
-      "default": "0",
-      "fieldname": "via_customer_portal",
-      "fieldtype": "Check",
-      "label": "Via Customer Portal"
-    },
-    {
-      "fieldname": "attachment",
-      "fieldtype": "Attach",
-      "hidden": 1,
-      "label": "Attachment"
-    },
-    {
-      "fieldname": "content_type",
-      "fieldtype": "Data",
-      "hidden": 1,
-      "label": "Content Type"
-    },
-    {
-      "fieldname": "customer_feedback_section",
-      "fieldtype": "Section Break"
-    },
-    {
-      "fieldname": "feedback_extra",
-      "fieldtype": "Long Text",
-      "label": "Feedback (Extra)",
-      "read_only": 1
-    },
-    {
-      "fieldname": "feedback",
-      "fieldtype": "Link",
-      "label": "Feedback (Option)",
-      "options": "HD Ticket Feedback Option",
-      "read_only": 1
-    },
-    {
-      "fieldname": "feedback_rating",
-      "fieldtype": "Rating",
-      "label": "Rating",
-      "read_only": 1
-    },
-    {
-      "fieldname": "sla_tab",
-      "fieldtype": "Tab Break",
-      "label": "SLA"
-    },
-    {
-      "fieldname": "response_tab",
-      "fieldtype": "Tab Break",
-      "label": "Response"
-    },
-    {
-      "fieldname": "resolution_tab",
-      "fieldtype": "Tab Break",
-      "label": "Resolution"
-    },
-    {
-      "fieldname": "reference_tab",
-      "fieldtype": "Tab Break",
-      "label": "Reference"
-    },
-    {
-      "fieldname": "feedback_tab",
-      "fieldtype": "Tab Break",
-      "label": "Feedback"
-    },
-    {
-      "fieldname": "summary",
-      "fieldtype": "Text Editor",
-      "label": "Summary"
-    },
-    {
-      "fieldname": "split_and_merge_section",
-      "fieldtype": "Section Break",
-      "label": "Split and Merge"
-    },
-    {
-      "default": "0",
-      "fieldname": "is_merged",
-      "fieldtype": "Check",
-      "label": "Ticket Merged",
-      "read_only": 1
-    },
-    {
-      "depends_on": "eval:doc.is_merged",
-      "fieldname": "merged_with",
-      "fieldtype": "Link",
-      "label": "Merged With",
-      "options": "HD Ticket",
-      "read_only": 1
-    },
-    {
-      "fieldname": "key",
-      "fieldtype": "Data",
-      "label": "Key",
-      "read_only": 1,
-      "set_only_once": 1
-    },
-    {
-      "fetch_from": "status.category",
-      "fieldname": "status_category",
-      "fieldtype": "Data",
-      "label": "Status Category",
-      "read_only": 1
-    },
-    {
-      "fieldname": "last_agent_response",
-      "fieldtype": "Datetime",
-      "label": "Last Agent Response",
-      "read_only": 1
-    },
-    {
-      "fieldname": "last_customer_response",
-      "fieldtype": "Datetime",
-      "label": "Last Customer Response",
-      "read_only": 1
-    },
-    {
-      "default": "False",
-      "fieldname": "raised_outside_working_hours",
-      "fieldtype": "Check",
-      "label": "Ticket raised outside working hours",
-      "read_only": 1,
-      "set_only_once": 1
-    }
-  ],
-  "grid_page_length": 50,
-  "icon": "fa fa-issue",
-  "idx": 61,
-  "links": [],
-  "modified": "2026-02-27 16:42:43.292656",
-  "modified_by": "Administrator",
-  "module": "Helpdesk",
-  "name": "HD Ticket",
-  "naming_rule": "Expression",
-  "owner": "Administrator",
-  "permissions": [
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "System Manager",
-      "share": 1,
-      "write": 1
-    },
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "Agent",
-      "share": 1,
-      "write": 1
-    },
-    {
-      "create": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "All",
-      "share": 1,
-      "write": 1
-    },
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "Agent Manager",
-      "share": 1,
-      "write": 1
-    }
-  ],
-  "quick_entry": 1,
-  "recipient_account_field": "email_account",
-  "row_format": "Dynamic",
-  "search_fields": "status,subject,raised_by",
-  "sender_field": "raised_by",
-  "show_title_field_in_link": 1,
-  "sort_field": "modified",
-  "sort_order": "DESC",
-  "states": [],
-  "subject_field": "subject",
-  "timeline_field": "contact",
-  "title_field": "subject",
-  "track_changes": 1,
-  "track_seen": 1
+ "actions": [],
+ "allow_import": 1,
+ "autoname": "autoincrement",
+ "creation": "2023-10-17 14:27:11.078679",
+ "doctype": "DocType",
+ "document_type": "Setup",
+ "email_append_to": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "subject_section",
+  "subject",
+  "raised_by",
+  "status",
+  "priority",
+  "status_category",
+  "cb00",
+  "ticket_type",
+  "agent_group",
+  "summary",
+  "sb_details",
+  "description",
+  "template",
+  "key",
+  "sla_tab",
+  "service_level_section",
+  "sla",
+  "response_by",
+  "raised_outside_working_hours",
+  "cb",
+  "agreement_status",
+  "resolution_by",
+  "service_level_agreement_creation",
+  "on_hold_since",
+  "total_hold_time",
+  "response_tab",
+  "response",
+  "first_response_time",
+  "first_responded_on",
+  "column_break_26",
+  "avg_response_time",
+  "last_agent_response",
+  "last_customer_response",
+  "resolution_tab",
+  "section_break_19",
+  "resolution_details",
+  "column_break1",
+  "opening_date",
+  "opening_time",
+  "resolution_date",
+  "resolution_time",
+  "user_resolution_time",
+  "reference_tab",
+  "additional_info",
+  "contact",
+  "customer",
+  "email_account",
+  "column_break_16",
+  "via_customer_portal",
+  "attachment",
+  "content_type",
+  "split_and_merge_section",
+  "is_merged",
+  "merged_with",
+  "ticket_split_from",
+  "feedback_tab",
+  "customer_feedback_section",
+  "feedback_rating",
+  "feedback",
+  "feedback_extra"
+ ],
+ "fields": [
+  {
+   "fieldname": "subject_section",
+   "fieldtype": "Section Break",
+   "options": "fa fa-flag"
+  },
+  {
+   "bold": 1,
+   "fieldname": "subject",
+   "fieldtype": "Data",
+   "in_global_search": 1,
+   "in_standard_filter": 1,
+   "label": "Subject",
+   "reqd": 1
+  },
+  {
+   "bold": 1,
+   "fieldname": "raised_by",
+   "fieldtype": "Data",
+   "in_global_search": 1,
+   "in_list_view": 1,
+   "label": "Raised By (Email)",
+   "oldfieldname": "raised_by",
+   "oldfieldtype": "Data",
+   "options": "Email"
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Status",
+   "no_copy": 1,
+   "oldfieldname": "status",
+   "oldfieldtype": "Select",
+   "options": "HD Ticket Status",
+   "search_index": 1
+  },
+  {
+   "fieldname": "priority",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Priority",
+   "options": "HD Ticket Priority"
+  },
+  {
+   "fieldname": "cb00",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "ticket_type",
+   "fieldtype": "Link",
+   "label": "Ticket Type",
+   "link_filters": "[[\"HD Ticket Type\",\"disabled\",\"=\",0]]",
+   "options": "HD Ticket Type"
+  },
+  {
+   "fieldname": "agent_group",
+   "fieldtype": "Link",
+   "label": "Team",
+   "options": "HD Team"
+  },
+  {
+   "fieldname": "ticket_split_from",
+   "fieldtype": "Link",
+   "label": "Ticket Split From",
+   "options": "HD Ticket",
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "eval:doc.status!=\"Closed\"",
+   "fieldname": "sb_details",
+   "fieldtype": "Section Break",
+   "label": "Details"
+  },
+  {
+   "bold": 1,
+   "fieldname": "description",
+   "fieldtype": "Text Editor",
+   "in_global_search": 1,
+   "label": "Description",
+   "oldfieldname": "problem_description",
+   "oldfieldtype": "Text"
+  },
+  {
+   "fieldname": "template",
+   "fieldtype": "Link",
+   "label": "Template",
+   "options": "HD Ticket Template"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "service_level_section",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "sla",
+   "fieldtype": "Link",
+   "label": "SLA",
+   "options": "HD Service Level Agreement"
+  },
+  {
+   "depends_on": "eval: doc.status_category != 'Paused' && doc.sla;",
+   "fieldname": "response_by",
+   "fieldtype": "Datetime",
+   "label": "Response By",
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "cb",
+   "fieldtype": "Column Break",
+   "options": "fa fa-pushpin",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval: doc.sla",
+   "fieldname": "agreement_status",
+   "fieldtype": "Select",
+   "label": "SLA Status",
+   "options": "\nFirst Response Due\nResolution Due\nFailed\nFulfilled\nPaused",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval: doc.status_category != 'Paused' && doc.sla;",
+   "fieldname": "resolution_by",
+   "fieldtype": "Datetime",
+   "label": "Resolution By",
+   "read_only": 1
+  },
+  {
+   "fieldname": "service_level_agreement_creation",
+   "fieldtype": "Datetime",
+   "hidden": 1,
+   "label": "SLA Creation",
+   "read_only": 1
+  },
+  {
+   "fieldname": "on_hold_since",
+   "fieldtype": "Datetime",
+   "label": "On Hold Since",
+   "read_only": 1
+  },
+  {
+   "fieldname": "total_hold_time",
+   "fieldtype": "Duration",
+   "label": "Total Hold Time",
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "response",
+   "fieldtype": "Section Break"
+  },
+  {
+   "bold": 1,
+   "fieldname": "first_response_time",
+   "fieldtype": "Duration",
+   "label": "First Response Time",
+   "read_only": 1
+  },
+  {
+   "fieldname": "first_responded_on",
+   "fieldtype": "Datetime",
+   "label": "First Responded On",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_26",
+   "fieldtype": "Column Break"
+  },
+  {
+   "bold": 1,
+   "fieldname": "avg_response_time",
+   "fieldtype": "Duration",
+   "label": "Average Response Time",
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "section_break_19",
+   "fieldtype": "Section Break"
+  },
+  {
+   "depends_on": "eval:!doc.__islocal",
+   "fieldname": "resolution_details",
+   "fieldtype": "Text Editor",
+   "label": "Resolution Details",
+   "no_copy": 1,
+   "oldfieldname": "resolution_details",
+   "oldfieldtype": "Text"
+  },
+  {
+   "depends_on": "eval:!doc.__islocal",
+   "fieldname": "column_break1",
+   "fieldtype": "Column Break",
+   "oldfieldtype": "Column Break",
+   "read_only": 1
+  },
+  {
+   "default": "Today",
+   "fieldname": "opening_date",
+   "fieldtype": "Date",
+   "label": "Opening Date",
+   "no_copy": 1,
+   "oldfieldname": "opening_date",
+   "oldfieldtype": "Date",
+   "read_only": 1
+  },
+  {
+   "fieldname": "opening_time",
+   "fieldtype": "Time",
+   "label": "Opening Time",
+   "no_copy": 1,
+   "oldfieldname": "opening_time",
+   "oldfieldtype": "Time",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:!doc.__islocal",
+   "fieldname": "resolution_date",
+   "fieldtype": "Datetime",
+   "label": "Resolution Date",
+   "no_copy": 1,
+   "oldfieldname": "resolution_date",
+   "oldfieldtype": "Date",
+   "read_only": 1
+  },
+  {
+   "fieldname": "resolution_time",
+   "fieldtype": "Duration",
+   "label": "Resolution Time",
+   "read_only": 1
+  },
+  {
+   "fieldname": "user_resolution_time",
+   "fieldtype": "Duration",
+   "label": "User Resolution Time",
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "additional_info",
+   "fieldtype": "Section Break",
+   "options": "fa fa-pushpin",
+   "read_only": 1
+  },
+  {
+   "fieldname": "contact",
+   "fieldtype": "Link",
+   "label": "Contact",
+   "options": "Contact"
+  },
+  {
+   "fieldname": "customer",
+   "fieldtype": "Link",
+   "in_standard_filter": 1,
+   "label": "Customer",
+   "options": "HD Customer"
+  },
+  {
+   "fieldname": "email_account",
+   "fieldtype": "Link",
+   "label": "Email Account",
+   "options": "Email Account"
+  },
+  {
+   "fieldname": "column_break_16",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "via_customer_portal",
+   "fieldtype": "Check",
+   "label": "Via Customer Portal"
+  },
+  {
+   "fieldname": "attachment",
+   "fieldtype": "Attach",
+   "hidden": 1,
+   "label": "Attachment"
+  },
+  {
+   "fieldname": "content_type",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Content Type"
+  },
+  {
+   "fieldname": "customer_feedback_section",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "feedback_extra",
+   "fieldtype": "Long Text",
+   "label": "Feedback (Extra)",
+   "read_only": 1
+  },
+  {
+   "fieldname": "feedback",
+   "fieldtype": "Link",
+   "label": "Feedback (Option)",
+   "options": "HD Ticket Feedback Option",
+   "read_only": 1
+  },
+  {
+   "fieldname": "feedback_rating",
+   "fieldtype": "Rating",
+   "label": "Rating",
+   "read_only": 1
+  },
+  {
+   "fieldname": "sla_tab",
+   "fieldtype": "Tab Break",
+   "label": "SLA"
+  },
+  {
+   "fieldname": "response_tab",
+   "fieldtype": "Tab Break",
+   "label": "Response"
+  },
+  {
+   "fieldname": "resolution_tab",
+   "fieldtype": "Tab Break",
+   "label": "Resolution"
+  },
+  {
+   "fieldname": "reference_tab",
+   "fieldtype": "Tab Break",
+   "label": "Reference"
+  },
+  {
+   "fieldname": "feedback_tab",
+   "fieldtype": "Tab Break",
+   "label": "Feedback"
+  },
+  {
+   "fieldname": "summary",
+   "fieldtype": "Text Editor",
+   "label": "Summary"
+  },
+  {
+   "fieldname": "split_and_merge_section",
+   "fieldtype": "Section Break",
+   "label": "Split and Merge"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_merged",
+   "fieldtype": "Check",
+   "label": "Ticket Merged",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.is_merged",
+   "fieldname": "merged_with",
+   "fieldtype": "Link",
+   "label": "Merged With",
+   "options": "HD Ticket",
+   "read_only": 1
+  },
+  {
+   "fieldname": "key",
+   "fieldtype": "Data",
+   "label": "Key",
+   "read_only": 1,
+   "set_only_once": 1
+  },
+  {
+   "fetch_from": "status.category",
+   "fieldname": "status_category",
+   "fieldtype": "Data",
+   "label": "Status Category",
+   "read_only": 1
+  },
+  {
+   "fieldname": "last_agent_response",
+   "fieldtype": "Datetime",
+   "label": "Last Agent Response",
+   "read_only": 1
+  },
+  {
+   "fieldname": "last_customer_response",
+   "fieldtype": "Datetime",
+   "label": "Last Customer Response",
+   "read_only": 1
+  },
+  {
+   "default": "False",
+   "fieldname": "raised_outside_working_hours",
+   "fieldtype": "Check",
+   "label": "Ticket raised outside working hours",
+   "read_only": 1,
+   "set_only_once": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "icon": "fa fa-issue",
+ "idx": 61,
+ "links": [],
+ "modified": "2026-02-27 16:42:43.292656",
+ "modified_by": "Administrator",
+ "module": "Helpdesk",
+ "name": "HD Ticket",
+ "naming_rule": "Autoincrement",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Agent",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "All",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Agent Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "quick_entry": 1,
+ "recipient_account_field": "email_account",
+ "row_format": "Dynamic",
+ "search_fields": "status,subject,raised_by",
+ "sender_field": "raised_by",
+ "show_title_field_in_link": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "subject_field": "subject",
+ "timeline_field": "contact",
+ "title_field": "subject",
+ "track_changes": 1,
+ "track_seen": 1
 }

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -69,9 +69,6 @@ class HDTicket(Document):
             "helpdesk:ticket-update", room=room, data={"ticket_id": self.name}
         )
 
-    def autoname(self):
-        return self.name
-
     def before_insert(self):
         self.generate_key()
 
@@ -995,7 +992,7 @@ class HDTicket(Document):
         columns = [
             {
                 "label": "ID",
-                "type": "Int",
+                "type": "Data",
                 "key": "name",
                 "width": "5rem",
             },
@@ -1081,7 +1078,7 @@ class HDTicket(Document):
         customer_portal_columns = [
             {
                 "label": "ID",
-                "type": "Int",
+                "type": "Data",
                 "key": "name",
                 "width": "5rem",
             },

--- a/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
@@ -596,7 +596,7 @@ class TestHDTicket(IntegrationTestCase):
         ticket1.reload()
         self.assertEqual(ticket1.status, "Closed")
         self.assertTrue(ticket1.is_merged)
-        self.assertEqual(int(ticket1.merged_with), int(ticket2.name))
+        self.assertEqual(ticket1.merged_with, ticket2.name)
 
         ticket2.reload()
         comments = frappe.get_all(

--- a/helpdesk/patches.txt
+++ b/helpdesk/patches.txt
@@ -11,6 +11,7 @@ helpdesk.patches.rename_canned_response_to_saved_reply
 helpdesk.patches.alter_hd_ticket_name_to_varchar
 
 [post_model_sync]
+helpdesk.patches.backfill_legacy_hd_tickets
 execute:frappe.delete_doc("Workspace", "Frappe Desk", force=True)
 helpdesk.patches.add_priority_integer
 helpdesk.patches.template_remove_default_fields

--- a/helpdesk/patches.txt
+++ b/helpdesk/patches.txt
@@ -8,6 +8,7 @@ execute:frappe.delete_doc("DocType", "HD Preset Filter Item")
 execute:frappe.delete_doc("DocType", "HD Pause Service Level Agreement On Status")
 execute:frappe.delete_doc("DocType", "HD Service Level Agreement Fulfilled On Status")
 helpdesk.patches.rename_canned_response_to_saved_reply
+helpdesk.patches.alter_hd_ticket_name_to_varchar
 
 [post_model_sync]
 execute:frappe.delete_doc("Workspace", "Frappe Desk", force=True)

--- a/helpdesk/patches/alter_hd_ticket_name_to_varchar.py
+++ b/helpdesk/patches/alter_hd_ticket_name_to_varchar.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe import _
 
 
 def execute():
@@ -24,7 +25,7 @@ def alter_new_column():
     current_type = get_current_column_type()
 
     if current_type is None:
-        frappe.throw("Could not find the `name` column in tabHD Ticket")
+        frappe.throw(_("Cou`ld not find the `name` column in tabHD Ticket"))
 
     if current_type == "varchar":
         print("alter_hd_ticket_name_to_varchar: column is already VARCHAR, skipping")

--- a/helpdesk/patches/alter_hd_ticket_name_to_varchar.py
+++ b/helpdesk/patches/alter_hd_ticket_name_to_varchar.py
@@ -1,0 +1,47 @@
+import frappe
+
+
+def execute():
+    alter_new_column()
+    drop_autoincrement_sequence()
+
+
+def get_current_column_type():
+    result = frappe.db.sql(
+        """
+        SELECT DATA_TYPE
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'tabHD Ticket'
+        AND COLUMN_NAME = 'name'
+        """,
+        as_dict=True,
+    )
+    return result[0]["DATA_TYPE"].lower() if result else None
+
+
+def alter_new_column():
+    current_type = get_current_column_type()
+
+    if current_type is None:
+        frappe.throw("Could not find the `name` column in tabHD Ticket")
+
+    if current_type == "varchar":
+        print("alter_hd_ticket_name_to_varchar: column is already VARCHAR, skipping")
+        return
+
+    frappe.db.sql_ddl(
+        "ALTER TABLE `tabHD Ticket` MODIFY COLUMN `name` VARCHAR(140) NOT NULL"
+    )
+
+    print(
+        f"alter_hd_ticket_name_to_varchar: changed `name` from {current_type} to VARCHAR(140)"
+    )
+
+
+def drop_autoincrement_sequence():
+    seq_name = frappe.scrub("HD Ticket") + "_id_seq"
+    frappe.db.sql_ddl(f"DROP SEQUENCE IF EXISTS `{seq_name}`")
+    print(
+        f"alter_hd_ticket_name_to_varchar: dropped sequence `{seq_name}` if it existed."
+    )

--- a/helpdesk/patches/backfill_legacy_hd_tickets.py
+++ b/helpdesk/patches/backfill_legacy_hd_tickets.py
@@ -3,6 +3,11 @@ from frappe.utils import getdate
 
 
 def execute():
+    migrate_ticket_names()
+    seed_series
+
+
+def migrate_ticket_names():
     legacy_tickets = frappe.db.sql(
         """
         SELECT name, creation 
@@ -33,6 +38,10 @@ def execute():
 
         frappe.db.commit()
 
+
+def seed_series():
+    # Extract year and sequence from names like:
+    # HD-TKT-2026-00001
     yearly_max_data = frappe.db.sql(
         """
         SELECT 

--- a/helpdesk/patches/backfill_legacy_hd_tickets.py
+++ b/helpdesk/patches/backfill_legacy_hd_tickets.py
@@ -1,69 +1,70 @@
 import frappe
 from frappe.utils import getdate
 
+
 def execute():
-    # 1. FETCH LEGACY TICKETS
-    # We use NOT LIKE to skip any tickets already renamed in previous tests
-    legacy_tickets = frappe.db.sql("""
+    legacy_tickets = frappe.db.sql(
+        """
         SELECT name, creation 
         FROM `tabHD Ticket` 
         WHERE name NOT LIKE 'HD-TKT-%'
         ORDER BY CAST(name AS UNSIGNED) ASC
-    """, as_dict=True)
+    """,
+        as_dict=True,
+    )
 
     if legacy_tickets:
-        # 2. RENAME LOOP
         for index, ticket in enumerate(legacy_tickets):
             old_name = ticket.name
             try:
                 old_id = int(old_name)
                 year = getdate(ticket.creation).year
                 new_name = f"HD-TKT-{year}-{old_id:05d}"
-                
-                # 'force=True' is mandatory to bypass the DocType metadata check
+
                 frappe.rename_doc("HD Ticket", old_name, new_name, force=True)
             except Exception:
                 frappe.log_error(
-                    frappe.get_traceback(), 
-                    f"Failed to migrate HD Ticket {old_name}"
+                    frappe.get_traceback(), f"Failed to migrate HD Ticket {old_name}"
                 )
                 continue
-            
-            # Commit in batches of 500 to keep the DB healthy
+
             if (index + 1) % 500 == 0:
                 frappe.db.commit()
 
         frappe.db.commit()
 
-    # 3. SERIES SEEDING (Using Raw SQL to avoid 'Unknown column modified' error)
-    yearly_max_data = frappe.db.sql("""
+    yearly_max_data = frappe.db.sql(
+        """
         SELECT 
             SUBSTRING(name, 8, 4) as year, 
             MAX(CAST(RIGHT(name, 5) AS UNSIGNED)) as max_id
         FROM `tabHD Ticket`
         WHERE name LIKE 'HD-TKT-____-_____'
         GROUP BY year
-    """, as_dict=True)
+    """,
+        as_dict=True,
+    )
 
     if yearly_max_data:
         for data in yearly_max_data:
             year = data.year
             max_id = data.max_id
             series_name = f"HD-TKT-{year}-"
-            
-            # Use raw SQL because tabSeries lacks standard Frappe columns
-            res = frappe.db.sql("SELECT current FROM `tabSeries` WHERE name=%s", (series_name,))
+
+            res = frappe.db.sql(
+                "SELECT current FROM `tabSeries` WHERE name=%s", (series_name,)
+            )
             current_val = res[0][0] if res else None
-            
+
             if current_val is None:
                 frappe.db.sql(
-                    "INSERT INTO `tabSeries` (name, current) VALUES (%s, %s)", 
-                    (series_name, max_id)
+                    "INSERT INTO `tabSeries` (name, current) VALUES (%s, %s)",
+                    (series_name, max_id),
                 )
             elif max_id > current_val:
                 frappe.db.sql(
-                    "UPDATE `tabSeries` SET current = %s WHERE name = %s", 
-                    (max_id, series_name)
+                    "UPDATE `tabSeries` SET current = %s WHERE name = %s",
+                    (max_id, series_name),
                 )
 
     frappe.db.commit()

--- a/helpdesk/patches/backfill_legacy_hd_tickets.py
+++ b/helpdesk/patches/backfill_legacy_hd_tickets.py
@@ -1,0 +1,69 @@
+import frappe
+from frappe.utils import getdate
+
+def execute():
+    # 1. FETCH LEGACY TICKETS
+    # We use NOT LIKE to skip any tickets already renamed in previous tests
+    legacy_tickets = frappe.db.sql("""
+        SELECT name, creation 
+        FROM `tabHD Ticket` 
+        WHERE name NOT LIKE 'HD-TKT-%'
+        ORDER BY CAST(name AS UNSIGNED) ASC
+    """, as_dict=True)
+
+    if legacy_tickets:
+        # 2. RENAME LOOP
+        for index, ticket in enumerate(legacy_tickets):
+            old_name = ticket.name
+            try:
+                old_id = int(old_name)
+                year = getdate(ticket.creation).year
+                new_name = f"HD-TKT-{year}-{old_id:05d}"
+                
+                # 'force=True' is mandatory to bypass the DocType metadata check
+                frappe.rename_doc("HD Ticket", old_name, new_name, force=True)
+            except Exception:
+                frappe.log_error(
+                    frappe.get_traceback(), 
+                    f"Failed to migrate HD Ticket {old_name}"
+                )
+                continue
+            
+            # Commit in batches of 500 to keep the DB healthy
+            if (index + 1) % 500 == 0:
+                frappe.db.commit()
+
+        frappe.db.commit()
+
+    # 3. SERIES SEEDING (Using Raw SQL to avoid 'Unknown column modified' error)
+    yearly_max_data = frappe.db.sql("""
+        SELECT 
+            SUBSTRING(name, 8, 4) as year, 
+            MAX(CAST(RIGHT(name, 5) AS UNSIGNED)) as max_id
+        FROM `tabHD Ticket`
+        WHERE name LIKE 'HD-TKT-____-_____'
+        GROUP BY year
+    """, as_dict=True)
+
+    if yearly_max_data:
+        for data in yearly_max_data:
+            year = data.year
+            max_id = data.max_id
+            series_name = f"HD-TKT-{year}-"
+            
+            # Use raw SQL because tabSeries lacks standard Frappe columns
+            res = frappe.db.sql("SELECT current FROM `tabSeries` WHERE name=%s", (series_name,))
+            current_val = res[0][0] if res else None
+            
+            if current_val is None:
+                frappe.db.sql(
+                    "INSERT INTO `tabSeries` (name, current) VALUES (%s, %s)", 
+                    (series_name, max_id)
+                )
+            elif max_id > current_val:
+                frappe.db.sql(
+                    "UPDATE `tabSeries` SET current = %s WHERE name = %s", 
+                    (max_id, series_name)
+                )
+
+    frappe.db.commit()

--- a/helpdesk/search_sqlite.py
+++ b/helpdesk/search_sqlite.py
@@ -84,7 +84,7 @@ class HelpdeskSearch(SQLiteSearch):
             and doc.reference_ticket
             and type(doc.reference_ticket) is str
         ):
-            document["reference_ticket"] = int(doc.reference_ticket)
+            document["reference_ticket"] = doc.reference_ticket
 
         if doc.doctype == "Communication":
             # For communications, ensure reference fields are set for ticket doctype
@@ -94,10 +94,10 @@ class HelpdeskSearch(SQLiteSearch):
                 and doc.reference_name
                 and type(doc.reference_name) is str
             ):
-                document["reference_name"] = int(doc.reference_name)
+                document["reference_name"] = doc.reference_name
 
         if doc.doctype == "HD Ticket":
-            document["reference_ticket"] = int(doc.name)
+            document["reference_ticket"] = doc.name
 
         # Map commented_by to owner for HD Ticket Comment
         if doc.doctype == "HD Ticket Comment":


### PR DESCRIPTION
Moving the ticket naming system from simple auto-incrementing integers to a structured, year-based format: HD-TKT-YYYY-#####.

The Architectural Approach
I split this into a two-phase migration to ensure the database stays stable:

Phase 1: Schema Alignment
The first patch converts the name column from BigInt to VarChar. Since we are moving from numbers to strings, the "pipe" had to be widened first before we could push any new data through.

Phase 2: Data Transformation & Seeding
The second patch handles the heavy lifting:

Backfilling: It iterates through legacy tickets and renames them to the new format based on their original creation year.

Series Recovery: It calculates the highest existing ID for each year to seed the tabSeries table. This ensures the next ticket created in the UI follows the sequence perfectly without crashing.

Performance Note
For the series seeding, the logic looks a bit less readable and ugly, but I thought if I did it in Python the OOM could happen. Not sure what kind of volumes the Helpdesk users have, so I went with SQL to keep the RAM safe by letting the DB handle the grouping and max-ID calculations.

fixes #3207 