### PR TITLE
fix: escape reserved keyword 'order' in ticket status query

### DIFF
--- a/helpdesk/helpdesk/report/ticket_summary/ticket_summary.py
+++ b/helpdesk/helpdesk/report/ticket_summary/ticket_summary.py
@@ -34,7 +34,7 @@ class TicketSummary:
             "HD Ticket Status",
             filters={"enabled": 1},
             fields=["label_agent", "color"],
-            order_by="`tabHD Ticket Status`.order",
+            order_by="`tabHD Ticket Status`.`order`",
         )
 
         self.statuses = [status.label_agent for status in status_data]


### PR DESCRIPTION
Wrapped the order field in backticks within get_ticket_statuses. 

This prevents potential SQL syntax errors caused by order being a reserved keyword, ensuring better database compatibility when SQL is run.


in reference to error

<img width="682" height="305" alt="image" src="https://github.com/user-attachments/assets/b24d0051-582d-4fe6-8cd1-26ce9dc15e48" />
