### PR TITLE
fix: add message in field allow reply via contact to show ticket message

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_settings/helpers.py
+++ b/helpdesk/helpdesk/doctype/hd_settings/helpers.py
@@ -37,7 +37,19 @@ def get_default_email_content(type: str) -> str:
   <p><strong>Subject:</strong> {{ doc.subject }}</p>
   <p><strong>Raised By:</strong> {{ doc.raised_by }}</p>
   <p><strong>Priority:</strong> {{ doc.priority }}</p>
-
+   <div style="margin-bottom: 10px">
+    <h3 style="margin-bottom: 20px">Message</h3>
+    <div
+      style="
+        background: #f3f5f8;
+        padding: 10px;
+        border-radius: 4px;
+        border: 1px solid #e5e9ee;
+      "
+    >
+      {{ message }}
+    </div>
+  </div>
   <br />
   <p>
     You can view and respond to this ticket by

--- a/helpdesk/helpdesk/doctype/hd_settings/helpers.py
+++ b/helpdesk/helpdesk/doctype/hd_settings/helpers.py
@@ -38,7 +38,7 @@ def get_default_email_content(type: str) -> str:
   <p><strong>Raised By:</strong> {{ doc.raised_by }}</p>
   <p><strong>Priority:</strong> {{ doc.priority }}</p>
    <div style="margin-bottom: 10px">
-    <h3 style="margin-bottom: 20px">Message</h3>
+    <p style="margin-bottom: 20px">Message</p>
     <div
       style="
         background: #f3f5f8;

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -694,7 +694,7 @@ class HDTicket(Document):
             "HD Settings", "enable_reply_email_to_agent"
         ):
             # send email to assigned agents
-            self.send_reply_email_to_agent()
+            self.send_reply_email_to_agent(message)
 
         # if self.status_category == "Paused" and not new_ticket:
         if not new_ticket:
@@ -754,7 +754,9 @@ class HDTicket(Document):
                 doc.attached_to_name = self.name
                 doc.save()
 
-    def send_reply_email_to_agent(self):
+    def send_reply_email_to_agent(
+        self, message: str = "Please check the latest update on the portal."
+    ):
         assigned_agents = self.get_assigned_agents()
         if not assigned_agents:
             return
@@ -775,7 +777,8 @@ class HDTicket(Document):
                     {
                         "ticket_url": frappe.utils.get_url(
                             "/helpdesk/tickets/" + str(self.name)
-                        )
+                        ),
+                        "message": message,
                     },
                 ),
                 reference_doctype="HD Ticket",


### PR DESCRIPTION
<img width="658" height="419" alt="image" src="https://github.com/user-attachments/assets/4546f8d2-335a-4866-b422-91c015295ef1" />

Problem
When a customer replied to a ticket, the email notification dispatched to assigned agents was missing the ticket subject. As a result the agent always had to open the ticket to view the content of the reply thus adding an extra step in their workflow.

this pr fixes it
<img width="708" height="462" alt="image" src="https://github.com/user-attachments/assets/c10e45a6-1bec-45a1-9193-c362c0d0f831" />

docs: http://docs.frappe.io/helpdesk/email-notifications#reply-from-contact