### PR TITLE
fix: avoid calling agent availability for customer

### DIFF
--- a/desk/src/composables/useAvailability.ts
+++ b/desk/src/composables/useAvailability.ts
@@ -1,10 +1,10 @@
 import { createResource, toast } from "frappe-ui";
 import { computed } from "vue";
 import { __ } from "@/translation";
+import { useAuthStore } from "@/stores/auth";
 
 const availability = createResource({
   url: "helpdesk.api.agent.get_my_availability",
-  auto: true,
 });
 
 const setAvailability = createResource({
@@ -15,6 +15,11 @@ const setAvailability = createResource({
 });
 
 export function useAvailability() {
+  const authStore = useAuthStore();
+  if (authStore.isAgent && !availability.fetched) {
+    availability.fetch();
+  }
+
   const currentStatus = computed(() => availability.data?.availability || "");
   const options = computed(() => availability.data?.options || []);
 


### PR DESCRIPTION
Currently, auto-fetching of agent status in the create resource causes an error toast to appear on the customer end.

This PR fixes it by calling it lazily and adding gated checks on customer end as well

depends on https://github.com/frappe/helpdesk/pull/3372