### PR TITLE
fix: ticket unexpectedly auto-closed due to inactivity

### DIFF
--- a/desk/src/telemetry.ts
+++ b/desk/src/telemetry.ts
@@ -1,5 +1,4 @@
 import { useTelemetry } from "frappe-ui/frappe";
-import "../../../frappe/frappe/public/js/lib/posthog.js";
 const APP = "helpdesk";
 
 interface CaptureOptions {

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -1350,6 +1350,11 @@ def close_tickets_after_n_days():
         "HD Settings", "HD Settings", ["auto_close_status", "auto_close_after_days"]
     )
 
+    # Compute the cutoff in the system timezone to match how communication_date is
+    # stored. Using the database's NOW() instead would select the wrong tickets when
+    # the DB server runs in a different timezone (e.g. UTC) than the Frappe system.
+    inactivity_cutoff = add_to_date(now_datetime(), days=-days_threshold)
+
     tickets_to_close = (
         frappe.db.sql(
             """
@@ -1357,14 +1362,14 @@ def close_tickets_after_n_days():
                 FROM `tabHD Ticket` t
                 INNER JOIN (
                     SELECT reference_name, MAX(communication_date) as last_communication_date
-                    FROM `tabCommunication` 
+                    FROM `tabCommunication`
                     WHERE reference_doctype = 'HD Ticket'
                     GROUP BY reference_name
                 ) latest_comm ON t.name = latest_comm.reference_name
                 WHERE t.status = %(status)s
-                AND latest_comm.last_communication_date < DATE_SUB(NOW(), INTERVAL %(days_threshold)s DAY)
+                AND latest_comm.last_communication_date < %(inactivity_cutoff)s
             """,
-            {"days_threshold": days_threshold, "status": status},
+            {"inactivity_cutoff": inactivity_cutoff, "status": status},
             pluck="name",
         )
         or []

--- a/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
@@ -1137,12 +1137,15 @@ class TestHDTicket(IntegrationTestCase):
         days_threshold = 5
         eligible_status = "Replied"
 
-        previous_settings = frappe.db.get_value(
-            "HD Settings",
-            "HD Settings",
-            ["auto_close_tickets", "auto_close_status", "auto_close_after_days"],
-            as_dict=True,
-        )
+        settings_fields = [
+            "auto_close_tickets",
+            "auto_close_status",
+            "auto_close_after_days",
+        ]
+        previous_settings = {
+            field: frappe.db.get_single_value("HD Settings", field)
+            for field in settings_fields
+        }
         frappe.db.set_single_value(
             "HD Settings",
             {

--- a/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
@@ -13,6 +13,7 @@ from helpdesk.helpdesk.doctype.hd_ticket.api import (
     show_outside_hours_banner,
     split_ticket,
 )
+from helpdesk.helpdesk.doctype.hd_ticket.hd_ticket import close_tickets_after_n_days
 from helpdesk.test_utils import (
     add_comment,
     add_holiday,
@@ -22,6 +23,7 @@ from helpdesk.test_utils import (
     make_status,
     make_ticket,
     remove_holidays,
+    set_ticket_status_and_communication_date,
     upload_test_file,
 )
 
@@ -1126,6 +1128,58 @@ class TestHDTicket(IntegrationTestCase):
         )
         for file in files:
             frappe.delete_doc("File", file)
+
+    def test_auto_close_respects_inactivity_cutoff_boundary(self):
+        """`close_tickets_after_n_days` closes a ticket whose last communication is
+        older than the inactivity cutoff and keeps one whose last communication
+        falls within it. The cutoff is computed in the system timezone, so the
+        boundary holds regardless of the database server's timezone."""
+        days_threshold = 5
+        eligible_status = "Replied"
+
+        previous_settings = frappe.db.get_value(
+            "HD Settings",
+            "HD Settings",
+            ["auto_close_tickets", "auto_close_status", "auto_close_after_days"],
+            as_dict=True,
+        )
+        frappe.db.set_single_value(
+            "HD Settings",
+            {
+                "auto_close_tickets": 1,
+                "auto_close_status": eligible_status,
+                "auto_close_after_days": days_threshold,
+            },
+        )
+
+        cutoff = add_to_date(now_datetime(), days=-days_threshold)
+        just_past_cutoff = cutoff - timedelta(minutes=5)  # inactive -> should close
+        within_cutoff = cutoff + timedelta(minutes=5)  # still active -> should stay
+
+        stale_ticket = make_ticket()
+        fresh_ticket = make_ticket()
+        set_ticket_status_and_communication_date(
+            stale_ticket.name, eligible_status, just_past_cutoff
+        )
+        set_ticket_status_and_communication_date(
+            fresh_ticket.name, eligible_status, within_cutoff
+        )
+
+        try:
+            close_tickets_after_n_days()
+
+            self.assertEqual(
+                frappe.db.get_value("HD Ticket", stale_ticket.name, "status"),
+                "Closed",
+                "Ticket inactive past the cutoff should be auto closed",
+            )
+            self.assertEqual(
+                frappe.db.get_value("HD Ticket", fresh_ticket.name, "status"),
+                eligible_status,
+                "Ticket active within the cutoff should not be closed",
+            )
+        finally:
+            frappe.db.set_single_value("HD Settings", previous_settings)
 
     def tearDown(self):
         frappe.set_user("Administrator")

--- a/helpdesk/test_utils.py
+++ b/helpdesk/test_utils.py
@@ -333,6 +333,22 @@ def add_comment(
     return comment
 
 
+def set_ticket_status_and_communication_date(ticket_name, status, communication_date):
+    """Force a ticket's status and the date of all its communications directly in the
+    database, bypassing controller side effects. Useful for testing scheduled jobs that
+    key off communication_date (auto close, SLA escalation, reminders)."""
+    frappe.db.set_value(
+        "HD Ticket", ticket_name, "status", status, update_modified=False
+    )
+    frappe.db.set_value(
+        "Communication",
+        {"reference_doctype": "HD Ticket", "reference_name": ticket_name},
+        "communication_date",
+        communication_date,
+        update_modified=False,
+    )
+
+
 def make_team(team_name, members=[], disabled=False):
     """Create an HD Team with optional members. A default agent is created if no members are provided."""
     if not members:

--- a/helpdesk/test_utils.py
+++ b/helpdesk/test_utils.py
@@ -340,13 +340,18 @@ def set_ticket_status_and_communication_date(ticket_name, status, communication_
     frappe.db.set_value(
         "HD Ticket", ticket_name, "status", status, update_modified=False
     )
-    frappe.db.set_value(
+    for comm_name in frappe.get_all(
         "Communication",
-        {"reference_doctype": "HD Ticket", "reference_name": ticket_name},
-        "communication_date",
-        communication_date,
-        update_modified=False,
-    )
+        filters={"reference_doctype": "HD Ticket", "reference_name": ticket_name},
+        pluck="name",
+    ):
+        frappe.db.set_value(
+            "Communication",
+            comm_name,
+            "communication_date",
+            communication_date,
+            update_modified=False,
+        )
 
 
 def make_team(team_name, members=[], disabled=False):


### PR DESCRIPTION
`close_tickets_after_n_days` compared communication_date against the database's NOW(), which selects the wrong tickets when the DB server runs in a different timezone (e.g. UTC) than the Frappe system. 

Compute the cutoff with now_datetime() so it matches how communication_date is stored.

fixes https://github.com/frappe/helpdesk/issues/3419
