### PR TITLE
fix: display proper labels for time elapsed

### DIFF
--- a/desk/src/utils.ts
+++ b/desk/src/utils.ts
@@ -91,44 +91,41 @@ export function prettyDate(date, mini = false) {
 
   let nowDatetime = dayjsLocal();
   let diff = nowDatetime.diff(date, "seconds");
+  let absDiff = Math.abs(diff);
 
-  let dayDiff = diff / 86400;
+  // Day-level labels ("Yesterday", "N days ago"...) count calendar dates, not
+  // elapsed 24h windows — otherwise they track time-of-day and an event lands
+  // in the wrong day around midnight. Sub-day labels below still use elapsed
+  // seconds, so recent events keep precise "minutes/hours ago".
+  let dayDiff = nowDatetime.startOf("day").diff(date.startOf("day"), "day");
 
   if (isNaN(dayDiff)) return "";
 
   if (mini) {
     // Return short format of time difference
-    if (dayDiff < 0) {
-      if (Math.abs(dayDiff) < 1) {
-        if (Math.abs(diff) < 60) {
-          return __("Now");
-        } else if (Math.abs(diff) < 3600) {
-          return __("in {0} m", [Math.floor(Math.abs(diff) / 60)]);
-        } else if (Math.abs(diff) < 86400) {
-          return __("in {0} h", [Math.floor(Math.abs(diff) / 3600)]);
-        }
+    if (absDiff < 86400) {
+      // Within a day — show sub-day granularity (past or future).
+      if (absDiff < 60) return __("Now");
+      if (absDiff < 3600) {
+        const minutes = Math.floor(absDiff / 60);
+        return diff >= 0 ? __("{0} m", [minutes]) : __("in {0} m", [minutes]);
       }
-      if (Math.abs(dayDiff) >= 1 && Math.abs(dayDiff) < 1.5) {
+      const hours = Math.floor(absDiff / 3600);
+      return diff >= 0 ? __("{0} h", [hours]) : __("in {0} h", [hours]);
+    } else if (diff < 0) {
+      const ahead = -dayDiff;
+      if (ahead === 1) {
         return __("Tomorrow");
-      } else if (Math.abs(dayDiff) < 7) {
-        return __("in {0} d", [Math.floor(Math.abs(dayDiff))]);
-      } else if (Math.abs(dayDiff) < 31) {
-        return __("in {0} w", [Math.floor(Math.abs(dayDiff) / 7)]);
-      } else if (Math.abs(dayDiff) < 365) {
-        return __("in {0} M", [Math.floor(Math.abs(dayDiff) / 30)]);
+      } else if (ahead < 7) {
+        return __("in {0} d", [ahead]);
+      } else if (ahead < 31) {
+        return __("in {0} w", [Math.floor(ahead / 7)]);
+      } else if (ahead < 365) {
+        return __("in {0} M", [Math.floor(ahead / 30)]);
       } else {
-        return __("in {0} y", [Math.floor(Math.abs(dayDiff) / 365)]);
-      }
-    } else if (dayDiff >= 0 && dayDiff < 1) {
-      if (diff < 60) {
-        return __("Now");
-      } else if (diff < 3600) {
-        return __("{0} m", [Math.floor(diff / 60)]);
-      } else if (diff < 86400) {
-        return __("{0} h", [Math.floor(diff / 3600)]);
+        return __("in {0} y", [Math.floor(ahead / 365)]);
       }
     } else {
-      dayDiff = Math.floor(dayDiff);
       if (dayDiff < 7) {
         return __("{0} d", [dayDiff]);
       } else if (dayDiff < 31) {
@@ -141,48 +138,36 @@ export function prettyDate(date, mini = false) {
     }
   } else {
     // Return long format of time difference
-    if (dayDiff < 0) {
-      if (Math.abs(dayDiff) < 1) {
-        if (Math.abs(diff) < 60) {
-          return __("Just now");
-        } else if (Math.abs(diff) < 120) {
-          return __("In 1 minute");
-        } else if (Math.abs(diff) < 3600) {
-          return __("In {0} minutes", [Math.floor(Math.abs(diff) / 60)]);
-        } else if (Math.abs(diff) < 7200) {
-          return __("In 1 hour");
-        } else if (Math.abs(diff) < 86400) {
-          return __("In {0} hours", [Math.floor(Math.abs(diff) / 3600)]);
-        }
+    if (absDiff < 86400) {
+      // Within a day — show sub-day granularity (past or future).
+      if (absDiff < 60) return __("Just now");
+      if (diff >= 0) {
+        if (absDiff < 120) return __("1 minute ago");
+        if (absDiff < 3600) return __("{0} minutes ago", [Math.floor(absDiff / 60)]);
+        if (absDiff < 7200) return __("1 hour ago");
+        return __("{0} hours ago", [Math.floor(absDiff / 3600)]);
       }
-      if (Math.abs(dayDiff) >= 1 && Math.abs(dayDiff) < 1.5) {
+      if (absDiff < 120) return __("In 1 minute");
+      if (absDiff < 3600) return __("In {0} minutes", [Math.floor(absDiff / 60)]);
+      if (absDiff < 7200) return __("In 1 hour");
+      return __("In {0} hours", [Math.floor(absDiff / 3600)]);
+    } else if (diff < 0) {
+      const ahead = -dayDiff;
+      if (ahead === 1) {
         return __("Tomorrow");
-      } else if (Math.abs(dayDiff) < 7) {
-        return __("In {0} days", [Math.floor(Math.abs(dayDiff))]);
-      } else if (Math.abs(dayDiff) < 31) {
-        return __("In {0} weeks", [Math.floor(Math.abs(dayDiff) / 7)]);
-      } else if (Math.abs(dayDiff) < 365) {
-        return __("In {0} months", [Math.floor(Math.abs(dayDiff) / 30)]);
-      } else if (Math.abs(dayDiff) < 730) {
+      } else if (ahead < 7) {
+        return __("In {0} days", [ahead]);
+      } else if (ahead < 31) {
+        return __("In {0} weeks", [Math.floor(ahead / 7)]);
+      } else if (ahead < 365) {
+        return __("In {0} months", [Math.floor(ahead / 30)]);
+      } else if (ahead < 730) {
         return __("In 1 year");
       } else {
-        return __("In {0} years", [Math.floor(Math.abs(dayDiff) / 365)]);
-      }
-    } else if (dayDiff >= 0 && dayDiff < 1) {
-      if (diff < 60) {
-        return __("Just now");
-      } else if (diff < 120) {
-        return __("1 minute ago");
-      } else if (diff < 3600) {
-        return __("{0} minutes ago", [Math.floor(diff / 60)]);
-      } else if (diff < 7200) {
-        return __("1 hour ago");
-      } else if (diff < 86400) {
-        return __("{0} hours ago", [Math.floor(diff / 3600)]);
+        return __("In {0} years", [Math.floor(ahead / 365)]);
       }
     } else {
-      dayDiff = Math.floor(dayDiff);
-      if (dayDiff >= 1 && dayDiff < 2) {
+      if (dayDiff === 1) {
         return __("Yesterday");
       } else if (dayDiff < 7) {
         return __("{0} days ago", [dayDiff]);


### PR DESCRIPTION
Display labels correctly for time that has elapsed in the activity timeline

Issues were faced when tickets where the timeline would incorrectly display the activity date. This issue was really caused because it would consider time elapsed via hours but not calendar dates

i.e 
24 -48 hours passed = yesterday  which can be wrong as something 40 hours ago should be labelled 2 days ago and not yesterday  


bug:
<img width="1428" height="847" alt="image" src="https://github.com/user-attachments/assets/5d5b6182-2918-4e89-b084-77e71fe3b53e" />


after fix:
<img width="1440" height="899" alt="image" src="https://github.com/user-attachments/assets/7cd0bbd2-e735-4a81-9dc0-54147cd931c0" />
