### PR TITLE
fix(multiselect): click pill to copy its value

### DIFF
--- a/desk/src/components/CommunicationArea.vue
+++ b/desk/src/components/CommunicationArea.vue
@@ -239,6 +239,7 @@ onClickOutside(
       ".tippy-content",
       ".PopoverContent",
       '[role="dialog"]',
+      ".dialog-overlay",
     ],
   }
 );
@@ -251,7 +252,13 @@ onClickOutside(
     }
   },
   {
-    ignore: [".tippy-box", ".tippy-content", ".PopoverContent"],
+    ignore: [
+      ".tippy-box",
+      ".tippy-content",
+      ".PopoverContent",
+      '[role="dialog"]',
+      ".dialog-overlay",
+    ],
   }
 );
 </script>

--- a/desk/src/components/EmailEditor.vue
+++ b/desk/src/components/EmailEditor.vue
@@ -288,7 +288,7 @@ const { isManager } = useAuthStore();
 const { onUserType, cleanup } = useTyping(props.ticketId);
 
 const editorRef = ref(null);
-const editor = computed(() => editorRef.value.editor);
+const editor = computed(() => editorRef.value?.editor);
 
 function focusEditorAtStart() {
   setTimeout(() => {

--- a/desk/src/components/MultiSelectInput.vue
+++ b/desk/src/components/MultiSelectInput.vue
@@ -8,11 +8,14 @@
         :label="value"
         theme="gray"
         variant="subtle"
+        tooltip="Click to copy"
+        class="cursor-pointer transition-transform active:scale-[0.98]"
+        @click="copy(value)"
         @keydown.delete.capture.stop="removeLastValue"
       >
         <template #suffix>
           <FeatherIcon
-            class="h-3.5"
+            class="h-3.5 cursor-pointer transition-transform active:scale-[0.96]"
             name="x"
             @click.stop="removeValue(value)"
           />
@@ -88,6 +91,7 @@
 
 <script setup lang="ts">
 import { UserAvatar } from "@/components/";
+import { copy } from "@/utils";
 import {
   Combobox,
   ComboboxInput,
@@ -95,7 +99,7 @@ import {
   ComboboxOptions,
 } from "@headlessui/vue";
 import { watchDebounced } from "@vueuse/core";
-import { Popover, createResource } from "frappe-ui";
+import { Button, Popover, createResource } from "frappe-ui";
 import { computed, nextTick, ref } from "vue";
 
 const props = defineProps({

--- a/desk/src/components/SavedRepliesSelectorModal.vue
+++ b/desk/src/components/SavedRepliesSelectorModal.vue
@@ -28,6 +28,7 @@
                 type="text"
                 class="focus:ring-0 border-outline-gray-2"
                 :debounce="300"
+                autofocus
               >
                 <template #prefix>
                   <LucideSearch class="size-4" />


### PR DESCRIPTION
- Clicking a pill in Email Editor copies the email id
- Autofocus on search field in Saved Replies Selector Modal
- Dont close Reply Area when we click outside the Saved Replies Selector Modal
