### PR TITLE
fix(field-dependency): show selected values first, refresh options

### DIFF
--- a/desk/src/components/Settings/FieldDependency/FieldDependency.vue
+++ b/desk/src/components/Settings/FieldDependency/FieldDependency.vue
@@ -77,9 +77,13 @@ import ConfirmDialog from "@/components/ConfirmDialog.vue";
 import { getMeta } from "@/stores/meta";
 import { getFieldDependencyLabel } from "@/utils";
 import { createResource, Switch, toast } from "frappe-ui";
-import { computed, onUnmounted, reactive, ref, watch } from "vue";
+import { computed, onMounted, onUnmounted, reactive, ref, watch } from "vue";
 import { disableSettingModalOutsideClick } from "../settingsModal";
-import { getFieldOptions, hiddenChildFields } from "./fieldDependency";
+import {
+  clearFieldOptionsCache,
+  getFieldOptions,
+  hiddenChildFields,
+} from "./fieldDependency";
 import FieldDependencyCriteria from "./FieldDependencyCriteria.vue";
 import FieldDependencyFieldsSelection from "./FieldDependencyFieldsSelection.vue";
 import FieldDependencyValueSelection from "./FieldDependencyValueSelection.vue";
@@ -328,6 +332,12 @@ watch(
     state.childSearch = ""; // Reset child search when parent selection changes
   }
 );
+
+onMounted(() => {
+  // Drop any cached field options so newly added link/select values
+  // (e.g. a freshly created ticket type) show up on each visit.
+  clearFieldOptionsCache();
+});
 
 onUnmounted(() => {
   disableSettingModalOutsideClick.value = false;

--- a/desk/src/components/Settings/FieldDependency/FieldDependencyList.vue
+++ b/desk/src/components/Settings/FieldDependency/FieldDependencyList.vue
@@ -94,10 +94,8 @@
                 >
                   <div>
                     <Switch
-                      :model-value="row.enabled"
-                      @update:modelValue="
-                        (e) => handleSwitchToggle(row.name, e)
-                      "
+                      :model-value="Boolean(row.enabled)"
+                      @update:modelValue="(e) => handleSwitchToggle(row, e)"
                       @click.stop
                     />
                   </div>
@@ -167,15 +165,23 @@ function getOptions(rowName: string) {
   });
 }
 
-function handleSwitchToggle(rowName: string, value: boolean) {
+function handleSwitchToggle(row: any, value: boolean) {
+  // Optimistically reflect the new state so the controlled Switch stays in
+  // sync; without this the bound value never changes and toggling keeps
+  // re-sending the same value (the disable never takes effect).
+  row.enabled = value;
   fieldDependenciesList.setValue.submit(
     {
-      name: rowName,
+      name: row.name,
       enabled: value,
     },
     {
       onSuccess: () => {
         toast.success(__("Field dependency updated successfully."));
+      },
+      onError: () => {
+        row.enabled = !value;
+        toast.error(__("Failed to update field dependency."));
       },
     }
   );

--- a/desk/src/components/Settings/FieldDependency/FieldDependencyValueSelection.vue
+++ b/desk/src/components/Settings/FieldDependency/FieldDependencyValueSelection.vue
@@ -149,9 +149,27 @@ const filteredParentFieldValues = computed(() => {
   );
 });
 
+// Order values that were already selected when the screen loaded to the top.
+// Uses the saved selections (not the live ones) so the list stays put while
+// the user is checking/unchecking values.
+const orderedChildFieldValues = computed(() => {
+  const parent = state.value.currentParentSelection;
+  const initialSelections = state.value.initialChildSelections?.[parent];
+  const values = state.value.childFieldValues;
+  if (!(initialSelections instanceof Set) || initialSelections.size === 0) {
+    return values;
+  }
+  const selected = [];
+  const unselected = [];
+  values.forEach((value) => {
+    (initialSelections.has(value) ? selected : unselected).push(value);
+  });
+  return [...selected, ...unselected];
+});
+
 const filteredChildFieldValues = computed(() => {
-  if (!state.value.childSearch) return state.value.childFieldValues;
-  return state.value.childFieldValues.filter((v) =>
+  if (!state.value.childSearch) return orderedChildFieldValues.value;
+  return orderedChildFieldValues.value.filter((v) =>
     v.toLowerCase().includes(state.value.childSearch.toLowerCase())
   );
 });

--- a/desk/src/components/Settings/FieldDependency/fieldDependency.ts
+++ b/desk/src/components/Settings/FieldDependency/fieldDependency.ts
@@ -25,6 +25,10 @@ export const hiddenChildFields = computed(() => {
 
 const optionsMap = reactive({});
 
+export function clearFieldOptionsCache(): void {
+  Object.keys(optionsMap).forEach((key) => delete optionsMap[key]);
+}
+
 export async function getFieldOptions(field: any): Promise<string[]> {
   if (optionsMap[field.value]) {
     return optionsMap[field.value];


### PR DESCRIPTION

- Show selected child values at the top.
- Update the list-view enabled toggle to reflect state locally so disabling actually persists (the controlled Switch was re-sending the same value)