### PR TITLE
fix: parse period filter

### DIFF
--- a/desk/src/pages/dashboard/Dashboard.vue
+++ b/desk/src/pages/dashboard/Dashboard.vue
@@ -332,12 +332,21 @@ const isEmpty = computed(() => {
   );
 });
 
+const parseFilters = (filters: Filters) => {
+  return {
+    from_date: filters.period.split(",")[0],
+    to_date: filters.period.split(",")[1],
+    team: filters.team,
+    agent: filters.agent,
+  };
+};
+
 const numberCards = createResource({
   url: "helpdesk.api.dashboard.get_dashboard_data",
   cache: ["Analytics", "NumberCards"],
   makeParams: () => ({
     dashboard_type: "number_card",
-    filters,
+    filters: parseFilters(filters),
   }),
 });
 
@@ -346,7 +355,7 @@ const masterData = createResource({
   cache: ["Analytics", "MasterCharts"],
   makeParams: () => ({
     dashboard_type: "master",
-    filters,
+    filters: parseFilters(filters),
   }),
 });
 
@@ -355,7 +364,7 @@ const trendData = createResource({
   cache: ["Analytics", "TrendCharts"],
   makeParams: () => ({
     dashboard_type: "trend",
-    filters,
+    filters: parseFilters(filters),
   }),
 });
 


### PR DESCRIPTION
## Problem                                                                    
Every date preset on `/helpdesk/dashboard` (Today, Last 7 / 30 / 60 / 90 Days, Custom Range) showed the **same** ticket count and chart data.

Regression from #3141

### Before Fix
[Screencast from 2026-05-07 15-44-09.webm](https://github.com/user-attachments/assets/5f8b07d4-9689-48c8-a3eb-71601eb7fb1f)

### After Fix
[Screencast from 2026-05-07 15-46-40.webm](https://github.com/user-attachments/assets/f6d0f86a-694b-473f-a286-b4a4ebab635b)
                                                                
          
