### PR TITLE
fix: prevent AssignTo crash when current user is the only agent

### DIFF
--- a/desk/src/components/ticket-agent/AssignTo.vue
+++ b/desk/src/components/ticket-agent/AssignTo.vue
@@ -302,7 +302,7 @@ const agentOptions = computed<AgentOption[]>(() => {
       image: currentUser.value.user_image || "",
       ...liveAvailability({ name: currentAgentName }),
     });
-    seen.add(currentAgentName);
+    options.add(currentAgentName);
   }
 
   if (agentResource.data) {


### PR DESCRIPTION
## Problem

Opening the assignee dropdown crashes with:

```
TypeError: Cannot read properties of undefined (reading 'length')
    at AssignTo.vue (sortedAgentOptions.length)
```

It triggers when the session user is themselves an agent (e.g. a setup with a single agent — that agent is you).

## Root cause

In `agentOptions`, the dedup Set was renamed to `options`, but the current-agent branch still called `seen.add(currentAgentName)`. Since `seen` no longer exists in that scope, the getter throws. Vue caches the failed computed as `undefined`, so the next render evaluates `sortedAgentOptions.length` on `undefined` — surfacing as the `reading 'length'` TypeError.

```diff
-    seen.add(currentAgentName);
+    options.add(currentAgentName);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)