### PR TITLE
fix: test isolation and override in_test bypass for security checks

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_agent/test_hd_agent.py
+++ b/helpdesk/helpdesk/doctype/hd_agent/test_hd_agent.py
@@ -20,11 +20,24 @@ class TestHDAgent(FrappeTestCase):
                     "send_welcome_email": 0,
                 }
             ).insert(ignore_permissions=True)
+        else:
+            frappe.get_doc("User", self.test_user)
+            
+        frappe.get_doc("User", self.test_user).remove_roles("System Manager", "Agent Manager")
+            
+    def tearDown(self):
+        frappe.set_user("Administrator")
+        frappe.delete_doc("User", self.test_user, force=True, ignore_missing=True)
 
     def test_unauthorized_role_update(self):
         frappe.set_user(self.test_user)
+        
+        frappe.flags.in_test = False
 
-        with self.assertRaises(frappe.PermissionError):
-            update_agent_role(self.test_user, "System Manager")
+        try:
+            with self.assertRaises(frappe.PermissionError):
+                update_agent_role(self.test_user, "System Manager")
+        finally:
+            frappe.flags.in_test = True
 
         frappe.set_user("Administrator")

--- a/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
@@ -633,11 +633,6 @@ class TestHDTicket(FrappeTestCase):
             ticket2_doc.name,
         )
 
-    def tearDown(self):
-        remove_holidays()
-        frappe.db.set_single_value("HD Settings", "default_ticket_status", "Open")
-        frappe.delete_doc("HD Ticket Status", "New", force=True)
-
     def test_ticket_inside_working_hours(self):
         inside_working_hour = get_current_week_monday(hours=14)
         with self.freeze_time(inside_working_hour):
@@ -710,6 +705,7 @@ class TestHDTicket(FrappeTestCase):
             self.assertFalse(banner_shown)
 
     def tearDown(self):
+        frappe.set_user("Administrator")
         remove_holidays()
         frappe.db.set_single_value("HD Settings", "default_ticket_status", "Open")
         frappe.delete_doc("HD Ticket Status", "New", force=True)


### PR DESCRIPTION
### Summary
This PR fixes the CI failures in the #3198 backport by addressing two specific issues found in the older branch's test scaffolding:

1. **State Isolation:** Moved the `Administrator` user reset and dummy user cleanup to `tearDown`. Previously, if a security test failed/crashed, the reset line was skipped, leaving the runner logged in as a standard user. This "poisoned" the state for all 48 subsequent tests, causing cascading `PermissionError` failures.
2. **Framework Bypass:** In this branch's Frappe version, `frappe.only_for` is bypassed if `frappe.flags.in_test` is true. I've added a temporary override in `test_unauthorized_role_update` to ensure the security logic is actually executed and verified.

[context](https://github.com/frappe/helpdesk/pull/3198#issuecomment-4238491886)

