### PR TITLE
fix #3411 : Marking HD Ticket as resolved does not close "ToDo" entry  #3411 

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -223,6 +223,7 @@ class HDTicket(Document):
         self.publish_update()
         self.capture_update_telemetry_events()
 
+
     def notify_agent(self, agent, notification_type="Assignment"):
         frappe.get_doc(
             frappe._dict(
@@ -1422,3 +1423,30 @@ def update_sla_status_in_ticket():
             )
             continue
         frappe.db.commit()  # nosemgrep
+
+def close_todos_on_resolve(doc, method=None):
+    if not doc.has_value_changed("status_category"):
+        return
+
+    if doc.status_category == "Resolved":
+        todo_status = "Closed"
+    elif doc.status_category == "Open":
+        todo_status = "Open"
+    else:
+        return
+
+    todos = frappe.get_all(
+        "ToDo",
+        filters={
+            "reference_type": "HD Ticket",
+            "reference_name": doc.name,
+        },
+        pluck="name",
+    )
+
+    def update_todos():
+        for todo in todos:
+            frappe.db.set_value("ToDo", todo, "status", todo_status)
+        frappe.db.commit()
+
+    frappe.db.after_commit.add(update_todos)

--- a/helpdesk/hooks.py
+++ b/helpdesk/hooks.py
@@ -70,6 +70,9 @@ doc_events = {
         "on_trash": "helpdesk.extends.assignment_rule.on_assignment_rule_trash",
         "validate": "helpdesk.extends.assignment_rule.on_assignment_rule_validate",
     },
+    "HD Ticket": {
+        "on_update": "helpdesk.helpdesk.doctype.hd_ticket.hd_ticket.close_todos_on_resolve",
+    }
 }
 
 has_permission = {


### PR DESCRIPTION
Fix #3411 issue where linked ToDo remained open after an HD Ticket was resolved.

This change synchronizes linked ToDo statuses with HD Ticket status changes:

* Resolved → Closed
* Open → Open

Uses an `on_update` hook and updates ToDos after the ticket transaction is committed.

Tickets:
<img width="1622" height="483" alt="image" src="https://github.com/user-attachments/assets/cee3f7bc-90f5-40e4-886f-e7de0448dc84" />

ToDos:
<img width="1633" height="490" alt="image" src="https://github.com/user-attachments/assets/acfdc788-a6b8-4e9b-9d42-a737cd21cb0b" />

