### PR TITLE
feat: add is_enterprise field for ticket filtering and sorting

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -13,6 +13,7 @@
   "raised_by",
   "status",
   "priority",
+  "is_enterprise",
   "status_category",
   "cb00",
   "ticket_type",
@@ -115,6 +116,14 @@
    "label": "Priority",
    "link_filters": "[[\"HD Ticket Priority\",\"disabled\",\"=\",0]]",
    "options": "HD Ticket Priority"
+  },
+  {
+    "default": "0",
+    "fieldname": "is_enterprise",
+    "fieldtype": "Check",
+    "label": "Is Enterprise Partner",
+    "in_standard_filter": 1,
+    "in_list_view": 1
   },
   {
    "fieldname": "cb00",


### PR DESCRIPTION
Added is_enterprise field to HD Ticket so enterprise tickets can be filtered, shown in list view and sorted easily.

**Changes made**

- added is_enterprise to field order in hd_ticket.json
- added field definition with:
   - in_standard_filter
   - in_list_view

This fixes #3257 since the list view already supports sorting and filters. The missing part was just exposing an enterprise flag on the doctype itself.

Did not test locally because bench runtime was not available in my environment, but verified the schema changes and field placement statically.

**Expected behavior**

- enterprise tickets can be shown as a column
- can filter enterprise tickets
- can sort enterprise tickets to top
- views can be saved normally using existing list view system

Closes #3257