### PR TITLE
feat(ui): generic Skeleton component and skeleton loading states

### DIFF
--- a/desk/src/components/DetailPageSkeleton.vue
+++ b/desk/src/components/DetailPageSkeleton.vue
@@ -1,0 +1,53 @@
+<template>
+  <div class="flex h-full flex-col gap-5" aria-hidden="true">
+    <div class="flex items-center justify-between px-5 pt-5">
+      <div class="flex items-center gap-4">
+        <Skeleton
+          variant="box"
+          class="h-12 w-12"
+          :class="avatarShape === 'circle' && 'rounded-full'"
+        />
+        <div class="space-y-2">
+          <Skeleton class="h-4 w-40" />
+          <Skeleton class="h-3 w-64" />
+        </div>
+      </div>
+      <div class="flex items-center gap-2">
+        <Skeleton variant="box" class="h-7 w-16" />
+        <Skeleton variant="box" class="h-7 w-7" />
+      </div>
+    </div>
+    <div class="grid grid-cols-4 gap-2.5 px-5">
+      <div
+        v-for="card in 4"
+        :key="card"
+        class="flex min-h-[120px] flex-col justify-between rounded-md border p-4"
+      >
+        <Skeleton class="h-4 w-1/2" />
+        <Skeleton variant="box" class="h-7 w-12" />
+        <Skeleton class="h-3 w-1/3" />
+      </div>
+    </div>
+    <div class="flex gap-6 border-b px-5 pb-2">
+      <Skeleton v-for="tab in 2" :key="tab" class="h-3.5 w-20" />
+    </div>
+    <div class="space-y-4 px-5">
+      <Skeleton
+        v-for="row in 6"
+        :key="row"
+        class="h-3.5"
+        :class="row % 2 ? 'w-full' : 'w-5/6'"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Skeleton } from "./Skeleton";
+
+interface Props {
+  avatarShape?: "circle" | "square";
+}
+
+withDefaults(defineProps<Props>(), { avatarShape: "circle" });
+</script>

--- a/desk/src/components/ListViewBuilder.vue
+++ b/desk/src/components/ListViewBuilder.vue
@@ -38,9 +38,29 @@
   <!-- Loading State -->
   <div
     v-if="list.loading && !list.data?.data?.length"
-    class="flex items-center justify-center h-full w-full absolute top-0 z-100"
+    class="flex-1 overflow-hidden sm:mx-5 mx-3"
   >
-    <LoadingIndicator :scale="8" />
+    <div class="flex items-center gap-6 border-b py-2.5">
+      <Skeleton
+        v-for="column in 5"
+        :key="column"
+        class="h-3"
+        :class="column === 1 ? 'w-2/5' : 'flex-1'"
+      />
+    </div>
+    <div
+      v-for="row in 12"
+      :key="row"
+      class="flex items-center gap-6 border-b py-3.5"
+    >
+      <div class="flex w-2/5 items-center gap-3">
+        <Skeleton variant="circle" class="h-5 w-5 shrink-0" />
+        <Skeleton class="h-3.5" :class="skeletonCellWidth(row, 0)" />
+      </div>
+      <div v-for="column in 4" :key="column" class="flex-1">
+        <Skeleton class="h-3.5" :class="skeletonCellWidth(row, column)" />
+      </div>
+    </div>
   </div>
   <!-- List View -->
   <ListView
@@ -156,7 +176,6 @@ import {
   ListRowItem,
   ListSelectBanner,
   ListView,
-  LoadingIndicator,
   dayjs,
   toast,
 } from "frappe-ui";
@@ -174,6 +193,7 @@ import { useRoute, useRouter } from "vue-router";
 
 import EmptyState from "./EmptyState.vue";
 import ListRows from "./ListRows.vue";
+import { Skeleton } from "./Skeleton";
 
 interface P {
   options: {
@@ -550,6 +570,11 @@ function listCell(column: any, row: any, item: any, idx: number) {
     class: "truncate flex-1",
     textContent: item,
   });
+}
+
+const skeletonWidths = ["w-3/5", "w-2/5", "w-4/5", "w-1/2"];
+function skeletonCellWidth(row: number, column: number): string {
+  return skeletonWidths[(row + column) % skeletonWidths.length];
 }
 
 function handleFieldClick(e: MouseEvent, column, row, item) {

--- a/desk/src/components/Skeleton/README.md
+++ b/desk/src/components/Skeleton/README.md
@@ -1,0 +1,33 @@
+# Skeleton
+
+Generic loading placeholder with no per-component configuration. Structured
+like a frappe-ui component (`Skeleton.vue`, `types.ts`, `index.ts`) so it can
+be lifted upstream as-is.
+
+## Bone mode
+
+Without a default slot it renders a single gray pulse block, shaped by props
+or utility classes:
+
+```vue
+<Skeleton class="h-4 w-40" />
+<Skeleton variant="circle" width="2rem" height="2rem" />
+<Skeleton variant="box" height="8rem" />
+```
+
+## Mask mode
+
+With a default slot and `loading` true, the slot renders inert (`aria-hidden`,
+no pointer events) and every leaf node — text, images, icons, buttons,
+inputs — is masked into a gray pulse block matching its real size. Once
+`loading` is false the slot renders untouched, so it wraps real content:
+
+```vue
+<Skeleton :loading="ticket.loading">
+  <TicketCard :ticket="ticket.data ?? mockTicket" />
+</Skeleton>
+```
+
+Mask mode only needs the component to *render its structure*; pass mock props
+when data is still loading. Components that fetch their own data should not be
+masked (they would fire real requests) — compose bones instead.

--- a/desk/src/components/Skeleton/Skeleton.vue
+++ b/desk/src/components/Skeleton/Skeleton.vue
@@ -1,0 +1,103 @@
+<template>
+  <div
+    v-if="loading && hasContent"
+    ref="root"
+    class="skeleton-mask animate-pulse"
+    aria-hidden="true"
+    inert
+    v-bind="$attrs"
+  >
+    <slot />
+  </div>
+  <div
+    v-else-if="loading"
+    class="animate-pulse bg-surface-gray-2"
+    :class="variantClasses[variant]"
+    :style="{ width, height }"
+    aria-hidden="true"
+    v-bind="$attrs"
+  />
+  <slot v-else />
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUpdated, ref, useSlots } from "vue";
+import type { SkeletonProps } from "./types";
+
+defineOptions({ inheritAttrs: false });
+
+const props = withDefaults(defineProps<SkeletonProps>(), {
+  loading: true,
+  variant: "line",
+});
+
+const slots = useSlots();
+const root = ref<HTMLElement | null>(null);
+
+const hasContent = computed(() => Boolean(slots.default));
+
+const variantClasses = {
+  line: "h-4 rounded",
+  circle: "rounded-full",
+  box: "rounded-md",
+};
+
+// Elements that always become a gray bone, without descending further.
+const boneTags = new Set([
+  "IMG",
+  "SVG",
+  "BUTTON",
+  "INPUT",
+  "TEXTAREA",
+  "SELECT",
+  "VIDEO",
+  "CANVAS",
+]);
+
+function markBones(): void {
+  if (root.value) {
+    for (const child of Array.from(root.value.children)) walk(child);
+  }
+}
+
+function walk(element: Element): void {
+  if (isBone(element)) {
+    element.classList.add("skeleton-bone");
+    return;
+  }
+  for (const child of Array.from(element.children)) walk(child);
+}
+
+function isBone(element: Element): boolean {
+  if (boneTags.has(element.tagName.toUpperCase())) return true;
+  return hasDirectText(element);
+}
+
+function hasDirectText(element: Element): boolean {
+  return Array.from(element.childNodes).some(
+    (node) => node.nodeType === Node.TEXT_NODE && node.textContent?.trim()
+  );
+}
+
+onMounted(markBones);
+onUpdated(markBones);
+</script>
+
+<style scoped>
+.skeleton-mask {
+  pointer-events: none;
+  user-select: none;
+}
+.skeleton-mask :deep(*) {
+  color: transparent !important;
+}
+.skeleton-mask :deep(.skeleton-bone) {
+  background-color: var(--surface-gray-2) !important;
+  background-image: none !important;
+  border-radius: 0.25rem;
+  box-shadow: none !important;
+}
+.skeleton-mask :deep(.skeleton-bone *) {
+  visibility: hidden !important;
+}
+</style>

--- a/desk/src/components/Skeleton/index.ts
+++ b/desk/src/components/Skeleton/index.ts
@@ -1,0 +1,2 @@
+export { default as Skeleton } from "./Skeleton.vue";
+export type { SkeletonProps } from "./types";

--- a/desk/src/components/Skeleton/types.ts
+++ b/desk/src/components/Skeleton/types.ts
@@ -1,0 +1,8 @@
+export interface SkeletonProps {
+  /** Render skeleton while true, the default slot untouched once false. */
+  loading?: boolean;
+  /** Shape of the standalone bone; ignored when a default slot is given. */
+  variant?: "line" | "circle" | "box";
+  width?: string;
+  height?: string;
+}

--- a/desk/src/pages/contact/Contact.vue
+++ b/desk/src/pages/contact/Contact.vue
@@ -5,10 +5,8 @@
         <Breadcrumbs :items="breadcrumbs" class="-ml-[2px]" />
       </template>
     </LayoutHeader>
-    <div
-      class="gap-5 flex flex-col h-full"
-      v-if="!contact.loading && contact.doc"
-    >
+    <DetailPageSkeleton v-if="contact.loading" avatar-shape="circle" />
+    <div class="gap-5 flex flex-col h-full" v-else-if="contact.doc">
       <!-- ContactInfo -->
       <PageInfo
         :avatar="{
@@ -118,6 +116,7 @@ import ContactCustomers from "@/components/contact/ContactCustomers.vue";
 import ContactFeedback from "@/components/contact/ContactFeedback.vue";
 import TicketsTab from "@/components/customer/TicketsTab.vue";
 import DeleteWithTicketsDialog from "@/components/DeleteWithTicketsDialog.vue";
+import DetailPageSkeleton from "@/components/DetailPageSkeleton.vue";
 import ModifiedIcon from "@/components/icons/ModifiedIcon.vue";
 import TicketFeedbackIcon from "@/components/icons/TicketFeedbackIcon.vue";
 import TicketHashIcon from "@/components/icons/TicketHashIcon.vue";

--- a/desk/src/pages/customer/Customer.vue
+++ b/desk/src/pages/customer/Customer.vue
@@ -5,10 +5,8 @@
         <Breadcrumbs :items="breadcrumbs" class="-ml-[2px]" />
       </template>
     </LayoutHeader>
-    <div
-      class="gap-5 flex flex-col h-full"
-      v-if="customer.doc && customer.doc?.name"
-    >
+    <DetailPageSkeleton v-if="!customer.doc?.name" avatar-shape="square" />
+    <div class="gap-5 flex flex-col h-full" v-else>
       <!-- customer detail -->
       <PageInfo
         :avatar="{
@@ -104,6 +102,7 @@ import CustomerContactTab from "@/components/customer/CustomerContactTab.vue";
 import TicketsTab from "@/components/customer/TicketsTab.vue";
 import TicketStats from "@/components/customer/TicketStats.vue";
 import DeleteWithTicketsDialog from "@/components/DeleteWithTicketsDialog.vue";
+import DetailPageSkeleton from "@/components/DetailPageSkeleton.vue";
 import TicketHashIcon from "@/components/icons/TicketHashIcon.vue";
 import LayoutHeader from "@/components/LayoutHeader.vue";
 import PageInfo from "@/components/PageInfo.vue";
@@ -136,7 +135,6 @@ const props = defineProps<{
 }>();
 const route = useRoute();
 const router = useRouter();
-
 const { isMobileView } = useScreenSize();
 const { ticketsListResource } = getTicketListResource();
 

--- a/desk/src/pages/ticket/TicketAgent.vue
+++ b/desk/src/pages/ticket/TicketAgent.vue
@@ -19,9 +19,41 @@
   </div>
   <div
     v-else-if="!ticket.doc && !ticket.get?.error"
-    class="grid h-full place-items-center"
+    class="flex h-full flex-col"
   >
-    <LoadingIndicator class="w-6 text-ink-gray-4" />
+    <div class="flex items-center justify-between border-b px-5 py-2.5">
+      <Skeleton class="h-4 w-48" />
+      <div class="flex items-center gap-2">
+        <Skeleton variant="box" class="h-7 w-7" />
+        <Skeleton variant="box" class="h-7 w-28" />
+      </div>
+    </div>
+    <div class="flex flex-1 overflow-hidden">
+      <div class="flex-1 space-y-8 px-10 py-6">
+        <div v-for="message in 3" :key="message" class="flex gap-3">
+          <Skeleton variant="circle" class="h-8 w-8 shrink-0" />
+          <div class="flex-1 space-y-2">
+            <Skeleton class="h-3 w-40" />
+            <Skeleton class="h-3 w-24" />
+            <Skeleton
+              variant="box"
+              class="!mt-4 h-24"
+              :class="message % 2 ? 'w-4/5' : 'w-3/5'"
+            />
+          </div>
+        </div>
+      </div>
+      <div class="w-80 space-y-6 border-l px-5 py-5">
+        <div
+          v-for="field in 8"
+          :key="field"
+          class="flex items-center justify-between"
+        >
+          <Skeleton class="h-3 w-24" />
+          <Skeleton class="h-3" :class="field % 2 ? 'w-32' : 'w-24'" />
+        </div>
+      </div>
+    </div>
   </div>
 
   <div v-else class="grid h-full place-items-center px-4 py-20 text-center">
@@ -72,12 +104,8 @@ import {
   TicketContactSymbol,
   TicketSymbol,
 } from "@/types";
-import {
-  createResource,
-  LoadingIndicator,
-  toast,
-  usePageMeta,
-} from "frappe-ui";
+import { Skeleton } from "@/components/Skeleton";
+import { createResource, toast, usePageMeta } from "frappe-ui";
 import { computed, onBeforeUnmount, onMounted, provide, ref, watch } from "vue";
 import { useRoute } from "vue-router";
 import { showCommentBox, showEmailBox } from "./modalStates";


### PR DESCRIPTION
## Description

Adds a single generic `<Skeleton />` component and uses it to replace spinners / blank screens with content-shaped loading states across the agent portal.

**The component** (`desk/src/components/Skeleton/`) has no per-screen configuration and two modes:

- **Bone mode** — no slot: renders one gray pulse block, shaped via `variant` (`line` / `circle` / `box`) and `width`/`height` or utility classes. This is the primitive everything else composes.
- **Mask mode** — slot + `loading`: renders the slotted component inert (`inert`, `aria-hidden`), walks the DOM and turns every leaf node (text, images, icons, buttons, inputs) into a gray pulse block at its real rendered size. When `loading` turns false the slot renders untouched. Meant for presentational components fed mock props.

The folder mirrors frappe-ui component conventions (`Skeleton.vue`, `types.ts`, `index.ts`), so it can be lifted upstream into frappe-ui as-is later.

**Screens wired up** (all bone composition, since these screens fetch their own data):

| Screen | Before | After |
|---|---|---|
| All list views (Tickets, Contacts, Customers, Call Logs, KB — via `ListViewBuilder`) | centered spinner on first load | table skeleton: header + 12 rows with avatar and varied-width lines |
| Agent ticket page (`TicketAgent.vue`) | small spinner | full-layout skeleton: header bar, 3 conversation bubbles, sidebar field pairs |
| Customer / Contact detail pages | blank screen while doc loads | shared `DetailPageSkeleton`: avatar header, 4 stat cards, tabs, list lines |

Skeletons show only on first load; reloads keep existing rows visible as before. Line widths vary deterministically (`(row + column) % 4`) so rows read organic without randomness.

## How to test

1. `cd desk && yarn dev`, open the agent portal.
2. Throttle the network in devtools (Slow 3G helps make the states visible).
3. Visit **Tickets / Contacts / Customers / Knowledge Base** — first load shows the table skeleton, then rows swap in place.
4. Open a **single ticket** — layout skeleton with conversation bubbles and sidebar until the doc loads.
5. Open a **customer** and a **contact** record — previously a blank screen, now the detail-page skeleton (square avatar for customer, circle for contact).
6. Reload a list that already has data — no skeleton flash; existing rows stay visible while refreshing.

`yarn build` verified after each commit.

## Related issue

No linked issue — raised from an internal improvement idea; happy to open one if needed.