### PR TITLE
fix: border in ticket fields

### DIFF
--- a/desk/src/components/TicketField.vue
+++ b/desk/src/components/TicketField.vue
@@ -156,7 +156,7 @@ function emitUpdate(fieldname: Field["fieldname"], value: FieldValue) {
 :deep(.form-control select),
 :deep(.form-control textarea),
 :deep(.form-control button) {
-  border-color: var(--outline-gray-2);
+  border-color: transparent;
   background: var(--surface-white);
 }
 

--- a/desk/src/components/frappe-ui/Autocomplete.vue
+++ b/desk/src/components/frappe-ui/Autocomplete.vue
@@ -111,7 +111,10 @@
                 No results found
               </li>
             </ComboboxOptions>
-            <div v-if="slots.footer" class="border-t border-outline-gray-modals p-1.5 pb-0.5">
+            <div
+              v-if="slots.footer"
+              class="border-t border-outline-gray-modals p-1.5 pb-0.5"
+            >
               <slot
                 name="footer"
                 v-bind="{ value: search?.el._value, close }"

--- a/desk/src/components/ticket-agent/AssignTo.vue
+++ b/desk/src/components/ticket-agent/AssignTo.vue
@@ -7,7 +7,9 @@
   >
     <template #target="{ togglePopover }">
       <div class="flex flex-col gap-1.5 w-full">
-        <span v-if="!hideLabel" class="block text-xs text-ink-gray-5">{{ __("Assignee") }}</span>
+        <span v-if="!hideLabel" class="block text-xs text-ink-gray-5"
+          >{{ __("Assignee") }}
+        </span>
         <Button
           ref="triggerRef"
           variant="outline"
@@ -149,6 +151,9 @@ import {
   toast,
 } from "frappe-ui";
 import { computed, inject, nextTick, ref, useTemplateRef, watch } from "vue";
+import LucideSearch from "~icons/lucide/search";
+import MultipleAvatar from "../MultipleAvatar.vue";
+import UserAvatar from "../UserAvatar.vue";
 
 interface Props {
   hideLabel?: boolean;
@@ -159,9 +164,6 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const { hideLabel } = props;
-import LucideSearch from "~icons/lucide/search";
-import MultipleAvatar from "../MultipleAvatar.vue";
-import UserAvatar from "../UserAvatar.vue";
 
 const ticket = inject(TicketSymbol)!;
 const assignees = inject(AssigneeSymbol)!;


### PR DESCRIPTION
Regression on the Ticket Side panel Custom Fields caused by https://github.com/frappe/helpdesk/pull/3246


**Expected:**
<img width="357" height="823" alt="image" src="https://github.com/user-attachments/assets/7c1a2219-b7e0-4f63-9dbd-b5c6585015fa" />



**Actual:**
<img width="357" height="823" alt="image" src="https://github.com/user-attachments/assets/e7f271e4-3f02-4981-ba93-e7d1edc92d05" />


depends-on: #3246 