### PR TITLE
fix: set customer only for new tickets

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -267,6 +267,9 @@ class HDTicket(Document):
                     self.contact = contact
 
     def set_customer(self):
+        if not self.is_new():
+            return  # don't auto-set customer on existing tickets
+
         contact_customers = get_customers(contact=self.contact) if self.contact else []
 
         if self.customer:

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -267,8 +267,9 @@ class HDTicket(Document):
                     self.contact = contact
 
     def set_customer(self):
-        if not self.is_new():
-            return  # don't auto-set customer on existing tickets
+        # For existing tickets, only validate if customer value has changed
+        if not self.is_new() and not self.has_value_changed("customer"):
+            return
 
         contact_customers = get_customers(contact=self.contact) if self.contact else []
 
@@ -281,9 +282,10 @@ class HDTicket(Document):
                     ).format(self.customer, self.contact),
                     frappe.ValidationError,
                 )
-            return  # customer is set and valid, return early
+            return
 
-        if self.contact:
+        # Auto-set customer only for new tickets
+        if self.is_new() and self.contact:
             if len(contact_customers) == 1:
                 self.customer = contact_customers[0]
             elif (


### PR DESCRIPTION
People are not able to reply on older tickets because of the "Customer Valdiation".
It should run only on new tickets, not the existing one