### PR TITLE
fix: empty state fix for cross browser compatibility

### DIFF
--- a/desk/src/components/EmptyState.vue
+++ b/desk/src/components/EmptyState.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="variant === 'badge'"
-    class="flex flex-col items-center justify-center gap-4 h-[stretch] absolute w-[stretch] left-0 top-5.5 pointer-events-none"
+    class="flex flex-col items-center justify-center gap-4 absolute inset-x-0 top-5.5 bottom-0 pointer-events-none"
   >
     <div
       class="p-4 size-14.5 rounded-full bg-surface-gray-1 flex justify-center items-center"
@@ -22,7 +22,7 @@
   </div>
   <div
     v-else
-    class="flex h-full items-center justify-center w-[stretch] absolute top-0 pointer-events-none"
+    class="flex h-full items-center justify-center absolute inset-x-0 top-0 pointer-events-none"
   >
     <div
       class="flex flex-col items-center gap-2 text-xl font-medium text-ink-gray-4 w-9/12 md:w-4/12"

--- a/desk/src/components/ListViewBuilder.vue
+++ b/desk/src/components/ListViewBuilder.vue
@@ -3,7 +3,7 @@
   <div
     :class="[
       'flex items-center justify-between gap-2 px-5 pb-4 pt-4',
-      list?.data?.data?.length > 0 ? 'relative' : 'absolute w-[stretch]',
+      list?.data?.data?.length > 0 ? 'relative' : 'absolute inset-x-0',
     ]"
     v-if="showViewControls"
   >

--- a/desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue
+++ b/desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue
@@ -32,7 +32,7 @@
     <template #content>
       <div
         v-if="getAssignmentRuleData.loading"
-        class="flex items-center justify-center h-[stretch] absolute w-[stretch] left-0 top-5.5"
+        class="flex items-center justify-center absolute inset-x-0 top-5.5 bottom-0"
       >
         <LoadingIndicator class="w-4" />
       </div>

--- a/desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue
+++ b/desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="assignmentRulesListData.loading && !assignmentRulesListData.data"
-    class="flex items-center justify-center h-[stretch] absolute w-[stretch] left-0 top-5.5"
+    class="flex items-center justify-center absolute inset-x-0 top-5.5 bottom-0"
   >
     <LoadingIndicator class="w-4" />
   </div>

--- a/desk/src/components/Settings/General/General.vue
+++ b/desk/src/components/Settings/General/General.vue
@@ -26,7 +26,7 @@
     <template #content>
       <div
         v-if="settingsDataResource.loading && !settingsDataResource.data"
-        class="flex items-center justify-center h-[stretch] absolute w-[stretch] left-0 top-5.5"
+        class="flex items-center justify-center absolute inset-x-0 top-5.5 bottom-0"
       >
         <LoadingIndicator class="w-4" />
       </div>

--- a/desk/src/components/Settings/Holiday/HolidayList.vue
+++ b/desk/src/components/Settings/Holiday/HolidayList.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="holidayList.list.loading && !holidayList.list.data"
-    class="flex items-center justify-center h-[stretch] absolute w-[stretch] left-0 top-5.5"
+    class="flex items-center justify-center absolute inset-x-0 top-5.5 bottom-0"
   >
     <LoadingIndicator class="w-4" />
   </div>

--- a/desk/src/components/Settings/SavedReplies/SavedRepliesList.vue
+++ b/desk/src/components/Settings/SavedReplies/SavedRepliesList.vue
@@ -77,7 +77,7 @@
     <template #content>
       <div
         v-if="savedRepliesListResource?.list?.loading"
-        class="flex items-center justify-center my-auto"
+        class="flex items-center justify-center absolute inset-x-0 top-5.5 bottom-0"
       >
         <LoadingIndicator class="w-4" />
       </div>

--- a/desk/src/components/Settings/SavedReplies/SavedReplyView.vue
+++ b/desk/src/components/Settings/SavedReplies/SavedReplyView.vue
@@ -36,7 +36,7 @@
     <template #content>
       <div
         v-if="getSavedReplyData.loading"
-        class="flex items-center justify-center h-[stretch] absolute w-[stretch] left-0 top-5.5"
+        class="flex items-center justify-center absolute inset-x-0 top-5.5 bottom-0"
       >
         <LoadingIndicator class="w-4" />
       </div>

--- a/desk/src/components/Settings/Sla/SlaPolicyList.vue
+++ b/desk/src/components/Settings/Sla/SlaPolicyList.vue
@@ -1,14 +1,14 @@
 <template>
   <div
     v-if="slaPolicyList.list.loading && !slaPolicyList.list.data"
-    class="flex items-center justify-center h-[stretch] absolute w-[stretch] left-0 top-5.5"
+    class="flex items-center justify-center absolute inset-x-0 top-5.5 bottom-0"
   >
     <LoadingIndicator class="w-4" />
   </div>
   <div v-else class="grow">
     <div
       v-if="!slaPolicyList.list.loading && !slaPolicyList.list.data?.length"
-      class="flex items-center justify-center h-[stretch] absolute w-[stretch] left-0 top-5.5"
+      class="flex items-center justify-center absolute inset-x-0 top-5.5 bottom-0"
     >
       <div
         class="p-4 size-14.5 rounded-full bg-surface-gray-1 flex justify-center items-center"

--- a/desk/src/components/Settings/Sla/SlaPolicyView.vue
+++ b/desk/src/components/Settings/Sla/SlaPolicyView.vue
@@ -28,7 +28,7 @@
     <template #content>
       <div
         v-if="slaData.loading"
-        class="flex items-center justify-center h-[stretch] absolute w-[stretch] left-0 top-5.5"
+        class="flex items-center justify-center absolute inset-x-0 top-5.5 bottom-0"
       >
         <LoadingIndicator class="w-4" />
       </div>

--- a/desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue
+++ b/desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue
@@ -19,7 +19,7 @@
       <!-- Loading State -->
       <div
         v-if="syncInfoResource.loading && !syncInfoResource.data"
-        class="flex items-center justify-center h-[stretch] absolute w-[stretch] left-0 top-5.5"
+        class="flex items-center justify-center absolute inset-x-0 top-5.5 bottom-0"
       >
         <LoadingIndicator class="w-4" />
       </div>


### PR DESCRIPTION
Some css properties native to chromium browsers were not rendering in Firefox and other browsers i.e h-[stretch], w-[stretch] etc.

this caused empty state to appear out of place

<img width="754" height="587" alt="image" src="https://github.com/user-attachments/assets/4ddfdba1-1bc5-4125-bc58-5e2f1da20f8e" />


fixed;
<img width="1439" height="814" alt="image" src="https://github.com/user-attachments/assets/58cca82e-1f25-4d25-afab-570617308365" />

add tailwind such as `inset-x-0` to replicate width behaviour
