### PR TITLE
fix: remove overscroll-behavior

### DIFF
--- a/desk/src/index.css
+++ b/desk/src/index.css
@@ -25,7 +25,6 @@ html,
 body {
   color: var(--ink-gray-9);
   background-color: var(--surface-white);
-  overscroll-behavior: none;
 }
 
 :root {

--- a/helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+++ b/helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "allow_rename": 1,
  "autoname": "field:label_agent",
  "creation": "2025-08-13 10:00:15.235225",
@@ -45,7 +46,7 @@
   },
   {
    "depends_on": "eval:doc.different_view",
-   "description": "Name shown on the customer portal<br> (e.g., Replied \u2192 Awaiting Response).",
+   "description": "Name shown on the customer portal<br> (e.g., Replied → Awaiting Response).",
    "fieldname": "label_customer",
    "fieldtype": "Data",
    "label": "Label (customer view)",
@@ -86,7 +87,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-03-24 10:41:46.489051",
+ "modified": "2026-06-26 18:18:39.871707",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Ticket Status",
@@ -121,6 +122,16 @@
    "read": 1,
    "role": "HD Customer",
    "select": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Agent",
+   "select": 1,
+   "share": 1
   }
  ],
  "row_format": "Dynamic",


### PR DESCRIPTION
## Issue
When scrolling inside the email reply box in a ticket, the outer conversation feed scroll would stop and stay stuck until page reload.

## Root Cause
 on the  rule prevents scroll chaining from inner scroll containers to the root viewport. When the email box (with its own scroll container) hit its scroll edge, leftover scroll deltas were consumed instead of propagating to the outer conversation feed.

## Fix
Removed  from the html/body rule. This allows scroll events to chain properly from nested scroll containers to the viewport.

## Testing
- Verified scrolling inside email box no longer blocks outer scroll
- Outer conversation feed now scrolls normally after using the email box
