### PR TITLE
fix: use db_insert instead of saving the doc

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -984,9 +984,8 @@ class HDTicket(Document):
 
         # Fetch description from communication if not set already. This might not be needed
         # anymore as a communication is created when a ticket is created.
-        self.description = self.description or c.content
-        # Save the ticket, allowing for hooks to run.
-        self.save()
+        description = self.description or c.content
+        self.db_set("description", description, update_modified=False)
 
     def attach_file_with_doc(self, doctype, docname, file_url):
         if frappe.db.exists(


### PR DESCRIPTION
**Issue**

When a new HD Ticket is created with a description, any Server Script (or Frappe-style hook) on the Before Save event for HD Ticket is invoked twice for a single user action:

- 1st fire — during the genuine insert → doc.is_new() == True ✓
- 2nd fire — during an internal re-save → doc.is_new() == False

This breaks any script that uses doc.is_new() to branch logic (e.g. "only run this on creation") — the second fire silently falls into the "not new" branch and runs unintended code, or runs the new-doc logic twice depending on how the script is written.


**Reason**

Lifecycle observed via tracing Document.run_method on a single HD Ticket.insert():

before_insert     is_new=True
before_validate   is_new=True
validate          is_new=True
before_save       is_new=True   ← 1st Before Save (expected)
[db_insert]
after_insert      is_new=False
  └─ create_communication_via_contact(description, new_ticket=True)
      └─ Communication.save()
          └─ Communication lifecycle invokes HD Ticket.on_communication_update(c)
              └─ self.save()                   ← recursive ticket save
                  before_validate   is_new=False
                  validate          is_new=False
                  before_save       is_new=False   ← 2nd Before Save (unexpected!)
                  on_update         is_new=False
                  on_change         is_new=False
on_update         is_new=False
on_change         is_new=False

The recursive save originates at helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:954:

def on_communication_update(self, c):
    ...
    self.description = self.description or c.content
    # Save the ticket, allowing for hooks to run.
    self.save()   # ← re-fires Before Save for the same in-flight ticket



**Solution:**
Instead of `self.save` do `db_insert`


