### PR TITLE
fix: dark mode regressions

### DIFF
--- a/desk/src/components/layouts/MobileSidebar.vue
+++ b/desk/src/components/layouts/MobileSidebar.vue
@@ -92,7 +92,7 @@
         leave-from="opacity-100"
         leave-to="opacity-0"
       >
-        <DialogOverlay class="fixed inset-0 bg-surface-gray-5 bg-opacity-50" />
+        <DialogOverlay class="fixed inset-0 bg-black-overlay-500" />
       </TransitionChild>
     </Dialog>
   </TransitionRoot>

--- a/desk/src/index.css
+++ b/desk/src/index.css
@@ -76,6 +76,10 @@ body {
   box-shadow: inset 0 2px 4px 0 rgba(0, 0, 0, 0.55);
 }
 
+[data-theme="dark"] hr {
+  border-color: var(--outline-gray-2);
+}
+
 /* Modern slim scrollbars */
 * {
   scrollbar-width: thin;

--- a/desk/src/pages/knowledge-base/NewArticle.vue
+++ b/desk/src/pages/knowledge-base/NewArticle.vue
@@ -34,7 +34,7 @@
         </div>
         <!-- Title -->
         <textarea
-          class="w-full resize-none border-0 text-3xl font-bold placeholder-ink-gray-3 p-0 pb-3 border-b border-outline-gray-modals focus:ring-0 focus:border-outline-gray-modals"
+          class="w-full resize-none border-0 bg-transparent text-3xl font-bold placeholder-ink-gray-3 p-0 pb-3 border-b border-outline-gray-modals focus:ring-0 focus:border-outline-gray-modals"
           v-model="title"
           :placeholder="__('Title')"
           rows="1"


### PR DESCRIPTION
PR to fix dark mode regression issues mentioned in https://github.com/frappe/helpdesk/issues/3358

Fixes: 
1. Invisible dividers in Settings list views -> bump `<hr>` to `--outline-gray-2` in dark mode only
2. Mobile sidebar washed the screen near-white -> use `bg-black-overlay-500`


https://github.com/user-attachments/assets/019c0ff9-5573-47ca-abcc-40da3a52d41b

