### PR TITLE
fix: redirect responses to correct merged ticket

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -461,7 +461,7 @@
    "read_only": 1
   },
   {
-   "default": "False",
+   "default": "0",
    "fieldname": "raised_outside_working_hours",
    "fieldtype": "Check",
    "label": "Ticket raised outside working hours",

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -919,11 +919,44 @@ class HDTicket(Document):
             "category",
         )
 
+    def get_merge_target(self):
+        # Follow the chain of merged tickets to the final, existing, non-merged ticket.
+        # `target` only advances to a ticket we have confirmed exists, and `seen` keeps a
+        # corrupt merge cycle from looping forever.
+        target = None
+        candidate = self.merged_with
+        seen = {self.name}
+        while candidate and candidate not in seen:
+            row = frappe.db.get_value(
+                "HD Ticket", candidate, ["is_merged", "merged_with"], as_dict=True
+            )
+            if not row:
+                break
+            seen.add(candidate)
+            target = candidate
+            if not row.is_merged or not row.merged_with:
+                break
+            candidate = row.merged_with
+        return target
+
+    def redirect_communication_to_merge_target(self, c):
+        target_name = self.get_merge_target()
+        if not target_name:
+            return
+        c.db_set("reference_name", target_name)
+        frappe.get_doc("HD Ticket", target_name).on_communication_update(c)
+
     # `on_communication_update` is a special method exposed from `Communication` doctype.
     # It is called when a communication is updated. Beware of changes as this effectively
     # is an external dependency. Refer `communication.py` of Frappe framework for more.
     # Since this is called from communication itself, `c` is the communication doc.
     def on_communication_update(self, c):
+        # A reply to a merged ticket belongs to the ticket it was merged into. Redirect
+        # the communication there instead of reopening this (merged) ticket.
+        if c.sent_or_received == "Received" and self.is_merged and self.merged_with:
+            self.redirect_communication_to_merge_target(c)
+            return
+
         # If communication is incoming, then it is a reply from customer, and ticket must
         # be reopened.
         # handle re opening tickets for email

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -920,10 +920,9 @@ class HDTicket(Document):
         )
 
     def get_merge_target(self):
-        # Follow the chain of merged tickets to the final, existing, non-merged ticket.
-        # `merge_target_name` only advances to a ticket we have confirmed exists, and
-        # `visited_ticket_names` keeps a corrupt merge cycle from looping forever.
-        merge_target_name = None
+        # Follow the chain of merged tickets to the final, non-merged ticket. Return None
+        # if the chain dead-ends on a missing ticket or loops back on itself (a corrupt
+        # cycle), so a reply is never redirected onto another merged ticket.
         current_ticket_name = self.merged_with
         visited_ticket_names = {self.name}
         while current_ticket_name and current_ticket_name not in visited_ticket_names:
@@ -934,13 +933,14 @@ class HDTicket(Document):
                 as_dict=True,
             )
             if not ticket:
-                break
+                return None
             visited_ticket_names.add(current_ticket_name)
-            merge_target_name = current_ticket_name
-            if not ticket.is_merged or not ticket.merged_with:
-                break
+            if not ticket.is_merged:
+                return current_ticket_name
+            if not ticket.merged_with:
+                return None
             current_ticket_name = ticket.merged_with
-        return merge_target_name
+        return None
 
     def redirect_communication_to_merge_target(self, communication):
         merge_target_name = self.get_merge_target()

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -921,30 +921,34 @@ class HDTicket(Document):
 
     def get_merge_target(self):
         # Follow the chain of merged tickets to the final, existing, non-merged ticket.
-        # `target` only advances to a ticket we have confirmed exists, and `seen` keeps a
-        # corrupt merge cycle from looping forever.
-        target = None
-        candidate = self.merged_with
-        seen = {self.name}
-        while candidate and candidate not in seen:
-            row = frappe.db.get_value(
-                "HD Ticket", candidate, ["is_merged", "merged_with"], as_dict=True
+        # `merge_target_name` only advances to a ticket we have confirmed exists, and
+        # `visited_ticket_names` keeps a corrupt merge cycle from looping forever.
+        merge_target_name = None
+        current_ticket_name = self.merged_with
+        visited_ticket_names = {self.name}
+        while current_ticket_name and current_ticket_name not in visited_ticket_names:
+            ticket = frappe.db.get_value(
+                "HD Ticket",
+                current_ticket_name,
+                ["is_merged", "merged_with"],
+                as_dict=True,
             )
-            if not row:
+            if not ticket:
                 break
-            seen.add(candidate)
-            target = candidate
-            if not row.is_merged or not row.merged_with:
+            visited_ticket_names.add(current_ticket_name)
+            merge_target_name = current_ticket_name
+            if not ticket.is_merged or not ticket.merged_with:
                 break
-            candidate = row.merged_with
-        return target
+            current_ticket_name = ticket.merged_with
+        return merge_target_name
 
-    def redirect_communication_to_merge_target(self, c):
-        target_name = self.get_merge_target()
-        if not target_name:
+    def redirect_communication_to_merge_target(self, communication):
+        merge_target_name = self.get_merge_target()
+        if not merge_target_name:
             return
-        c.db_set("reference_name", target_name)
-        frappe.get_doc("HD Ticket", target_name).on_communication_update(c)
+        communication.db_set("reference_name", merge_target_name)
+        merge_target = frappe.get_doc("HD Ticket", merge_target_name)
+        merge_target.on_communication_update(communication)
 
     # `on_communication_update` is a special method exposed from `Communication` doctype.
     # It is called when a communication is updated. Beware of changes as this effectively

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -945,21 +945,23 @@ class HDTicket(Document):
     def redirect_communication_to_merge_target(self, communication):
         merge_target_name = self.get_merge_target()
         if not merge_target_name:
-            return
+            return False
         communication.db_set("reference_name", merge_target_name)
         merge_target = frappe.get_doc("HD Ticket", merge_target_name)
         merge_target.on_communication_update(communication)
+        return True
 
     # `on_communication_update` is a special method exposed from `Communication` doctype.
     # It is called when a communication is updated. Beware of changes as this effectively
     # is an external dependency. Refer `communication.py` of Frappe framework for more.
     # Since this is called from communication itself, `c` is the communication doc.
     def on_communication_update(self, c):
-        # A reply to a merged ticket belongs to the ticket it was merged into. Redirect
-        # the communication there instead of reopening this (merged) ticket.
+        # A reply to a merged ticket belongs to its merge target; redirect it there. If no
+        # safe target resolves (cycle/dead-end), fall through and handle it here so the
+        # reply isn't dropped.
         if c.sent_or_received == "Received" and self.is_merged and self.merged_with:
-            self.redirect_communication_to_merge_target(c)
-            return
+            if self.redirect_communication_to_merge_target(c):
+                return
 
         # If communication is incoming, then it is a reply from customer, and ticket must
         # be reopened.

--- a/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
@@ -628,6 +628,40 @@ class TestHDTicket(IntegrationTestCase):
             len(comments), 3
         )  # 2 original comments + 1 merge comment (Ticket 1 merged into Ticket 2)
 
+    def test_reply_to_merged_ticket_redirects_to_target(self):
+        source = make_ticket(description="Merged source")
+        target = make_ticket(description="Merge target")
+
+        merge_ticket(source=source.name, target=target.name)
+        source.reload()
+        self.assertTrue(source.is_merged)
+        self.assertEqual(source.status, "Closed")
+
+        # An incoming reply lands on the merged source ticket.
+        communication = frappe.get_doc(
+            {
+                "doctype": "Communication",
+                "communication_type": "Communication",
+                "communication_medium": "Email",
+                "sent_or_received": "Received",
+                "subject": f"Re: {source.subject}",
+                "content": "Customer reply to merged ticket",
+                "reference_doctype": "HD Ticket",
+                "reference_name": source.name,
+            }
+        ).insert(ignore_permissions=True)
+
+        # The merged source must stay closed and merged.
+        source.reload()
+        self.assertEqual(source.status, "Closed")
+        self.assertTrue(source.is_merged)
+
+        # The communication is redirected to the target ticket.
+        self.assertEqual(
+            frappe.db.get_value("Communication", communication.name, "reference_name"),
+            target.name,
+        )
+
     def test_ticket_split(self):
         ticket1 = make_ticket(description="Test Desc for split")
 

--- a/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
@@ -676,6 +676,37 @@ class TestHDTicket(IntegrationTestCase):
         ticket_a.reload()
         self.assertIsNone(ticket_a.get_merge_target())
 
+    def test_reply_on_unresolvable_merge_is_not_dropped(self):
+        # No safe merge target (corrupt cycle): the reply must be handled here, not dropped.
+        ticket_a = make_ticket(description="Cycle A")
+        ticket_b = make_ticket(description="Cycle B")
+
+        merge_ticket(source=ticket_a.name, target=ticket_b.name)
+        ticket_b.reload()
+        ticket_b.db_set("is_merged", 1)
+        ticket_b.db_set("merged_with", ticket_a.name)
+
+        communication = frappe.get_doc(
+            {
+                "doctype": "Communication",
+                "communication_type": "Communication",
+                "communication_medium": "Email",
+                "sent_or_received": "Received",
+                "subject": f"Re: {ticket_a.subject}",
+                "content": "Customer reply on cyclic merge",
+                "reference_doctype": "HD Ticket",
+                "reference_name": ticket_a.name,
+            }
+        ).insert(ignore_permissions=True)
+
+        # The reply stays on this ticket (not redirected) and is handled here.
+        self.assertEqual(
+            frappe.db.get_value("Communication", communication.name, "reference_name"),
+            ticket_a.name,
+        )
+        ticket_a.reload()
+        self.assertIsNotNone(ticket_a.last_customer_response)
+
     def test_ticket_split(self):
         ticket1 = make_ticket(description="Test Desc for split")
 

--- a/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
@@ -662,6 +662,20 @@ class TestHDTicket(IntegrationTestCase):
             target.name,
         )
 
+    def test_merge_cycle_does_not_resolve_target(self):
+        # A corrupt cycle (A merged into B, B merged back into A) must not redirect a reply
+        # onto another merged ticket, which would recurse until the request fails.
+        ticket_a = make_ticket(description="Cycle A")
+        ticket_b = make_ticket(description="Cycle B")
+
+        merge_ticket(source=ticket_a.name, target=ticket_b.name)
+        ticket_b.reload()
+        ticket_b.db_set("is_merged", 1)
+        ticket_b.db_set("merged_with", ticket_a.name)
+
+        ticket_a.reload()
+        self.assertIsNone(ticket_a.get_merge_target())
+
     def test_ticket_split(self):
         ticket1 = make_ticket(description="Test Desc for split")
 


### PR DESCRIPTION
Issue caused due to no handling for response to a merged ticket

example:

Ticket A is merged to Ticket B

if user responds to ticket A the communication is appended to ticket A

this is not expected behaviour since ticket is already merged on closed thus leading to reopening if ticket

Solution:
This pr fixes it by checking if communication is received on a ticket which is merged or not, if yes it searches for the target ticket it was merged with and then appends the communication accordingly

closes: https://github.com/frappe/helpdesk/issues/2539


