### PR TITLE
perf: index HD Ticket columns used by the ticket list

### DIFF
--- a/helpdesk/patches.txt
+++ b/helpdesk/patches.txt
@@ -40,3 +40,4 @@ helpdesk.patches.set_std_views_non_public
 helpdesk.helpdesk.doctype.hd_ticket.patches.backfill_sla_failed_by
 helpdesk.patches.rename_and_update_std_views #v2
 helpdesk.patches.set_hd_ticket_naming_series
+helpdesk.patches.add_hd_ticket_list_indexes

--- a/helpdesk/patches/add_hd_ticket_list_indexes.py
+++ b/helpdesk/patches/add_hd_ticket_list_indexes.py
@@ -1,0 +1,31 @@
+import frappe
+
+
+def execute():
+	"""Add b-tree indexes on HD Ticket for the columns the ticket list filters
+	and sorts on most often.
+
+	On large ``tabHD Ticket`` tables the default list queries otherwise fall
+	back to full table scans / filesorts:
+
+	- ``ORDER BY modified DESC`` and ``WHERE status = ... ORDER BY modified`` →
+	  covered by the ``(status, modified)`` composite.
+	- ``WHERE raised_by / owner / contact = ...`` (used by the permission query
+	  for portal users and by the agent/customer filters).
+	- ``WHERE ticket_type = ...`` (type filter).
+
+	``frappe.db.add_index`` is a no-op when the index already exists, so this
+	patch is safe to re-run.
+	"""
+	if not frappe.db.table_exists("HD Ticket"):
+		return
+
+	indexes = [
+		(["status", "modified"], "status_modified_index"),
+		(["raised_by"], "raised_by_index"),
+		(["owner"], "owner_index"),
+		(["ticket_type"], "ticket_type_index"),
+		(["contact"], "contact_index"),
+	]
+	for fields, index_name in indexes:
+		frappe.db.add_index("HD Ticket", fields, index_name=index_name)


### PR DESCRIPTION
Adds b-tree indexes on `HD Ticket` for the columns the ticket list filters and
sorts on most often. On large `tabHD Ticket` tables these turn full table scans
/ filesorts into index range scans:

- `(status, modified)` composite — for `ORDER BY modified DESC` and
  `WHERE status = ... ORDER BY modified`.
- `raised_by`, `owner`, `contact` — used by the permission query (portal users)
  and the agent / customer filters.
- `ticket_type` — the type filter.

`develop` already has the `ft_subject` / `ft_description` FULLTEXT indexes; this
adds the missing b-tree ones. Uses `frappe.db.add_index` (a no-op when the index
already exists), so it's safe to re-run.

Surfaced from running a ~90K-ticket production Helpdesk the list endpoint was
filesorting the whole table without these.
