### PR TITLE
ci: build and upload prebuilt assets to rolling release on push

### DIFF
--- a/.github/workflows/build-and-commit-assets.yml
+++ b/.github/workflows/build-and-commit-assets.yml
@@ -1,0 +1,83 @@
+name: Build and Upload Assets
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+      - 'version-*'
+
+concurrency:
+  group: build-assets-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  build-assets:
+    name: Build assets and upload to release
+    runs-on: ubuntu-latest
+    env:
+      # Vite/esbuild builds of large SPAs can exceed Node's default heap and
+      # abort with "JavaScript heap out of memory" (exit 134) even when the
+      # runner has free RAM. Raise the old-space limit to be safe.
+      NODE_OPTIONS: --max-old-space-size=4096
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: frappe/frappe
+          path: apps/frappe
+          ref: ${{ github.ref_name }}
+
+      - uses: actions/checkout@v4
+        with:
+          path: apps/helpdesk
+
+      - name: Create bench structure
+        run: |
+          mkdir -p sites
+          printf "frappe\nhelpdesk\n" > sites/apps.txt
+          # desk/src/socket.ts imports socketio_port from this file at build time
+          echo '{"socketio_port": 9000}' > sites/common_site_config.json
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: yarn
+          cache-dependency-path: apps/frappe/yarn.lock
+
+      - name: Install frappe JS dependencies
+        working-directory: apps/frappe
+        run: yarn install --frozen-lockfile
+
+      - name: Install helpdesk JS dependencies
+        working-directory: apps/helpdesk
+        run: yarn install --frozen-lockfile
+
+      - name: Link node_modules into public/
+        working-directory: apps/frappe
+        run: ln -s "$PWD/node_modules" frappe/public/node_modules
+
+      - name: Build frappe bundles (production)
+        working-directory: apps/frappe
+        run: yarn run production
+
+      - name: Build helpdesk SPA
+        working-directory: apps/helpdesk
+        run: yarn build
+
+      - name: Package assets
+        run: |
+          tar czf helpdesk-assets.tar.gz \
+            --exclude=node_modules --exclude=.gitkeep \
+            -C apps/helpdesk/helpdesk/public .
+
+      - name: Upload to rolling release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="assets-${GITHUB_REF_NAME//\//-}"
+          gh release create "$TAG" -R "$GITHUB_REPOSITORY" --prerelease --title "Assets: $GITHUB_REF_NAME" --notes "" 2>/dev/null || true
+          gh release upload "$TAG" -R "$GITHUB_REPOSITORY" helpdesk-assets.tar.gz --clobber

--- a/.github/workflows/build-and-commit-assets.yml
+++ b/.github/workflows/build-and-commit-assets.yml
@@ -17,6 +17,10 @@ permissions:
 jobs:
   build-assets:
     name: Build assets and upload to release
+    # semantic-release pushes a "chore(release): Bumped to Version x" commit to
+    # main (no [skip ci]), which would otherwise trigger a redundant rebuild.
+    # Skip it — the assets are identical to the merge commit that preceded it.
+    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}
     runs-on: ubuntu-latest
     env:
       # Vite/esbuild builds of large SPAs can exceed Node's default heap and


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow that, on every push to `develop` / `main` / `version-*`, builds the app's assets (frappe bundles + the Vue SPA) and uploads them as `helpdesk-assets.tar.gz` to a rolling `assets-<branch>` prerelease.

## Why

Bench setup currently builds each app's JS/CSS from source on every install, which is slow and needs Node + memory. frappe, erpnext and hrms already publish prebuilt asset tarballs this way so tooling can download them instead of building. This brings helpdesk in line so a fresh bench can fetch prebuilt assets rather than running `yarn build`.

## Notes

- Additive only: one workflow file, no app code touched.
- Tarball packs the app's `public/` output (SPA + any bundles), excluding `node_modules`.
- `NODE_OPTIONS=--max-old-space-size=4096` guards against the SPA build hitting Node's default heap limit.
- Verified end to end on a fork: workflow runs green and publishes a downloadable `assets-develop` release.