### PR TITLE
fix: SLA Status Logic

### DIFF
--- a/desk/src/components/EmailContent.vue
+++ b/desk/src/components/EmailContent.vue
@@ -218,6 +218,21 @@ watch(iframeRef, (iframe) => {
         );
       });
 
+      // This is to ensure that keyboard shortcuts work even when the iframe is focused. For example, pressing "r" to reply to an email should work even if the user has clicked inside the email content.
+      iframe.contentDocument?.addEventListener("keydown", (e) => {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key: e.key,
+            code: e.code,
+            ctrlKey: e.ctrlKey,
+            metaKey: e.metaKey,
+            shiftKey: e.shiftKey,
+            altKey: e.altKey,
+            bubbles: true,
+          })
+        );
+      });
+
       const replyCollapsers = emailContent.querySelectorAll(".replyCollapser");
       if (replyCollapsers.length) {
         replyCollapsers.forEach((replyCollapser) => {

--- a/desk/src/components/MultiSelectInput.vue
+++ b/desk/src/components/MultiSelectInput.vue
@@ -85,16 +85,16 @@
 </template>
 
 <script setup lang="ts">
+import { UserAvatar } from "@/components/";
 import {
   Combobox,
   ComboboxInput,
-  ComboboxOptions,
   ComboboxOption,
+  ComboboxOptions,
 } from "@headlessui/vue";
-import { UserAvatar } from "@/components/";
-import { Popover, createResource } from "frappe-ui";
-import { ref, computed, nextTick } from "vue";
 import { watchDebounced } from "@vueuse/core";
+import { Popover, createResource } from "frappe-ui";
+import { computed, nextTick, ref } from "vue";
 
 const props = defineProps({
   validate: {
@@ -135,7 +135,7 @@ watchDebounced(
     text.value = val;
     reload(val);
   },
-  { debounce: 50, immediate: true }
+  { debounce: 400, immediate: true }
 );
 
 const filterOptions = createResource({

--- a/desk/src/components/ticket-agent/TicketContact.vue
+++ b/desk/src/components/ticket-agent/TicketContact.vue
@@ -64,10 +64,10 @@ const ticket = inject(TicketSymbol)!;
 
 const contact = inject(TicketContactSymbol)!;
 const contactImage = computed(() => {
+  if (!contact.value?.data) return "";
+  const email = contact.value?.data?.email_id ?? "";
   return (
-    contact.value?.data?.image ||
-    getUser(contact.value?.data?.email_id)?.user_image ||
-    null
+    contact.value?.data?.image || (email && getUser(email)?.user_image) || ""
   );
 });
 

--- a/helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py
+++ b/helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py
@@ -279,16 +279,17 @@ class HDServiceLevelAgreement(Document):
 
     def handle_agreement_status(self, doc: Document):
         is_failed = self.is_first_response_failed(doc) or self.is_resolution_failed(doc)
-        options = {
-            "Fulfilled": True,
-            "Resolution Due": self.apply_sla_for_resolution and not doc.resolution_date,
-            "First Response Due": not doc.first_responded_on,
-            "Failed": is_failed,
-            "Paused": doc.on_hold_since,
-        }
-        for status in options:
-            if options[status]:
-                doc.agreement_status = status
+
+        if is_failed:
+            doc.agreement_status = "Failed"
+        elif doc.on_hold_since:
+            doc.agreement_status = "Paused"
+        elif not doc.first_responded_on:
+            doc.agreement_status = "First Response Due"
+        elif self.apply_sla_for_resolution and not doc.resolution_date:
+            doc.agreement_status = "Resolution Due"
+        else:
+            doc.agreement_status = "Fulfilled"
 
     def is_first_response_failed(self, doc: Document):
         if not doc.first_responded_on:

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -1375,5 +1375,37 @@ def close_tickets_after_n_days():
                 message=f"Failed to auto close ticket {doc.name} after {days_threshold} days. Error: {e}",
                 title="Auto Close Ticket Failed",
             )
+            continue
 
+        frappe.db.commit()  # nosemgrep
+
+
+def update_sla_status_in_ticket():
+    stale_tickets = frappe.get_all(
+        "HD Ticket",
+        filters={
+            "status_category": ["=", "Open"],
+            "sla": ["is", "set"],
+        },
+        pluck="name",
+    )
+    for ticket in stale_tickets:
+        doc = frappe.get_doc("HD Ticket", ticket)
+        sla = frappe.get_doc("HD Service Level Agreement", doc.sla)
+        sla.handle_agreement_status(doc)
+        try:
+            frappe.db.set_value(
+                "HD Ticket",
+                doc.name,
+                "agreement_status",
+                doc.agreement_status,
+                update_modified=False,
+            )
+
+        except Exception as e:
+            frappe.log_error(
+                message=f"Failed to update agreement status for ticket {doc.name}. Error: {e}",
+                title="Update SLA Status Failed",
+            )
+            continue
         frappe.db.commit()  # nosemgrep

--- a/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
@@ -773,3 +773,125 @@ class TestHDTicket(IntegrationTestCase):
         # ticket created without any type or priority should pick up priority from applied SLA's default
         ticket5 = make_ticket()
         self.assertEqual(ticket5.priority, "Low")
+
+    # Test cases for agreement_status field which is computed based on response_by, resolution_by, first_responded_on, on_hold_since and resolution_date fields
+    # In total there are 7 scenarios for agreement_status which are covered in the below test cases:
+    def test_agreement_status_first_response_failed(self):
+        # Case 1: No reply before response_by (T+30min) → Failed
+        # At T+1h, response_by (T+30min) < now (T+1h) → first response failed
+        # resolution_by (T+2h) > now (T+1h) → resolution not yet failed
+        # is_failed = True → "Failed"
+        date = get_current_week_monday(hours=10)
+        with self.freeze_time(date):
+            ticket = make_ticket(priority="Urgent")
+
+        with self.freeze_time(add_to_date(date, hours=1)):
+            ticket.reload()
+            ticket.save()
+            self.assertEqual(ticket.agreement_status, "Failed")
+
+    def test_agreement_status_resolution_failed(self):
+        # Case 2: First response in time, resolution misses deadline → Failed
+        #
+        # Timeline (Urgent: response_by=T+30min, resolution_by=T+2h):
+        #   T+10min  → Replied (Paused): first_responded_on set, on_hold_since=T+10min
+        #   T+20min  → Open: off hold, hold_time=10min(600s),
+        #              new resolution_by = T + 2h + 10min = T+2h10min
+        #   T+2h15min → save: resolution_by (T+2h10min) < now (T+2h15min) → Failed
+        date = get_current_week_monday(hours=10)
+        with self.freeze_time(date):
+            ticket = make_ticket(priority="Urgent")
+
+        with self.freeze_time(add_to_date(date, minutes=10)):
+            ticket.reload()
+            ticket.status = "Replied"
+            ticket.save()
+
+        with self.freeze_time(add_to_date(date, minutes=20)):
+            ticket.reload()
+            ticket.status = "Open"
+            ticket.save()
+            self.assertEqual(ticket.agreement_status, "Resolution Due")
+
+        # Re-save past the extended resolution_by (T+2h10min) without changing status
+        with self.freeze_time(add_to_date(date, hours=2, minutes=15)):
+            ticket.reload()
+            ticket.save()
+            self.assertEqual(ticket.agreement_status, "Failed")
+
+    def test_agreement_status_both_failed(self):
+        # Case 3: No reply given, past both response_by (T+30min) and resolution_by (T+2h)
+        # At T+3h: response_by < now AND resolution_by < now → is_failed = True → "Failed"
+        date = get_current_week_monday(hours=10)
+        with self.freeze_time(date):
+            ticket = make_ticket(priority="Urgent")
+
+        with self.freeze_time(add_to_date(date, hours=3)):
+            ticket.reload()
+            ticket.save()
+            self.assertEqual(ticket.agreement_status, "Failed")
+
+    def test_agreement_status_resolution_due_on_hold(self):
+        # Case 4: First response given, resolution due, ticket on hold → Paused
+        # "Replied" is a Paused-category status — sets first_responded_on AND on_hold_since
+        date = get_current_week_monday(hours=10)
+        with self.freeze_time(date):
+            ticket = make_ticket(priority="Urgent")
+
+        with self.freeze_time(add_to_date(date, minutes=10)):
+            ticket.reload()
+            ticket.status = "Replied"
+            ticket.save()
+            self.assertTrue(ticket.first_responded_on)
+            self.assertTrue(ticket.on_hold_since)
+            self.assertIsNone(ticket.resolution_date)
+            self.assertEqual(ticket.agreement_status, "Paused")
+
+    def test_agreement_status_first_response_due(self):
+        # Case 5: Fresh ticket — no reply, not on hold → First Response Due
+        date = get_current_week_monday(hours=10)
+        with self.freeze_time(date):
+            ticket = make_ticket(priority="Urgent")
+            self.assertIsNone(ticket.first_responded_on)
+            self.assertIsNone(ticket.on_hold_since)
+            self.assertEqual(ticket.agreement_status, "First Response Due")
+
+    def test_agreement_status_resolution_due(self):
+        # Case 6: First response given, came off hold, resolution still pending → Resolution Due
+        #
+        # Timeline:
+        #   T+10min → Replied (Paused): first_responded_on set, on_hold_since set
+        #   T+20min → Open: off hold, hold_time=10min, resolution_by extended to T+2h10min
+        #   At T+20min: first_responded_on set, on_hold_since=None,
+        #               resolution_date=None, now < resolution_by → Resolution Due
+        date = get_current_week_monday(hours=10)
+        with self.freeze_time(date):
+            ticket = make_ticket(priority="Urgent")
+
+        with self.freeze_time(add_to_date(date, minutes=10)):
+            ticket.reload()
+            ticket.status = "Replied"
+            ticket.save()
+
+        with self.freeze_time(add_to_date(date, minutes=20)):
+            ticket.reload()
+            ticket.status = "Open"
+            ticket.save()
+            self.assertTrue(ticket.first_responded_on)
+            self.assertIsNone(ticket.on_hold_since)
+            self.assertIsNone(ticket.resolution_date)
+            self.assertEqual(ticket.agreement_status, "Resolution Due")
+
+    def test_agreement_status_fulfilled(self):
+        # Case 7: Resolved within both deadlines → Fulfilled
+        # Resolved at T+10min: first_responded_on=T+10min < response_by=T+30min ✓
+        # resolution_date=T+10min < resolution_by=T+2h ✓ → Fulfilled
+        date = get_current_week_monday(hours=10)
+        with self.freeze_time(date):
+            ticket = make_ticket(priority="Urgent")
+
+        with self.freeze_time(add_to_date(date, minutes=10)):
+            ticket.reload()
+            ticket.status = "Resolved"
+            ticket.save()
+            self.assertEqual(ticket.agreement_status, "Fulfilled")

--- a/helpdesk/hooks.py
+++ b/helpdesk/hooks.py
@@ -41,6 +41,9 @@ scheduler_events = {
     "daily": [
         "helpdesk.helpdesk.doctype.hd_ticket.hd_ticket.close_tickets_after_n_days"
     ],
+    "hourly_long": [
+        "helpdesk.helpdesk.doctype.hd_ticket.hd_ticket.update_sla_status_in_ticket"
+    ],
 }
 
 


### PR DESCRIPTION
**Issue:**
The handle_agreement_status method used a dict of options iterated in insertion order, setting `agreement_status` to the last truthy value. This approach had two bugs:

1. Failed was masked by Paused: If a ticket had already breached the first response SLA but was then put on hold, the "Paused" key came after "Failed" in the dict and would overwrite it, hiding the breach.
2. Priority was implicit and fragile: The status precedence depended entirely on dict key order, making the logic hard to reason about and easy to break with any reordering.

**Solution:**
Use if/else instead, in this particular order:

`Failed → Paused → First Response Due → Resolution Due → Fulfilled`

Failed is now checked first and cannot be overridden by any other condition. Paused only applies when there is no active SLA breach. 
**Cases:**

| # | First Response SLA | Resolution SLA | On Hold | Final SLA Status |
|---|--------------------|----------------|---------|------------------|
| 1 | Breached | Any | Any | Failed |
| 2 | Met | Breached | No | Failed |
| 3 | Breached | Breached | No | Failed |
| 4 | Met | Pending | Yes | Paused |
| 5 | Pending | N/A | No | First Response Pending |
| 6 | Met | Pending | No | Resolution Pending |
| 7 | Met | Met | No | Fulfilled |




**Other changes:**
1. Add hourly job to update SLA status for the Open Tickets.
2. Add debounce while searching for contacts in Email Editor.
3. Dont initially show "session users" image in the Ticket "Contact" Avatar.


Added tests covering all the possible cases for `agreement_status`

closes: https://github.com/frappe/helpdesk/issues/3279