### PR TITLE
fix: stale conversation when ticket reopens after customer reply

### DIFF
--- a/desk/src/composables/useTicket.ts
+++ b/desk/src/composables/useTicket.ts
@@ -75,3 +75,7 @@ export function reloadTicket(ticketId: string) {
   ticketData.assignees.reload();
   ticketData.activities.reload();
 }
+
+export function isTicketCached(ticketId: string): boolean {
+  return !!ticketMap[ticketId];
+}

--- a/desk/src/pages/ticket/TicketAgent.vue
+++ b/desk/src/pages/ticket/TicketAgent.vue
@@ -153,6 +153,11 @@ watch(
 
     if (oldTicketId) stopViewing(oldTicketId as string);
     startViewing(newTicketId as string);
+
+    // When switching between tickets without unmounting, reload the incoming
+    // ticket's data so a customer reply that arrived while the agent was away
+    // is always visible immediately rather than requiring a manual page reload.
+    if (oldTicketId) reloadTicket(newTicketId as string);
   },
   { immediate: true }
 );
@@ -165,6 +170,11 @@ type TicketUpdateData = {
 };
 
 onMounted(() => {
+  // Always reload when the ticket page mounts so that a customer reply that
+  // arrived while the agent was away (and the socket listener was torn down)
+  // is immediately visible without requiring a manual page reload.
+  reloadTicket(props.ticketId);
+
   ticketsToNavigate.update({
     params: {
       ticket: props.ticketId,

--- a/desk/src/pages/ticket/TicketAgent.vue
+++ b/desk/src/pages/ticket/TicketAgent.vue
@@ -54,7 +54,11 @@ import TicketHeader from "@/components/ticket-agent/TicketHeader.vue";
 import TicketSidebar from "@/components/ticket-agent/TicketSidebar.vue";
 import SetContactPhoneModal from "@/components/ticket/SetContactPhoneModal.vue";
 import { useActiveViewers } from "@/composables/realtime";
-import { isTicketCached, reloadTicket, useTicket } from "@/composables/useTicket";
+import {
+  isTicketCached,
+  reloadTicket,
+  useTicket,
+} from "@/composables/useTicket";
 import { ticketsToNavigate } from "@/composables/useTicketNavigation";
 import { globalStore } from "@/stores/globalStore";
 import { useTelephonyStore } from "@/stores/telephony";

--- a/desk/src/pages/ticket/TicketAgent.vue
+++ b/desk/src/pages/ticket/TicketAgent.vue
@@ -54,7 +54,7 @@ import TicketHeader from "@/components/ticket-agent/TicketHeader.vue";
 import TicketSidebar from "@/components/ticket-agent/TicketSidebar.vue";
 import SetContactPhoneModal from "@/components/ticket/SetContactPhoneModal.vue";
 import { useActiveViewers } from "@/composables/realtime";
-import { reloadTicket, useTicket } from "@/composables/useTicket";
+import { isTicketCached, reloadTicket, useTicket } from "@/composables/useTicket";
 import { ticketsToNavigate } from "@/composables/useTicketNavigation";
 import { globalStore } from "@/stores/globalStore";
 import { useTelephonyStore } from "@/stores/telephony";
@@ -90,6 +90,9 @@ const props = defineProps({
 const route = useRoute();
 const showPhoneModal = ref(false);
 
+// Captured before setup creates the cache entry so onMounted can tell
+// whether this is a first open (auto:true handles it) or a revisit.
+const wasAlreadyCached = isTicketCached(props.ticketId);
 const ticketComposable = computed(() => useTicket(props.ticketId));
 const ticket = computed(() => ticketComposable.value.ticket);
 const customizations: Resource<Customizations> = createResource({
@@ -154,10 +157,12 @@ watch(
     if (oldTicketId) stopViewing(oldTicketId as string);
     startViewing(newTicketId as string);
 
-    // When switching between tickets without unmounting, reload the incoming
-    // ticket's data so a customer reply that arrived while the agent was away
-    // is always visible immediately rather than requiring a manual page reload.
-    if (oldTicketId) reloadTicket(newTicketId as string);
+    // Only reload if already cached. The watcher fires before the computed
+    // re-evaluates, so uncached tickets don't have a ticketMap entry yet —
+    // their auto:true fetch will provide fresh data when the entry is created.
+    if (oldTicketId && isTicketCached(newTicketId as string)) {
+      reloadTicket(newTicketId as string);
+    }
   },
   { immediate: true }
 );
@@ -170,10 +175,11 @@ type TicketUpdateData = {
 };
 
 onMounted(() => {
-  // Always reload when the ticket page mounts so that a customer reply that
-  // arrived while the agent was away (and the socket listener was torn down)
-  // is immediately visible without requiring a manual page reload.
-  reloadTicket(props.ticketId);
+  // Reload only for revisits (stale cache). First-time opens get fresh
+  // data via auto:true on the newly created cache entry.
+  if (wasAlreadyCached) {
+    reloadTicket(props.ticketId);
+  }
 
   ticketsToNavigate.update({
     params: {


### PR DESCRIPTION
## Problem

When an agent replies to a ticket and it moves to **Replied** status, the ticket is removed from their queue. When the customer replies back via email, the ticket reappears in the queue — but clicking on it shows a **stale conversation** that is missing the customer's latest reply. The new message only appears after a manual page reload.

### Root cause

`useTicket.ts` maintains a module-level `ticketMap` cache. When an agent opens a ticket, the resources (ticket, assignees, activities) are created with `auto: true` and cached.

When the agent navigates away, `onBeforeUnmount` tears down the `helpdesk:ticket-update` socket listener:

```js
onBeforeUnmount(() => {
  $socket.off("helpdesk:ticket-update");  // listener removed
  ...
});
```

When the customer replies, `on_communication_update()` on the `HD Ticket` document calls `self.save()` → `on_update()` → `publish_update()`, which emits `helpdesk:ticket-update`. But the agent's listener is already gone, so `reloadTicket()` is never called and the `ticketMap` entry stays stale.

When the agent clicks the ticket in the queue, `useTicket(ticketId)` returns the **stale cached entry** — activities do not include the customer's reply. The socket listeners are re-registered in `onMounted`, but the event has already fired and won't fire again.

## Fix

Call `reloadTicket(props.ticketId)` in `onMounted` so the conversation is always fetched fresh when the ticket page loads, regardless of what happened while the agent was away.

Also reload when navigating directly between ticket detail pages (the same `TicketAgent.vue` component instance stays mounted while `ticketId` changes), to cover that navigation path too.

```diff
+ onMounted(() => {
+   // Always reload on mount so a customer reply that arrived while the
+   // agent was away is immediately visible without a manual page reload.
+   reloadTicket(props.ticketId);
    ...
  });

  watch(() => route.params.ticketId, (newTicketId, oldTicketId) => {
    ...
+   // Reload when switching tickets so stale cached data is not shown.
+   if (oldTicketId) reloadTicket(newTicketId as string);
  }, { immediate: true });
```

## Test plan

- [ ] Reply to a ticket → ticket moves to Replied status and disappears from queue
- [ ] Have the customer reply back via email
- [ ] Ticket reappears in queue — click it
- [ ] Customer's latest reply should be visible **immediately** without reloading the page
- [ ] Clicking a name/copy field in the sidebar should still copy to clipboard correctly (unrelated regression check)
- [ ] Navigating directly between two ticket pages (using prev/next arrows) should show each ticket's latest messages without stale data

🤖 Generated with [Claude Code](https://claude.com/claude-code)