### PR TITLE
fix: preserve formatting for thunderbird received emails

### DIFF
--- a/desk/src/components/EmailContent.vue
+++ b/desk/src/components/EmailContent.vue
@@ -45,9 +45,9 @@ const outlookReplyToContent = doc.querySelectorAll("div#appendonsend");
 const replyToContent = doc.querySelectorAll("p.reply-to-content");
 
 if (doc.body.children.length === 0) {
-  // Plain-text emails (e.g. from Thunderbird) arrive as text with newlines and no spacing losing formatting
-  // Preserve line breaks with pre-wrap (content is already escaped by stripEmailColors).
-  _content.value = `<div class="plain-text-content">${doc.body.innerHTML}</div>`;
+  // Plain-text emails (e.g. from Thunderbird) arrive as text with newlines and no spacing losing formatting.
+  const plainText = doc.body.innerHTML.replace(/\n\n/g, "\n");
+  _content.value = `<div class="whitespace-pre-wrap">${plainText}</div>`;
 } else if (gmailReplyToContent.length) {
   _content.value = parseReplyToContent(doc, "div.gmail_quote", true);
 } else if (outlookReplyToContent.length) {
@@ -184,10 +184,6 @@ const htmlContent = computed(
         word-break: break-word;
       }
       
-      .plain-text-content {
-        white-space: pre-wrap;
-        line-height: 1.5;
-      }
           
       .email-content :is(:where(img):not(:where([class~='not-prose'], [class~='not-prose'] *))) {
         border-width: 0;

--- a/desk/src/components/EmailContent.vue
+++ b/desk/src/components/EmailContent.vue
@@ -47,7 +47,7 @@ const replyToContent = doc.querySelectorAll("p.reply-to-content");
 if (doc.body.children.length === 0) {
   // Plain-text emails (e.g. from Thunderbird) arrive as text with newlines and no spacing losing formatting
   // Preserve line breaks with pre-wrap (content is already escaped by stripEmailColors).
-  _content.value = `<div class="plain-text-content">${_content.value}</div>`;
+  _content.value = `<div class="plain-text-content">${doc.body.innerHTML}</div>`;
 } else if (gmailReplyToContent.length) {
   _content.value = parseReplyToContent(doc, "div.gmail_quote", true);
 } else if (outlookReplyToContent.length) {

--- a/desk/src/components/EmailContent.vue
+++ b/desk/src/components/EmailContent.vue
@@ -47,7 +47,7 @@ const replyToContent = doc.querySelectorAll("p.reply-to-content");
 if (doc.body.children.length === 0) {
   // Plain-text emails (e.g. from Thunderbird) arrive as text with newlines and no spacing losing formatting
   // Preserve line breaks with pre-wrap (content is already escaped by stripEmailColors).
-  _content.value = `<div style="white-space: pre-wrap">${_content.value}</div>`;
+  _content.value = `<div class="plain-text-content">${_content.value}</div>`;
 } else if (gmailReplyToContent.length) {
   _content.value = parseReplyToContent(doc, "div.gmail_quote", true);
 } else if (outlookReplyToContent.length) {
@@ -182,6 +182,11 @@ const htmlContent = computed(
       }
       .email-content {
         word-break: break-word;
+      }
+      
+      .plain-text-content {
+        white-space: pre-wrap;
+        line-height: 1.5;
       }
           
       .email-content :is(:where(img):not(:where([class~='not-prose'], [class~='not-prose'] *))) {

--- a/desk/src/components/EmailContent.vue
+++ b/desk/src/components/EmailContent.vue
@@ -44,7 +44,11 @@ const gmailReplyToContent = doc.querySelectorAll("div.gmail_quote");
 const outlookReplyToContent = doc.querySelectorAll("div#appendonsend");
 const replyToContent = doc.querySelectorAll("p.reply-to-content");
 
-if (gmailReplyToContent.length) {
+if (doc.body.children.length === 0) {
+  // Plain-text emails (e.g. from Thunderbird) arrive as text with newlines and no spacing losing formatting
+  // Preserve line breaks with pre-wrap (content is already escaped by stripEmailColors).
+  _content.value = `<div style="white-space: pre-wrap">${_content.value}</div>`;
+} else if (gmailReplyToContent.length) {
   _content.value = parseReplyToContent(doc, "div.gmail_quote", true);
 } else if (outlookReplyToContent.length) {
   _content.value = parseReplyToContent(doc, "div#appendonsend");

--- a/desk/src/components/EmailEditor.vue
+++ b/desk/src/components/EmailEditor.vue
@@ -526,6 +526,13 @@ function addToReply(
   ccEmailsClone.value = ccEmails;
   bccEmailsClone.value = bccEmails;
 
+  // Plain-text emails (e.g. Thunderbird) have no HTML tags, so their newlines/spacing
+  // thus lose formatting when added to replied content
+  const doc = new DOMParser().parseFromString(body, "text/html");
+  if (doc.body.children.length === 0) {
+    body = `<div style="white-space: pre-wrap; line-height: 1.5">${doc.body.innerHTML}</div>`;
+  }
+
   if (body !== quotedContent.value) {
     //trigger change for watch when replied to body data is different from current quoted content
     quotedContent.value = null;


### PR DESCRIPTION
Mails received from Thunderbird don't have any formatting inside the HTML

Spacing for the mails operate on using \n and new line which caused issues in spacing causing inconsistencies in the mails received

bug:
<img width="554" height="272" alt="image" src="https://github.com/user-attachments/assets/a3a52db5-0dc9-4f6f-9021-28db952bc45e" />


fix:
<img width="879" height="771" alt="image" src="https://github.com/user-attachments/assets/41b7c981-895d-4d67-b472-9dd46d550481" />





