### PR TITLE
refactor: point ticket assignment notifications to agent portal

### DIFF
--- a/helpdesk/extends/notification_log.py
+++ b/helpdesk/extends/notification_log.py
@@ -1,0 +1,10 @@
+import frappe
+
+
+def before_insert(doc, method=None):
+    if (
+        doc.type == "Assignment"
+        and doc.document_type == "HD Ticket"
+        and doc.document_name
+    ):
+        doc.link = frappe.utils.get_url("/helpdesk/tickets/" + str(doc.document_name))

--- a/helpdesk/hooks.py
+++ b/helpdesk/hooks.py
@@ -89,6 +89,9 @@ doc_events = {
         "on_update": "helpdesk.integrations.erpnext.doc_share.on_update",
         "on_trash": "helpdesk.integrations.erpnext.doc_share.on_trash",
     },
+    "Notification Log": {
+        "before_insert": "helpdesk.extends.notification_log.before_insert",
+    },
 }
 
 has_permission = {


### PR DESCRIPTION
  Ticket assignment emails (and the in-app notification) linked to the
  backend Desk form (/desk/hd-ticket/<name>) instead of the agent portal.

  Add a Notification Log before_insert hook that sets the link to
  /helpdesk/tickets/<name> for HD Ticket assignment notifications. Scoped
  to type == "Assignment", so mentions, shares, and follow notifications
  keep their default behavior.