### PR TITLE
fix: add clear formatting utility in text editor

### DIFF
--- a/desk/src/components/CommentTextEditor.vue
+++ b/desk/src/components/CommentTextEditor.vue
@@ -14,7 +14,7 @@
     :editable="editable"
     :mentions="dropdown"
     @change="editable ? (newComment = $event) : null"
-    :extensions="[ComponentUtils, HandleExcelPaste]"
+    :extensions="[ComponentUtils, HandleExcelPaste, CleanStyles]"
     :uploadFunction="(file:any)=>uploadFunction(file, doctype, ticketId)"
   >
     <template #bottom>
@@ -113,7 +113,11 @@ import { AttachmentIcon } from "@/components/icons/";
 import { useTyping } from "@/composables/realtime";
 import { useAgentStore } from "@/stores/agent";
 import { useAuthStore } from "@/stores/auth";
-import { ComponentUtils, HandleExcelPaste } from "@/tiptap-extensions";
+import {
+  ComponentUtils,
+  HandleExcelPaste,
+  CleanStyles,
+} from "@/tiptap-extensions";
 import {
   getFontFamily,
   isContentEmpty,

--- a/desk/src/components/EmailEditor.vue
+++ b/desk/src/components/EmailEditor.vue
@@ -11,7 +11,7 @@
     :placeholder="placeholder"
     :editable="editable"
     @change="editable ? (newEmail = $event) : null"
-    :extensions="[ComponentUtils, HandleExcelPaste]"
+    :extensions="[ComponentUtils, HandleExcelPaste, CleanStyles]"
     :uploadFunction="(file:any)=>uploadFunction(file, doctype, ticketId)"
     @keydown.capture="handleKeydown"
   >
@@ -178,7 +178,11 @@ import { EditorContent } from "@tiptap/vue-3";
 import { AttachmentIcon } from "@/components/icons";
 import { useTyping } from "@/composables/realtime";
 import { useAuthStore } from "@/stores/auth";
-import { ComponentUtils, HandleExcelPaste } from "@/tiptap-extensions";
+import {
+  ComponentUtils,
+  HandleExcelPaste,
+  CleanStyles,
+} from "@/tiptap-extensions";
 import {
   getFontFamily,
   isContentEmpty,

--- a/desk/src/components/TextEditor.vue
+++ b/desk/src/components/TextEditor.vue
@@ -60,7 +60,7 @@
 import { UserAvatar } from "@/components";
 import { useAuthStore } from "@/stores/auth";
 import { ComponentUtils, HandleExcelPaste } from "@/tiptap-extensions";
-import { getFontFamily } from "@/utils";
+import { ClearFormattingUtility, getFontFamily } from "@/utils";
 import { TextEditor as FTextEditor, TextEditorFixedMenu } from "frappe-ui";
 import { computed, nextTick, ref } from "vue";
 
@@ -86,13 +86,19 @@ const authStore = useAuthStore();
 const fixedMenu = [
   "Paragraph",
   ["Heading 2", "Heading 3", "Heading 4", "Heading 5"],
+  "Separator",
+  "Bold",
+  "Italic",
+  "Separator",
   "Bullet List",
   "Numbered List",
+  "Separator",
   "Image",
   "Video",
   "Link",
   "Blockquote",
   "Code",
+  ClearFormattingUtility,
 ];
 
 defineExpose({

--- a/desk/src/components/TextEditor.vue
+++ b/desk/src/components/TextEditor.vue
@@ -2,7 +2,7 @@
   <div class="rounded p-3 shadow w-full">
     <FTextEditor
       ref="e"
-      :extensions="[ComponentUtils, HandleExcelPaste]"
+      :extensions="[ComponentUtils, HandleExcelPaste, CleanStyles]"
       v-bind="$attrs"
       :editor-class="[
         'prose-f max-h-64 max-w-none  overflow-auto my-4 min-h-[5rem]',
@@ -59,7 +59,11 @@
 <script setup lang="ts">
 import { UserAvatar } from "@/components";
 import { useAuthStore } from "@/stores/auth";
-import { ComponentUtils, HandleExcelPaste } from "@/tiptap-extensions";
+import {
+  CleanStyles,
+  ComponentUtils,
+  HandleExcelPaste,
+} from "@/tiptap-extensions";
 import { ClearFormattingUtility, getFontFamily } from "@/utils";
 import { TextEditor as FTextEditor, TextEditorFixedMenu } from "frappe-ui";
 import { computed, nextTick, ref } from "vue";

--- a/desk/src/components/TextEditor.vue
+++ b/desk/src/components/TextEditor.vue
@@ -33,8 +33,8 @@
             class="flex flex-col space-y-1.5 overflow-auto sm:flex-row sm:justify-between"
           >
             <div class="flex items-center">
-              <TextEditorFixedMenu :buttons="fixedMenu" />
               <slot name="bottom-left" />
+              <TextEditorFixedMenu :buttons="fixedMenu" />
             </div>
             <div class="flex items-center gap-2">
               <Button

--- a/desk/src/index.css
+++ b/desk/src/index.css
@@ -8,12 +8,13 @@
   .prose-f {
     @apply break-normal max-w-none prose prose-code:break-all prose-code:whitespace-pre-wrap prose-img:border prose-img:rounded-lg prose-sm;
   }
-  .prose-f *{
+  .prose-f * {
     unicode-bidi: plaintext;
   }
   .prose-f:not(.not-prose):not(.not-prose *) pre {
     background-color: var(--surface-gray-2);
-    color: var(--ink-gray-9);}
+    color: var(--ink-gray-9);
+  }
 }
 
 .tiptap input[placeholder="Add caption"] {

--- a/desk/src/index.css
+++ b/desk/src/index.css
@@ -11,10 +11,9 @@
   .prose-f *{
     unicode-bidi: plaintext;
   }
-  .prose-f pre {
+  .prose-f:not(.not-prose):not(.not-prose *) pre {
     background-color: var(--surface-gray-2);
-    color: var(--ink-gray-9);
-  }
+    color: var(--ink-gray-9);}
 }
 
 .tiptap input[placeholder="Add caption"] {

--- a/desk/src/index.css
+++ b/desk/src/index.css
@@ -8,6 +8,13 @@
   .prose-f {
     @apply break-normal max-w-none prose prose-code:break-all prose-code:whitespace-pre-wrap prose-img:border prose-img:rounded-lg prose-sm;
   }
+  .prose-f *{
+    unicode-bidi: plaintext;
+  }
+  .prose-f pre {
+    background-color: var(--surface-gray-2);
+    color: var(--ink-gray-9);
+  }
 }
 
 .tiptap input[placeholder="Add caption"] {

--- a/desk/src/pages/knowledge-base/Article.vue
+++ b/desk/src/pages/knowledge-base/Article.vue
@@ -164,7 +164,7 @@
           ref="editorRef"
           :editor-class="editorClass"
           :content="textEditorContentWithIDs"
-          :extensions="[ComponentUtils]"
+          :extensions="[ComponentUtils, CleanStyles]"
           :editable="editable"
           @change="(event:string) => {
 			      content = event;
@@ -246,7 +246,7 @@ import {
   likeArticle,
 } from "@/stores/knowledgeBase";
 import { capture } from "@/telemetry";
-import { ComponentUtils } from "@/tiptap-extensions";
+import { CleanStyles, ComponentUtils } from "@/tiptap-extensions";
 import { Article, Breadcrumb, Error, FeedbackAction, Resource } from "@/types";
 import {
   copyToClipboard,

--- a/desk/src/tiptap-extensions.ts
+++ b/desk/src/tiptap-extensions.ts
@@ -744,3 +744,89 @@ export const HandleExcelPaste = Extension.create({
     ];
   },
 });
+
+
+// Handle formatting cleanup
+type StyleValidator = (value: string) => boolean;
+type StyleNormalizer = (value: string) => string | null;
+
+export interface CleanStylesOptions {
+  validators?: Record<string, StyleValidator>;
+  normalizers?: Record<string, StyleNormalizer>;
+  allowProperty?: (property: string, value: string) => boolean;
+}
+
+export const CleanStyles = Extension.create<CleanStylesOptions>({
+  name: "cleanStyles",
+
+  addOptions() {
+    return {
+      validators: {},
+      normalizers: {},
+      allowProperty: () => true,
+    };
+  },
+
+  addCommands() {
+    return {
+      cleanStyles:
+        () =>
+        ({ state, tr, dispatch }) => {
+          const { doc, schema } = state;
+          const textStyleType = schema.marks.textStyle;
+
+          if (!textStyleType) return true;
+
+          const {
+            validators = {},
+            normalizers = {},
+            allowProperty = () => true,
+          } = this.options;
+
+          doc.descendants((node, pos) => {
+            if (!node.isText) return;
+
+            const styleMark = node.marks.find((m) => m.type === textStyleType);
+            if (!styleMark) return;
+
+            const oldAttrs: Record<string, any> = styleMark.attrs ?? {};
+            const newAttrs: Record<string, any> = {};
+
+            for (const [key, rawValue] of Object.entries(oldAttrs)) {
+              if (rawValue == null) continue;
+              const value = String(rawValue);
+
+              if (!allowProperty(key, value)) continue;
+
+              const validator = validators[key];
+              if (validator && !validator(value)) continue;
+
+              const normalizer = normalizers[key];
+              if (normalizer) {
+                const normalized = normalizer(value);
+                if (normalized === null) continue;
+                newAttrs[key] = normalized;
+              } else {
+                newAttrs[key] = rawValue;
+              }
+            }
+
+            const from = pos;
+            const to = pos + node.nodeSize;
+
+            tr.removeMark(from, to, textStyleType);
+
+            if (Object.keys(newAttrs).length > 0) {
+              tr.addMark(from, to, textStyleType.create(newAttrs));
+            }
+          });
+
+          if (tr.steps.length && dispatch) {
+            dispatch(tr);
+          }
+
+          return true;
+        },
+    } as any;
+  },
+});

--- a/desk/src/utils.ts
+++ b/desk/src/utils.ts
@@ -11,6 +11,7 @@ import {
 import { gemoji } from "gemoji";
 import { h, markRaw, ref } from "vue";
 import zod from "zod";
+import LucideBrushCleaning from '~icons/lucide/brush-cleaning'
 import TicketIcon from "./components/icons/TicketIcon.vue";
 import { getMeta } from "./stores/meta";
 import { __ } from "./translation";
@@ -289,6 +290,19 @@ export async function copyToClipboard(
 export const textEditorMenuButtons = [
   "Paragraph",
   ["Heading 2", "Heading 3", "Heading 4", "Heading 5", "Heading 6"],
+    {
+      label: 'Clear formatting',
+      icon: LucideBrushCleaning,
+      action: (editor) => {
+        editor.chain()
+          .focus()
+          .unsetAllMarks()
+          .clearNodes()
+          .cleanStyles()
+          .run()
+      },
+      isActive: () => false,
+    },
   "Separator",
   "Bold",
   "Italic",

--- a/desk/src/utils.ts
+++ b/desk/src/utils.ts
@@ -287,10 +287,7 @@ export async function copyToClipboard(
   toast.success(toastMessage);
 }
 
-export const textEditorMenuButtons = [
-  "Paragraph",
-  ["Heading 2", "Heading 3", "Heading 4", "Heading 5", "Heading 6"],
-    {
+export const ClearFormattingUtility = {
       label: 'Clear formatting',
       icon: LucideBrushCleaning,
       action: (editor) => {
@@ -301,19 +298,22 @@ export const textEditorMenuButtons = [
           .cleanStyles()
           .run()
       },
-      isActive: () => false,
-    },
+      isActive: () => false,  
+}
+
+export const textEditorMenuButtons = [
+  "Paragraph",
+  ["Heading 2", "Heading 3", "Heading 4", "Heading 5", "Heading 6"],
   "Separator",
   "Bold",
   "Italic",
+  "FontColor",
   "Separator",
+  ["Align Left",
+  "Align Center",
+  "Align Right"],
   "Bullet List",
   "Numbered List",
-  "Separator",
-  "Align Left",
-  "Align Center",
-  "Align Right",
-  "FontColor",
   "Separator",
   "Image",
   "Video",
@@ -336,6 +336,9 @@ export const textEditorMenuButtons = [
     "ToggleHeaderCell",
     "DeleteTable",
   ],
+  "Separator",
+  ClearFormattingUtility,
+
 ];
 
 export function isContentEmpty(content: string) {


### PR DESCRIPTION
Implemented a formatting utility in text editors

https://github.com/user-attachments/assets/810faf00-c7a3-4389-82e8-74cdde89ff8a

inspired by the formatting feature in drive


**why**
Support agents constantly paste content from external sources (email, docs, web), which brings in inline styles, classes, and inconsistent markup. As a result, they can use this shortcut to clean up faster.


Other fixes:

- better handling for rtl based inputs in text editor
i.e 
<img width="637" height="452" alt="image" src="https://github.com/user-attachments/assets/be24a805-03c9-4a14-834d-75201e505054" />



- better handling of pre tag

before :
<img width="839" height="276" alt="image" src="https://github.com/user-attachments/assets/9fa0320f-582f-40b6-b49d-7eec21fb38fd" />

after:
<img width="839" height="276" alt="image" src="https://github.com/user-attachments/assets/5526bc6c-be8e-45ef-bff0-bdae2fad57ba" />



