### PR TITLE
feat: categories and language for saved replies

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
+++ b/helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -8,6 +8,8 @@
  "engine": "InnoDB",
  "field_order": [
   "title",
+  "category",
+  "language",
   "scope",
   "teams",
   "section_break_ybsb",
@@ -20,6 +22,21 @@
    "label": "Title",
    "reqd": 1,
    "unique": 1
+  },
+  {
+   "fieldname": "category",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Category",
+   "options": "HD Saved Reply Category"
+  },
+  {
+   "fieldname": "language",
+   "fieldtype": "Link",
+   "in_standard_filter": 1,
+   "label": "Language",
+   "options": "Language"
   },
   {
    "fieldname": "message",

--- a/helpdesk/helpdesk/doctype/hd_saved_reply_category/hd_saved_reply_category.json
+++ b/helpdesk/helpdesk/doctype/hd_saved_reply_category/hd_saved_reply_category.json
@@ -1,0 +1,78 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:title",
+ "creation": "2026-06-05 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "title",
+  "color",
+  "description"
+ ],
+ "fields": [
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Title",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "color",
+   "fieldtype": "Color",
+   "in_list_view": 1,
+   "label": "Color"
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-06-05 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Helpdesk",
+ "name": "HD Saved Reply Category",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Agent Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "read": 1,
+   "role": "Agent"
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "title"
+}

--- a/helpdesk/helpdesk/doctype/hd_saved_reply_category/hd_saved_reply_category.py
+++ b/helpdesk/helpdesk/doctype/hd_saved_reply_category/hd_saved_reply_category.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class HDSavedReplyCategory(Document):
+	pass


### PR DESCRIPTION
Hi team

As a helpdesk grows, the saved-reply list gets long fast — and today there's no
way to organise it. This small PR adds two optional fields to HD Saved Reply to
help:

Category — a Link to a new lightweight "HD Saved Reply Category" doctype
   (title, colour, description). Group replies into buckets like Refunds,
   Onboarding, or Billing so agents find the right one quickly.

Language — a Link to Frappe's built-in Language doctype, so multilingual
   teams can keep per-language variants of the same reply.

Both fields are completely optional and fully declarative — no patch needed,
bench migrate creates the new doctype + columns. Permissions follow the existing
HD Saved Reply roles (System Manager / Agent Manager manage; Agent reads).

This PR is just the data model — the saved-reply picker could later filter by
these. Totally open to your preference on naming or approach (e.g. tags instead
of a category doctype). Happy to iterate! 🙌

Thanks for the great project!
