### PR TITLE
fix: use v-show instead of v-if

### DIFF
--- a/desk/src/components/CommunicationArea.vue
+++ b/desk/src/components/CommunicationArea.vue
@@ -30,7 +30,7 @@
     </div>
     <Transition name="slide">
       <div
-        v-if="showEmailBox"
+        v-show="showEmailBox"
         ref="emailBoxRef"
         @keydown.ctrl.enter.capture.stop="submitEmail"
         @keydown.meta.enter.capture.stop="submitEmail"
@@ -65,7 +65,7 @@
     </Transition>
     <Transition name="slide">
       <div
-        v-if="showCommentBox"
+        v-show="showCommentBox"
         ref="commentBoxRef"
         @keydown.ctrl.enter.capture.stop="submitComment"
         @keydown.meta.enter.capture.stop="submitComment"

--- a/desk/src/components/ticket-agent/TicketActivityPanel.vue
+++ b/desk/src/components/ticket-agent/TicketActivityPanel.vue
@@ -14,13 +14,13 @@
         :ticket-status="ticket.doc.status"
         @email:reply="
           (e) => {
-            communicationAreaRef.replyToEmail(e);
+            communicationAreaRef?.replyToEmail(e);
           }
         "
         @update="
           () => {
             activities.reload();
-            ticketAgentActivitiesRef.scrollToLatestActivity();
+            ticketAgentActivitiesRef?.scrollToLatestActivity();
           }
         "
       />
@@ -41,7 +41,7 @@
     @update="
       () => {
         activities.reload();
-        ticketAgentActivitiesRef.scrollToLatestActivity();
+        ticketAgentActivitiesRef?.scrollToLatestActivity();
       }
     "
   />
@@ -67,12 +67,17 @@ import {
 import { Button, Tabs } from "frappe-ui";
 import { storeToRefs } from "pinia";
 import { computed, ComputedRef, inject, ref } from "vue";
+import { TicketAgentActivities } from "../ticket";
 
 const ticket = inject(TicketSymbol)!;
 const activities = inject(ActivitiesSymbol)!;
 
-const ticketAgentActivitiesRef = ref(null);
-const communicationAreaRef = ref(null);
+const ticketAgentActivitiesRef = ref<InstanceType<
+  typeof TicketAgentActivities
+> | null>(null);
+const communicationAreaRef = ref<InstanceType<typeof CommunicationArea> | null>(
+  null
+);
 const telephonyStore = useTelephonyStore();
 const { isCallingEnabled } = storeToRefs(telephonyStore);
 


### PR DESCRIPTION
The Reply and Comment text editor, breaks with v-if.

Because as soon as the reply is sent we emit @submit event which closes the editor which then removes the editor's existence from the DOM, hence preventing state change.


depends-on: https://github.com/frappe/helpdesk/pull/3224