### PR TITLE
feat: support custom helpdesk settings tabs

### DIFF
--- a/desk/src/components/Settings/settingsModal.ts
+++ b/desk/src/components/Settings/settingsModal.ts
@@ -29,10 +29,54 @@ import ProfilePage from "./Profile/ProfilePage.vue";
 
 export const showSettingsModal = ref(false);
 
+type SettingsTabItem = {
+  label: string;
+  icon?: unknown;
+  component: unknown;
+  condition?: () => boolean;
+};
+
+type SettingsTab = {
+  label: string;
+  hideLabel?: boolean;
+  noborder?: boolean;
+  condition?: () => boolean;
+  items: SettingsTabItem[];
+};
+
+type HelpdeskSettingsTabRegistry = SettingsTab[] | (() => SettingsTab[]);
+
+declare global {
+  interface Window {
+    helpdeskSettingsTabs?: HelpdeskSettingsTabRegistry;
+  }
+}
+
+const getCustomSettingsTabs = (): SettingsTab[] => {
+  const registry = window.helpdeskSettingsTabs;
+  if (!registry) return [];
+
+  const customTabs = typeof registry === "function" ? registry() : registry;
+  if (!Array.isArray(customTabs)) return [];
+
+  return customTabs.map((tab) => ({
+    ...tab,
+    items: (tab.items || []).map((item) => ({
+      ...item,
+      icon:
+        item.icon && typeof item.icon === "object" ? markRaw(item.icon) : item.icon,
+      component:
+        item.component && typeof item.component === "object"
+          ? markRaw(item.component)
+          : item.component,
+    })),
+  }));
+};
+
 const auth = useAuthStore();
 
 export const tabs = computed(() => {
-  const _tabs = [
+  const _tabs: SettingsTab[] = [
     {
       label: __("My settings"),
       hideLabel: true,
@@ -135,6 +179,8 @@ export const tabs = computed(() => {
     },
   ];
 
+  _tabs.push(...getCustomSettingsTabs());
+
   return _tabs.filter((tab) => {
     if (tab.condition && !tab.condition()) return false;
     if (tab.items) {
@@ -168,7 +214,7 @@ type TabName =
   | "Telephony"
   | "Saved Replies";
 
-export const setActiveSettingsTab = (tabName: TabName) => {
+export const setActiveSettingsTab = (tabName: TabName | string) => {
   activeTab.value =
     (tabName &&
       tabs.value

--- a/desk/yarn.lock
+++ b/desk/yarn.lock
@@ -2649,10 +2649,10 @@ fraction.js@^5.3.4:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-5.3.4.tgz#8c0fcc6a9908262df4ed197427bdeef563e0699a"
   integrity sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==
 
-frappe-ui@0.1.269:
-  version "0.1.269"
-  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-0.1.269.tgz#d694cd23fe6eadbd7bb898bb3f46e0414c27f829"
-  integrity sha512-1D4AW8cPoC7OIRqEzYnF169/r+v0EfVBvfCi/ovmk76FBPKY+qIVOzL+Vx/9TcYvJubc1tSU19F/jX177e3axA==
+frappe-ui@0.1.271:
+  version "0.1.271"
+  resolved "https://registry.yarnpkg.com/frappe-ui/-/frappe-ui-0.1.271.tgz#206aa52f4faa541da0cfdb2b32ae845e622b08e1"
+  integrity sha512-H6FDKLynUCXxo3eIainJd6FjWrBtAZ3WZXVRM4tvLT3J7x7P5JjoNefB6YD8WZ+MQThKSwMC+/Kzg8vY2mc5XQ==
   dependencies:
     "@floating-ui/dom" "^1.7.4"
     "@floating-ui/vue" "^1.1.6"


### PR DESCRIPTION
## Summary
- Adds a generic `window.helpdeskSettingsTabs` registry for Helpdesk Settings tabs.
- Allows custom apps to append their own Settings groups/items without copying custom UI into Helpdesk core.
- Normalizes custom tab icon/component objects with `markRaw` and keeps existing permission/condition filtering.
- Refreshes `desk/yarn.lock` to match the stable main branch `desk/package.json` `frappe-ui` version so the build can install cleanly.

## Base
- Upstream stable branch: `main`
- Helpdesk version: `1.24.1`
- Base commit: `92de4ab5e921570a7e408fa7f1cf70634081a5ab`

## Test Plan
- `git diff --check`
- `cd desk && yarn install`
- `cd desk && yarn build`

## Notes
This is intended as the minimal core extension point for custom apps such as Helpdesk Plus to register their own Settings tabs from their frontend bootstrap code.
