### PR TITLE
fix: allow agents added locally to reflect their status

### DIFF
--- a/desk/src/components/ticket-agent/AssignTo.vue
+++ b/desk/src/components/ticket-agent/AssignTo.vue
@@ -155,6 +155,7 @@ import {
   ActivitiesSymbol,
   AgentOption,
   AssigneeSymbol,
+  LocalAssignee,
   TicketSymbol,
 } from "@/types";
 import type { HDAgent } from "@/types/doctypes";
@@ -205,12 +206,8 @@ const popoverIsOpen = ref(false);
 const hasBeenOpened = ref(false);
 
 // Local copy of assignees
-const localAssignees = ref<{ name: string; image: string; label: string }[]>(
-  []
-);
-const snapshotAssignees = ref<{ name: string; image: string; label: string }[]>(
-  []
-);
+const localAssignees = ref<LocalAssignee[]>([]);
+const snapshotAssignees = ref<LocalAssignee[]>([]);
 
 // Sync from injected assignees when popover is not open
 watch(
@@ -258,7 +255,7 @@ const agentResource = createListResource({
     "availability",
     "availability_changed_on",
   ],
-  filters: { is_active: true },
+  filters: { is_active: true, name: ["!=", "christopherwhitaker@example.net"] },
   pageLength: 20,
   auto: true,
 });
@@ -360,8 +357,9 @@ const sortedAgentOptions = computed<AgentOption[]>(() => {
         const user = getUser(a.name);
         options.push({
           value: a.name,
-          label: a.label || user.full_name || a.name,
-          image: a.image || user.user_image,
+          label: a.label || a.agent_name || user.full_name || a.name,
+          image: a.image || a.user_image || user.user_image,
+          ...liveAvailability(a),
         });
         seen.add(a.name);
       }
@@ -430,11 +428,17 @@ function toggleAgent(agent: AgentOption) {
       pinnedSelectedNames.value.delete(agent.value);
     }
   } else {
-    localAssignees.value.push({
+    const added: LocalAssignee = {
       name: agent.value,
       image: agent.image || "",
       label: agent.label,
-    });
+    };
+    // Carry the option's status so it survives the localAssignees fallback in
+    // sortedAgentOptions (e.g. a search-added agent outside the default page resource call).
+    if (agent.availability) added.availability = agent.availability;
+    if (agent.availability_changed_on)
+      added.availability_changed_on = agent.availability_changed_on;
+    localAssignees.value.push(added);
     // Pin only when selecting during search so they stay visible when search clears
     if (isSearching) {
       pinnedSelectedNames.value.add(agent.value);

--- a/desk/src/composables/useTicket.ts
+++ b/desk/src/composables/useTicket.ts
@@ -4,6 +4,7 @@ import type {
   RecentSimilarTicket,
   Resource,
   TicketActivities,
+  TicketAssignee,
   TicketContact,
 } from "@/types";
 import type { HDTicket } from "@/types/doctypes";
@@ -12,7 +13,7 @@ import { reactive } from "vue";
 
 interface MapValue {
   ticket: DocumentResource<HDTicket>;
-  assignees: Resource<Record<"name", string>[]>;
+  assignees: Resource<TicketAssignee[]>;
   contact: Resource<TicketContact>;
   recentSimilarTickets: Resource<RecentSimilarTicket>;
   activities: Resource<TicketActivities>;
@@ -45,12 +46,6 @@ export const useTicket = (ticketId: string): MapValue => {
         url: "helpdesk.helpdesk.doctype.hd_ticket.api.get_ticket_assignees",
         params: { ticket: ticketId },
         auto: true,
-        transform: (data: string) => {
-          return JSON.parse(data).map((name: string) => ({ name })) as Record<
-            "name",
-            string
-          >[];
-        },
       }),
       contact: createResource({
         url: "helpdesk.helpdesk.doctype.hd_ticket.api.get_ticket_contact",

--- a/desk/src/types.ts
+++ b/desk/src/types.ts
@@ -589,6 +589,23 @@ export interface TicketContact {
   image: string;
 }
 
+// A ticket assignee enriched with their agent status by get_ticket_assignees.
+// Non-agent assignees only carry `name`.
+export interface TicketAssignee {
+  name: string;
+  agent_name?: string;
+  user_image?: string;
+  availability?: string;
+  availability_changed_on?: string;
+}
+
+// A TicketAssignee plus the option fields AssignTo keeps when an agent is
+// picked from the dropdown (image/label come from AgentOption).
+export interface LocalAssignee extends TicketAssignee {
+  image?: string;
+  label?: string;
+}
+
 export type RecentTicket = Record<
   "subject" | "status" | "priority" | "name" | "creation",
   string

--- a/helpdesk/helpdesk/doctype/hd_ticket/api.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/api.py
@@ -753,10 +753,33 @@ def get_ticket_activities(ticket: str):
 
 
 @frappe.whitelist()
-def get_ticket_assignees(ticket: str):
+def get_ticket_assignees(ticket: str) -> list[dict]:
     frappe.has_permission("HD Ticket", "read", ticket, throw=True)
-    assignees = frappe.db.get_value("HD Ticket", ticket, "_assign") or "[]"
-    return assignees
+    assignee_names = json.loads(
+        frappe.db.get_value("HD Ticket", ticket, "_assign") or "[]"
+    )
+    if not assignee_names:
+        return []
+    # Presence details are for the agent desk only; customers get plain names.
+    if not is_agent():
+        return [{"name": name} for name in assignee_names]
+    # Enrich each assignee with their agent status so the UI can show presence
+    # without a separate lookup. Non-agent assignees fall back to just the name.
+    agents = {
+        agent.name: agent
+        for agent in frappe.get_all(
+            "HD Agent",
+            filters={"name": ["in", assignee_names]},
+            fields=[
+                "name",
+                "agent_name",
+                "user_image",
+                "availability",
+                "availability_changed_on",
+            ],
+        )
+    }
+    return [agents.get(name, {"name": name}) for name in assignee_names]
 
 
 def show_banner_next_day(ticket):


### PR DESCRIPTION
if a ticket's assignee wasn't in the first 20 agents we fetch for the assign dropdown, their status dot showed up grey with nothing on hover those assignees get rendered straight from the local assignee list, which only had the name field so there was no availability to colour the dot or fill the tooltip.

fixed it at the source: get_ticket_assignees now returns the availability (plus agent name + image) with each assignee, so it carries through to the popover and resolves like any other agent.


depends on https://github.com/frappe/helpdesk/pull/3372