### PR TITLE
fix: add saved replies before signature and fix cursor position

### DIFF
--- a/desk/src/components/EmailEditor.vue
+++ b/desk/src/components/EmailEditor.vue
@@ -422,14 +422,20 @@ async function removeAttachment(attachment) {
 
 const showSavedRepliesSelectorModal = ref(false);
 
+// function applySavedReplies(template: string) {
+//   isContentEmpty(newEmail.value)
+//     ? (newEmail.value = template)
+//     : (newEmail.value =  template + newEmail.value);
+//   newEmail.value += "<p></p>";
+//   nextTick(() => {
+//     editorRef.value?.editor?.commands?.focus("end");
+//   });
+// }
+
 function applySavedReplies(template: string) {
-  isContentEmpty(newEmail.value)
-    ? (newEmail.value = template)
-    : (newEmail.value = newEmail.value + "\n" + template);
-  newEmail.value += "<p></p>";
-  nextTick(() => {
-    editorRef.value?.editor?.commands?.focus("end");
-  });
+  const textEditor = editorRef.value?.editor;
+  if (!textEditor) return;
+  textEditor.chain().focus("start").insertContent(template).run();
 }
 
 const sendMail = createResource({
@@ -485,6 +491,10 @@ function submitMail() {
   sendMail.submit();
 }
 
+function getInitialContent() {
+  return emailSignature.value ? emailSignature.value : "<p></p>";
+}
+
 function addToReply(
   body: string,
   toEmails: string[],
@@ -505,9 +515,7 @@ function addToReply(
   }
 
   nextTick(() => {
-    newEmail.value = emailSignature.value
-      ? emailSignature.value
-      : editorRef.value.editor.getHTML();
+    newEmail.value = getInitialContent();
   });
   focusEditorAtStart();
 }
@@ -522,7 +530,7 @@ function resetState() {
 
 function handleDiscard() {
   attachments.value = [];
-  newEmail.value = emailSignature.value ? emailSignature.value : null;
+  newEmail.value = getInitialContent();
   quotedContent.value = null;
   ccEmailsClone.value = [];
   bccEmailsClone.value = [];
@@ -595,6 +603,12 @@ function handleKeydown(e: KeyboardEvent) {
     return;
   }
 }
+
+watch(emailSignature, (sig) => {
+  if (sig && isContentEmpty(newEmail.value)) {
+    newEmail.value = sig;
+  }
+});
 
 onBeforeUnmount(() => {
   cleanup();

--- a/desk/src/components/EmailEditor.vue
+++ b/desk/src/components/EmailEditor.vue
@@ -422,16 +422,6 @@ async function removeAttachment(attachment) {
 
 const showSavedRepliesSelectorModal = ref(false);
 
-// function applySavedReplies(template: string) {
-//   isContentEmpty(newEmail.value)
-//     ? (newEmail.value = template)
-//     : (newEmail.value =  template + newEmail.value);
-//   newEmail.value += "<p></p>";
-//   nextTick(() => {
-//     editorRef.value?.editor?.commands?.focus("end");
-//   });
-// }
-
 function applySavedReplies(template: string) {
   const textEditor = editorRef.value?.editor;
   if (!textEditor) return;


### PR DESCRIPTION
Templates were being added after the signature.

Fixed the UX of cursor landing after the injected template ends.

This pr fixes these issues
depends-on: https://github.com/frappe/helpdesk/pull/3188