### PR TITLE
fix: restore doctype permissions reverted in #3512

### DIFF
--- a/helpdesk/api/knowledge_base.py
+++ b/helpdesk/api/knowledge_base.py
@@ -88,7 +88,7 @@ def move_to_category(category: str, articles: list[str]):
 
 @frappe.whitelist()
 def get_categories():
-    categories = frappe.get_all(
+    categories = frappe.get_list(
         "HD Article Category",
         fields=["name", "category_name", "modified"],
     )
@@ -104,7 +104,7 @@ def get_categories():
 
 @frappe.whitelist()
 def get_category_articles(category: str):
-    articles = frappe.get_all(
+    articles = frappe.get_list(
         "HD Article",
         filters={"category": category, "status": "Published"},
         fields=["name", "title", "published_on", "modified", "author", "content"],

--- a/helpdesk/helpdesk/doctype/hd_article/hd_article.json
+++ b/helpdesk/helpdesk/doctype/hd_article/hd_article.json
@@ -1,138 +1,148 @@
 {
-  "actions": [],
-  "autoname": "hash",
-  "creation": "2022-02-08 18:13:42.994713",
-  "doctype": "DocType",
-  "editable_grid": 1,
-  "engine": "InnoDB",
-  "field_order": [
-    "title",
-    "status",
-    "published_on",
-    "views",
-    "column_break_7",
-    "category",
-    "author",
-    "title_slug",
-    "content_section",
-    "content"
-  ],
-  "fields": [
-    {
-      "allow_in_quick_entry": 1,
-      "fieldname": "title",
-      "fieldtype": "Data",
-      "in_list_view": 1,
-      "in_standard_filter": 1,
-      "label": "Title",
-      "reqd": 1
-    },
-    {
-      "fieldname": "category",
-      "fieldtype": "Link",
-      "in_list_view": 1,
-      "label": "Category",
-      "options": "HD Article Category"
-    },
-    {
-      "allow_in_quick_entry": 1,
-      "fieldname": "content_section",
-      "fieldtype": "Section Break",
-      "label": "Content"
-    },
-    {
-      "allow_in_quick_entry": 1,
-      "fieldname": "content",
-      "fieldtype": "Text Editor",
-      "label": "Content"
-    },
-    {
-      "depends_on": "author",
-      "fieldname": "author",
-      "fieldtype": "Link",
-      "label": "Author",
-      "options": "User",
-      "read_only": 1
-    },
-    {
-      "depends_on": "eval:doc.status === \"Published\"",
-      "fieldname": "published_on",
-      "fieldtype": "Datetime",
-      "label": "Published On",
-      "read_only": 1
-    },
-    {
-      "fieldname": "column_break_7",
-      "fieldtype": "Column Break"
-    },
-    {
-      "default": "Draft",
-      "fieldname": "status",
-      "fieldtype": "Select",
-      "in_standard_filter": 1,
-      "label": "Status",
-      "options": "Published\nDraft\nArchived"
-    },
-    {
-      "fieldname": "title_slug",
-      "fieldtype": "Data",
-      "is_virtual": 1,
-      "label": "Title Slug"
-    },
-    {
-      "default": "0",
-      "fieldname": "views",
-      "fieldtype": "Int",
-      "label": "Views",
-      "read_only": 1
-    }
-  ],
-  "links": [],
-  "make_attachments_public": 1,
-  "modified": "2026-03-24 20:11:47.835393",
-  "modified_by": "Administrator",
-  "module": "Helpdesk",
-  "name": "HD Article",
-  "naming_rule": "Random",
-  "owner": "Administrator",
-  "permissions": [
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "System Manager",
-      "share": 1,
-      "write": 1
-    },
-    {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "Agent",
-      "share": 1,
-      "write": 1
-    },
-    {
-      "email": 1,
-      "export": 1,
-      "print": 1,
-      "read": 1,
-      "report": 1,
-      "role": "HD Customer",
-      "share": 1
-    }
-  ],
-  "row_format": "Dynamic",
-  "sort_field": "modified",
-  "sort_order": "DESC",
-  "states": [],
-  "track_changes": 1
+ "actions": [],
+ "allow_bulk_edit": 1,
+ "autoname": "hash",
+ "creation": "2022-02-08 18:13:42.994713",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "title",
+  "status",
+  "published_on",
+  "views",
+  "column_break_7",
+  "category",
+  "author",
+  "title_slug",
+  "content_section",
+  "content"
+ ],
+ "fields": [
+  {
+   "allow_in_quick_entry": 1,
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Title",
+   "reqd": 1
+  },
+  {
+   "fieldname": "category",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Category",
+   "options": "HD Article Category"
+  },
+  {
+   "allow_in_quick_entry": 1,
+   "fieldname": "content_section",
+   "fieldtype": "Section Break",
+   "label": "Content"
+  },
+  {
+   "allow_in_quick_entry": 1,
+   "fieldname": "content",
+   "fieldtype": "Text Editor",
+   "label": "Content"
+  },
+  {
+   "depends_on": "author",
+   "fieldname": "author",
+   "fieldtype": "Link",
+   "label": "Author",
+   "options": "User",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.status === \"Published\"",
+   "fieldname": "published_on",
+   "fieldtype": "Datetime",
+   "label": "Published On",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_7",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "Draft",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Published\nDraft\nArchived"
+  },
+  {
+   "fieldname": "title_slug",
+   "fieldtype": "Data",
+   "is_virtual": 1,
+   "label": "Title Slug"
+  },
+  {
+   "default": "0",
+   "fieldname": "views",
+   "fieldtype": "Int",
+   "label": "Views",
+   "read_only": 1
+  }
+ ],
+ "links": [],
+ "make_attachments_public": 1,
+ "modified": "2026-06-28 13:55:21.075010",
+ "modified_by": "Administrator",
+ "module": "Helpdesk",
+ "name": "HD Article",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Agent",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "HD Customer",
+   "share": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "HD Customer Manager",
+   "share": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
 }

--- a/helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+++ b/helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "allow_guest_to_view": 1,
  "autoname": "hash",
  "creation": "2022-02-08 18:13:42.039744",
@@ -37,7 +38,7 @@
   }
  ],
  "links": [],
- "modified": "2026-03-24 10:38:20.749980",
+ "modified": "2026-06-28 13:55:47.056437",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Article Category",
@@ -72,6 +73,10 @@
   {
    "read": 1,
    "role": "HD Customer"
+  },
+  {
+   "read": 1,
+   "role": "HD Customer Manager"
   }
  ],
  "row_format": "Dynamic",

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "allow_import": 1,
  "autoname": ".####",
  "creation": "2023-10-17 14:27:11.078679",
@@ -487,7 +488,7 @@
  "icon": "fa fa-issue",
  "idx": 61,
  "links": [],
- "modified": "2026-05-11 18:25:54.352721",
+ "modified": "2026-06-28 13:51:31.692161",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Ticket",
@@ -520,17 +521,6 @@
   },
   {
    "create": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "All",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "create": 1,
    "delete": 1,
    "email": 1,
    "export": 1,
@@ -538,6 +528,28 @@
    "read": 1,
    "report": 1,
    "role": "Agent Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "HD Customer",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "HD Customer Manager",
    "share": 1,
    "write": 1
   }

--- a/helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+++ b/helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "allow_rename": 1,
  "autoname": "field:template_name",
  "creation": "2022-02-25 12:54:38.382222",
@@ -41,7 +42,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-03-24 10:42:00.970632",
+ "modified": "2026-06-27 19:24:12.121049",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Ticket Template",
@@ -80,6 +81,18 @@
    "report": 1,
    "role": "HD Customer",
    "share": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Agent Manager",
+   "share": 1,
+   "write": 1
   }
  ],
  "row_format": "Dynamic",

--- a/helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
+++ b/helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "allow_import": 1,
  "allow_rename": 1,
  "autoname": "Prompt",
@@ -42,7 +43,7 @@
   }
  ],
  "links": [],
- "modified": "2026-03-24 10:42:49.026000",
+ "modified": "2026-06-27 19:24:45.498088",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Ticket Type",
@@ -89,6 +90,16 @@
    "read": 1,
    "role": "HD Customer",
    "select": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "HD Customer Manager",
+   "select": 1,
+   "share": 1
   }
  ],
  "quick_entry": 1,

--- a/helpdesk/helpdesk/doctype/hd_view/hd_view.json
+++ b/helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "allow_rename": 1,
  "autoname": "format:VIEW-{dt}-{###}",
  "creation": "2025-02-11 16:05:11.457844",
@@ -161,7 +162,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-01-21 17:32:11.036366",
+ "modified": "2026-06-27 19:42:04.891287",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD View",
@@ -225,7 +226,20 @@
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "Guest",
+   "role": "HD Customer",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "if_owner": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "HD Customer Manager",
    "share": 1,
    "write": 1
   }

--- a/helpdesk/helpdesk/report/support_hour_distribution/support_hour_distribution.json
+++ b/helpdesk/helpdesk/report/support_hour_distribution/support_hour_distribution.json
@@ -1,30 +1,32 @@
 {
-	"add_total_row": 0,
-	"columns": [],
-	"creation": "2017-07-13 17:14:40.408706",
-	"disable_prepared_report": 0,
-	"disabled": 0,
-	"docstatus": 0,
-	"doctype": "Report",
-	"filters": [],
-	"idx": 0,
-	"is_standard": "Yes",
-	"letter_head": "",
-	"modified": "2021-10-21 14:31:29.524026",
-	"modified_by": "Administrator",
-	"module": "Helpdesk",
-	"name": "Support Hour Distribution",
-	"owner": "Administrator",
-	"prepared_report": 0,
-	"ref_doctype": "Issue",
-	"report_name": "Support Hour Distribution",
-	"report_type": "Script Report",
-	"roles": [
-		{
-			"role": "Support Team"
-		},
-		{
-			"role": "System Manager"
-		}
-	]
+ "add_total_row": 0,
+ "add_translate_data": 0,
+ "columns": [],
+ "creation": "2017-07-13 17:14:40.408706",
+ "disable_prepared_report_automation": 0,
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "generate_csv": 0,
+ "idx": 0,
+ "is_standard": "Yes",
+ "modified": "2026-06-27 19:27:45.200503",
+ "modified_by": "Administrator",
+ "module": "Helpdesk",
+ "name": "Support Hour Distribution",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "HD Ticket",
+ "report_name": "Support Hour Distribution",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "Support Team"
+  },
+  {
+   "role": "System Manager"
+  }
+ ],
+ "timeout": 0
 }

--- a/helpdesk/helpdesk/report/support_hour_distribution/support_hour_distribution.py
+++ b/helpdesk/helpdesk/report/support_hour_distribution/support_hour_distribution.py
@@ -61,7 +61,7 @@ def get_data(filters):
 def get_hours_count(start_time, end_time):
     data = (
         frappe.db.sql(
-            """ select count(*) from `tabIssue` where creation
+            """ select count(*) from `tabHD Ticket` where creation
 		between %(start_time)s and %(end_time)s""",
             {"start_time": start_time, "end_time": end_time},
             as_list=1,


### PR DESCRIPTION
Re-applies the DocType permission changes that were bundled into #3502 and lost when it was reverted (#3512):

- HD Ticket: replace 'All' with 'HD Customer' and 'HD Customer Manager'
- HD View: replace 'Guest' with 'HD Customer' and 'HD Customer Manager'
- HD Article / HD Article Category / HD Ticket Type: add 'HD Customer Manager'
- HD Ticket Template: add 'Agent Manager'

Also restores the Support Hour Distribution report export.