### PR TITLE
fix: restrict Helpdesk app visibility by role

### DIFF
--- a/helpdesk/api/permission.py
+++ b/helpdesk/api/permission.py
@@ -1,15 +1,12 @@
 import frappe
 
 
+ALLOWED_APP_ROLES = {"Agent", "Agent Manager", "System Manager"}
+
+
 def has_app_permission():
     """Check if the user has permission to access the app."""
     if frappe.session.user == "Administrator":
         return True
 
-    roles = frappe.get_roles()
-    helpdesk_roles = ["Agent"]
-    if any(role in roles for role in helpdesk_roles):
-        return True
-
-    # TODO: Check for Customer permission once the role is added
-    return True
+    return bool(ALLOWED_APP_ROLES.intersection(frappe.get_roles()))

--- a/helpdesk/api/permission.py
+++ b/helpdesk/api/permission.py
@@ -1,6 +1,5 @@
 import frappe
 
-
 ALLOWED_APP_ROLES = {"Agent", "Agent Manager", "System Manager"}
 
 

--- a/helpdesk/api/test_permission.py
+++ b/helpdesk/api/test_permission.py
@@ -1,0 +1,54 @@
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from helpdesk.api.permission import has_app_permission
+from helpdesk.test_utils import create_agent
+
+
+class TestPermission(FrappeTestCase):
+    website_user = "helpdesk-website-user@example.com"
+    manager_user = "helpdesk-manager@example.com"
+    original_user = None
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.original_user = frappe.session.user
+
+    def tearDown(self):
+        frappe.set_user(self.original_user or "Administrator")
+
+    def test_agent_can_access_helpdesk_app(self):
+        create_agent("helpdesk-agent@example.com")
+
+        frappe.set_user("helpdesk-agent@example.com")
+
+        self.assertTrue(has_app_permission())
+
+    def test_agent_manager_can_access_helpdesk_app(self):
+        user = self._get_or_create_user(self.manager_user)
+        user.add_roles("Agent Manager")
+
+        frappe.set_user(self.manager_user)
+
+        self.assertTrue(has_app_permission())
+
+    def test_regular_website_user_cannot_access_helpdesk_app(self):
+        self._get_or_create_user(self.website_user)
+
+        frappe.set_user(self.website_user)
+
+        self.assertFalse(has_app_permission())
+
+    def _get_or_create_user(self, email):
+        if frappe.db.exists("User", email):
+            return frappe.get_doc("User", email)
+
+        return frappe.get_doc(
+            {
+                "doctype": "User",
+                "email": email,
+                "first_name": email.split("@")[0],
+                "send_welcome_email": 0,
+            }
+        ).insert(ignore_permissions=True)


### PR DESCRIPTION
## Summary
- restrict Helpdesk app visibility to internal Helpdesk roles
- stop returning app access for every logged-in user
- add tests for agent, agent manager, and regular website users

## Why
`helpdesk.api.permission.has_app_permission()` currently falls through to `return True`, which exposes Helpdesk to all users. For website users this makes `get_default_path()` resolve to `/helpdesk`, overriding role-based home pages like `/customer/home`.