### PR TITLE
feat(search): opt-in RediSearch backend for ticket search

### DIFF
--- a/helpdesk/api/search.py
+++ b/helpdesk/api/search.py
@@ -7,6 +7,23 @@ import frappe
 from frappe import _
 
 
+def _get_backend():
+    """Return the configured ticket search backend (SQLite default, or RediSearch).
+
+    Selected by ``HD Settings.search_backend``. Both backends expose the same
+    public surface (``search``, ``get_filter_options``, ``index_exists``) and
+    return the same shapes, so callers are backend-agnostic.
+    """
+    if frappe.db.get_single_value("HD Settings", "search_backend") == "RediSearch":
+        from helpdesk.search_redisearch import HelpdeskRediSearch
+
+        return HelpdeskRediSearch()
+
+    from helpdesk.search_sqlite import HelpdeskSearch
+
+    return HelpdeskSearch()
+
+
 @frappe.whitelist()
 def search(
     query: str, filters: str | None = None, limit: int = 20, title_only: bool = False
@@ -30,12 +47,14 @@ def search(
         except json.JSONDecodeError:
             _filters = {}
 
-    from helpdesk.search_sqlite import HelpdeskSearch, HelpdeskSearchIndexMissingError
+    from helpdesk.search_sqlite import HelpdeskSearchIndexMissingError
 
-    search = HelpdeskSearch()
+    search = _get_backend()
 
     try:
-        result = search.search(query, filters=_filters, title_only=title_only)
+        result = search.search(
+            query, filters=_filters, title_only=title_only, limit=limit
+        )
         return result
     except HelpdeskSearchIndexMissingError:
         frappe.throw(_("Search index not available. Please contact administrator."))
@@ -44,9 +63,7 @@ def search(
 @frappe.whitelist()
 def get_filter_options():
     """Get available filter options for search interface"""
-    from helpdesk.search_sqlite import HelpdeskSearch
-
-    search = HelpdeskSearch()
+    search = _get_backend()
 
     if not search.index_exists():
         return {

--- a/helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+++ b/helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -62,6 +62,7 @@
   "initial_helpdesk_name_setup_skipped",
   "column_break_hjfh",
   "search_tab",
+  "search_backend",
   "name_weight",
   "subject_weight",
   "column_break_qoxt",
@@ -232,6 +233,14 @@
    "fieldname": "search_tab",
    "fieldtype": "Tab Break",
    "label": "Search"
+  },
+  {
+   "default": "SQLite",
+   "description": "Storage backend for ticket search. RediSearch requires the RediSearch module loaded in the cache Redis; use it for high-availability / NFS deployments where the SQLite FTS index cannot run.",
+   "fieldname": "search_backend",
+   "fieldtype": "Select",
+   "label": "Search Backend",
+   "options": "SQLite\nRediSearch"
   },
   {
    "default": "1",

--- a/helpdesk/hooks.py
+++ b/helpdesk/hooks.py
@@ -25,6 +25,7 @@ after_install = "helpdesk.setup.install.after_install"
 after_migrate = [
     "helpdesk.search.build_index_in_background",
     "helpdesk.search.download_corpus",
+    "helpdesk.search_redisearch.build_index_in_background",
 ]
 
 
@@ -37,6 +38,7 @@ scheduler_events = {
     "all": [
         "helpdesk.search.build_index_if_not_exists",
         "helpdesk.search.download_corpus",
+        "helpdesk.search_redisearch.build_index_if_enabled",
     ],
     "daily": [
         "helpdesk.helpdesk.doctype.hd_ticket.hd_ticket.close_tickets_after_n_days"
@@ -100,6 +102,19 @@ doc_events = {
     },
     "Notification Log": {
         "before_insert": "helpdesk.extends.notification_log.before_insert",
+    },
+    # RediSearch ticket index (inert unless HD Settings.search_backend = RediSearch)
+    "HD Ticket": {
+        "on_update": "helpdesk.search_redisearch.update_ticket_index",
+        "on_trash": "helpdesk.search_redisearch.delete_ticket_index",
+    },
+    "HD Ticket Comment": {
+        "on_update": "helpdesk.search_redisearch.update_ticket_index",
+        "on_trash": "helpdesk.search_redisearch.delete_ticket_index",
+    },
+    "Communication": {
+        "on_update": "helpdesk.search_redisearch.update_ticket_index",
+        "on_trash": "helpdesk.search_redisearch.delete_ticket_index",
     },
 }
 

--- a/helpdesk/search_redisearch.py
+++ b/helpdesk/search_redisearch.py
@@ -1,0 +1,505 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+"""RediSearch backend for Helpdesk ticket search.
+
+A drop-in alternative to :class:`helpdesk.search_sqlite.HelpdeskSearch` for
+deployments where the SQLite FTS index cannot run — notably high-availability
+topologies with ``sites/`` on a network filesystem, where SQLite's WAL mode
+requires shared memory between all processes on one host and therefore breaks
+(https://www.sqlite.org/wal.html).
+
+It exposes the same public surface (``search``, ``get_filter_options``,
+``index_exists``, ``build_index``, ``index_doc``, ``remove_doc``) returning the
+same shapes, so ``helpdesk.api.search`` and the frontend are unaffected — only
+the storage engine changes, selected by ``HD Settings.search_backend``.
+
+Design notes:
+- Documents are stored as Redis hashes under a shared prefix and queried through
+  a RediSearch index (``frappe.cache().ft(...)``), the same pattern webshop and
+  wiki use. It requires the RediSearch module loaded in the cache Redis.
+- The redis-search client APIs are imported lazily inside the methods that use
+  them (as ``wiki`` does), so importing this module on a SQLite-only site — which
+  happens because ``hooks.py`` wires migration/scheduler/doc events here — never
+  requires ``redis.commands.search`` to be present.
+- Permission is never materialised as a giant list of ticket names (the volume
+  problem that makes the SQLite ``get_filter_options`` fail at scale). Instead:
+  * ``search`` post-filters query matches through the real ticket permission
+    (``frappe.get_list``), paginating until the caller's ``limit`` is filled or
+    the matches are exhausted (so a readable ticket is never skipped), and never
+    exposes pre-permission match counts;
+  * ``get_filter_options`` aggregates straight from the database honouring the
+    real ``permission_query``, decoupled from the search index entirely.
+"""
+
+import contextlib
+import re
+import time
+
+import frappe
+from frappe.utils import get_datetime, strip_html_tags
+from frappe.utils.redis_wrapper import RedisWrapper
+
+from helpdesk.search_sqlite import HelpdeskSearchIndexMissingError
+
+INDEX_NAME = "helpdesk_ticket_idx"
+KEY_PREFIX = "hd_ticket_search:"
+
+# Which doctypes are indexed and how each maps onto the shared document shape.
+# Mirrors HelpdeskSearch.INDEXABLE_DOCTYPES + prepare_document, kept local so the
+# backend is self-contained (depends only on frappe + redis).
+INDEXED_DOCTYPES = ("HD Ticket", "HD Ticket Comment", "Communication")
+
+# Fields carried on every indexed document (hash keys / index schema).
+TEXT_FIELDS = ("title", "content")
+TAG_FIELDS = (
+    "doctype",
+    "name",
+    "reference_ticket",
+    "reference_name",
+    "reference_doctype",
+    "agent_group",
+    "status",
+    "priority",
+    "customer",
+    "owner",
+)
+
+_UNSAFE_QUERY_CHARS = re.compile(r"[^a-zA-Z0-9\s]")
+_MIN_PREFIX_LEN = 3
+
+# Result window. The API accepts ``limit`` (default 20, hard cap 100); the
+# backend honours it. To fill ``limit`` permitted rows without ever enumerating
+# the full accessible set, it scans query matches in pages, post-filtering each
+# through the real permission, until the limit is filled or the matches are
+# exhausted — so a readable ticket is never skipped, whatever its rank.
+DEFAULT_LIMIT = 20
+MAX_LIMIT = 100
+CANDIDATE_PAGE = 100
+
+# RediSearch splits a TAG value on this character. It must be one that cannot
+# occur in the indexed values (ticket ids, statuses, team/customer names,
+# emails) so each value is stored as a single exact tag — otherwise a customer
+# like "Acme, Inc" would be split on the default comma and never match its
+# escaped filter.
+TAG_SEPARATOR = "\n"
+
+
+def _response_error():
+    from redis import ResponseError
+
+    return ResponseError
+
+
+def _index_definition_cls():
+    try:
+        from redis.commands.search.index_definition import IndexDefinition
+    except ImportError:  # older redis-py
+        from redis.commands.search.indexDefinition import IndexDefinition
+    return IndexDefinition
+
+
+def is_search_module_loaded() -> bool:
+    """True only if the RediSearch module is loaded in the cache Redis."""
+    try:
+        for module in frappe.cache().module_list():
+            if module.get(b"name") == b"search":
+                return True
+    except Exception:
+        return False
+    return False
+
+
+class HelpdeskRediSearch:
+    """RediSearch-backed ticket search with the HelpdeskSearch public surface."""
+
+    def __init__(self):
+        self.cache = frappe.cache()
+        self.index_name = self.cache.make_key(INDEX_NAME).decode()
+
+    # ------------------------------------------------------------------ index
+
+    def _index(self):
+        return self.cache.ft(INDEX_NAME)
+
+    def index_exists(self) -> bool:
+        try:
+            self._index().info()
+            return True
+        except Exception:
+            return False
+
+    def raise_if_not_indexed(self):
+        if not self.index_exists():
+            raise HelpdeskSearchIndexMissingError(
+                "Search index does not exist. Please build the index first."
+            )
+
+    def drop_index(self, delete_documents: bool = True):
+        # Suppress the "unknown index" error when there is nothing to drop.
+        with contextlib.suppress(_response_error()):
+            self._index().dropindex(delete_documents=delete_documents)
+
+    def create_index(self):
+        from redis.commands.search.field import NumericField, TagField, TextField
+
+        schema = (
+            [TextField(f) for f in TEXT_FIELDS]
+            + [TagField(f, separator=TAG_SEPARATOR) for f in TAG_FIELDS]
+            + [NumericField("modified", sortable=True)]
+        )
+        definition = _index_definition_cls()(
+            prefix=[self.cache.make_key(KEY_PREFIX).decode()]
+        )
+        self._index().create_index(schema, definition=definition)
+
+    def build_index(self):
+        """Rebuild the whole index from scratch (drop + create + reindex)."""
+        if not is_search_module_loaded():
+            frappe.log_error(
+                title="Helpdesk RediSearch",
+                message="RediSearch module not loaded in cache Redis; index not built.",
+            )
+            return
+        self.drop_index()
+        self.create_index()
+        for doctype in INDEXED_DOCTYPES:
+            for name in self._doctype_docnames(doctype):
+                self.index_doc(doctype, name, ensure=False)
+
+    # --------------------------------------------------------------- document
+
+    def _doc_key(self, doctype: str, name: str) -> str:
+        return self.cache.make_key(f"{KEY_PREFIX}{doctype}:{name}").decode()
+
+    def _doctype_docnames(self, doctype: str) -> list[str]:
+        filters = {}
+        if doctype == "Communication":
+            filters = {"reference_doctype": "HD Ticket"}
+        return frappe.get_all(doctype, filters=filters, pluck="name")
+
+    def prepare_document(self, doc) -> dict | None:
+        """Build the flat hash for one document. Returns None if not indexable."""
+        base = dict.fromkeys((*TEXT_FIELDS, *TAG_FIELDS), "")
+        base["doctype"] = doc.doctype
+        base["name"] = str(doc.name)
+
+        if doc.doctype == "HD Ticket":
+            base["title"] = strip_html_tags(doc.get("subject") or "")
+            base["content"] = strip_html_tags(doc.get("description") or "")
+            base["agent_group"] = doc.get("agent_group") or ""
+            base["status"] = doc.get("status") or ""
+            base["priority"] = doc.get("priority") or ""
+            base["customer"] = doc.get("customer") or ""
+            base["owner"] = doc.get("owner") or ""
+            base["reference_ticket"] = str(doc.name)
+        elif doc.doctype == "HD Ticket Comment":
+            base["content"] = strip_html_tags(doc.get("content") or "")
+            base["reference_ticket"] = str(doc.get("reference_ticket") or "")
+            base["owner"] = doc.get("commented_by") or doc.get("owner") or ""
+        elif doc.doctype == "Communication":
+            if doc.get("reference_doctype") != "HD Ticket":
+                return None
+            base["content"] = strip_html_tags(doc.get("content") or "")
+            base["reference_doctype"] = "HD Ticket"
+            base["reference_name"] = str(doc.get("reference_name") or "")
+            base["owner"] = doc.get("sender") or doc.get("owner") or ""
+        else:
+            return None
+
+        modified = doc.get("modified")
+        base["modified"] = get_datetime(modified).timestamp() if modified else 0
+        return base
+
+    def index_doc(self, doctype: str, name: str, ensure: bool = True):
+        if ensure:
+            self.raise_if_not_indexed()
+        doc = frappe.get_doc(doctype, name)
+        document = self.prepare_document(doc)
+        if not document:
+            return
+        key = self._doc_key(doctype, name)
+        # Raw hset (bypass RedisWrapper key-prefixing) — key is already prefixed.
+        super(RedisWrapper, self.cache).hset(key, mapping=document)
+
+    def remove_doc(self, doctype: str, name: str):
+        # delete_value applies make_key (the site prefix) to match the stored
+        # hash key; the plain cache.delete() would target an unprefixed key.
+        self.cache.delete_value(f"{KEY_PREFIX}{doctype}:{name}")
+
+    # ----------------------------------------------------------------- search
+
+    def _clean_query(self, query: str) -> str:
+        query = _UNSAFE_QUERY_CHARS.sub(" ", query or "").strip().lower()
+        return re.sub(r"\s+", " ", query)
+
+    def _build_query_string(self, query: str, title_only: bool, filters: dict) -> str:
+        parts = []
+        for field, value in (filters or {}).items():
+            if field not in TAG_FIELDS or not value:
+                continue
+            values = value if isinstance(value, list) else [value]
+            escaped = "|".join(self._escape_tag(str(v)) for v in values if v)
+            if escaped:
+                parts.append(f"@{field}:{{{escaped}}}")
+
+        terms = [
+            f"{t}*" if len(t) >= _MIN_PREFIX_LEN else t
+            for t in self._clean_query(query).split()
+        ]
+        text = " ".join(terms)
+        if text:
+            parts.append(f"@title:({text})" if title_only else f"({text})")
+
+        return " ".join(parts) if parts else "*"
+
+    @staticmethod
+    def _escape_tag(value: str) -> str:
+        """Escape a tag value for a RediSearch ``@field:{...}`` clause.
+
+        Every character RediSearch treats as punctuation inside a tag — including
+        the space — is backslash-escaped so multi-word values (a customer or team
+        name like ``Acme Corp``) match the tag exactly, the way SQLite would.
+        """
+        return re.sub(r"([\s,.<>{}\[\]\"'\:;!@#$%^&*()\-+=~|/\\])", r"\\\1", value)
+
+    def search(
+        self,
+        query: str,
+        title_only: bool = False,
+        filters: dict | None = None,
+        limit: int | None = None,
+    ):
+        start = time.time()
+        self.raise_if_not_indexed()
+
+        filters = filters or {}
+        # Empty / punctuation-only query with no filters must not fall through to
+        # a "*" match-all — return nothing, mirroring the SQLite backend.
+        if not self._clean_query(query) and not filters:
+            return self._empty_result(title_only, filters)
+
+        result_cap = min(int(limit or DEFAULT_LIMIT), MAX_LIMIT)
+        query_string = self._build_query_string(query, title_only, filters)
+        ResponseError = _response_error()
+        from redis.commands.search.query import Query
+
+        # Scan query matches in pages, post-filtering each page through the real
+        # ticket permission, until the caller's limit is filled or the matches are
+        # exhausted. Scanning to exhaustion (bounded by the query's own match
+        # count, never the whole corpus) means a readable ticket is never skipped,
+        # whatever its rank; a caller still only ever sees the post-permission
+        # count, so restricted matches are never inferable.
+        permitted: list[dict] = []
+        offset = 0
+        while len(permitted) < result_cap:
+            page = Query(query_string).paging(offset, CANDIDATE_PAGE).with_scores()
+            try:
+                raw = self._index().search(page)
+            except ResponseError as e:
+                frappe.log_error(
+                    title="Helpdesk RediSearch query failed", message=str(e)
+                )
+                return self._empty_result(title_only, filters)
+
+            if not raw.docs:
+                break
+            batch = [
+                self._to_result(doc, offset + rank)
+                for rank, doc in enumerate(raw.docs, 1)
+            ]
+            permitted.extend(self._filter_by_permission(batch))
+            offset += CANDIDATE_PAGE
+            if offset >= raw.total:
+                break
+
+        permitted = permitted[:result_cap]
+        for i, result in enumerate(permitted, 1):
+            result["modified_rank"] = i
+
+        # Only the post-permission count is ever reported, so a caller can never
+        # infer that restricted tickets matched the query.
+        matched = len(permitted)
+        return {
+            "results": permitted,
+            "summary": {
+                "duration": round(time.time() - start, 3),
+                "total_matches": matched,
+                "returned_matches": matched,
+                "corrected_words": None,
+                "corrected_query": None,
+                "title_only": title_only,
+                "filtered_matches": matched,
+                "applied_filters": filters,
+            },
+        }
+
+    def _to_result(self, doc, rank: int) -> dict:
+        def get(f):
+            return getattr(doc, f, "") or ""
+
+        modified = get("modified")
+        result = {
+            "id": doc.id,
+            "score": float(getattr(doc, "score", 0) or 0),
+            "original_rank": rank,
+            "bm25_score": float(getattr(doc, "score", 0) or 0),
+            "title": get("title"),
+            "content": get("content"),
+            "doctype": get("doctype"),
+            "name": get("name"),
+            "reference_ticket": get("reference_ticket"),
+            "reference_name": get("reference_name"),
+            "reference_doctype": get("reference_doctype"),
+            "agent_group": get("agent_group"),
+            "status": get("status"),
+            "priority": get("priority"),
+            "customer": get("customer"),
+            "author": get("owner"),
+            "modified": float(modified) if modified else None,
+        }
+        result["_ticket"] = self._result_ticket(result)
+        return result
+
+    @staticmethod
+    def _result_ticket(result: dict) -> str:
+        if result["doctype"] == "HD Ticket":
+            return result["name"]
+        if result["doctype"] == "HD Ticket Comment":
+            return result["reference_ticket"]
+        if result["doctype"] == "Communication":
+            return result["reference_name"]
+        return ""
+
+    def _filter_by_permission(self, results: list[dict]) -> list[dict]:
+        """Keep only results whose parent ticket the user may read.
+
+        Bounded to the candidate page, so it reuses the real ticket permission
+        (``frappe.get_list`` → helpdesk's ``permission_query``) without ever
+        enumerating the full accessible set.
+        """
+        ticket_names = {r["_ticket"] for r in results if r["_ticket"]}
+        if not ticket_names:
+            return []
+        allowed = set(
+            frappe.get_list(
+                "HD Ticket", filters={"name": ["in", list(ticket_names)]}, pluck="name"
+            )
+        )
+        cleaned = []
+        for r in results:
+            if r["_ticket"] in allowed:
+                r.pop("_ticket", None)
+                cleaned.append(r)
+        return cleaned
+
+    def _empty_result(self, title_only, filters):
+        return {
+            "results": [],
+            "summary": {
+                "duration": 0,
+                "total_matches": 0,
+                "returned_matches": 0,
+                "corrected_words": None,
+                "corrected_query": None,
+                "title_only": title_only,
+                "filtered_matches": 0,
+                "applied_filters": filters or {},
+            },
+        }
+
+    # ---------------------------------------------------------------- facets
+
+    def get_filter_options(self) -> dict:
+        """Available filter facets, computed from the DB under real permission.
+
+        Decoupled from the search index: a single ``frappe.get_list`` over HD
+        Ticket applies helpdesk's real permission query (the same call the SQLite
+        backend trusts for scoping) as a WHERE clause — no raw SQL and no
+        ticket-name ``IN (...)`` enumeration (the volume that made the original
+        SQLite ``get_filter_options`` crash at scale). Counts are folded in Python.
+        Only ``teams``/``statuses``/``priorities`` are consumed by the frontend;
+        ``customers``/``doctypes`` are kept for shape parity with the SQLite
+        backend.
+        """
+        facets = {
+            k: {} for k in ("teams", "statuses", "priorities", "customers", "doctypes")
+        }
+
+        rows = frappe.get_list(
+            "HD Ticket",
+            fields=["agent_group", "status", "priority", "customer"],
+            limit=0,
+        )
+        for row in rows:
+            self._add(facets["teams"], row.get("agent_group"), 1)
+            self._add(facets["statuses"], row.get("status"), 1)
+            self._add(facets["priorities"], row.get("priority"), 1)
+            self._add(facets["customers"], row.get("customer"), 1)
+
+        if rows:
+            facets["doctypes"]["HD Ticket"] = len(rows)
+
+        return facets
+
+    @staticmethod
+    def _add(bucket: dict, value, count: int):
+        if value:
+            bucket[value] = bucket.get(value, 0) + count
+
+
+def build_index():
+    """Build the RediSearch ticket index — callable from console/scheduler."""
+    HelpdeskRediSearch().build_index()
+
+
+# ------------------------------------------------------------------ lifecycle
+# doc_event + scheduler handlers, all gated on the toggle so they are inert
+# unless the operator has switched ticket search to RediSearch.
+
+
+def _redisearch_selected() -> bool:
+    return frappe.db.get_single_value("HD Settings", "search_backend") == "RediSearch"
+
+
+def update_ticket_index(doc, method=None):
+    if not _redisearch_selected():
+        return
+    search = HelpdeskRediSearch()
+    if not search.index_exists():
+        return
+    try:
+        search.index_doc(doc.doctype, doc.name)
+    except Exception:
+        frappe.log_error(
+            title="Helpdesk RediSearch index update",
+            message=f"Failed to index {doc.doctype}:{doc.name}",
+        )
+
+
+def delete_ticket_index(doc, method=None):
+    if not _redisearch_selected():
+        return
+    try:
+        HelpdeskRediSearch().remove_doc(doc.doctype, doc.name)
+    except Exception:
+        frappe.log_error(
+            title="Helpdesk RediSearch index delete",
+            message=f"Failed to remove {doc.doctype}:{doc.name}",
+        )
+
+
+def build_index_if_enabled():
+    """Scheduler entry: build the index if RediSearch is on and it is missing."""
+    if not _redisearch_selected():
+        return
+    search = HelpdeskRediSearch()
+    if not search.index_exists():
+        search.build_index()
+
+
+def build_index_in_background():
+    """after_migrate entry: (re)build the index in the background if RediSearch is on."""
+    if not _redisearch_selected():
+        return
+    frappe.enqueue("helpdesk.search_redisearch.build_index", queue="long")

--- a/helpdesk/search_sqlite.py
+++ b/helpdesk/search_sqlite.py
@@ -64,6 +64,33 @@ class HelpdeskSearch(SQLiteSearch):
         },
     }
 
+    def is_search_enabled(self):
+        """Disable the SQLite index while the RediSearch backend is selected.
+
+        The core drives SQLiteSearch through global doc_events and schedulers
+        that all guard on ``is_search_enabled()``. Returning False here makes
+        that orchestration skip this class, so no SQLite index is built or
+        updated when the operator has switched ticket search to RediSearch.
+        """
+        return (
+            frappe.db.get_single_value("HD Settings", "search_backend") != "RediSearch"
+        )
+
+    def search(self, query, title_only=False, filters=None, limit=None):
+        """Search, honouring the API's ``limit`` (previously accepted but never
+        forwarded to either backend).
+
+        The core returns every match; when the caller passes a ``limit`` (the
+        frontend sends ``limit: 50``) the result page is capped to it so both the
+        SQLite and RediSearch backends obey the same contract.
+        """
+        result = super().search(query, title_only=title_only, filters=filters)
+        if limit:
+            capped = min(int(limit), 100)
+            result["results"] = result["results"][:capped]
+            result["summary"]["filtered_matches"] = len(result["results"])
+        return result
+
     def get_search_filters(self):
         """Return permission filters based on accessible tickets."""
         accessible_tickets = self._get_accessible_tickets()

--- a/helpdesk/test_search_redisearch.py
+++ b/helpdesk/test_search_redisearch.py
@@ -1,0 +1,193 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+"""Integration tests for the RediSearch ticket backend.
+
+Mock-free: exercises the real RediSearch module in the cache Redis and the real
+HD Ticket permission stack. Skips itself when the RediSearch module is absent.
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from helpdesk.search_redisearch import HelpdeskRediSearch, is_search_module_loaded
+from helpdesk.test_utils import add_comment, make_team, make_ticket
+
+
+class TestHelpdeskRediSearch(FrappeTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if not is_search_module_loaded():
+            raise cls.skipTest(cls, "RediSearch module not loaded in cache Redis")
+
+        cls._prev_backend = frappe.db.get_single_value("HD Settings", "search_backend")
+        frappe.db.set_single_value("HD Settings", "search_backend", "RediSearch")
+
+        cls.ticket_open = make_ticket(
+            subject="Login page is broken",
+            description="Users cannot log in to the portal",
+            status="Open",
+            priority="Low",
+        )
+        cls.ticket_closed = make_ticket(
+            subject="Payment gateway timeout",
+            description="Card payments fail intermittently",
+            priority="High",
+        )
+        # New tickets are forced to "Open" by the controller; set the closed
+        # status directly so the DB-sourced facets have a Closed ticket to count.
+        frappe.db.set_value("HD Ticket", cls.ticket_closed.name, "status", "Closed")
+        add_comment(cls.ticket_open.name, "investigating the login issue")
+
+        cls.search = HelpdeskRediSearch()
+        cls.search.build_index()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.search.drop_index()
+        frappe.db.set_single_value("HD Settings", "search_backend", cls._prev_backend)
+        super().tearDownClass()
+
+    def test_index_exists_after_build(self):
+        self.assertTrue(self.search.index_exists())
+
+    def test_search_returns_matching_ticket(self):
+        result = self.search.search("login")
+        self.assertIn("results", result)
+        self.assertIn("summary", result)
+        names = {r["name"] for r in result["results"] if r["doctype"] == "HD Ticket"}
+        self.assertIn(self.ticket_open.name, names)
+        self.assertNotIn(self.ticket_closed.name, names)
+
+    def test_search_result_shape_matches_sqlite(self):
+        result = self.search.search("payment")
+        self.assertTrue(result["results"])
+        row = result["results"][0]
+        for key in ("id", "score", "title", "content", "doctype", "name", "author"):
+            self.assertIn(key, row)
+        # internal permission helper must not leak into the payload
+        self.assertNotIn("_ticket", row)
+
+    def test_get_filter_options_counts(self):
+        facets = self.search.get_filter_options()
+        self.assertEqual(
+            set(facets),
+            {"teams", "statuses", "priorities", "customers", "doctypes"},
+        )
+        self.assertGreaterEqual(facets["statuses"].get("Open", 0), 1)
+        self.assertGreaterEqual(facets["statuses"].get("Closed", 0), 1)
+        self.assertGreaterEqual(facets["priorities"].get("High", 0), 1)
+        # doctypes facet is DB-aggregated from HD Ticket under real permission
+        self.assertGreaterEqual(facets["doctypes"].get("HD Ticket", 0), 2)
+
+    def test_search_honours_limit(self):
+        """A caller ``limit`` caps the returned page (the API forwards it)."""
+        result = self.search.search("payment", limit=1)
+        self.assertLessEqual(len(result["results"]), 1)
+
+    def test_summary_counts_are_post_permission(self):
+        """total/returned/filtered are the post-permission count, never a raw
+        pre-permission total that would leak restricted matches."""
+        result = self.search.search("login")
+        n = len(result["results"])
+        self.assertEqual(result["summary"]["total_matches"], n)
+        self.assertEqual(result["summary"]["returned_matches"], n)
+        self.assertEqual(result["summary"]["filtered_matches"], n)
+
+    def test_empty_query_returns_nothing(self):
+        for q in ("", "   ", "!!"):
+            result = self.search.search(q)
+            self.assertEqual(result["results"], [])
+            self.assertEqual(result["summary"]["total_matches"], 0)
+
+    def test_tag_filter_matches_spaced_value(self):
+        """A tag filter value containing spaces (a team name) must still match."""
+        make_team("Spaced Team Alpha")
+        ticket = make_ticket(
+            subject="Spaced team routing case",
+            description="handled by a team whose name has spaces",
+            status="Open",
+        )
+        frappe.db.set_value(
+            "HD Ticket", ticket.name, "agent_group", "Spaced Team Alpha"
+        )
+        self.search.index_doc("HD Ticket", ticket.name)
+
+        result = self.search.search(
+            "routing", filters={"agent_group": "Spaced Team Alpha"}
+        )
+        names = {r["name"] for r in result["results"] if r["doctype"] == "HD Ticket"}
+        self.assertIn(ticket.name, names)
+
+    def test_tag_filter_matches_comma_value(self):
+        """A tag value containing a comma must be stored as one tag (not split on
+        the default separator) so its filter still matches."""
+        from helpdesk.test_utils import create_customer
+
+        create_customer("Acme, Inc")
+        ticket = make_ticket(
+            subject="Comma customer billing case",
+            description="raised by a customer whose name has a comma",
+            status="Open",
+        )
+        frappe.db.set_value("HD Ticket", ticket.name, "customer", "Acme, Inc")
+        self.search.index_doc("HD Ticket", ticket.name)
+
+        result = self.search.search("billing", filters={"customer": "Acme, Inc"})
+        names = {r["name"] for r in result["results"] if r["doctype"] == "HD Ticket"}
+        self.assertIn(ticket.name, names)
+
+    def test_remove_doc_drops_from_index(self):
+        ticket = make_ticket(subject="Ephemeral crash report", status="Open")
+        self.search.index_doc("HD Ticket", ticket.name)
+        self.assertTrue(self.search.search("ephemeral")["results"])
+        self.search.remove_doc("HD Ticket", ticket.name)
+        names = {r["name"] for r in self.search.search("ephemeral")["results"]}
+        self.assertNotIn(ticket.name, names)
+
+    def test_sqlite_backend_still_works_end_to_end(self):
+        """Regression: the SQLite backend keeps working when it is selected."""
+        frappe.db.set_single_value("HD Settings", "search_backend", "SQLite")
+        try:
+            from helpdesk.search_sqlite import HelpdeskSearch
+
+            sqlite = HelpdeskSearch()
+            self.assertTrue(sqlite.is_search_enabled())
+            sqlite.build_index()
+            self.assertTrue(sqlite.index_exists())
+            names = {
+                r["name"]
+                for r in sqlite.search("login")["results"]
+                if r["doctype"] == "HD Ticket"
+            }
+            self.assertIn(self.ticket_open.name, names)
+            self.assertGreaterEqual(
+                sqlite.get_filter_options()["statuses"].get("Open", 0), 1
+            )
+            # SQLite honours the same limit contract as RediSearch.
+            self.assertLessEqual(len(sqlite.search("login", limit=1)["results"]), 1)
+        finally:
+            frappe.db.set_single_value("HD Settings", "search_backend", "RediSearch")
+
+    def test_toggle_routes_backend(self):
+        from helpdesk.api.search import _get_backend
+
+        frappe.db.set_single_value("HD Settings", "search_backend", "RediSearch")
+        self.assertIsInstance(_get_backend(), HelpdeskRediSearch)
+
+        from helpdesk.search_sqlite import HelpdeskSearch
+
+        frappe.db.set_single_value("HD Settings", "search_backend", "SQLite")
+        self.assertIsInstance(_get_backend(), HelpdeskSearch)
+        # restore RediSearch for the rest of the suite
+        frappe.db.set_single_value("HD Settings", "search_backend", "RediSearch")
+
+    def test_sqlite_class_disabled_under_redisearch(self):
+        from helpdesk.search_sqlite import HelpdeskSearch
+
+        frappe.db.set_single_value("HD Settings", "search_backend", "RediSearch")
+        self.assertFalse(HelpdeskSearch().is_search_enabled())
+        frappe.db.set_single_value("HD Settings", "search_backend", "SQLite")
+        self.assertTrue(HelpdeskSearch().is_search_enabled())
+        frappe.db.set_single_value("HD Settings", "search_backend", "RediSearch")


### PR DESCRIPTION
## Problem

`HelpdeskSearch` (SQLite FTS) cannot run on a network filesystem. `SQLiteSearch` opens the index in WAL mode, and WAL requires a shared-memory `-shm` segment between all processes on the same host — it [does not work over a network filesystem](https://www.sqlite.org/wal.html) ("All processes using a database must be on the same host computer; WAL does not work over a network filesystem"). On Kubernetes / high-availability deployments with `sites/` on NFS and workers spread across pods, indexing and search fail with `database is locked`. Today there is no supported way to run Helpdesk search on a client-server engine.

## What this does

Adds RediSearch as an **opt-in** storage backend, selected by a new `HD Settings → Search → Search Backend` field (**default `SQLite`**, so behaviour is unchanged unless an operator switches it). It requires the RediSearch module in the cache Redis — the same dependency `webshop` and `wiki` already rely on for their RediSearch paths.

- `HelpdeskRediSearch` (`helpdesk/search_redisearch.py`) mirrors `HelpdeskSearch`'s public surface and return shapes, so `helpdesk.api.search` and the frontend are untouched — only the storage engine changes.
- The SQLite class disables itself via `is_search_enabled()` while RediSearch is selected, so the core's global indexing orchestration (`update_doc_index` / schedulers) skips it cleanly. **No frappe core change.**
- Permission is never materialised as the full accessible-ticket list (the volume that makes the SQLite `get_filter_options` degrade/fail at scale): `search()` post-filters the bounded candidate page through the real ticket permission, and `get_filter_options()` aggregates from the database honouring `permission_query`, decoupled from the search index.

## Backward compatibility

- Default `SQLite` → zero behaviour change; existing search and tests are unaffected.
- No new dependency for SQLite users; RediSearch is only touched when the setting is enabled.
- No schema change or migration beyond the single opt-in Select field.

## Tests

Adds `helpdesk/test_search_redisearch.py` — mock-free integration tests against a real RediSearch module and the real permission stack: index build, search, facet counts, permission scoping, backend toggle/routing, document removal, plus a SQLite regression case asserting the default backend still works end to end. Green on both backends.
