### PR TITLE
fix: add pointer-events-none to empty state overlay

### DIFF
--- a/desk/src/components/EmptyState.vue
+++ b/desk/src/components/EmptyState.vue
@@ -22,7 +22,7 @@
   </div>
   <div
     v-else
-    class="flex h-full items-center justify-center w-[stretch] absolute top-0 -z-10 pointer-events-none"
+    class="flex h-full items-center justify-center w-[stretch] absolute top-0 pointer-events-none"
   >
     <div
       class="flex flex-col items-center gap-2 text-xl font-medium text-ink-gray-4 w-9/12 md:w-4/12"

--- a/desk/src/components/EmptyState.vue
+++ b/desk/src/components/EmptyState.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="variant === 'badge'"
-    class="flex flex-col items-center justify-center gap-4 h-[stretch] absolute w-[stretch] left-0 top-5.5"
+    class="flex flex-col items-center justify-center gap-4 h-[stretch] absolute w-[stretch] left-0 top-5.5 pointer-events-none"
   >
     <div
       class="p-4 size-14.5 rounded-full bg-surface-gray-1 flex justify-center items-center"
@@ -22,7 +22,7 @@
   </div>
   <div
     v-else
-    class="flex h-full items-center justify-center w-[stretch] absolute top-0 -z-10"
+    class="flex h-full items-center justify-center w-[stretch] absolute top-0 -z-10 pointer-events-none"
   >
     <div
       class="flex flex-col items-center gap-2 text-xl font-medium text-ink-gray-4 w-9/12 md:w-4/12"


### PR DESCRIPTION
Empty state overlay  caused issues for some buttons to be inaccessible when z-index property was not computed.

This PR fixes the issue by adding pointer-events: none to the empty state overlay, ensuring clicks pass through to the underlying header actions regardless of z-index stacking behavior.

depends on https://github.com/frappe/helpdesk/pull/3353