### PR TITLE
fix: keep image size intact in customer portal

### DIFF
--- a/desk/src/pages/ticket/TicketCommunication.vue
+++ b/desk/src/pages/ticket/TicketCommunication.vue
@@ -60,7 +60,7 @@ function sanitize(html: string) {
     allowedAttributes: {
       a: ["href"],
       video: ["src", "controls"],
-      img: ["src"],
+      img: ["src", "width", "height"],
       table: ["border", "cellpadding", "cellspacing", "width", "data-type"],
       td: ["colspan", "rowspan", "width", "align", "valign"],
       th: ["colspan", "rowspan", "width", "align", "valign"],


### PR DESCRIPTION
Images in customer portal lose their attributes as we santize them thus appearing larger than sizes

This pr changes the sanitize function so it retains its Heigh and Width

depends-on: https://github.com/frappe/helpdesk/pull/3188