### PR TITLE
fix: dedupe recent tickets, feedback rating by resolution date, staledashboard stats

### DIFF
--- a/desk/src/composables/useTicket.ts
+++ b/desk/src/composables/useTicket.ts
@@ -75,3 +75,11 @@ export function reloadTicket(ticketId: string) {
   ticketData.assignees.reload();
   ticketData.activities.reload();
 }
+
+// Refresh a ticket that may have gone stale
+export function revalidateTicket(ticketId: string | number) {
+  const ticketData = ticketMap[ticketId];
+  if (ticketData?.ticket.get.fetched && !ticketData.ticket.get.loading) {
+    reloadTicket(ticketId as string);
+  }
+}

--- a/desk/src/pages/dashboard/Dashboard.vue
+++ b/desk/src/pages/dashboard/Dashboard.vue
@@ -335,9 +335,11 @@ const parseFilters = (filters: Filters) => {
   };
 };
 
+// No `cache` key here: a static cache key makes frappe-ui return the same
+// resource instance across navigations, still bound to the previous mount's
+// `filters` closure, so reloads after navigating back send stale params.
 const numberCards = createResource({
   url: "helpdesk.api.dashboard.get_dashboard_data",
-  cache: ["Analytics", "NumberCards"],
   makeParams: () => ({
     dashboard_type: "number_card",
     filters: parseFilters(filters),
@@ -346,7 +348,6 @@ const numberCards = createResource({
 
 const masterData = createResource({
   url: "helpdesk.api.dashboard.get_dashboard_data",
-  cache: ["Analytics", "MasterCharts"],
   makeParams: () => ({
     dashboard_type: "master",
     filters: parseFilters(filters),
@@ -355,7 +356,6 @@ const masterData = createResource({
 
 const trendData = createResource({
   url: "helpdesk.api.dashboard.get_dashboard_data",
-  cache: ["Analytics", "TrendCharts"],
   makeParams: () => ({
     dashboard_type: "trend",
     filters: parseFilters(filters),

--- a/desk/src/pages/ticket/MobileTicketAgent.vue
+++ b/desk/src/pages/ticket/MobileTicketAgent.vue
@@ -214,7 +214,11 @@ import {
 } from "@/composables/formCustomisation";
 import { useScreenSize } from "@/composables/screen";
 import { useActiveTabManager } from "@/composables/useActiveTabManager";
-import { reloadTicket, useTicket } from "@/composables/useTicket";
+import {
+  reloadTicket,
+  revalidateTicket,
+  useTicket,
+} from "@/composables/useTicket";
 import { globalStore } from "@/stores/globalStore";
 import { getMeta } from "@/stores/meta";
 import { useTelephonyStore } from "@/stores/telephony";
@@ -613,6 +617,9 @@ function filterActivities(eventType: TicketTab) {
 
 onMounted(() => {
   document.title = props.ticketId;
+  // Revisiting a ticket: show the cached conversation immediately and refresh it
+  // in place (mobile has no live socket refresh to keep the cache current).
+  revalidateTicket(props.ticketId);
 });
 
 onUnmounted(() => {

--- a/desk/src/pages/ticket/TicketAgent.vue
+++ b/desk/src/pages/ticket/TicketAgent.vue
@@ -54,7 +54,11 @@ import TicketHeader from "@/components/ticket-agent/TicketHeader.vue";
 import TicketSidebar from "@/components/ticket-agent/TicketSidebar.vue";
 import SetContactPhoneModal from "@/components/ticket/SetContactPhoneModal.vue";
 import { useActiveViewers } from "@/composables/realtime";
-import { reloadTicket, useTicket } from "@/composables/useTicket";
+import {
+  reloadTicket,
+  revalidateTicket,
+  useTicket,
+} from "@/composables/useTicket";
 import { ticketsToNavigate } from "@/composables/useTicketNavigation";
 import { globalStore } from "@/stores/globalStore";
 import { useTelephonyStore } from "@/stores/telephony";
@@ -153,6 +157,10 @@ watch(
 
     if (oldTicketId) stopViewing(oldTicketId as string);
     startViewing(newTicketId as string);
+
+    // Switching to an already-visited ticket: show its cached conversation and
+    // refresh it in the background in case it changed while we were elsewhere.
+    if (oldTicketId) revalidateTicket(newTicketId as string);
   },
   { immediate: true }
 );
@@ -165,6 +173,10 @@ type TicketUpdateData = {
 };
 
 onMounted(() => {
+  // Revisiting a ticket: show the cached conversation immediately and refresh it
+  // in place, since a reply may have arrived while the socket listener was off.
+  revalidateTicket(props.ticketId);
+
   ticketsToNavigate.update({
     params: {
       ticket: props.ticketId,

--- a/helpdesk/api/dashboard.py
+++ b/helpdesk/api/dashboard.py
@@ -318,16 +318,19 @@ class HelpdeskDashboard:
         rating = "Rating"
         rated_tickets = "Rated Tickets"
 
-        base_cond = (self.ticket.creation > self.from_date) & (
-            self.ticket.creation < self.to_date_next
-        )
+        # Plot feedback against the resolution date so this trend matches the
+        # number-card average (get_avg_feedback_score), which also keys feedback
+        # off resolution_date rather than creation.
+        date_field = self.ticket.resolution_date
+
+        base_cond = (date_field > self.from_date) & (date_field < self.to_date_next)
         if self.combined_cond:
             base_cond = base_cond & self.combined_cond
 
         query = (
             frappe.qb.from_(self.ticket)
             .select(
-                Function("DATE", self.ticket.creation).as_("date"),
+                Function("DATE", date_field).as_("date"),
                 (
                     Avg(
                         Case()
@@ -345,8 +348,8 @@ class HelpdeskDashboard:
                 ).as_(rated_tickets),
             )
             .where(base_cond)
-            .groupby(Function("DATE", self.ticket.creation))
-            .orderby(Function("DATE", self.ticket.creation))
+            .groupby(Function("DATE", date_field))
+            .orderby(Function("DATE", date_field))
         )
 
         result = query.run(as_dict=True)
@@ -356,7 +359,7 @@ class HelpdeskDashboard:
             frappe.qb.from_(self.ticket)
             .select((Avg(self.ticket.feedback_rating) * 5).as_("avg_rating"))
             .where(
-                (self.ticket.creation.between(self.from_date, self.to_date_next))
+                (date_field.between(self.from_date, self.to_date_next))
                 & (self.ticket.feedback_rating > 0)
             )
         )

--- a/helpdesk/api/dashboard.py
+++ b/helpdesk/api/dashboard.py
@@ -114,8 +114,9 @@ class HelpdeskDashboard:
             )
         return conds
 
-    def _get_case(self, start, end, value, func, extra_cond=None):
-        cond = (self.ticket.creation >= start) & (self.ticket.creation < end)
+    def _get_case(self, start, end, value, func, extra_cond=None, date_field=None):
+        date_field = date_field or self.ticket.creation
+        cond = (date_field >= start) & (date_field < end)
         if extra_cond:
             cond = cond & extra_cond
         if self.combined_cond:
@@ -123,12 +124,12 @@ class HelpdeskDashboard:
 
         return func(Case().when(cond, value).else_(None))
 
-    def get_metric_data(self, value, func, extra_cond=None):
+    def get_metric_data(self, value, func, extra_cond=None, date_field=None):
         current_expr = self._get_case(
-            self.from_date, self.to_date_next, value, func, extra_cond
+            self.from_date, self.to_date_next, value, func, extra_cond, date_field
         )
         prev_expr = self._get_case(
-            self.prev_from_date, self.from_date, value, func, extra_cond
+            self.prev_from_date, self.from_date, value, func, extra_cond, date_field
         )
 
         query = frappe.qb.from_(self.ticket).select(
@@ -222,9 +223,15 @@ class HelpdeskDashboard:
         }
 
     def get_avg_feedback_score(self):
+        # Feedback belongs to the period a ticket was resolved in, not when it
+        # was raised, so include every ticket resolved within the date range
+        # regardless of its creation date.
         extra_cond = self.ticket.feedback_rating > 0
         current, prev = self.get_metric_data(
-            self.ticket.feedback_rating, Avg, extra_cond
+            self.ticket.feedback_rating,
+            Avg,
+            extra_cond,
+            date_field=self.ticket.resolution_date,
         )
 
         return {
@@ -233,7 +240,7 @@ class HelpdeskDashboard:
             "suffix": "/5",
             "delta": (current - prev) * 5,
             "deltaSuffix": " " + _("stars"),
-            "tooltip": _("Avg. feedback rating for the tickets resolved"),
+            "tooltip": _("Avg. feedback rating for tickets resolved in this period"),
         }
 
     def get_trend_data(self):

--- a/helpdesk/helpdesk/doctype/hd_ticket/api.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/api.py
@@ -718,11 +718,14 @@ def get_recent_tickets(ticket: str):
         )
 
     if raised_by:
+        # Exclude the current ticket and any already picked up as org tickets,
+        # otherwise a ticket matching both `customer` and `raised_by` shows twice.
+        excluded = [ticket] + [t.name for t in org_tickets]
         user_tickets = (
             frappe.get_list(
                 "HD Ticket",
                 filters={
-                    "name": ["!=", ticket],
+                    "name": ["not in", excluded],
                     "raised_by": raised_by,
                 },
                 fields=fields,


### PR DESCRIPTION

- get_recent_tickets: exclude current + org tickets from the raised_by query so a ticket matching both customer and raised_by no longer appears twice.
- Dashboard avg feedback rating: filter on resolution_date instead of creation, so every ticket resolved in the period is counted regardless of when it was raised.
- Dashboard.vue: drop the static frappe-ui cache keys on the stat resources; the shared cached instance stayed bound to a previous mount's filters and sent stale params after navigating away and back.