### PR TITLE
fix: badges having borders & width truncation for texts

### DIFF
--- a/desk/src/pages/ticket/TicketCustomerTemplateFields.vue
+++ b/desk/src/pages/ticket/TicketCustomerTemplateFields.vue
@@ -3,7 +3,7 @@
     <div class="flex items-center gap-4">
       <span class="w-[150px] shrink-0 text-sm text-ink-gray-5">Status</span>
       <span
-        class="flex-1 break-words rounded border border-outline-gray-2 bg-surface-white px-2 py-1 text-base font-medium text-ink-gray-9"
+        class="flex-1 truncate rounded border border-outline-gray-2 bg-surface-white px-2 py-1 text-base font-medium text-ink-gray-9"
       >
         {{ ticket.data.status }}
       </span>
@@ -12,7 +12,7 @@
     <div class="flex items-center gap-4">
       <span class="w-[150px] shrink-0 text-sm text-ink-gray-5">Priority</span>
       <span
-        class="flex-1 break-words rounded border border-outline-gray-2 bg-surface-white px-2 py-1 text-base font-medium text-ink-gray-9"
+        class="flex-1 truncate rounded border border-outline-gray-2 bg-surface-white px-2 py-1 text-base font-medium text-ink-gray-9"
       >
         {{ ticket.data.priority }}
       </span>
@@ -28,16 +28,17 @@
           data.title
         }}</span>
       </Tooltip>
+      <Badge
+        v-if="data.showSla"
+        :label="data.label"
+        :theme="data.theme"
+        variant="outline"
+      />
       <span
-        class="flex-1 rounded border border-outline-gray-2 bg-surface-white px-2 py-1 text-base font-medium text-ink-gray-9"
+        v-else
+        class="flex-1 truncate rounded border border-outline-gray-2 bg-surface-white px-2 py-1 text-base font-medium text-ink-gray-9"
       >
-        <Badge
-          v-if="data.showSla"
-          :label="data.label"
-          :theme="data.theme"
-          variant="outline"
-        />
-        <span v-else>{{ dayjs.tz(data.value).fromNow() }}</span>
+        {{ dayjs.tz(data.value).fromNow() }}
       </span>
     </div>
 
@@ -50,7 +51,7 @@
         field.label
       }}</span>
       <span
-        class="flex-1 break-words rounded border border-outline-gray-2 bg-surface-white px-2 py-1 text-base font-medium"
+        class="flex-1 truncate rounded border border-outline-gray-2 bg-surface-white px-2 py-1 text-base font-medium"
         :class="
           ticket.data[field.fieldname] ? 'text-ink-gray-9' : 'text-ink-gray-4'
         "


### PR DESCRIPTION
  Restyle the customer-portal ticket Details fields to match the agent view:

  - SLA badges render on their own outline instead of being double-boxed.
  - Long values (e.g. Site Name) truncate with an ellipsis instead of overflowing.