### PR TITLE
fix: loader appearing on top in SLa view

### DIFF
--- a/desk/src/components/Settings/Sla/SlaPolicyView.vue
+++ b/desk/src/components/Settings/Sla/SlaPolicyView.vue
@@ -36,6 +36,7 @@
     </template>
     <template #content>
       <div
+        v-if="!slaData.loading"
         class="flex items-center justify-center h-[stretch] absolute w-[stretch] left-0 top-5.5"
       >
         <LoadingIndicator class="w-4" />

--- a/desk/src/components/Settings/Sla/SlaPolicyView.vue
+++ b/desk/src/components/Settings/Sla/SlaPolicyView.vue
@@ -36,7 +36,7 @@
     </template>
     <template #content>
       <div
-        v-if="!slaData.loading"
+        v-if="slaData.loading"
         class="flex items-center justify-center h-[stretch] absolute w-[stretch] left-0 top-5.5"
       >
         <LoadingIndicator class="w-4" />


### PR DESCRIPTION
Loading state loader was appearing on top of the sla policy view, this pr fixes the issue

issue caused due to regression in https://github.com/frappe/helpdesk/pull/3353

depends on https://github.com/frappe/helpdesk/pull/3353

closes https://github.com/frappe/helpdesk/issues/3364