### PR TITLE
fix: dont always set default type

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -254,6 +254,8 @@ class HDTicket(Document):
         )
 
     def set_raised_by(self):
+        if self.raised_by:
+            return
         self.raised_by = frappe.session.user
 
     def set_contact(self):

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -18,7 +18,6 @@ from pypika.functions import Count
 from pypika.queries import Query
 from pypika.terms import Criterion
 
-from helpdesk.consts import DEFAULT_TICKET_PRIORITY, DEFAULT_TICKET_TYPE
 from helpdesk.helpdesk.doctype.hd_settings.helpers import (
     get_default_email_content,
     is_email_content_empty,
@@ -250,12 +249,12 @@ class HDTicket(Document):
     def set_ticket_type(self):
         if self.ticket_type:
             return
-        settings = frappe.get_doc("HD Settings")
-        ticket_type = settings.default_ticket_type or DEFAULT_TICKET_TYPE
-        self.ticket_type = ticket_type
+        self.ticket_type = (
+            frappe.db.get_single_value("HD Settings", "default_ticket_type") or ""
+        )
 
     def set_raised_by(self):
-        self.raised_by = self.raised_by if is_agent() else frappe.session.user
+        self.raised_by = frappe.session.user
 
     def set_contact(self):
         email_id = parseaddr(self.raised_by)[1]


### PR DESCRIPTION
1. We always set a default ticket type. If the type is not found, then dont attach unwanted ticket type.
2. Set raised by accordingly


depends-on: https://github.com/frappe/helpdesk/pull/3271