### PR TITLE
refactor: Use read replica for all get APIs

### DIFF
--- a/helpdesk/api/agent_home/agent_home.py
+++ b/helpdesk/api/agent_home/agent_home.py
@@ -17,6 +17,7 @@ from helpdesk.utils import agent_only, format_time_difference
 
 
 @frappe.whitelist()
+@frappe.read_only()
 @agent_only
 def get_dashboard(reset_layout: bool = False):
     dashboard = frappe.db.exists("HD Field Layout", {"user": frappe.session.user})
@@ -54,6 +55,7 @@ def get_dashboard(reset_layout: bool = False):
 
 
 @frappe.whitelist()
+@frappe.read_only()
 @agent_only
 def get_agent_tickets(period: str = "last month"):
     current_from, current_to, previous_from, previous_to = _resolve_window(period)
@@ -216,6 +218,7 @@ def _get_avg_time_metric(period: str, value_expr, extra_cond) -> dict:
 
 
 @frappe.whitelist()
+@frappe.read_only()
 @agent_only
 def get_avg_first_response_time(period: str = "last month"):
     Ticket = DocType("HD Ticket")
@@ -227,6 +230,7 @@ def get_avg_first_response_time(period: str = "last month"):
 
 
 @frappe.whitelist()
+@frappe.read_only()
 @agent_only
 def get_avg_resolution_time(period: str = "last month"):
     Ticket = DocType("HD Ticket")
@@ -244,6 +248,7 @@ def get_avg_resolution_time(period: str = "last month"):
 
 
 @frappe.whitelist()
+@frappe.read_only()
 @agent_only
 def get_recent_feedback(
     period: str = "all_time",
@@ -366,6 +371,7 @@ def get_recent_feedback(
 
 
 @frappe.whitelist()
+@frappe.read_only()
 @agent_only
 def get_avg_time_metrics(
     period: str = "6m", from_date: str = None, to_date: str = None
@@ -682,6 +688,7 @@ def _get_pending_response_tickets(limit=10):
 
 
 @frappe.whitelist()
+@frappe.read_only()
 @agent_only
 def get_pending_tickets(ticket_type: str = "upcoming_sla"):
     min_priority, max_priority = _get_priority_range()

--- a/helpdesk/api/article.py
+++ b/helpdesk/api/article.py
@@ -42,6 +42,7 @@ def sanitize_query(query: str) -> str:
 
 
 @frappe.whitelist()
+@frappe.read_only()
 def get_article_stats(article_name: str):
     views = frappe.db.get_value("HD Article", article_name, "views")
 

--- a/helpdesk/api/assignment_rule.py
+++ b/helpdesk/api/assignment_rule.py
@@ -2,6 +2,7 @@ import frappe
 
 
 @frappe.whitelist()
+@frappe.read_only()
 def get_assignment_rules_list():
     if not frappe.has_permission("Assignment Rule", "read"):
         frappe.throw(

--- a/helpdesk/api/auth.py
+++ b/helpdesk/api/auth.py
@@ -5,6 +5,7 @@ from helpdesk.utils import is_agent as _is_agent
 
 
 @frappe.whitelist()
+@frappe.read_only()
 def get_user():
     current_user = frappe.session.user
     filters = {"name": current_user}
@@ -56,6 +57,7 @@ def get_user():
 
 
 @frappe.whitelist()
+@frappe.read_only()
 @agent_only
 def get_current_user_email_info():
     user = frappe.session.user

--- a/helpdesk/api/config.py
+++ b/helpdesk/api/config.py
@@ -1,7 +1,7 @@
 import frappe
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True)  # nosemgrep
 @frappe.read_only()
 def get_config():
     fields = [

--- a/helpdesk/api/config.py
+++ b/helpdesk/api/config.py
@@ -2,6 +2,7 @@ import frappe
 
 
 @frappe.whitelist(allow_guest=True)
+@frappe.read_only()
 def get_config():
     fields = [
         "brand_name",

--- a/helpdesk/api/contact.py
+++ b/helpdesk/api/contact.py
@@ -4,6 +4,7 @@ import frappe
 
 
 @frappe.whitelist(methods=["GET"])
+@frappe.read_only()
 def search_contacts(
     txt: str,
 ) -> list[dict[Literal["full_name", "name", "email_id"], str]]:

--- a/helpdesk/api/dashboard.py
+++ b/helpdesk/api/dashboard.py
@@ -21,6 +21,7 @@ COUNT_DESC = "count desc"
 
 
 @frappe.whitelist()
+@frappe.read_only()
 @agent_only
 def get_dashboard_data(
     dashboard_type: str, filters: dict[str, any] = None

--- a/helpdesk/api/doc.py
+++ b/helpdesk/api/doc.py
@@ -16,6 +16,7 @@ from helpdesk.utils import (
 
 
 @frappe.whitelist()
+@frappe.read_only()
 def get_list_data(
     doctype: str,
     # flake8: noqa
@@ -232,6 +233,7 @@ def get_list_data(
 
 
 @frappe.whitelist()
+@frappe.read_only()
 @redis_cache()
 def get_filterable_fields(
     doctype: str,
@@ -371,6 +373,7 @@ def get_filterable_fields(
 
 
 @frappe.whitelist()
+@frappe.read_only()
 def sort_options(doctype: str, show_customer_portal_fields: bool = False):
     fields = frappe.get_meta(doctype).fields
     fields = [field for field in fields if field.fieldtype not in no_value_fields]
@@ -400,6 +403,7 @@ def sort_options(doctype: str, show_customer_portal_fields: bool = False):
 
 
 @frappe.whitelist()
+@frappe.read_only()
 def get_quick_filters(doctype: str, show_customer_portal_fields: bool = False):
     meta = frappe.get_meta(doctype)
     fields = [field for field in meta.fields if field.in_standard_filter]

--- a/helpdesk/api/knowledge_base.py
+++ b/helpdesk/api/knowledge_base.py
@@ -7,7 +7,7 @@ from frappe.utils import get_user_info_for_avatar
 from helpdesk.utils import is_agent
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist(allow_guest=True)  # nosemgrep
 @frappe.read_only()
 def get_article(name: str):
     article = frappe.get_doc("HD Article", name).as_dict()

--- a/helpdesk/api/knowledge_base.py
+++ b/helpdesk/api/knowledge_base.py
@@ -8,6 +8,7 @@ from helpdesk.utils import is_agent
 
 
 @frappe.whitelist(allow_guest=True)
+@frappe.read_only()
 def get_article(name: str):
     article = frappe.get_doc("HD Article", name).as_dict()
 
@@ -39,8 +40,6 @@ def get_article(name: str):
         "category_id": article.category,
         "feedback": int(feedback),
     }
-
-    return article
 
 
 @frappe.whitelist()
@@ -87,6 +86,7 @@ def move_to_category(category: str, articles: list[str]):
 
 
 @frappe.whitelist()
+@frappe.read_only()
 def get_categories():
     categories = frappe.get_all(
         "HD Article Category",
@@ -103,6 +103,7 @@ def get_categories():
 
 
 @frappe.whitelist()
+@frappe.read_only()
 def get_category_articles(category: str):
     articles = frappe.get_all(
         "HD Article",
@@ -140,6 +141,7 @@ def merge_category(source: str, target: str):
 
 
 @frappe.whitelist()
+@frappe.read_only()
 def get_general_category():
     return frappe.db.get_value(
         "HD Article Category", {"category_name": "General"}, "name"
@@ -147,6 +149,7 @@ def get_general_category():
 
 
 @frappe.whitelist()
+@frappe.read_only()
 def get_category_title(category: str):
     return frappe.db.get_value("HD Article Category", category, "category_name")
 

--- a/helpdesk/api/onboarding.py
+++ b/helpdesk/api/onboarding.py
@@ -22,6 +22,7 @@ def get_first_ticket(ticket: str | None = None):
 
 
 @frappe.whitelist()
+@frappe.read_only()
 def get_general_category_id():
     """Get the id of the general category"""
     category = frappe.get_all(

--- a/helpdesk/api/saved_replies.py
+++ b/helpdesk/api/saved_replies.py
@@ -5,6 +5,7 @@ from helpdesk.utils import agent_only
 
 
 @frappe.whitelist()
+@frappe.read_only()
 @agent_only
 def get_rendered_saved_reply(ticket_id: str | int, saved_reply_id: str | None = None):
     if not saved_reply_id:

--- a/helpdesk/api/session.py
+++ b/helpdesk/api/session.py
@@ -4,6 +4,7 @@ from helpdesk.utils import agent_only
 
 
 @frappe.whitelist()
+@frappe.read_only()
 @agent_only
 def get_users():
     users = frappe.qb.get_query(

--- a/helpdesk/helpdesk/doctype/hd_ticket/api.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/api.py
@@ -29,7 +29,14 @@ from helpdesk.utils import (
 )
 
 
-@frappe.whitelist()
+def check_guest_access():
+    is_guest_allowed_to_create_ticket = frappe.db.get_single_value(
+        "HD Settings", "allow_anyone_to_create_tickets"
+    )
+    return is_guest_allowed_to_create_ticket
+
+
+@frappe.whitelist(allow_guest=check_guest_access())
 # flake8: noqa
 def new(doc: dict, attachments: list[dict] = []):
     doc["doctype"] = "HD Ticket"
@@ -40,6 +47,7 @@ def new(doc: dict, attachments: list[dict] = []):
 
 
 @frappe.whitelist()
+@frappe.read_only()
 def get_one(name: str | int, is_customer_portal: bool = False):
     frappe.has_permission("HD Ticket", "read", name, throw=True)
     QBContact = frappe.qb.DocType("Contact")
@@ -556,6 +564,7 @@ def duplicate_ticket(ticket_doc, subject):
 
 
 @frappe.whitelist()
+@frappe.read_only()
 @agent_only
 def get_ticket_customizations():
     # get form script
@@ -610,7 +619,7 @@ def get_navigation_filters(ticket: str, current_view: str = None):
                 filters = (
                     json.loads(_filters) if isinstance(_filters, str) else _filters
                 )
-            except json.JSONDecodeError, TypeError:
+            except (json.JSONDecodeError, TypeError):
                 filters = []
 
     if not filters:
@@ -627,7 +636,7 @@ def get_navigation_filters(ticket: str, current_view: str = None):
                     if isinstance(default_view, str)
                     else default_view
                 )
-            except json.JSONDecodeError, TypeError:
+            except (json.JSONDecodeError, TypeError):
                 filters = []
 
     # Base filters - exclude the current ticket
@@ -664,6 +673,7 @@ def get_navigation_order_by(view):
 
 
 @frappe.whitelist()
+@frappe.read_only()
 def get_ticket_contact(ticket: str | int):
     frappe.has_permission("HD Ticket", "read", ticket, throw=True)
     if not frappe.db.exists("HD Ticket", ticket):
@@ -688,6 +698,7 @@ def get_ticket_contact(ticket: str | int):
 
 
 @frappe.whitelist()
+@frappe.read_only()
 def get_recent_similar_tickets(ticket: str | int):
     frappe.has_permission("HD Ticket", "read", str(ticket), throw=True)
     if not frappe.db.exists("HD Ticket", ticket):
@@ -739,6 +750,7 @@ def get_recent_tickets(ticket: str):
 
 
 @frappe.whitelist()
+@frappe.read_only()
 def get_ticket_activities(ticket: str | int):
     frappe.has_permission("HD Ticket", "read", ticket, throw=True)
     activities = {
@@ -752,6 +764,7 @@ def get_ticket_activities(ticket: str | int):
 
 
 @frappe.whitelist()
+@frappe.read_only()
 def get_ticket_assignees(ticket: str | int):
     frappe.has_permission("HD Ticket", "read", ticket, throw=True)
     assignees = frappe.db.get_value("HD Ticket", ticket, "_assign") or "[]"


### PR DESCRIPTION
This pr introduces 2 changes:

- Wrap GET calls with `frappe.read_only`.
- Allow anyone to create ticket via `helpdesk.doctype.hd_ticket.api.new`.
    -  There is setting in `HD Settings` which allows anyone to create the ticket if setting is enabled, but the api itself does not checks the guest permission, so check is added for same.

ref: https://github.com/frappe/helpdesk/issues/3336