### PR TITLE
fix: recents tickets condition

### DIFF
--- a/desk/src/pages/ticket/Tickets.vue
+++ b/desk/src/pages/ticket/Tickets.vue
@@ -351,7 +351,7 @@ function reset(reload = false) {
 }
 
 const slaStatusColorMap = {
-  Fulfilled: "green",
+  Fulfilled: "gray",
   Failed: "red",
   "Resolution Due": "orange",
   "First Response Due": "orange",

--- a/helpdesk/helpdesk/doctype/hd_ticket/api.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/api.py
@@ -722,7 +722,8 @@ def get_recent_tickets(ticket: str):
             )
             or []
         )
-    elif raised_by:
+
+    if raised_by:
         user_tickets = (
             frappe.get_list(
                 "HD Ticket",


### PR DESCRIPTION
1. Recent tickets missing user's tickets — In get_recent_tickets, the org (customer) and user (raised_by) queries were mutually exclusive (if customer … elif raised_by). When a ticket had a customer, the requester's own recent tickets were never fetched. Fixed by making it an independent if raised_by.
2. SLA "Fulfilled" badge color — Fulfilled SLA showed as green; changed to gray to read as a neutral/completed state.


depends-on: https://github.com/frappe/helpdesk/pull/3422
