### PR TITLE
Allow only a group of agents to have a assign permission

### DIFF
--- a/desk/src/components/ticket-agent/AssignTo.vue
+++ b/desk/src/components/ticket-agent/AssignTo.vue
@@ -1,4 +1,5 @@
 <template>
+  <template v-if="canAssign">
   <Popover class="flex w-full" placement="bottom-end">
     <template #target="{ open, close, togglePopover }">
       <div class="flex flex-col gap-1.5 w-full">
@@ -47,19 +48,39 @@
       />
     </template>
   </Popover>
+  </template>
+  <template v-else>
+    <div class="flex flex-col gap-1.5 w-full">
+      <span class="block text-xs text-gray-600">{{ __("Assignee") }}</span>
+      <div class="text-sm text-ink-gray-6 py-1 px-1">
+        <span v-if="assignees.data?.length">
+          {{ assignees.data.map((a) => a.name).join(", ") }}
+        </span>
+        <span v-else class="text-ink-gray-4">{{ __("No assignees") }}</span>
+      </div>
+    </div>
+  </template>
 </template>
 
 <script setup lang="ts">
 import { useShortcut } from "@/composables/shortcuts";
 import { ActivitiesSymbol, AssigneeSymbol, TicketSymbol } from "@/types";
 import { Popover } from "frappe-ui";
-import { inject, useTemplateRef } from "vue";
+import { computed, inject, useTemplateRef } from "vue";
+import { createResource } from "frappe-ui";
 import LucideChevronDown from "~icons/lucide/chevron-down";
 import MultipleAvatar from "../MultipleAvatar.vue";
 import AssignToBody from "./AssignToBody.vue";
 const ticket = inject(TicketSymbol);
 const assignees = inject(AssigneeSymbol);
 const activities = inject(ActivitiesSymbol);
+
+const assignPermission = createResource({
+  url: "helpdesk.api.doc.can_assign_ticket",
+  auto: true,
+});
+
+const canAssign = computed(() => assignPermission.data === true);
 async function saveAssignees(
   addedAssignees,
   removedAssignees,

--- a/helpdesk/api/doc.py
+++ b/helpdesk/api/doc.py
@@ -521,12 +521,7 @@ def handle_at_me_support(filters):
 
 
 @frappe.whitelist()
-def remove_assignments(
-    doctype: str,
-    name: str | int,
-    assignees: list[str],
-    ignore_permissions: bool = False,
-):
+def remove_assignments(doctype, name, assignees, ignore_permissions=False):
     if not can_assign_ticket():
         frappe.throw("You are not allowed to modify ticket assignments")
     assignees = frappe.parse_json(assignees)

--- a/helpdesk/api/doc.py
+++ b/helpdesk/api/doc.py
@@ -521,7 +521,14 @@ def handle_at_me_support(filters):
 
 
 @frappe.whitelist()
-def remove_assignments(doctype, name, assignees, ignore_permissions=False):
+def remove_assignments(
+    doctype: str,
+    name: str | int,
+    assignees: list[str],
+    ignore_permissions: bool = False,
+):
+    if not can_assign_ticket():
+        frappe.throw("You are not allowed to modify ticket assignments")
     assignees = frappe.parse_json(assignees)
 
     if not assignees:
@@ -536,3 +543,12 @@ def remove_assignments(doctype, name, assignees, ignore_permissions=False):
             status="Cancelled",
             ignore_permissions=ignore_permissions,
         )
+
+@frappe.whitelist()
+def can_assign_ticket():
+    roles = frappe.get_roles(frappe.session.user)
+    return (
+        "Ticket Assigner" in roles
+        or "Agent Manager" in roles
+        or "System Manager" in roles
+    )


### PR DESCRIPTION
Currently, any user can assign or remove assignees from a ticket.
There is no restriction based on roles.

This can cause issues because:

Unauthorized users can change ticket assignments
No proper control over who can manage tickets

For that i came up with the solution:

I added a role-based check to control ticket assignment.

Backend
Created a method can_assign_ticket() to check user roles
Allowed roles:
Ticket Assigner
Agent Manager
System Manager
Added validation in remove_assignments:
If user does not have permission → throw error
Frontend
Updated AssignTo.vue
If user has permission:
Show assign UI
If not:
Show assignee list as read-only

#issue https://github.com/frappe/helpdesk/issues/2488