### PR TITLE
fix: resolve @me filters during export in Helpdesk Portal

### DIFF
--- a/desk/src/pages/ticket/Tickets.vue
+++ b/desk/src/pages/ticket/Tickets.vue
@@ -255,6 +255,21 @@ async function exportRows(
   const order_by = list.params.order_by;
 
   let filters = { ...list.params.filters };
+  // Replace @me with actual logged in user
+  Object.keys(filters).forEach((key) => {
+    const value = filters[key];
+    // case: owner = "@me"
+    if (value === "@me") {
+      filters[key] = userId;
+      console.log("filters1", filters);
+    }
+
+    // case: ["=", "@me"]
+    if (Array.isArray(value) && value[1] === "@me") {
+      filters[key][1] = userId;
+      console.log("filters2", filters);
+    }
+  });
   let pageLength: number;
 
   if (export_all) {
@@ -266,7 +281,9 @@ async function exportRows(
     filters = JSON.stringify(filters);
   }
 
-  window.location.href = `/api/method/frappe.desk.reportview.export_query?file_format_type=${export_type}&title=HD Ticket&doctype=HD Ticket&fields=${fields}&filters=${filters}&order_by=${order_by}&page_length=${pageLength}&start=0&view=Report&with_comment_count=1`;
+  window.location.href = `/api/method/frappe.desk.reportview.export_query?file_format_type=${export_type}&title=HD Ticket&doctype=HD Ticket&fields=${fields}&filters=${encodeURIComponent(
+    filters
+  )}&order_by=${order_by}&page_length=${pageLength}&start=0&view=Report&with_comment_count=1`;
   reset();
   showExportModal.value = false;
 }

--- a/desk/src/pages/ticket/Tickets.vue
+++ b/desk/src/pages/ticket/Tickets.vue
@@ -255,19 +255,18 @@ async function exportRows(
   const order_by = list.params.order_by;
 
   let filters = { ...list.params.filters };
-  // Replace @me with actual logged in user
+  // Resolve `@me` filters to the current session user before export
   Object.keys(filters).forEach((key) => {
     const value = filters[key];
-    // case: owner = "@me"
+
+    // Handle direct filter format: { owner: "@me" }
     if (value === "@me") {
       filters[key] = userId;
-      console.log("filters1", filters);
     }
 
-    // case: ["=", "@me"]
+    // Handle operator-based filter format: { owner: ["=", "@me"] }
     if (Array.isArray(value) && value[1] === "@me") {
       filters[key][1] = userId;
-      console.log("filters2", filters);
     }
   });
   let pageLength: number;

--- a/desk/src/pages/ticket/Tickets.vue
+++ b/desk/src/pages/ticket/Tickets.vue
@@ -262,12 +262,14 @@ async function exportRows(
     // Handle direct filter format: { owner: "@me" }
     if (value === "@me") {
       filters[key] = userId;
+      return;
     }
+    if (!Array.isArray(value)) return;
 
-    // Handle operator-based filter format: { owner: ["=", "@me"] }
-    if (Array.isArray(value) && value[1] === "@me") {
-      filters[key][1] = userId;
-    }
+    // Handle all operator-based filter format: { owner: ["=", "@me"], _assign: ["LIKE", "%@me%"] }
+    filters[key] = value.map((entry) =>
+      entry === "@me" ? userId : entry === "%@me%" ? `%${userId}%` : entry
+    );
   });
   let pageLength: number;
 


### PR DESCRIPTION
## Summary

Resolves an issue where exporting records from Helpdesk Portal list views did not correctly handle filters containing `@me`.

Previously, filters using `@me` were passed directly to `frappe.desk.reportview.export_query`, causing export results to differ from the visible list view data.

This change resolves `@me` to the current session user before sending export filters, ensuring export behavior matches the filtered Portal list view.

Closes #3388

## Before

* Helpdesk Portal list view correctly displayed records for filters like:

  * `Owner = @me`
* Export returned incorrect or empty results

## After

* `@me` filters are resolved before export
* Exported data now matches the filtered Portal list view

## Testing

Tested with:

* Export selected rows
* Export all rows
* Filters containing `@me`
