### PR TITLE
fix: add disabled field in ticket priority

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_saved_reply/test_hd_saved_reply.py
+++ b/helpdesk/helpdesk/doctype/hd_saved_reply/test_hd_saved_reply.py
@@ -4,6 +4,8 @@
 import frappe
 from frappe.tests import IntegrationTestCase
 
+from helpdesk.test_utils import make_team
+
 # Test user emails
 AGENT1 = "saved_reply_agent1@test.com"
 AGENT2 = "saved_reply_agent2@test.com"
@@ -46,38 +48,6 @@ def make_agent(user_email):
     )
     agent.insert(ignore_permissions=True)
     return agent
-
-
-def make_team(team_name, members=None):
-    """Create an HD Team with optional members."""
-    if frappe.db.exists("HD Team", team_name):
-        # Delete existing team members
-        frappe.db.delete("HD Team Member", {"parent": team_name})
-        # Add new members directly to DB
-        if members:
-            for idx, member in enumerate(members):
-                frappe.get_doc(
-                    {
-                        "doctype": "HD Team Member",
-                        "parent": team_name,
-                        "parenttype": "HD Team",
-                        "parentfield": "users",
-                        "user": member,
-                        "idx": idx + 1,
-                    }
-                ).db_insert()
-        return frappe.get_doc("HD Team", team_name)
-
-    # Create new team - this will trigger after_insert which creates assignment rule
-    team = frappe.get_doc(
-        {
-            "doctype": "HD Team",
-            "team_name": team_name,
-            "users": [{"user": m} for m in (members or [])],
-        }
-    )
-    team.insert(ignore_permissions=True)
-    return team
 
 
 def make_saved_reply(title, message, scope="Global", teams=None, owner=ADMIN_AGENT):

--- a/helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+++ b/helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_rename": 1,
  "autoname": "field:service_level",
  "creation": "2023-08-22 11:14:25.683372",
  "doctype": "DocType",
@@ -179,7 +180,7 @@
   }
  ],
  "links": [],
- "modified": "2026-02-02 11:54:59.519053",
+ "modified": "2026-04-30 20:00:06.247098",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Service Level Agreement",

--- a/helpdesk/helpdesk/doctype/hd_team/hd_team.py
+++ b/helpdesk/helpdesk/doctype/hd_team/hd_team.py
@@ -15,11 +15,9 @@ class HDTeam(Document):
     def after_insert(self):
         self.create_assignment_rule()
         assignment_rule_doc = frappe.get_doc("Assignment Rule", self.assignment_rule)
-        print("\n\n", "HERE", "\n\n")
 
         for user in self.users:
             _user = user.get("user")
-            print("\n\n", _user, "\n\n")
             if not _user:
                 continue
             assignment_rule_doc.append("users", {"user": _user})

--- a/helpdesk/helpdesk/doctype/hd_team/hd_team.py
+++ b/helpdesk/helpdesk/doctype/hd_team/hd_team.py
@@ -8,20 +8,18 @@ from frappe.exceptions import DoesNotExistError
 from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists
 
-from helpdesk.utils import capture_event
+from helpdesk.utils import agent_only, capture_event
 
 
 class HDTeam(Document):
-    @frappe.whitelist()
-    def rename_self(self, new_name: str):
-        self.rename(new_name)
-
     def after_insert(self):
         self.create_assignment_rule()
         assignment_rule_doc = frappe.get_doc("Assignment Rule", self.assignment_rule)
+        print("\n\n", "HERE", "\n\n")
 
         for user in self.users:
             _user = user.get("user")
+            print("\n\n", _user, "\n\n")
             if not _user:
                 continue
             assignment_rule_doc.append("users", {"user": _user})
@@ -179,6 +177,7 @@ class HDTeam(Document):
 
 
 @frappe.whitelist()
+@agent_only
 def get_team_members(team: str):
     """
     Returns the team members for the given team name

--- a/helpdesk/helpdesk/doctype/hd_team/test_hd_team.py
+++ b/helpdesk/helpdesk/doctype/hd_team/test_hd_team.py
@@ -1,9 +1,36 @@
 # Copyright (c) 2022, Frappe Technologies and Contributors
 # See license.txt
 
-# import frappe
-import unittest
+import json
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from helpdesk.test_utils import make_agent, make_team
 
 
-class TestHDTeam(unittest.TestCase):
-    pass
+class TestHDTeam(FrappeTestCase):
+    def test_assignment_rule_creation(self):
+        team = make_team("Test Team")
+        self.assertTrue(team.assignment_rule)
+
+    def test_team_rename_updates_assignment_rule(self):
+        team = make_team("Test Team Rename")
+        old_rule_name = team.assignment_rule
+        new_team_name = "Renamed Test Team"
+        frappe.rename_doc("HD Team", team.name, new_team_name)
+        team = frappe.get_doc("HD Team", new_team_name)
+        updated_rule = frappe.get_doc("Assignment Rule", old_rule_name)
+        expected_condition = f"status == 'Open' and agent_group == '{new_team_name}'"
+        self.assertEqual(updated_rule.assign_condition, expected_condition)
+
+    def test_team_agent_sync_with_assignment_rule(self):
+        agent1 = make_agent("testagent1@example.com")
+        agent2 = make_agent("testagent2@example.com")
+        team = make_team("Test Team Sync", [agent1, agent2])
+
+        rule_doc = frappe.get_doc("Assignment Rule", team.assignment_rule)
+
+        assignment_rule_users = [user.user for user in rule_doc.users]
+        agents_in_team = [agent.user for agent in team.users]
+        self.assertEqual(json.dumps(assignment_rule_users), json.dumps(agents_in_team))

--- a/helpdesk/helpdesk/doctype/hd_team/test_hd_team.py
+++ b/helpdesk/helpdesk/doctype/hd_team/test_hd_team.py
@@ -13,6 +13,8 @@ class TestHDTeam(FrappeTestCase):
     def test_assignment_rule_creation(self):
         team = make_team("Test Team")
         self.assertTrue(team.assignment_rule)
+        ar_name = f"{team.name} - Support Rotation"
+        self.assertTrue(frappe.db.exists("Assignment Rule", ar_name))
 
     def test_team_rename_updates_assignment_rule(self):
         team = make_team("Test Team Rename")

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -111,6 +111,7 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Priority",
+   "link_filters": "[[\"HD Ticket Priority\",\"disabled\",\"=\",0]]",
    "options": "HD Ticket Priority"
   },
   {
@@ -469,7 +470,7 @@
  "icon": "fa fa-issue",
  "idx": 61,
  "links": [],
- "modified": "2026-02-27 16:42:43.292656",
+ "modified": "2026-04-30 19:58:44.919596",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Ticket",

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -286,11 +286,9 @@ class HDTicket(Document):
     def set_priority(self):
         if self.priority:
             return
-        self.priority = (
-            frappe.get_cached_value("HD Ticket Type", self.ticket_type, "priority")
-            or frappe.get_cached_value("HD Settings", "HD Settings", "default_priority")
-            or DEFAULT_TICKET_PRIORITY
-        )
+        self.priority = frappe.get_cached_value(
+            "HD Ticket Type", self.ticket_type, "priority"
+        ) or frappe.get_cached_value("HD Settings", "HD Settings", "default_priority")
 
     def set_first_responded_on(self):
         if self.is_new():

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -84,7 +84,6 @@ class HDTicket(Document):
         self.set_feedback_values()
         self.set_default_status()
         self.set_status_category()
-        # self.apply_escalation_rule()
         self.set_sla()
 
         self.set_contact()
@@ -402,11 +401,6 @@ class HDTicket(Document):
                 not is_agent_in_assigned_team
             ) and self.users_present_in_team_assignment_rule():
                 clear_all_assignments("HD Ticket", self.name)
-                frappe.publish_realtime(
-                    "helpdesk:update-ticket-assignee",
-                    {"ticket_id": self.name},
-                    after_commit=True,
-                )
 
     def agent_in_assigned_team(self, agent, team):
         return frappe.db.exists(
@@ -881,19 +875,6 @@ class HDTicket(Document):
                     return rule
             except Exception:
                 pass
-
-    def apply_escalation_rule(self):
-        if not self.status_category == "Open" or self.is_new():
-            return
-        escalation_rule = self.get_escalation_rule()
-        if not escalation_rule:
-            return
-        self.agent_group = escalation_rule.to_team or self.agent_group
-        self.priority = escalation_rule.to_priority or self.priority
-        self.ticket_type = escalation_rule.to_ticket_type or self.ticket_type
-
-        if escalation_rule.to_agent:
-            self.assign_agent(escalation_rule.to_agent)
 
     def set_sla(self):
         """

--- a/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
@@ -739,3 +739,37 @@ class TestHDTicket(IntegrationTestCase):
             get_recent_similar_tickets(ticket.name)
 
         frappe.set_user("Administrator")
+
+    def test_ticket_priority(self):
+        # if priority is set, ticket will have the applied priority
+        ticket1 = make_ticket(priority="High")
+        self.assertEqual(ticket1.priority, "High")
+
+        # if ticket type is set, and ticket type has a priority, the ticket's priority will be the same as type's priority
+        ticket_type = frappe.get_doc("HD Ticket Type", "Bug")
+        ticket_type.priority = "High"
+        ticket_type.save()
+        ticket2 = make_ticket(ticket_type="Bug")
+        self.assertEqual(ticket2.priority, "High")
+
+        # if ticket type and priority is set, applied priority is given preference
+        ticket3 = make_ticket(priority="Low", ticket_type="Bug")
+        self.assertEqual(ticket3.priority, "Low")
+
+        # if ticket type is set, and ticket type does not has a priority, the ticket's priority will be the same as applied sla's default priority
+        sla_doc = frappe.get_doc("HD Service Level Agreement", "Default")
+        for p in sla_doc.priorities:
+            if p.priority == "Low":
+                p.default_priority = 1
+            else:
+                p.default_priority = 0
+        sla_doc.save()
+
+        ticket4 = make_ticket(ticket_type="Incident")  # type with no priority
+        self.assertEqual(
+            ticket4.priority, "Low"
+        )  # applied SLA's default priority is assigned
+
+        # ticket created without any type or priority should pick up priority from applied SLA's default
+        ticket5 = make_ticket()
+        self.assertEqual(ticket5.priority, "Low")

--- a/helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+++ b/helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
@@ -6,9 +6,9 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "integer_value",
-  "column_break_fzcl",
-  "description"
+  "disabled",
+  "description",
+  "integer_value"
  ],
  "fields": [
   {
@@ -26,13 +26,15 @@
    "reqd": 1
   },
   {
-   "fieldname": "column_break_fzcl",
-   "fieldtype": "Column Break"
+   "default": "0",
+   "fieldname": "disabled",
+   "fieldtype": "Check",
+   "label": "Disabled"
   }
  ],
  "grid_page_length": 50,
  "links": [],
- "modified": "2026-02-02 17:01:58.293256",
+ "modified": "2026-04-30 19:56:12.860954",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Ticket Priority",

--- a/helpdesk/test_utils.py
+++ b/helpdesk/test_utils.py
@@ -299,3 +299,27 @@ def add_comment(
     if save:
         return comment.insert()
     return comment
+
+
+def make_team(team_name, members=[]):
+    """Create an HD Team with optional members."""
+    if frappe.db.exists("HD Team", team_name):
+        # Delete existing team members
+        team = frappe.get_doc("HD Team", team_name)
+        team.users = []
+        for member in members:
+            team.append("users", {"user": member})
+        team.save(ignore_permissions=True)
+        return team
+
+    # Create new team - this will trigger after_insert which creates assignment rule
+    team = frappe.get_doc(
+        {
+            "doctype": "HD Team",
+            "team_name": team_name,
+        }
+    )
+    for member in members:
+        team.append("users", {"user": member})
+    team.insert(ignore_permissions=True)
+    return team

--- a/helpdesk/test_utils.py
+++ b/helpdesk/test_utils.py
@@ -22,6 +22,7 @@ def before_tests():
     frappe.db.set_single_value(
         "HD Settings", "enable_email_ticket_feedback", 0
     )  # nosemgrep
+    frappe.db.set_single_value("HD Settings", "default_priority", None)
     # frappe.flags.mute_emails = True
     make_holiday_list()
     make_new_sla()


### PR DESCRIPTION
1. Add "disabled" field in HD Ticket Priority
2. Allow renaming of SLA document
3. Add test case for setting up priority in the ticket
4. Add test case for team and assignment rule creation