### PR TITLE
fix: harden perms for agent related fields

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -18,6 +18,7 @@ from pypika.functions import Count
 from pypika.queries import Query
 from pypika.terms import Criterion
 
+from helpdesk.consts import DEFAULT_TICKET_TEMPLATE
 from helpdesk.helpdesk.doctype.hd_settings.helpers import (
     get_default_email_content,
     is_email_content_empty,
@@ -74,6 +75,7 @@ class HDTicket(Document):
         self.generate_key()
 
     def before_validate(self):
+        self.restrict_non_agent_fields()
         self.check_update_perms()
         self.set_ticket_type()
         self.set_raised_by()
@@ -339,6 +341,48 @@ class HDTicket(Document):
 
         frappe.throw(
             _("Ticket must be resolved with a feedback"), frappe.ValidationError
+        )
+
+    # Standard fields a non-agent may change on a ticket they already own:
+    customer_whitelisted_fields = (
+        "subject",
+        "description",
+        "status",
+        "feedback",
+        "feedback_extra",
+        "feedback_rating",
+    )
+
+    def restrict_non_agent_fields(self):
+        """
+        Allow-list what a non-agent may change on an existing ticket.
+        """
+        if self.is_new() or is_agent():
+            return
+        allowed_fields = set(self.customer_whitelisted_fields)
+        allowed_fields.update(self.get_customer_template_fields())
+        changed_fields = [
+            df.fieldname
+            for df in self.meta.fields
+            if df.fieldname not in allowed_fields
+            and self.has_value_changed(df.fieldname)
+        ]
+        if changed_fields:
+            frappe.throw(
+                _("You are not permitted to modify: {0}").format(
+                    ", ".join(changed_fields)
+                ),
+                frappe.PermissionError,
+            )
+
+    # TODO: will have refactor once template swtiching is implemented
+    def get_customer_template_fields(self):
+        """Custom fields the ticket's template exposes to the customer."""
+        template = self.template or DEFAULT_TICKET_TEMPLATE
+        return frappe.get_all(
+            "HD Ticket Template Field",
+            filters={"parent": template, "hide_from_customer": 0},
+            pluck="fieldname",
         )
 
     def check_update_perms(self):

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -365,6 +365,10 @@ class HDTicket(Document):
             df.fieldname
             for df in self.meta.fields
             if df.fieldname not in allowed_fields
+            # Skip fields the framework always recomputes (e.g. `status_category`
+            # is fetched from `status`); the client cannot control these, so they
+            # change only as a side effect of an allowed edit.
+            and not (df.fetch_from and not df.fetch_if_empty)
             and self.has_value_changed(df.fieldname)
         ]
         if changed_fields:

--- a/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
@@ -20,6 +20,7 @@ from helpdesk.test_utils import (
     get_latest_ticket_communication,
     get_priority_response_resolution_time,
     make_status,
+    make_team,
     make_ticket,
     remove_holidays,
     upload_test_file,
@@ -190,6 +191,7 @@ class TestHDTicket(IntegrationTestCase):
         frappe.get_doc({"doctype": "HD Ticket Type", "name": "Test Type"}).insert(
             ignore_if_duplicate=True
         )
+        team = make_team("Test Team")
         template = frappe.get_doc(
             {
                 "doctype": "HD Ticket Template",
@@ -223,7 +225,7 @@ class TestHDTicket(IntegrationTestCase):
 
             # A template field hidden from the customer stays blocked
             ticket = frappe.get_doc("HD Ticket", ticket.name)
-            ticket.agent_group = "Test Type"
+            ticket.agent_group = team.name
             self.assertRaises(frappe.PermissionError, ticket.save)
         finally:
             frappe.set_user("Administrator")

--- a/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
@@ -146,6 +146,81 @@ class TestHDTicket(IntegrationTestCase):
         ticket.save()
         self.assertTrue(ticket)
 
+    def test_non_agent_cannot_modify_restricted_fields(self):
+        ticket = frappe.get_doc(get_ticket_obj())
+        ticket.raised_by = non_agent
+        ticket.insert()
+
+        frappe.set_user(non_agent)
+        try:
+            ticket = frappe.get_doc("HD Ticket", ticket.name)
+            ticket.priority = "Urgent"
+            self.assertRaises(frappe.PermissionError, ticket.save)
+        finally:
+            frappe.set_user("Administrator")
+
+    def test_non_agent_can_close_own_ticket(self):
+        ticket = frappe.get_doc(get_ticket_obj())
+        ticket.raised_by = non_agent
+        ticket.insert()
+
+        frappe.set_user(non_agent)
+        try:
+            ticket = frappe.get_doc("HD Ticket", ticket.name)
+            ticket.status = "Closed"
+            ticket.save()
+            self.assertEqual(ticket.status, "Closed")
+        finally:
+            frappe.set_user("Administrator")
+
+    def test_agent_can_modify_restricted_fields(self):
+        ticket = frappe.get_doc(get_ticket_obj())
+        ticket.insert()
+
+        frappe.set_user(agent)
+        try:
+            ticket = frappe.get_doc("HD Ticket", ticket.name)
+            ticket.priority = "Urgent"
+            ticket.save()
+            self.assertEqual(ticket.priority, "Urgent")
+        finally:
+            frappe.set_user("Administrator")
+
+    def test_non_agent_can_only_edit_customer_visible_template_fields(self):
+        frappe.get_doc({"doctype": "HD Ticket Type", "name": "Test Type"}).insert(
+            ignore_if_duplicate=True
+        )
+        template = frappe.get_doc(
+            {
+                "doctype": "HD Ticket Template",
+                "template_name": "Test Template",
+                "fields": [
+                    {"fieldname": "ticket_type", "hide_from_customer": 0},
+                    {"fieldname": "agent_group", "hide_from_customer": 1},
+                ],
+            }
+        ).insert(ignore_if_duplicate=True)
+
+        ticket = frappe.get_doc(get_ticket_obj())
+        ticket.raised_by = non_agent
+        ticket.template = template.name
+        ticket.insert()
+
+        frappe.set_user(non_agent)
+        try:
+            # A template field exposed to the customer is editable
+            ticket = frappe.get_doc("HD Ticket", ticket.name)
+            ticket.ticket_type = "Test Type"
+            ticket.save()
+            self.assertEqual(ticket.ticket_type, "Test Type")
+
+            # A template field hidden from the customer stays blocked
+            ticket = frappe.get_doc("HD Ticket", ticket.name)
+            ticket.agent_group = "Some Team"
+            self.assertRaises(frappe.PermissionError, ticket.save)
+        finally:
+            frappe.set_user("Administrator")
+
     # Working hours default to 10:00 to 18:00 from Monday to Friday
     # And priorities default to
     # Low: 24 hour response, 72 hours resolution

--- a/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
@@ -206,6 +206,13 @@ class TestHDTicket(IntegrationTestCase):
         ticket.template = template.name
         ticket.insert()
 
+        # Only fields exposed to the customer resolve from the template
+        ticket = frappe.get_doc("HD Ticket", ticket.name)
+        self.assertEqual(ticket.template, template.name)
+        visible_fields = ticket.get_customer_template_fields()
+        self.assertIn("ticket_type", visible_fields)
+        self.assertNotIn("agent_group", visible_fields)
+
         frappe.set_user(non_agent)
         try:
             # A template field exposed to the customer is editable
@@ -216,7 +223,7 @@ class TestHDTicket(IntegrationTestCase):
 
             # A template field hidden from the customer stays blocked
             ticket = frappe.get_doc("HD Ticket", ticket.name)
-            ticket.agent_group = "Some Team"
+            ticket.agent_group = "Test Type"
             self.assertRaises(frappe.PermissionError, ticket.save)
         finally:
             frappe.set_user("Administrator")


### PR DESCRIPTION
Adds a permission guard on HD Ticket so that non-agents can only modify a defined set of fields on a ticket that already exists — the standard customer fields (subject, description, status, feedback) plus any field their ticket template explicitly exposes to customers (hide_from_customer = 0). Everything else (priority, team, ticket type, SLA fields, …) is editable only by agents.