### PR TITLE
fix: handle missing headers in email threading

### DIFF
--- a/helpdesk/overrides/email_account.py
+++ b/helpdesk/overrides/email_account.py
@@ -13,8 +13,7 @@ class CustomInboundMail(InboundMail):
     """
     Extend InboundMail with robust thread stitching for forwarded emails.
        1. Run the standard Frappe parent_communication lookups first (In-Reply-To → Communication, EmailQueue, communication-name fallback)
-       2. If no parent found, probe In-Reply-To against EmailQueue directly (catches replies to agent-sent emails when site name != email domain)
-       3. If still no parent, use the References header from emails, which may contain multiple message IDs in a thread
+       2. If still no parent, use the References header from emails, which may contain multiple message IDs in a thread
     """
 
     def _find_communication_by_message_id(self, msg_id: str):
@@ -38,29 +37,22 @@ class CustomInboundMail(InboundMail):
         if self._parent_communication is not None:
             return self._parent_communication
 
-        # Run the standard Frappe lookups first (In-Reply-To → Communication,
-        # EmailQueue, communication-name fallback)
+        # Run the standard Frappe lookup method first. Checks for finding in reply to in Communication then if not found it looks in EmailQueue
         result = super().parent_communication()
         if result:
             return result
 
-        # set parent communication to empty string if no parent found, to avoid repeated lookups on subsequent calls
-        self._parent_communication = None
+        # fallback: use the References header from emails
+        references_raw = self.mail.get("References") or ""
+        ref_ids = re.findall(r"<([^>]+)>", references_raw)
 
-        # fallback 1: compare In-Reply-To against sent emails in EmailQueue directly
-        communication = self._find_communication_by_message_id(self.in_reply_to)
+        for ref_id in reversed(ref_ids):
+            communication = self._find_communication_by_message_id(ref_id)
+            if communication:
+                self._parent_communication = communication
+                return self._parent_communication
 
-        # fallback 2: use the References header from emails
-        if not communication:
-            references_raw = self.mail.get("References") or ""
-            ref_ids = re.findall(r"<([^>]+)>", references_raw)
-
-            for ref_id in reversed(ref_ids):
-                communication = self._find_communication_by_message_id(ref_id)
-                if communication:
-                    break
-
-        self._parent_communication = communication or ""
+        self._parent_communication = ""
         return self._parent_communication
 
 

--- a/helpdesk/overrides/email_account.py
+++ b/helpdesk/overrides/email_account.py
@@ -1,9 +1,67 @@
+import re
 from email import message_from_string
 
 import frappe
 from frappe import _
+from frappe.core.doctype.communication.communication import Communication
 from frappe.email.doctype.email_account.email_account import EmailAccount
+from frappe.email.doctype.email_queue.email_queue import EmailQueue
 from frappe.email.receive import InboundMail
+
+
+class CustomInboundMail(InboundMail):
+    """
+    Extend InboundMail with robust thread stitching for forwarded emails.
+       1. Run the standard Frappe parent_communication lookups first (In-Reply-To → Communication, EmailQueue, communication-name fallback)
+       2. If no parent found, probe In-Reply-To against EmailQueue directly (catches replies to agent-sent emails when site name != email domain)
+       3. If still no parent, use the References header from emails, which may contain multiple message IDs in a thread
+    """
+
+    def _find_communication_by_message_id(self, msg_id: str):
+        """Return a Communication for msg_id, checking both Communication and EmailQueue."""
+        # Direct hit: incoming email stored its message_id on Communication
+        comm = Communication.find_one_by_filters(
+            message_id=msg_id, order_by="creation DESC"
+        )
+        if comm:
+            return comm
+
+        # Outgoing email: message_id lives in EmailQueue, not on Communication
+        eq = EmailQueue.find_one_by_filters(message_id=msg_id)
+        if eq and eq.communication:
+            return Communication.find(eq.communication, ignore_error=True) or None
+
+        return None
+
+    def parent_communication(self):
+        # Respect cached result from any prior call on this instance
+        if self._parent_communication is not None:
+            return self._parent_communication
+
+        # Run the standard Frappe lookups first (In-Reply-To → Communication,
+        # EmailQueue, communication-name fallback)
+        result = super().parent_communication()
+        if result:
+            return result
+
+        # set parent communication to empty string if no parent found, to avoid repeated lookups on subsequent calls
+        self._parent_communication = None
+
+        # fallback 1: compare In-Reply-To against sent emails in EmailQueue directly
+        communication = self._find_communication_by_message_id(self.in_reply_to)
+
+        # fallback 2: use the References header from emails
+        if not communication:
+            references_raw = self.mail.get("References") or ""
+            ref_ids = re.findall(r"<([^>]+)>", references_raw)
+
+            for ref_id in reversed(ref_ids):
+                communication = self._find_communication_by_message_id(ref_id)
+                if communication:
+                    break
+
+        self._parent_communication = communication or ""
+        return self._parent_communication
 
 
 class CustomEmailAccount(EmailAccount):
@@ -29,7 +87,7 @@ class CustomEmailAccount(EmailAccount):
                     )
                     seen_status = messages.get("seen_status", {}).get(uid)
                     if self.email_sync_option != "UNSEEN" or seen_status != "SEEN":
-                        _inbound_mail = InboundMail(
+                        _inbound_mail = CustomInboundMail(
                             message,
                             self,
                             frappe.safe_decode(uid),


### PR DESCRIPTION
Issue with email threading faced when mails were forwarded or source of tickets originating from hd.


### breaking scenario

1. User A creates a ticket on helpdesk. 
2. mail is sent to the recipient who is user B (in reply to maybe message id of site i.e <177563189722.57091.7819083472139080506@helpdesk.fin> ).
3. User B forwards the mail or replies (without including User A)  to a member of his team lets say User C
4. User C replies to user A (headers missing because our threading system mainly works on comparing communications created) system of user A has no context of this communication, as it happened completely outside
5. User A with their mail connected to HD receives the reply to the forwarded mail, but it creates a new ticket (bug)

### So the real issues are:
- Forwarded emails lose the In-Reply-To header entirely
- Missing/unique message IDs in certain communications or mails mean no parent communication is found, thus system thinks it's a new ticket

We heavily resort to communication names for linking of tickets in the framework, when communications weren't properly linked, or there was some missing data in the email headers, it led to creating a new ticket, which is not intended, as it should be in the same ticket thread.


For more context
<img width="1142" height="470" alt="image" src="https://github.com/user-attachments/assets/70fa90b9-8d8d-4b4d-897c-a15c0aeda27c" />



solution:

6:57 PMAdding fallbacks for ticket thread linking by overriding Frappe's inbound mail processing to use the References header when In-Reply-To is missing or unresolvable

what is the References header?

> References header is created when a user replies to or forwards an email, allowing email clients to thread messages together. It is generated by the sender's email client, which copies the original message's Message-ID and appends it to the new message

if you click on see original or view the mail in .eml format  you get the references displayed  (present in mails that have been forwarded or replied to)

<img width="1071" height="92" alt="image" src="https://github.com/user-attachments/assets/12179ebc-3eec-469b-b366-6db8e9496688" />

So this basically this has a chain of history of message IDs


```
        references_raw = self.mail.get("References") or ""
        ref_ids = re.findall(r"<([^>]+)>", references_raw)

        for ref_id in reversed(ref_ids):
            communication = self._find_communication_by_message_id(ref_id)
            if communication:
                self._parent_communication = communication
                return self._parent_communication

```
the regex pattern finds all message IDs present in the References Header. 

We search within communications for matching a message ID by iterating them in reverse, as the newest message_id is appended at the end. 


Helper to replicate searching of message_id's in communication and email queue

```
    def _find_communication_by_message_id(self, msg_id: str):
        """Return a Communication for msg_id, checking both Communication and EmailQueue."""
        comm = Communication.find_one_by_filters(
            message_id=msg_id, order_by="creation DESC"
        )
        if comm:
            return comm

        eq = EmailQueue.find_one_by_filters(message_id=msg_id)
        if eq and eq.communication:
            return Communication.find(eq.communication, ignore_error=True) or None

        return None
```

When the relevant match is found it is returned as the parent_communication and threading is maintained

