### PR TITLE
fix: add weighted_users support in hd team 

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,48 @@ apiCall.submit({ ticket_id: "<id>", agent_id: "<agent>" });
 - Use proper field types and validation in DocType definitions
 - Leverage DocType methods for business logic encapsulation
 
+## Controller Code Structure
+
+All controller logic must follow this structure strictly:
+
+**Rule: Lifecycle hooks call methods. Methods are defined below on the class. Nothing goes outside the class except `@frappe.whitelist()` API functions.**
+
+```python
+class HDFoo(Document):
+    # 1. Lifecycle hooks at the top — each hook calls methods, no inline logic
+    def after_insert(self):
+        self.do_a()
+        self.do_b()
+
+    def on_update(self):
+        self.do_a()
+
+    # 2. Methods below — one responsibility each
+    def do_a(self):
+        pass
+
+    def do_b(self):
+        pass
+
+
+```
+
+**Rules:**
+
+- Lifecycle hooks (`after_insert`, `on_update`, `before_save`, `on_trash`, `after_rename`, etc.) contain **no inline logic** — they only call `self.method()`.
+- All logic lives in methods on the class, not in module-level helper functions.
+- Methods that mutate a related document (e.g. an Assignment Rule) receive that doc as an argument and mutate it in memory. The **caller** is responsible for the final `doc.save()` — this keeps saves to a minimum (one save per hook).
+- Never fetch the same document twice in one hook. Fetch once, pass the doc through the call chain.
+- `@staticmethod` is allowed for pure transformations (e.g. building a condition string) that don't touch `self` or any Frappe doc.
+
+**Save discipline:**
+
+- Mutate all fields on a document before calling `.save()` once.
+- Never call `.save()` inside a helper method — save in the hook or the method that owns the full mutation.
+- Exception: if a method truly owns a complete document lifecycle (e.g. `create_assignment_rule` creates and fully initialises a new doc), it may save internally.
+Take inspiration from "helpdesk.doctype.hd_team.hd_team.HDTeam" and its test file for examples of this pattern in practice.
+```
+
 ## Conventions & Patterns
 
 - **API Design:** Python modules in `helpdesk/api/` follow RESTful patterns. Extend via `helpdesk/extends/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,7 +232,7 @@ apiCall.submit({ ticket_id: "<id>", agent_id: "<agent>" });
 
 All controller logic must follow this structure strictly:
 
-**Rule: Lifecycle hooks call methods. Methods are defined below on the class. Nothing goes outside the class except `@frappe.whitelist()` API functions.**
+**Rule: Lifecycle hooks call methods. Methods are defined below on the class.**
 
 ```python
 class HDFoo(Document):
@@ -267,7 +267,7 @@ class HDFoo(Document):
 - Mutate all fields on a document before calling `.save()` once.
 - Never call `.save()` inside a helper method — save in the hook or the method that owns the full mutation.
 - Exception: if a method truly owns a complete document lifecycle (e.g. `create_assignment_rule` creates and fully initialises a new doc), it may save internally.
-Take inspiration from "helpdesk.doctype.hd_team.hd_team.HDTeam" and its test file for examples of this pattern in practice.
+Take inspiration from "helpdesk.doctype.hd_team.hd_team.HDTeam" for examples of this pattern in practice.
 ```
 
 ## Conventions & Patterns

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,7 +268,6 @@ class HDFoo(Document):
 - Never call `.save()` inside a helper method — save in the hook or the method that owns the full mutation.
 - Exception: if a method truly owns a complete document lifecycle (e.g. `create_assignment_rule` creates and fully initialises a new doc), it may save internally.
 Take inspiration from "helpdesk.doctype.hd_team.hd_team.HDTeam" for examples of this pattern in practice.
-```
 
 ## Conventions & Patterns
 

--- a/desk/src/components/CommentBox.vue
+++ b/desk/src/components/CommentBox.vue
@@ -305,7 +305,7 @@ const deleteComment = createResource({
   }),
   onSuccess() {
     emit("update");
-    toast.success(__("Comment deleted sucessfully."));
+    toast.success(__("Comment deleted successfully."));
   },
 });
 

--- a/desk/src/components/Settings/SavedReplies/SavedReplyView.vue
+++ b/desk/src/components/Settings/SavedReplies/SavedReplyView.vue
@@ -269,6 +269,9 @@ const getTeamsListResource = createListResource({
   doctype: "HD Team",
   auto: true,
   fields: ["name"],
+  filters: {
+    disabled: 0,
+  },
   start: 0,
   pageLength: 999,
   transform: (data: Array<Team>) => {

--- a/desk/src/components/Settings/Teams/NewTeam.vue
+++ b/desk/src/components/Settings/Teams/NewTeam.vue
@@ -21,13 +21,21 @@
       </div>
     </template>
     <template #header-actions>
-      <Button
-        :label="__('Save')"
-        variant="solid"
-        @click="saveTeam()"
-        :disabled="!isDirty"
-        :loading="teamsList.insert.loading"
-      />
+      <div class="flex items-center gap-4">
+        <div class="flex items-center gap-2 cursor-pointer">
+          <Switch v-model="teamData.enabled" />
+          <span class="text-sm text-ink-gray-7 font-medium">
+            {{ __("Enabled") }}
+          </span>
+        </div>
+        <Button
+          :label="__('Save')"
+          variant="solid"
+          @click="saveTeam()"
+          :disabled="!isDirty"
+          :loading="teamsList.insert.loading"
+        />
+      </div>
     </template>
     <template #content>
       <div class="flex flex-col gap-4">
@@ -66,7 +74,14 @@
 <script setup lang="ts">
 import { computed, inject, onMounted, ref } from "vue";
 import SettingsLayoutBase from "@/components/layouts/SettingsLayoutBase.vue";
-import { Badge, ErrorMessage, FormControl, FormLabel, toast } from "frappe-ui";
+import {
+  Badge,
+  ErrorMessage,
+  FormControl,
+  FormLabel,
+  Switch,
+  toast,
+} from "frappe-ui";
 import { __ } from "@/translation";
 import AgentSelector from "./components/AgentSelector.vue";
 import { useAgentStore } from "@/stores/agent";
@@ -95,6 +110,7 @@ const showConfirmDialog = ref({
 const teamData = ref({
   name: "",
   agents: [],
+  enabled: true,
 });
 
 const errors = ref({
@@ -133,6 +149,7 @@ const saveTeam = () => {
     {
       team_name: teamData.value.name,
       users: teamData.value.agents.map((agent) => ({ user: agent })),
+      disabled: !teamData.value.enabled,
     },
     {
       onSuccess: (data) => {

--- a/desk/src/components/Settings/Teams/RenameTeamModal.vue
+++ b/desk/src/components/Settings/Teams/RenameTeamModal.vue
@@ -10,6 +10,7 @@
     <template #actions>
       <Button
         variant="solid"
+        class="flex w-full"
         @click="renameTeam"
         :loading="renameTeamResource.loading"
         :disabled="teamName == dialog.teamName || teamName.trim() == ''"

--- a/desk/src/components/Settings/Teams/TeamEdit.vue
+++ b/desk/src/components/Settings/Teams/TeamEdit.vue
@@ -15,13 +15,21 @@
       </div>
     </template>
     <template #header-actions>
-      <Dropdown placement="right" :options="options">
-        <Button variant="ghost">
-          <template #icon>
-            <LucideMoreHorizontal class="h-4 w-4" />
-          </template>
-        </Button>
-      </Dropdown>
+      <div class="flex items-center gap-4">
+        <div class="flex items-center justify-between gap-2 cursor-pointer">
+          <Switch v-model="teamEnabled" />
+          <span class="text-sm text-ink-gray-7 font-medium">
+            {{ __("Enabled") }}
+          </span>
+        </div>
+        <Dropdown placement="right" :options="options">
+          <Button variant="ghost">
+            <template #icon>
+              <LucideMoreHorizontal class="h-4 w-4" />
+            </template>
+          </Button>
+        </Dropdown>
+      </div>
     </template>
     <template #header-bottom>
       <!-- Add member -->
@@ -151,6 +159,7 @@ import {
   createResource,
   Dialog,
   Dropdown,
+  Switch,
   toast,
   Tooltip,
 } from "frappe-ui";
@@ -189,6 +198,31 @@ const team = createDocumentResource({
       toast.success(__("Team deleted successfully."));
       emit("update:step", "team-list");
     },
+  },
+});
+
+const teamEnabled = computed({
+  get() {
+    return !team.doc?.disabled;
+  },
+  set(value: boolean) {
+    if (!team.doc) return;
+    team.doc.disabled = !value;
+    team.setValue.submit(
+      {
+        disabled: !value,
+      },
+      {
+        onSuccess: () => {
+          toast.success(
+            value
+              ? __("Team enabled successfully.")
+              : __("Team disabled successfully.")
+          );
+          team.reload();
+        },
+      }
+    );
   },
 });
 

--- a/desk/src/components/Settings/Teams/TeamEdit.vue
+++ b/desk/src/components/Settings/Teams/TeamEdit.vue
@@ -161,7 +161,6 @@ import {
   Dropdown,
   Switch,
   toast,
-  Tooltip,
 } from "frappe-ui";
 import { computed, h, inject, markRaw, onMounted, ref } from "vue";
 import LucideLock from "~icons/lucide/lock";
@@ -310,7 +309,7 @@ function renameTeam(close) {
 
 const showDelete = ref(false);
 
-const options = [
+const options = computed(() => [
   {
     label: __("View Assignment rule"),
     icon: markRaw(h(Settings, { class: "rotate-90" })),
@@ -327,71 +326,31 @@ const options = [
     icon: "edit-3",
     onClick: () => (showRename.value = !showRename.value),
   },
-  {
-    condition: () => teamRestrictionApplied,
-    label: team.doc?.ignore_restrictions
-      ? __("Disable Bypass Restrictions")
-      : __("Enable Bypass Restrictions"),
-    component: () =>
-      h(
-        Tooltip,
+  ...(teamRestrictionApplied
+    ? [
         {
-          text: ignoreRestrictions.value
-            ? __(
-                "Members of this team will see the tickets assigned to this team only"
-              )
-            : __(
-                "Members of this team will be able to see the tickets assigned to all the teams"
-              ),
+          label: ignoreRestrictions.value
+            ? __("Access only this team's tickets")
+            : __("Access all team tickets"),
+          icon: markRaw(ignoreRestrictions.value ? LucideLock : LucideUnlock),
+          onClick: () => {
+            ignoreRestrictions.value = !ignoreRestrictions.value;
+            toast.success(
+              ignoreRestrictions.value
+                ? __("Team can now access all tickets.")
+                : __("Team will only see their own tickets.")
+            );
+          },
         },
-        {
-          default: () => [
-            //create a div with 2 columns, one for icon and one for label
-            h(
-              "div",
-              {
-                class:
-                  "flex items-center gap-2 p-2 cursor-pointer hover:bg-gray-100 rounded",
-                onClick: () =>
-                  (ignoreRestrictions.value = !ignoreRestrictions.value),
-              },
-              [
-                h(team.doc?.ignore_restrictions ? LucideLock : LucideUnlock, {
-                  class: "h-4 w-4 text-gray-700",
-                  stroke: "currentColor",
-                  "aria-hidden": "true",
-                }),
-                h(
-                  "span",
-                  {
-                    class: "whitespace-nowrap text-ink-gray-7 text-p-base",
-                  },
-                  [
-                    team.doc?.ignore_restrictions
-                      ? __("Access only this team's tickets")
-                      : __("Access all team tickets"),
-                  ]
-                ),
-              ]
-            ),
-          ],
-        }
-      ),
-  },
+      ]
+    : []),
   {
     label: __("Delete"),
-    component: h(Button, {
-      label: __("Delete"),
-      variant: "ghost",
-      iconLeft: "trash-2",
-      theme: "red",
-      style: "width: 100%; justify-content: flex-start;",
-      onClick: () => {
-        showDelete.value = !showDelete.value;
-      },
-    }),
+    icon: "trash-2",
+    theme: "red",
+    onClick: () => (showDelete.value = !showDelete.value),
   },
-];
+]);
 
 const isConfirmingDelete = ref(false);
 

--- a/desk/src/components/Settings/Teams/TeamEdit.vue
+++ b/desk/src/components/Settings/Teams/TeamEdit.vue
@@ -72,6 +72,7 @@
               <AgentCard :agent="member" class="!py-0">
                 <template #right>
                   <Dropdown
+                    v-if="teamMembers.length > 1"
                     :options="memberDropdownOptions(member)"
                     placement="right"
                   >
@@ -108,40 +109,15 @@
       </div>
     </template>
   </SettingsLayoutBase>
-  <Dialog v-model="showDelete" :options="{ title: 'Delete team' }">
-    <template #body-content>
-      <p class="text-p-base text-ink-gray-7">
-        {{
-          __(
-            "Are you sure you want to delete this team? This action cannot be reversed!"
-          )
-        }}
-      </p>
-      <Button
-        variant="solid"
-        class="mt-4 float-right"
-        :label="__('Confirm')"
-        theme="red"
-        @click="
-          () => {
-            team.delete.submit();
-            showDelete = false;
-            emit('update:step', 'team-list');
-          }
-        "
-      />
-    </template>
-  </Dialog>
-  <Dialog v-model="showRename" :options="renameDialogOptions">
-    <template #body-content>
-      <FormControl
-        v-model="_teamName"
-        :label="__('Title')"
-        :placeholder="__('Product Experts')"
-        maxlength="50"
-      />
-    </template>
-  </Dialog>
+  <RenameTeamModal
+    v-model="showRename"
+    @onRename="
+      () => {
+        teamsList.reload();
+        emit('update:step', 'team-list');
+      }
+    "
+  />
 </template>
 
 <script setup lang="ts">
@@ -156,13 +132,12 @@ import { ConfirmDelete } from "@/utils";
 import {
   Button,
   createDocumentResource,
-  createResource,
-  Dialog,
   Dropdown,
   Switch,
   toast,
 } from "frappe-ui";
 import { computed, h, inject, markRaw, onMounted, ref } from "vue";
+import RenameTeamModal from "./RenameTeamModal.vue";
 import LucideLock from "~icons/lucide/lock";
 import Settings from "~icons/lucide/settings-2";
 import LucideUnlock from "~icons/lucide/unlock";
@@ -187,7 +162,6 @@ const teamsList = inject(TeamListResourceSymbol);
 const { teamRestrictionApplied } = useConfigStore();
 const invitees = ref<string[]>([]);
 
-const _teamName = ref(props.teamName);
 const team = createDocumentResource({
   doctype: "HD Team",
   name: props.teamName,
@@ -264,50 +238,12 @@ function addMember(users: string[]) {
   invitees.value = [];
 }
 
-const showRename = ref(false);
+const showRename = ref({
+  show: false,
+  teamName: props.teamName,
+});
 
-const renameDialogOptions = {
-  title: __("Rename team"),
-  message: __("Enter the new name for the team"),
-  actions: [
-    {
-      label: __("Confirm"),
-      variant: "solid",
-      loading: team.loading,
-      onClick: ({ close }) => {
-        renameTeam(close);
-      },
-    },
-  ],
-};
-
-function renameTeam(close) {
-  const r = createResource({
-    url: "frappe.client.rename_doc",
-    makeParams() {
-      return {
-        doctype: "HD Team",
-        old_name: props.teamName,
-        new_name: _teamName.value,
-      };
-    },
-    validate(params) {
-      if (!params.new_name) return __("New title is required");
-      if (params.new_name === params.old_name)
-        return __("New and old title cannot be same");
-    },
-    onSuccess() {
-      teamsList.reload();
-      toast.success(__("Team renamed successfully."));
-      close();
-      emit("update:step", "team-list");
-    },
-  });
-
-  r.submit();
-}
-
-const showDelete = ref(false);
+const isConfirmingTeamDelete = ref(false);
 
 const options = computed(() => [
   {
@@ -324,7 +260,9 @@ const options = computed(() => [
   {
     label: __("Rename"),
     icon: "edit-3",
-    onClick: () => (showRename.value = !showRename.value),
+    onClick: () => {
+      showRename.value = { show: true, teamName: props.teamName };
+    },
   },
   ...(teamRestrictionApplied
     ? [
@@ -344,12 +282,10 @@ const options = computed(() => [
         },
       ]
     : []),
-  {
-    label: __("Delete"),
-    icon: "trash-2",
-    theme: "red",
-    onClick: () => (showDelete.value = !showDelete.value),
-  },
+  ...ConfirmDelete({
+    isConfirmingDelete: isConfirmingTeamDelete,
+    onConfirmDelete: () => team.delete.submit(),
+  }),
 ]);
 
 const isConfirmingDelete = ref(false);

--- a/desk/src/components/Settings/Teams/TeamEdit.vue
+++ b/desk/src/components/Settings/Teams/TeamEdit.vue
@@ -17,7 +17,7 @@
     <template #header-actions>
       <div class="flex items-center gap-4">
         <div class="flex items-center justify-between gap-2 cursor-pointer">
-          <Switch v-model="teamEnabled" />
+          <Switch v-model="teamEnabled" v-if="!team.loading" />
           <span class="text-sm text-ink-gray-7 font-medium">
             {{ __("Enabled") }}
           </span>

--- a/desk/src/components/Settings/Teams/TeamsConfig.vue
+++ b/desk/src/components/Settings/Teams/TeamsConfig.vue
@@ -29,7 +29,7 @@ const teamsSearchQuery = ref("");
 const teams = createListResource({
   doctype: "HD Team",
   cache: ["Teams"],
-  fields: ["name"],
+  fields: ["name", "disabled"],
   auto: true,
   orderBy: "modified desc",
   start: 0,

--- a/desk/src/components/Settings/Teams/TeamsList.vue
+++ b/desk/src/components/Settings/Teams/TeamsList.vue
@@ -45,7 +45,7 @@
         class="w-full h-full -ml-2"
       >
         <div class="flex text-sm text-gray-600">
-          <div class="ml-2">{{ __("Team name") }}</div>
+          <p class="ml-2">{{ __("Team name") }}</p>
         </div>
         <hr class="mx-2 mt-2" />
         <div v-for="(team, index) in teams.data" :key="team.name">
@@ -53,12 +53,13 @@
             class="flex items-center cursor-pointer hover:bg-gray-50 rounded h-12.5"
           >
             <div
-              class="w-full py-3 pl-2"
+              class="w-full py-3 pl-2 flex gap-1 items-center"
               @click="() => emit('update:step', 'team-edit', team.name)"
             >
-              <div class="text-base text-ink-gray-7 font-medium">
+              <p class="text-base text-ink-gray-7 font-medium">
                 {{ team.name }}
-              </div>
+              </p>
+              <Badge :label="__('Disabled')" v-if="team.disabled" />
             </div>
             <div class="flex justify-between items-center pr-2">
               <div>
@@ -135,15 +136,15 @@
 </template>
 
 <script setup lang="ts">
+import EditIcon from "@/components/icons/EditIcon.vue";
+import SettingsLayoutBase from "@/components/layouts/SettingsLayoutBase.vue";
+import { __ } from "@/translation";
+import { TeamListResourceSymbol } from "@/types";
+import { ConfirmDelete } from "@/utils";
 import { Dropdown, Input, toast } from "frappe-ui";
 import { inject, markRaw, Ref, ref, watch } from "vue";
 import NewTeamModal from "../NewTeamModal.vue";
-import { ConfirmDelete } from "@/utils";
-import EditIcon from "@/components/icons/EditIcon.vue";
 import RenameTeamModal from "./RenameTeamModal.vue";
-import { __ } from "@/translation";
-import SettingsLayoutBase from "@/components/layouts/SettingsLayoutBase.vue";
-import { TeamListResourceSymbol } from "@/types";
 
 interface E {
   (event: "update:step", step: string, team: string): void;
@@ -152,7 +153,7 @@ interface E {
 const emit = defineEmits<E>();
 const teamsSearchQuery = inject<Ref>("teamsSearchQuery");
 
-const teams = inject(TeamListResourceSymbol);
+const teams = inject(TeamListResourceSymbol)!;
 const showForm = ref(false);
 const showRename = ref({
   show: false,

--- a/desk/src/composables/useTicket.ts
+++ b/desk/src/composables/useTicket.ts
@@ -31,7 +31,7 @@ export const useTicket = (ticketId: string | number): MapValue => {
         },
         setValue: {
           onSuccess: () => {
-            toast.success(__("Ticket updated sucessfully."));
+            toast.success(__("Ticket updated successfully."));
           },
           onError: (error) => {
             const msg = error.exc_type

--- a/desk/src/types.ts
+++ b/desk/src/types.ts
@@ -646,6 +646,7 @@ export interface SlaPolicy {
 export interface Team {
   name: string;
   team: string;
+  disabled: boolean;
 }
 
 export interface SavedReply {

--- a/desk/src/types/doctypes.ts
+++ b/desk/src/types/doctypes.ts
@@ -267,3 +267,23 @@ export interface HDAgent extends DocType {
   /** Image: Attach Image */
   user_image?: string;
 }
+
+// Last updated: 2022-12-22 18:52:50.658355
+export interface HDTeamMember extends ChildDocType {
+  /** User: Link (User) */
+  user?: string;
+}
+
+// Last updated: 2026-05-11 13:28:58.204342
+export interface HDTeam extends DocType {
+  /** Name: Data */
+  team_name: string;
+  /** Assignment Rule: Link (Assignment Rule) */
+  assignment_rule?: string;
+  /** Users: Table MultiSelect (HD Team Member) */
+  users: HDTeamMember[];
+  /** Ignore Restrictions: Check */
+  ignore_restrictions: 0 | 1;
+  /** Disabled: Check */
+  disabled: 0 | 1;
+}

--- a/desk/tsconfig.json
+++ b/desk/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
-		"allowUnreachableCode": true,
+		"allowUnreachableCode": false,
 		"baseUrl": ".",
 		"paths": {
 			"@/*": ["./src/*"]

--- a/desk/tsconfig.json
+++ b/desk/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
+		"allowUnreachableCode": true,
 		"baseUrl": ".",
 		"paths": {
 			"@/*": ["./src/*"]
@@ -9,6 +10,13 @@
 			"unplugin-icons/types/vue",
 			"vite/client"
 		],
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"allowUnusedLabels": false,
+		"noUncheckedSideEffectImports": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedIndexedAccess": true,
+		"exactOptionalPropertyTypes": true
 
 	},
 	"extends":"frappe-ui/tsconfig.base.json",

--- a/desk/vite.config.js
+++ b/desk/vite.config.js
@@ -34,6 +34,7 @@ export default defineConfig(async ({ mode }) => {
               "hd_service_holiday_list",
               "hd_service_level_agreement",
               "hd_agent",
+              "hd_team",
             ],
             frappe: ["assignment_rule"],
           },

--- a/helpdesk/extends/assignment_rule.py
+++ b/helpdesk/extends/assignment_rule.py
@@ -5,13 +5,13 @@ from helpdesk.utils import is_json_valid
 
 
 def on_assignment_rule_trash(doc, event):
-    if doc.document_type != "HD Ticket" or doc.disabled:
+    if doc.document_type != "HD Ticket":
         return
     if not frappe.get_all(
         "Assignment Rule",
         filters={"document_type": "HD Ticket", "name": ["!=", doc.name]},
     ):
-        frappe.throw(_("There should atleast be 1 assignment rule for ticket"))
+        frappe.throw(_("There should be at least 1 assignment rule for ticket"))
 
 
 def on_assignment_rule_validate(doc, event):

--- a/helpdesk/extends/assignment_rule.py
+++ b/helpdesk/extends/assignment_rule.py
@@ -28,3 +28,45 @@ def on_assignment_rule_validate(doc, event):
                 "Condition format should be like this e.g [['status','==','open']], it's recommended to use portal view to create conditions.",
             )
         )
+
+    validate_users(doc)
+
+
+def validate_users(doc):
+    """
+    When AR's users or weighted_users change, show a message if the AR is linked to a team and the user is not part of the team.
+    """
+    team_name = frappe.db.get_value("HD Team", {"assignment_rule": doc.name}, "name")
+    if not team_name:
+        return
+
+    team_agents = frappe.get_all(
+        "HD Team Member", filters={"parent": team_name}, pluck="user"
+    )
+
+    msg = _(
+        "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
+    )
+
+    if doc.rule == "Weighted Distribution":
+        users = [u.user for u in doc.weighted_users if u.user]
+        for user in users:
+            if user not in team_agents:
+                frappe.msgprint(
+                    msg.format(
+                        f"<a href='/app/hd-team/{team_name}'><b>{team_name}</b></a>",
+                        f"<u>{user}</u>",
+                        f"<a href='/app/hd-team/{team_name}'><b>{team_name}</b></a>",
+                    )
+                )
+
+    elif doc.rule == "Round Robin" or doc.rule == "Load Balancing":
+        for user in doc.users:
+            if user.user not in team_agents:
+                frappe.msgprint(
+                    msg.format(
+                        f"<a href='/app/hd-team/{team_name}'><b>{team_name}</b></a>",
+                        f"<u>{user.user}</u>",
+                        f"<a href='/app/hd-team/{team_name}'><b>{team_name}</b></a>",
+                    )
+                )

--- a/helpdesk/extends/assignment_rule.py
+++ b/helpdesk/extends/assignment_rule.py
@@ -5,11 +5,13 @@ from helpdesk.utils import is_json_valid
 
 
 def on_assignment_rule_trash(doc, event):
+    if doc.document_type != "HD Ticket" or doc.disabled:
+        return
     if not frappe.get_all(
         "Assignment Rule",
         filters={"document_type": "HD Ticket", "name": ["!=", doc.name]},
     ):
-        frappe.throw("There should atleast be 1 assignment rule for ticket")
+        frappe.throw(_("There should atleast be 1 assignment rule for ticket"))
 
 
 def on_assignment_rule_validate(doc, event):
@@ -36,6 +38,8 @@ def validate_users(doc):
     """
     When AR's users or weighted_users change, show a message if the AR is linked to a team and the user is not part of the team.
     """
+    if doc.document_type != "HD Ticket" or doc.disabled:
+        return
     team_name = frappe.db.get_value("HD Team", {"assignment_rule": doc.name}, "name")
     if not team_name:
         return

--- a/helpdesk/helpdesk/doctype/hd_team/hd_team.json
+++ b/helpdesk/helpdesk/doctype/hd_team/hd_team.json
@@ -11,6 +11,7 @@
   "assignment_rule",
   "users",
   "column_break_feto",
+  "disabled",
   "ignore_restrictions"
  ],
  "fields": [
@@ -44,11 +45,17 @@
    "fieldname": "column_break_feto",
    "fieldtype": "Column Break",
    "label": "Settings"
+  },
+  {
+   "default": "0",
+   "fieldname": "disabled",
+   "fieldtype": "Check",
+   "label": "Disabled"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-02-02 17:28:31.798544",
+ "modified": "2026-05-07 02:22:38.744911",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Team",

--- a/helpdesk/helpdesk/doctype/hd_team/hd_team.json
+++ b/helpdesk/helpdesk/doctype/hd_team/hd_team.json
@@ -18,10 +18,13 @@
   {
    "fieldname": "team_name",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Name",
+   "reqd": 1,
    "unique": 1
   },
   {
+   "depends_on": "eval:doc.assignment_rule",
    "fieldname": "assignment_rule",
    "fieldtype": "Link",
    "label": "Assignment Rule",
@@ -29,10 +32,11 @@
    "read_only": 1
   },
   {
-   "fieldname": "users",
-   "fieldtype": "Table MultiSelect",
-   "label": "Users",
-   "options": "HD Team Member"
+    "fieldname": "users",
+    "fieldtype": "Table MultiSelect",
+    "label": "Users",
+    "options": "HD Team Member",
+    "reqd": 1
   },
   {
    "default": "0",
@@ -55,7 +59,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-05-07 02:22:38.744911",
+ "modified": "2026-05-11 13:28:58.204342",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Team",

--- a/helpdesk/helpdesk/doctype/hd_team/hd_team.py
+++ b/helpdesk/helpdesk/doctype/hd_team/hd_team.py
@@ -8,100 +8,35 @@ from frappe.model.naming import append_number_if_name_exists
 
 from helpdesk.utils import agent_only, capture_event
 
+ASSIGNMENT_DAYS = [
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+    "Sunday",
+]
+
 
 class HDTeam(Document):
-    def before_save(self):
-        if self.is_new():
-            return
-        assignment_rule_doc = frappe.get_doc("Assignment Rule", self.assignment_rule)
-        if self.has_value_changed("disabled"):
-            assignment_rule_doc.disabled = bool(self.disabled)
-        assignment_rule_doc.save(ignore_permissions=True)
-
     def after_insert(self):
         self.create_assignment_rule()
-        self.sync_users_to_assignment_rule()
         self.capture_team_creation_event()
 
-    def create_assignment_rule(self):
-        """Creates the assignment rule for this group"""
-        rule_doc = frappe.new_doc("Assignment Rule")
-        rule_doc.name = append_number_if_name_exists(
-            "Assignment Rule", f"{self.name} - Support Rotation"
-        )
-        rule_doc.document_type = "HD Ticket"
-        rule_doc.assign_condition = f"status == 'Open' and agent_group == '{self.name}'"
-        rule_doc.assign_condition_json = (
-            f'[["status","==","Open"],"and",["agent_group","==","{self.name}"]]'
-        )
-        rule_doc.unassign_condition = f"agent_group != '{self.name}'"
-        rule_doc.unassign_condition_json = f'[["agent_group","!=","{self.name}"]]'
-        rule_doc.priority = 1
-        if self.disabled:
-            rule_doc.disabled = True
-
-        for day in [
-            "Monday",
-            "Tuesday",
-            "Wednesday",
-            "Thursday",
-            "Friday",
-            "Saturday",
-            "Sunday",
-        ]:
-            rule_doc.append(
-                "assignment_days", {"doctype": "Assignment Rule Day", "day": day}
-            )
-
-        rule_doc.save(ignore_permissions=True)
-        self.assignment_rule = rule_doc.name
-        self.save(ignore_permissions=True)
-
-    def sync_users_to_assignment_rule(self):
-        """
-        Syncs HD Team members into the linked AR's `users` and `weighted_users`.
-        """
-        if not self.assignment_rule:
-            return
-
-        members = [u.user for u in self.users if u.user]
-
-        ar_doc = frappe.get_doc("Assignment Rule", self.assignment_rule)
-
-        if ar_doc.get("rule") == "Weighted Distribution":
-            existing_weights = {
-                row.user: row.weight for row in ar_doc.weighted_users if row.user
-            }
-            ar_doc.weighted_users = []
-            for user in members:
-                ar_doc.append(
-                    "weighted_users",
-                    {"user": user, "weight": existing_weights.get(user, 1)},
-                )
-            ar_doc.save(ignore_permissions=True)
-            return
-        else:
-            ar_doc.users = []
-            for user in members:
-                ar_doc.append("users", {"user": user})
-            return ar_doc.save(ignore_permissions=True)
-
-    def capture_team_creation_event(self):
-        should_capture = self.name not in ["Product Experts", "Billing"]
-        if should_capture:
-            capture_event("team_created")
-
     def on_update(self):
-        self.sync_users_to_assignment_rule()
+        ar = frappe.get_doc("Assignment Rule", self.assignment_rule)
+        self.sync_users(ar)
+        ar.disabled = bool(self.disabled)
+        ar.save(ignore_permissions=True)
 
     def on_trash(self):
-        rule = self.assignment_rule
-        if not rule:
+        if not self.assignment_rule:
             return
         try:
             frappe.delete_doc(
                 "Assignment Rule",
-                rule,
+                self.assignment_rule,
                 ignore_permissions=True,
                 force=True,
                 ignore_on_trash=True,
@@ -110,31 +45,76 @@ class HDTeam(Document):
         except DoesNotExistError:
             frappe.log_error(
                 title="Assignment Rule not found",
-                message=f"Assignment Rule {rule} not found",
+                message=f"Assignment Rule {self.assignment_rule} not found",
             )
 
     def after_rename(self, olddn, newdn, merge=False):
-        rule = self.get_assignment_rule()
-        rule_doc = frappe.get_doc("Assignment Rule", rule)
-        rule_doc.assign_condition = f"status == 'Open' and agent_group == '{newdn}'"
-        rule_doc.assign_condition_json = (
-            f'[["status", "==", "Open"], "and", ["agent_group", "==", "{newdn}"]]'
-        )
-        rule_doc.unassign_condition = f"agent_group != '{newdn}'"
-        rule_doc.unassign_condition_json = f'[["agent_group", "!=", "{newdn}"]]'
-        rule_doc.save(ignore_permissions=True)
-
-    def get_assignment_rule(self):
         if not self.assignment_rule:
             self.create_assignment_rule()
-        return self.assignment_rule
+        ar = frappe.get_doc("Assignment Rule", self.assignment_rule)
+        ar.assign_condition, ar.assign_condition_json = self.assign_condition(newdn)
+        ar.unassign_condition, ar.unassign_condition_json = self.unassign_condition(
+            newdn
+        )
+        ar.save(ignore_permissions=True)
+
+    def create_assignment_rule(self):
+        ar = frappe.new_doc("Assignment Rule")
+        ar.name = append_number_if_name_exists(
+            "Assignment Rule", f"{self.name} - Support Rotation"
+        )
+        ar.document_type = "HD Ticket"
+        ar.assign_condition, ar.assign_condition_json = self.assign_condition(self.name)
+        ar.unassign_condition, ar.unassign_condition_json = self.unassign_condition(
+            self.name
+        )
+        ar.priority = 1
+        ar.disabled = bool(self.disabled)
+
+        for day in ASSIGNMENT_DAYS:
+            ar.append("assignment_days", {"doctype": "Assignment Rule Day", "day": day})
+
+        self.sync_users(ar)
+        ar.save(ignore_permissions=True)
+        self.assignment_rule = ar.name
+        self.save(ignore_permissions=True)
+
+    def sync_users(self, ar):
+        members = [u.user for u in self.users if u.user]
+
+        if ar.get("rule") == "Weighted Distribution":
+            existing_weights = {
+                row.user: row.weight for row in ar.weighted_users if row.user
+            }
+            ar.weighted_users = []
+            for user in members:
+                ar.append(
+                    "weighted_users",
+                    {"user": user, "weight": existing_weights.get(user, 1)},
+                )
+        else:
+            ar.users = []
+            for user in members:
+                ar.append("users", {"user": user})
+
+    def capture_team_creation_event(self):
+        if self.name not in ["Product Experts", "Billing"]:
+            capture_event("team_created")
+
+    def assign_condition(self, team_name: str) -> tuple[str, str]:
+        condition = f"status == 'Open' and agent_group == '{team_name}'"
+        condition_json = (
+            f'[["status","==","Open"],"and",["agent_group","==","{team_name}"]]'
+        )
+        return condition, condition_json
+
+    def unassign_condition(self, team_name: str) -> tuple[str, str]:
+        condition = f"agent_group != '{team_name}'"
+        condition_json = f'[["agent_group","!=","{team_name}"]]'
+        return condition, condition_json
 
 
 @frappe.whitelist()
 @agent_only
 def get_team_members(team: str):
-    """
-    Returns the team members for the given team name
-    """
-    members = frappe.get_all("HD Team Member", filters={"parent": team}, pluck="user")
-    return members
+    return frappe.get_all("HD Team Member", filters={"parent": team}, pluck="user")

--- a/helpdesk/helpdesk/doctype/hd_team/hd_team.py
+++ b/helpdesk/helpdesk/doctype/hd_team/hd_team.py
@@ -2,8 +2,6 @@
 # For license information, please see license.txt
 
 import frappe
-from frappe import _
-from frappe.core.doctype.version.version import get_diff
 from frappe.exceptions import DoesNotExistError
 from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists
@@ -14,40 +12,80 @@ from helpdesk.utils import agent_only, capture_event
 class HDTeam(Document):
     def after_insert(self):
         self.create_assignment_rule()
-        assignment_rule_doc = frappe.get_doc("Assignment Rule", self.assignment_rule)
-
-        for user in self.users:
-            _user = user.get("user")
-            if not _user:
-                continue
-            assignment_rule_doc.append("users", {"user": _user})
-
-        if assignment_rule_doc.disabled and assignment_rule_doc.users:
-            assignment_rule_doc.disabled = False
-        assignment_rule_doc.save()
-
+        self.sync_users_to_assignment_rule()
         self.capture_team_creation_event()
+
+    def create_assignment_rule(self):
+        """Creates the assignment rule for this group"""
+        rule_doc = frappe.new_doc("Assignment Rule")
+        rule_doc.name = append_number_if_name_exists(
+            "Assignment Rule", f"{self.name} - Support Rotation"
+        )
+        rule_doc.document_type = "HD Ticket"
+        rule_doc.assign_condition = f"status == 'Open' and agent_group == '{self.name}'"
+        rule_doc.assign_condition_json = (
+            f'[["status","==","Open"],"and",["agent_group","==","{self.name}"]]'
+        )
+        rule_doc.unassign_condition = f"agent_group != '{self.name}'"
+        rule_doc.unassign_condition_json = f'[["agent_group","!=","{self.name}"]]'
+        rule_doc.priority = 1
+        rule_doc.disabled = True
+
+        for day in [
+            "Monday",
+            "Tuesday",
+            "Wednesday",
+            "Thursday",
+            "Friday",
+            "Saturday",
+            "Sunday",
+        ]:
+            rule_doc.append(
+                "assignment_days", {"doctype": "Assignment Rule Day", "day": day}
+            )
+
+        rule_doc.save(ignore_permissions=True)
+        self.assignment_rule = rule_doc.name
+        self.save(ignore_permissions=True)
+
+    def sync_users_to_assignment_rule(self):
+        """
+        Syncs HD Team members into the linked AR's `users` and `weighted_users`.
+        """
+        if not self.assignment_rule:
+            return
+
+        members = [u.user for u in self.users if u.user]
+
+        ar_doc = frappe.get_doc("Assignment Rule", self.assignment_rule)
+
+        if ar_doc.get("rule") == "Weighted Distribution":
+            existing_weights = {
+                row.user: row.weight for row in ar_doc.weighted_users if row.user
+            }
+            ar_doc.weighted_users = []
+            for user in members:
+                ar_doc.append(
+                    "weighted_users",
+                    {"user": user, "weight": existing_weights.get(user, 1)},
+                )
+            ar_doc.save(ignore_permissions=True)
+            return
+        else:
+            ar_doc.users = []
+            for user in members:
+                ar_doc.append("users", {"user": user})
+            return ar_doc.save(ignore_permissions=True)
 
     def capture_team_creation_event(self):
         should_capture = self.name not in ["Product Experts", "Billing"]
         if should_capture:
             capture_event("team_created")
 
-    def after_rename(self, olddn, newdn, merge=False):
-        # Update the condition for the linked assignment rule
-        rule = self.get_assignment_rule()
-        rule_doc = frappe.get_doc("Assignment Rule", rule)
-        rule_doc.assign_condition = f"status == 'Open' and agent_group == '{newdn}'"
-        rule_doc.assign_condition_json = (
-            f'[["status", "==", "Open"], "and", ["agent_group", "==", "{newdn}"]]'
-        )
-        rule_doc.save(ignore_permissions=True)
-
     def on_update(self):
-        self.update_support_rotations()
+        self.sync_users_to_assignment_rule()
 
     def on_trash(self):
-        # Deletes the assignment rule for this group
         rule = self.assignment_rule
         if not rule:
             return
@@ -66,112 +104,21 @@ class HDTeam(Document):
                 message=f"Assignment Rule {rule} not found",
             )
 
-    def create_assignment_rule(self):
-        """Creates the assignment rule for this group"""
-
-        rule_doc = frappe.new_doc("Assignment Rule")
-        rule_doc.name = append_number_if_name_exists(
-            "Assignment Rule", f"{self.name} - Support Rotation"
-        )
-        rule_doc.document_type = "HD Ticket"
-        rule_doc.assign_condition = f"status == 'Open' and agent_group == '{self.name}'"
+    def after_rename(self, olddn, newdn, merge=False):
+        rule = self.get_assignment_rule()
+        rule_doc = frappe.get_doc("Assignment Rule", rule)
+        rule_doc.assign_condition = f"status == 'Open' and agent_group == '{newdn}'"
         rule_doc.assign_condition_json = (
-            f'[["status","==","Open"],"and",["agent_group","==","{self.name}"]]'
+            f'[["status", "==", "Open"], "and", ["agent_group", "==", "{newdn}"]]'
         )
-        rule_doc.priority = 1
-        rule_doc.disabled = True  # Disable the rule by default, when agents are added to the group, the rule will be enabled
-
-        for day in [
-            "Monday",
-            "Tuesday",
-            "Wednesday",
-            "Thursday",
-            "Friday",
-            "Saturday",
-            "Sunday",
-        ]:
-            day_doc = frappe.get_doc({"doctype": "Assignment Rule Day", "day": day})
-            rule_doc.append("assignment_days", day_doc)
-
+        rule_doc.unassign_condition = f"agent_group != '{newdn}'"
+        rule_doc.unassign_condition_json = f'[["agent_group", "!=", "{newdn}"]]'
         rule_doc.save(ignore_permissions=True)
-        self.assignment_rule = rule_doc.name
-        self.save(ignore_permissions=True)
 
     def get_assignment_rule(self):
-        """
-        Returns the assignment rule for this group, if not found creates one
-        and returns it
-        """
         if not self.assignment_rule:
             self.create_assignment_rule()
-
         return self.assignment_rule
-
-    def update_support_rotations(self):
-        """
-        Update the support rotations for the hd_agent
-        # If agent removed, remove from the support rule of the team
-        # If agent added add to the support rule of the team and also, while adding remove from base Support Rotation
-        """
-        assg_rule_doc = frappe.get_doc("Assignment Rule", self.assignment_rule)
-        if not assg_rule_doc:
-            return
-
-        previous_doc = self.get_doc_before_save()
-        diff = get_diff(previous_doc, self)
-        if not diff:
-            return
-
-        if not diff.get("removed") and not diff.get("added"):
-            return
-
-        for user in diff.get("removed"):
-            self.update_assignment_rule_users(user, assg_rule_doc, action="remove")
-
-        for user in diff.get("added"):
-            self.update_assignment_rule_users(user, assg_rule_doc)
-
-    def update_assignment_rule_users(self, user, assignment_rule_doc, action="add"):
-        _user = user[1].get("user")
-        if not user:
-            frappe.throw(_("User Not found"))
-            return
-
-        if action == "add":
-            assignment_rule_doc.append("users", {"user": _user})
-            if assignment_rule_doc.disabled:
-                assignment_rule_doc.disabled = False
-            assignment_rule_doc.save()
-
-            # remove the user from the base assignment rule
-            base_assignment_rule = frappe.get_value(
-                "HD Settings", "HD Settings", "base_support_rotation"
-            )
-            base_assignment_rule = frappe.get_doc(
-                "Assignment Rule", base_assignment_rule
-            )
-            user_id = frappe.get_value(
-                "Assignment Rule User",
-                {"user": _user, "parent": base_assignment_rule.name},
-            )
-            if user_id:
-                frappe.delete_doc("Assignment Rule User", user_id)
-        else:
-            user_id = frappe.get_value(
-                "Assignment Rule User",
-                {"user": _user, "parent": assignment_rule_doc.name},
-            )
-            if not user_id:
-                return
-            frappe.delete_doc("Assignment Rule User", user_id)
-
-            # disable the assignment rule if there are no users
-            total_users_in_assignment_rule = frappe.db.count(
-                "Assignment Rule User", {"parent": assignment_rule_doc.name}
-            )
-            if total_users_in_assignment_rule == 0:
-                assignment_rule_doc.disabled = True
-                assignment_rule_doc.save()
 
 
 @frappe.whitelist()

--- a/helpdesk/helpdesk/doctype/hd_team/hd_team.py
+++ b/helpdesk/helpdesk/doctype/hd_team/hd_team.py
@@ -25,6 +25,8 @@ class HDTeam(Document):
         self.capture_team_creation_event()
 
     def on_update(self):
+        if not self.assignment_rule:
+            return
         ar = frappe.get_doc("Assignment Rule", self.assignment_rule)
         self.sync_users(ar)
         ar.disabled = bool(self.disabled)
@@ -76,8 +78,7 @@ class HDTeam(Document):
 
         self.sync_users(ar)
         ar.save(ignore_permissions=True)
-        self.assignment_rule = ar.name
-        self.save(ignore_permissions=True)
+        self.db_set("assignment_rule", ar.name, update_modified=False)
 
     def sync_users(self, ar):
         members = [u.user for u in self.users if u.user]

--- a/helpdesk/helpdesk/doctype/hd_team/hd_team.py
+++ b/helpdesk/helpdesk/doctype/hd_team/hd_team.py
@@ -10,6 +10,14 @@ from helpdesk.utils import agent_only, capture_event
 
 
 class HDTeam(Document):
+    def before_save(self):
+        if self.is_new():
+            return
+        assignment_rule_doc = frappe.get_doc("Assignment Rule", self.assignment_rule)
+        if self.has_value_changed("disabled"):
+            assignment_rule_doc.disabled = bool(self.disabled)
+        assignment_rule_doc.save(ignore_permissions=True)
+
     def after_insert(self):
         self.create_assignment_rule()
         self.sync_users_to_assignment_rule()
@@ -29,7 +37,8 @@ class HDTeam(Document):
         rule_doc.unassign_condition = f"agent_group != '{self.name}'"
         rule_doc.unassign_condition_json = f'[["agent_group","!=","{self.name}"]]'
         rule_doc.priority = 1
-        rule_doc.disabled = True
+        if self.disabled:
+            rule_doc.disabled = True
 
         for day in [
             "Monday",

--- a/helpdesk/helpdesk/doctype/hd_team/test_hd_team.py
+++ b/helpdesk/helpdesk/doctype/hd_team/test_hd_team.py
@@ -1,38 +1,113 @@
 # Copyright (c) 2022, Frappe Technologies and Contributors
 # See license.txt
 
-import json
-
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
-from helpdesk.test_utils import make_agent, make_team
+from helpdesk.test_utils import make_agent, make_team, make_ticket
 
 
 class TestHDTeam(FrappeTestCase):
-    def test_assignment_rule_creation(self):
-        team = make_team("Test Team")
+
+    def test_assignment_rule_created_on_team_insert(self):
+        team = make_team("Test AR Creation")
         self.assertTrue(team.assignment_rule)
-        ar_name = f"{team.name} - Support Rotation"
-        self.assertTrue(frappe.db.exists("Assignment Rule", ar_name))
+        self.assertTrue(frappe.db.exists("Assignment Rule", team.assignment_rule))
 
-    def test_team_rename_updates_assignment_rule(self):
-        team = make_team("Test Team Rename")
-        old_rule_name = team.assignment_rule
-        new_team_name = "Renamed Test Team"
-        frappe.rename_doc("HD Team", team.name, new_team_name)
-        team = frappe.get_doc("HD Team", new_team_name)
-        updated_rule = frappe.get_doc("Assignment Rule", old_rule_name)
-        expected_condition = f"status == 'Open' and agent_group == '{new_team_name}'"
-        self.assertEqual(updated_rule.assign_condition, expected_condition)
+    def test_conditions_set_on_creation(self):
+        team = make_team("Test Conditions Creation")
+        ar = frappe.get_doc("Assignment Rule", team.assignment_rule)
 
-    def test_team_agent_sync_with_assignment_rule(self):
-        agent1 = make_agent("testagent1@example.com")
-        agent2 = make_agent("testagent2@example.com")
-        team = make_team("Test Team Sync", [agent1, agent2])
+        self.assertEqual(
+            ar.assign_condition,
+            f"status == 'Open' and agent_group == '{team.name}'",
+        )
+        self.assertIn(team.name, ar.assign_condition_json)
 
-        rule_doc = frappe.get_doc("Assignment Rule", team.assignment_rule)
+        self.assertEqual(ar.unassign_condition, f"agent_group != '{team.name}'")
+        self.assertIn(team.name, ar.unassign_condition_json)
+        self.assertIn("!=", ar.unassign_condition_json)
 
-        assignment_rule_users = [user.user for user in rule_doc.users]
-        agents_in_team = [agent.user for agent in team.users]
-        self.assertEqual(json.dumps(assignment_rule_users), json.dumps(agents_in_team))
+    def test_conditions_updated_on_rename(self):
+        team = make_team("Test Conditions Rename Old")
+        ar_name = team.assignment_rule
+        new_name = "Test Conditions Rename New"
+
+        frappe.rename_doc("HD Team", team.name, new_name)
+
+        ar = frappe.get_doc("Assignment Rule", ar_name)
+        self.assertEqual(
+            ar.assign_condition,
+            f"status == 'Open' and agent_group == '{new_name}'",
+        )
+        self.assertIn(new_name, ar.assign_condition_json)
+        self.assertEqual(ar.unassign_condition, f"agent_group != '{new_name}'")
+        self.assertIn(new_name, ar.unassign_condition_json)
+
+    def test_round_robin_users_synced(self):
+        agent1 = make_agent("rr_sync_1@example.com")
+        agent2 = make_agent("rr_sync_2@example.com")
+        team = make_team("Test RR Sync", [agent1, agent2])
+
+        # Both members should be in AR users
+        ar = frappe.get_doc("Assignment Rule", team.assignment_rule)
+        ar_users = {u.user for u in ar.users}
+        self.assertEqual(ar_users, {agent1, agent2})
+
+        # Remove agent2 from team
+        team.reload()
+        team.users = [u for u in team.users if u.user != agent2]
+        team.save(ignore_permissions=True)
+
+        ar.reload()
+        ar_users = {u.user for u in ar.users}
+        self.assertIn(agent1, ar_users)
+        self.assertNotIn(agent2, ar_users)
+
+    def test_weighted_users_synced(self):
+        agent1 = make_agent("wd_sync_1@example.com")
+        agent2 = make_agent("wd_sync_2@example.com")
+        agent3 = make_agent("wd_sync_3@example.com")
+        team = make_team("Test Weighted Sync", [agent1, agent2])
+
+        # Switch AR to Weighted Distribution
+        ar = frappe.get_doc("Assignment Rule", team.assignment_rule)
+        ar.rule = "Weighted Distribution"
+        ar.save(ignore_permissions=True)
+
+        # Trigger sync by saving team
+        team.reload()
+        team.save(ignore_permissions=True)
+
+        ar.reload()
+        ar_weighted = {u.user for u in ar.weighted_users}
+        self.assertEqual(ar_weighted, {agent1, agent2})
+
+        # Set agent1's weight directly in DB — no hooks triggered
+        row = next(r for r in ar.weighted_users if r.user == agent1)
+        frappe.db.set_value("Assignment Rule User", row.name, "weight", 5)
+
+        # Add agent3 — triggers resync
+        team.reload()
+        team.append("users", {"user": agent3})
+        team.save(ignore_permissions=True)
+
+        ar.reload()
+        preserved = next((r for r in ar.weighted_users if r.user == agent1), None)
+        self.assertIsNotNone(preserved)
+        self.assertEqual(preserved.weight, 5)
+
+        added = next((r for r in ar.weighted_users if r.user == agent3), None)
+        self.assertIsNotNone(added)
+        self.assertEqual(added.weight, 1)
+
+        # Remove agent2 — triggers resync
+        team.reload()
+        team.users = [u for u in team.users if u.user != agent2]
+        team.save(ignore_permissions=True)
+
+        ar.reload()
+        ar_weighted = {u.user for u in ar.weighted_users}
+        self.assertIn(agent1, ar_weighted)
+        self.assertIn(agent3, ar_weighted)
+        self.assertNotIn(agent2, ar_weighted)

--- a/helpdesk/helpdesk/doctype/hd_team/test_hd_team.py
+++ b/helpdesk/helpdesk/doctype/hd_team/test_hd_team.py
@@ -8,7 +8,6 @@ from helpdesk.test_utils import make_agent, make_team, make_ticket
 
 
 class TestHDTeam(FrappeTestCase):
-
     def test_assignment_rule_created_on_team_insert(self):
         team = make_team("Test AR Creation")
         self.assertTrue(team.assignment_rule)
@@ -111,3 +110,22 @@ class TestHDTeam(FrappeTestCase):
         self.assertIn(agent1, ar_weighted)
         self.assertIn(agent3, ar_weighted)
         self.assertNotIn(agent2, ar_weighted)
+
+    def test_assignment_rule_enabled_disabled(self):
+        team = make_team("Test AR Enable Disable")
+        ar = frappe.get_doc("Assignment Rule", team.assignment_rule)
+        self.assertFalse(ar.disabled)
+
+        team.disabled = True
+        team.save(ignore_permissions=True)
+        ar.reload()
+        self.assertTrue(ar.disabled)
+
+        team.disabled = False
+        team.save(ignore_permissions=True)
+        ar.reload()
+        self.assertFalse(ar.disabled)
+
+        team2 = make_team("Test AR Enable Disable 2", disabled=True)
+        ar2 = frappe.get_doc("Assignment Rule", team2.assignment_rule)
+        self.assertTrue(ar2.disabled)

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -37,6 +37,7 @@
   "response",
   "first_response_time",
   "first_responded_on",
+  "first_response_failed_by",
   "column_break_26",
   "avg_response_time",
   "last_agent_response",
@@ -50,6 +51,7 @@
   "resolution_date",
   "resolution_time",
   "user_resolution_time",
+  "resolution_failed_by",
   "reference_tab",
   "additional_info",
   "contact",
@@ -129,6 +131,7 @@
    "fieldname": "agent_group",
    "fieldtype": "Link",
    "label": "Team",
+   "link_filters": "[[\"HD Team\",\"disabled\",\"=\",0]]",
    "options": "HD Team"
   },
   {
@@ -464,13 +467,27 @@
    "label": "Ticket raised outside working hours",
    "read_only": 1,
    "set_only_once": 1
+  },
+  {
+   "depends_on": "eval:doc.first_responded_on",
+   "fieldname": "first_response_failed_by",
+   "fieldtype": "Duration",
+   "label": "First Response Failed By",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.status_category == \"Resolved\"",
+   "fieldname": "resolution_failed_by",
+   "fieldtype": "Duration",
+   "label": "Resolution Failed By",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "icon": "fa fa-issue",
  "idx": 61,
  "links": [],
- "modified": "2026-04-30 19:58:44.919596",
+ "modified": "2026-05-11 17:56:26.750850",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Ticket",

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -37,7 +37,6 @@
   "response",
   "first_response_time",
   "first_responded_on",
-  "first_response_failed_by",
   "column_break_26",
   "avg_response_time",
   "last_agent_response",
@@ -51,7 +50,6 @@
   "resolution_date",
   "resolution_time",
   "user_resolution_time",
-  "resolution_failed_by",
   "reference_tab",
   "additional_info",
   "contact",
@@ -467,27 +465,13 @@
    "label": "Ticket raised outside working hours",
    "read_only": 1,
    "set_only_once": 1
-  },
-  {
-   "depends_on": "eval:doc.first_responded_on",
-   "fieldname": "first_response_failed_by",
-   "fieldtype": "Duration",
-   "label": "First Response Failed By",
-   "read_only": 1
-  },
-  {
-   "depends_on": "eval:doc.status_category == \"Resolved\"",
-   "fieldname": "resolution_failed_by",
-   "fieldtype": "Duration",
-   "label": "Resolution Failed By",
-   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "icon": "fa fa-issue",
  "idx": 61,
  "links": [],
- "modified": "2026-05-11 17:56:26.750850",
+ "modified": "2026-05-11 18:25:54.352721",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Ticket",

--- a/helpdesk/setup/install.py
+++ b/helpdesk/setup/install.py
@@ -223,6 +223,7 @@ def add_website_settings_permission():
         update_permission_property(doctype, role, 0, p, 1)
 
 
+# TODO: why?
 def add_default_assignment_rule():
     support_settings = frappe.get_doc("HD Settings")
     support_settings.create_base_support_rotation()

--- a/helpdesk/setup/install.py
+++ b/helpdesk/setup/install.py
@@ -172,7 +172,7 @@ def add_default_agent_groups():
         if not frappe.db.exists("HD Team", agent_group):
             agent_group_doc = frappe.new_doc("HD Team")
             agent_group_doc.team_name = agent_group
-            agent_group_doc.insert()
+            agent_group_doc.insert(ignore_mandatory=True)
 
 
 def update_agent_role_permissions():

--- a/helpdesk/setup/install.py
+++ b/helpdesk/setup/install.py
@@ -223,7 +223,6 @@ def add_website_settings_permission():
         update_permission_property(doctype, role, 0, p, 1)
 
 
-# TODO: why?
 def add_default_assignment_rule():
     support_settings = frappe.get_doc("HD Settings")
     support_settings.create_base_support_rotation()

--- a/helpdesk/test_utils.py
+++ b/helpdesk/test_utils.py
@@ -301,7 +301,7 @@ def add_comment(
     return comment
 
 
-def make_team(team_name, members=[]):
+def make_team(team_name, members=[], disabled=False):
     """Create an HD Team with optional members. A default agent is created if no members are provided."""
     if not members:
         members = [make_agent("default_team_agent@example.com")]

--- a/helpdesk/test_utils.py
+++ b/helpdesk/test_utils.py
@@ -302,9 +302,11 @@ def add_comment(
 
 
 def make_team(team_name, members=[]):
-    """Create an HD Team with optional members."""
+    """Create an HD Team with optional members. A default agent is created if no members are provided."""
+    if not members:
+        members = [make_agent("default_team_agent@example.com")]
+
     if frappe.db.exists("HD Team", team_name):
-        # Delete existing team members
         team = frappe.get_doc("HD Team", team_name)
         team.users = []
         for member in members:

--- a/helpdesk/test_utils.py
+++ b/helpdesk/test_utils.py
@@ -308,6 +308,7 @@ def make_team(team_name, members=[], disabled=False):
 
     if frappe.db.exists("HD Team", team_name):
         team = frappe.get_doc("HD Team", team_name)
+        team.disabled = disabled
         team.users = []
         for member in members:
             team.append("users", {"user": member})
@@ -323,5 +324,6 @@ def make_team(team_name, members=[], disabled=False):
     )
     for member in members:
         team.append("users", {"user": member})
+    team.disabled = disabled
     team.insert(ignore_permissions=True)
     return team

--- a/helpdesk/utils.py
+++ b/helpdesk/utils.py
@@ -175,15 +175,16 @@ def agent_only(fn):
 
 
 def get_agents_team():
-    QBTeam = frappe.qb.DocType("HD Team")
-    QBTeamMember = frappe.qb.DocType("HD Team Member")
+    Team = frappe.qb.DocType("HD Team")
+    TeamMember = frappe.qb.DocType("HD Team Member")
 
     teams = (
-        frappe.qb.from_(QBTeamMember)
-        .where(QBTeamMember.user == frappe.session.user)
-        .join(QBTeam)
-        .on(QBTeam.name == QBTeamMember.parent)
-        .select(QBTeam.team_name, QBTeam.ignore_restrictions)
+        frappe.qb.from_(TeamMember)
+        .where(TeamMember.user == frappe.session.user)
+        .where(Team.disabled == 0)
+        .join(Team)
+        .on(Team.name == TeamMember.parent)
+        .select(Team.team_name, Team.ignore_restrictions)
         .run(as_dict=True)
     )
     return teams

--- a/helpdesk/utils.py
+++ b/helpdesk/utils.py
@@ -180,10 +180,10 @@ def get_agents_team():
 
     teams = (
         frappe.qb.from_(TeamMember)
-        .where(TeamMember.user == frappe.session.user)
-        .where(Team.disabled == 0)
         .join(Team)
         .on(Team.name == TeamMember.parent)
+        .where(TeamMember.user == frappe.session.user)
+        .where(Team.disabled == 0)
         .select(Team.team_name, Team.ignore_restrictions)
         .run(as_dict=True)
     )


### PR DESCRIPTION
1. Adds disabled field in HD Team
2. Display "enabled" switch in UI of Teams in Settings.
3. Add support for Weighted Users (Assignment Rule) in HD Team.
4. Refactor HD Team doctype


depends-on: https://github.com/frappe/frappe/pull/37741 & https://github.com/frappe/frappe/pull/39220