### PR TITLE
fix: hide onboarding banner and popup after onboarding is completed

### DIFF
--- a/desk/src/components/layouts/Sidebar.vue
+++ b/desk/src/components/layouts/Sidebar.vue
@@ -401,7 +401,7 @@ const logo = h(
   null
 );
 
-const canShowOnboarding = ref(true);
+const canShowOnboarding = ref(false);
 
 const showOnboardingBanner = computed(() => {
   return (
@@ -621,7 +621,7 @@ const articles = ref([
 const showIntermediateModal = ref(false);
 const currentStep = ref({});
 
-const { isOnboardingStepsCompleted, setUp, updateOnboardingStep } =
+const { isOnboardingStepsCompleted, setUp, updateOnboardingStep, skipAll } =
   useOnboarding("helpdesk");
 
 async function handleFirstTicketNavigation() {
@@ -664,8 +664,11 @@ async function setUpOnboarding() {
   } catch {
     canShowOnboarding.value = true;
   }
-  if (!canShowOnboarding.value) return;
   setUp(steps);
+  if (!canShowOnboarding.value) {
+    skipAll();
+    return;
+  }
   useShortcut({ key: "h", meta: true }, () => {
     showHelpModal.value = !showHelpModal.value;
   });

--- a/desk/src/components/layouts/Sidebar.vue
+++ b/desk/src/components/layouts/Sidebar.vue
@@ -401,11 +401,14 @@ const logo = h(
   null
 );
 
+const canShowOnboarding = ref(true);
+
 const showOnboardingBanner = computed(() => {
   return (
     !isCustomerPortal.value &&
     !isOnboardingStepsCompleted.value &&
-    authStore.isManager
+    authStore.isManager &&
+    canShowOnboarding.value
   );
 });
 
@@ -652,8 +655,16 @@ async function getGeneralCategory() {
   return generalCategory;
 }
 
-function setUpOnboarding() {
+async function setUpOnboarding() {
   if (!authStore.isManager) return;
+  try {
+    canShowOnboarding.value = await call(
+      "helpdesk.api.onboarding.should_show_onboarding"
+    );
+  } catch {
+    canShowOnboarding.value = true;
+  }
+  if (!canShowOnboarding.value) return;
   setUp(steps);
   useShortcut({ key: "h", meta: true }, () => {
     showHelpModal.value = !showHelpModal.value;

--- a/helpdesk/api/onboarding.py
+++ b/helpdesk/api/onboarding.py
@@ -1,10 +1,6 @@
 import frappe
 from frappe.utils import add_days, get_datetime, now_datetime
 
-# Hide the onboarding popup once user is familiar with product
-ONBOARDING_TICKET_THRESHOLD = 50
-ONBOARDING_AGE_DAYS = 30
-
 
 @frappe.whitelist()
 def should_show_onboarding() -> bool:
@@ -19,12 +15,22 @@ def should_show_onboarding() -> bool:
     ``useOnboarding("helpdesk").isOnboardingStepsCompleted``, so it's not
     re-checked here.
     """
+
+    settings = frappe.db.get_value(
+        "HD Settings",
+        "HD Settings",
+        ["ticket_count_limit", "user_age_limit"],
+        as_dict=True,
+    )
+
+    ticket_threshold = settings.ticket_count_limit or 50
+    age_days = settings.user_age_limit or 30
     ticket_count = frappe.db.count("HD Ticket")
-    count_condition = ticket_count > ONBOARDING_TICKET_THRESHOLD
+    count_condition = ticket_count > ticket_threshold
 
     user_creation = frappe.db.get_value("User", frappe.session.user, "creation")
     user_age_condition = user_creation and get_datetime(user_creation) < add_days(
-        now_datetime(), -ONBOARDING_AGE_DAYS
+        now_datetime(), -age_days
     )
     if count_condition and user_age_condition:
         return False

--- a/helpdesk/api/onboarding.py
+++ b/helpdesk/api/onboarding.py
@@ -2,7 +2,7 @@ import frappe
 from frappe.utils import add_days, get_datetime, now_datetime
 
 # Hide the onboarding popup once user is familiar with product
-ONBOARDING_TICKET_THRESHOLD = 100
+ONBOARDING_TICKET_THRESHOLD = 50
 ONBOARDING_AGE_DAYS = 30
 
 
@@ -12,7 +12,7 @@ def should_show_onboarding() -> bool:
     Decide whether the onboarding banner + auto-popup should still be shown.
 
     Returns False when:
-      - there are more than ``ONBOARDING_TICKET_THRESHOLD`` tickets, or
+      - there are more than ``ONBOARDING_TICKET_THRESHOLD`` tickets, and
       - the current user's account is older than ``ONBOARDING_AGE_DAYS`` days.
 
     Step completion is already tracked on the client via
@@ -20,15 +20,14 @@ def should_show_onboarding() -> bool:
     re-checked here.
     """
     ticket_count = frappe.db.count("HD Ticket")
-    if ticket_count > ONBOARDING_TICKET_THRESHOLD:
-        return False
+    count_condition = ticket_count > ONBOARDING_TICKET_THRESHOLD
 
     user_creation = frappe.db.get_value("User", frappe.session.user, "creation")
-    if user_creation and get_datetime(user_creation) < add_days(
+    user_age_condition = user_creation and get_datetime(user_creation) < add_days(
         now_datetime(), -ONBOARDING_AGE_DAYS
-    ):
+    )
+    if count_condition and user_age_condition:
         return False
-
     return True
 
 

--- a/helpdesk/api/onboarding.py
+++ b/helpdesk/api/onboarding.py
@@ -16,25 +16,21 @@ def should_show_onboarding() -> bool:
     re-checked here.
     """
 
-    settings = frappe.db.get_value(
-        "HD Settings",
-        "HD Settings",
-        ["ticket_count_limit", "user_age_limit"],
-        as_dict=True,
-    )
+    ticket_count_limit = frappe.db.get_single_value("HD Settings", "ticket_count_limit")
+    user_age_limit = frappe.db.get_single_value("HD Settings", "user_age_limit")
 
-    ticket_threshold = settings.ticket_count_limit or 50
-    age_days = settings.user_age_limit or 30
+    ticket_threshold = ticket_count_limit or 50
+    age_days = user_age_limit or 30
     ticket_count = frappe.db.count("HD Ticket")
     count_condition = ticket_count > ticket_threshold
 
     user_creation = frappe.db.get_value("User", frappe.session.user, "creation")
-    user_age_condition = user_creation and get_datetime(user_creation) < add_days(
-        now_datetime(), -age_days
-    )
-    if count_condition and user_age_condition:
-        return False
-    return True
+    user_age_condition = False
+    if user_age_condition:
+        user_age_condition = user_creation and get_datetime(user_creation) < add_days(
+            now_datetime(), -age_days
+        )
+    return not (count_condition and user_age_condition)
 
 
 @frappe.whitelist()

--- a/helpdesk/api/onboarding.py
+++ b/helpdesk/api/onboarding.py
@@ -1,4 +1,35 @@
 import frappe
+from frappe.utils import add_days, get_datetime, now_datetime
+
+# Hide the onboarding popup once user is familiar with product
+ONBOARDING_TICKET_THRESHOLD = 100
+ONBOARDING_AGE_DAYS = 30
+
+
+@frappe.whitelist()
+def should_show_onboarding() -> bool:
+    """
+    Decide whether the onboarding banner + auto-popup should still be shown.
+
+    Returns False when:
+      - there are more than ``ONBOARDING_TICKET_THRESHOLD`` tickets, or
+      - the current user's account is older than ``ONBOARDING_AGE_DAYS`` days.
+
+    Step completion is already tracked on the client via
+    ``useOnboarding("helpdesk").isOnboardingStepsCompleted``, so it's not
+    re-checked here.
+    """
+    ticket_count = frappe.db.count("HD Ticket")
+    if ticket_count > ONBOARDING_TICKET_THRESHOLD:
+        return False
+
+    user_creation = frappe.db.get_value("User", frappe.session.user, "creation")
+    if user_creation and get_datetime(user_creation) < add_days(
+        now_datetime(), -ONBOARDING_AGE_DAYS
+    ):
+        return False
+
+    return True
 
 
 @frappe.whitelist()

--- a/helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+++ b/helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -58,6 +58,9 @@
   "setup_complete",
   "initial_helpdesk_name_setup_skipped",
   "column_break_hjfh",
+  "onboarding_section",
+  "ticket_count_limit",
+  "user_age_limit",
   "search_tab",
   "name_weight",
   "subject_weight",
@@ -504,12 +507,27 @@
    "fieldname": "enable_outside_hours_banner",
    "fieldtype": "Check",
    "label": "Apply outside working hours"
+  },
+  {
+   "fieldname": "onboarding_section",
+   "fieldtype": "Section Break",
+   "label": "Onboarding"
+  },
+  {
+   "fieldname": "ticket_count_limit",
+   "fieldtype": "Int",
+   "label": "Ticket Count"
+  },
+  {
+   "fieldname": "user_age_limit",
+   "fieldtype": "Int",
+   "label": "User Age"
   }
  ],
  "grid_page_length": 50,
  "issingle": 1,
  "links": [],
- "modified": "2026-01-23 18:30:40.906948",
+ "modified": "2026-04-25 23:16:57.680550",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Settings",


### PR DESCRIPTION
the Help Center banner is always visible in the menu even after user is familiar with the product which is sometimes annoying

<img width="464" height="815" alt="image" src="https://github.com/user-attachments/assets/cb1800d2-7222-409b-944b-3c191bfe5519" />

this pr aims to fix that
