### PR TITLE
fix: improve agent status UX

### DIFF
--- a/desk/src/components/ticket-agent/AssignTo.vue
+++ b/desk/src/components/ticket-agent/AssignTo.vue
@@ -551,6 +551,8 @@ function warnUnavailableAgents(addedNames: string[]): boolean {
   let hasUnavailable = false;
   for (const agent of agents) {
     if (!addedNames.includes(agent.name)) continue;
+    // No point warning agents about their own status when assigning themselves.
+    if (agent.name === currentAgentName) continue;
     const category = agentStatusStore.getStatus(
       agent.availability || ""
     )?.category;

--- a/desk/src/components/ticket-agent/AssignTo.vue
+++ b/desk/src/components/ticket-agent/AssignTo.vue
@@ -403,15 +403,16 @@ function availabilitySubtitle(
 
   const label = __(availability);
   if (!changedOn) return label;
-  // prettyDate says "Just now" under a minute, which reads oddly after "since";
-  // keep the "… ago" phrasing consistent with the longer durations.
+  // Suffix with how long ago they were last active, e.g. "Away · Last seen 2
+  // minutes ago". prettyDate says "Just now" under a minute, which we lowercase
+  // so it reads cleanly after "Last seen".
   const secondsSinceChange = dayjsLocal().diff(
     dayjsLocal(changedOn),
     "seconds"
   );
-  const timeSinceChange =
-    secondsSinceChange < 60 ? __("a few seconds ago") : prettyDate(changedOn);
-  return timeSinceChange ? __("{0} since {1}", label, timeSinceChange) : label;
+  const lastSeen =
+    secondsSinceChange < 60 ? __("just now") : prettyDate(changedOn);
+  return lastSeen ? __("{0} · Last active {1}", label, lastSeen) : label;
 }
 
 function isSelected(agentName: string): boolean {

--- a/helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+++ b/helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -9,11 +9,11 @@
  "field_order": [
   "agent_status",
   "enable",
-  "status_order",
-  "section_break_jqvx",
   "category",
+  "section_break_jqvx",
+  "color",
   "column_break_ekva",
-  "color"
+  "status_order"
  ],
  "fields": [
   {
@@ -32,6 +32,7 @@
    "fieldtype": "Section Break"
   },
   {
+   "description": "Active: The agent is available and working.<br>\nAway: The agent is temporarily unreachable.<br>\nUnavailable: The agent is off and unavailable.",
    "fieldname": "category",
    "fieldtype": "Select",
    "in_list_view": 1,
@@ -43,14 +44,14 @@
    "fieldname": "color",
    "fieldtype": "Select",
    "label": "Color",
-   "options": "Black\nGray\nBlue\nGreen\nRed\nPink\nOrange\nAmber\nYellow\nCyan\nTeal\nViolet\npurple"
+   "options": "Gray\nBlue\nGreen\nRed\nPink\nOrange\nAmber\nYellow\nCyan\nTeal\nViolet\npurple"
   },
   {
    "fieldname": "column_break_ekva",
    "fieldtype": "Column Break"
   },
   {
-   "default": "0",
+   "default": "1",
    "fieldname": "enable",
    "fieldtype": "Check",
    "label": "Enable"
@@ -59,7 +60,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-06-06 00:00:00.000000",
+ "modified": "2026-06-08 13:19:57.646908",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Agent Status",


### PR DESCRIPTION
Improved layout of the doctype HD Agent status

<img width="923" height="597" alt="image" src="https://github.com/user-attachments/assets/4eebad97-3684-4ab9-a335-64c14ac8b7db" />

Improved UX copy for the tooltip
<img width="424" height="378" alt="image" src="https://github.com/user-attachments/assets/79f27bd0-d947-4758-911f-2fd361a92692" />

depends on https://github.com/frappe/helpdesk/pull/3372

