### PR TITLE
fix: make onboarding steps to depend on ticket creation

### DIFF
--- a/desk/src/components/layouts/Sidebar.vue
+++ b/desk/src/components/layouts/Sidebar.vue
@@ -188,7 +188,7 @@ import { useNotificationStore } from "@/stores/notification";
 import { useSidebarStore } from "@/stores/sidebar";
 import { capture } from "@/telemetry";
 import { isCustomerPortal } from "@/utils";
-import { call } from "frappe-ui";
+import { call, toast } from "frappe-ui";
 import {
   GettingStartedBanner,
   HelpModal,
@@ -457,6 +457,7 @@ const steps = [
     name: "assign_to_agent",
     title: __("Assign a ticket to an agent"),
     completed: false,
+    dependsOn: "create_first_ticket",
     icon: markRaw(UserPen),
     onClick: async () => {
       await handleFirstTicketNavigation();
@@ -468,6 +469,7 @@ const steps = [
     name: "reply_on_ticket",
     title: __("Reply on a ticket"),
     completed: false,
+    dependsOn: "create_first_ticket",
     icon: markRaw(MailOpen),
     onClick: async () => {
       await handleFirstTicketNavigation();
@@ -480,6 +482,7 @@ const steps = [
     name: "comment_on_ticket",
     title: __("Add a comment on a ticket"),
     completed: false,
+    dependsOn: "create_first_ticket",
     icon: markRaw(MessageCircle),
     onClick: async () => {
       await handleFirstTicketNavigation();
@@ -624,20 +627,30 @@ const { isOnboardingStepsCompleted, setUp, updateOnboardingStep } =
 async function handleFirstTicketNavigation() {
   const ticket = await getFirstTicket();
 
-  if (ticket) {
-    router.push({
-      name: "TicketAgent",
-      params: { ticketId: ticket },
-    });
-  } else {
+  if (!ticket) {
     router.push({ name: "TicketAgentNew" });
+    updateOnboardingStep("create_first_ticket", false); // reset the step as first ticket is not created
+    toast.error("Please create a new ticket to proceed with the next step.");
+    return;
   }
+
+  router.push({
+    name: "TicketAgent",
+    params: { ticketId: ticket },
+  });
 }
 
 async function getFirstTicket() {
-  let ticket = localStorage.getItem("firstTicket");
-  if (ticket) return ticket;
-  return await call("helpdesk.api.onboarding.get_first_ticket");
+  let cachedTicket = localStorage.getItem("firstTicket");
+  const ticket = await call("helpdesk.api.onboarding.get_first_ticket", {
+    ticket: cachedTicket,
+  });
+  if (ticket) {
+    localStorage.setItem("firstTicket", ticket);
+  } else {
+    localStorage.removeItem("firstTicket");
+  }
+  return ticket;
 }
 
 async function getGeneralCategory() {

--- a/helpdesk/api/onboarding.py
+++ b/helpdesk/api/onboarding.py
@@ -2,9 +2,13 @@ import frappe
 
 
 @frappe.whitelist()
-def get_first_ticket():
+def get_first_ticket(ticket: str | None = None):
     """Get first ticket created except the default ticket"""
-    ticket = frappe.get_all(
+    # If a cached ticket ID was passed, verify it still exists
+    if ticket and frappe.db.exists("HD Ticket", ticket):
+        return ticket
+
+    result = frappe.get_all(
         "HD Ticket",
         filters={
             "subject": ["!=", "Welcome to Helpdesk"],
@@ -14,7 +18,7 @@ def get_first_ticket():
         order_by="creation asc",
         limit=1,
     )
-    return ticket[0].name if ticket else None
+    return result[0].name if result else None
 
 
 @frappe.whitelist()


### PR DESCRIPTION
The onboarding steps were active even without checking if the First ticket has been created or not,

this pr fixes it by using the dependsOn property in frappe-ui onboarding module.

<img width="491" height="748" alt="image" src="https://github.com/user-attachments/assets/c93b5156-18e6-47e4-a200-e30c6daf03f5" />

also handles edge cases where the first ticket may have been created but later deleted. The user is then prompted to   create a new ticket.

 