### PR TITLE
fix: inline reply images broken in outgoing email

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -1202,10 +1202,11 @@ class HDTicket(Document):
         soup = BeautifulSoup(content, "html.parser")
 
         for tag in soup.find_all(["img", "video"]):
-            if tag.name == "img":
-                tag["embed"] = tag.get("src")
-            elif tag.name == "video":
-                tag["embed"] = tag.get("src")
+            # replace src with embed so the framework inlines the file as a
+            # cid attachment; a leftover src would duplicate and win, leaving
+            # recipients a broken /private/files/ link (#3421)
+            tag["embed"] = tag.get("src")
+            del tag["src"]
 
         return str(soup)
 

--- a/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
@@ -1081,6 +1081,21 @@ class TestHDTicket(IntegrationTestCase):
         if hasattr(communication_doc, "bcc") and communication_doc.bcc:
             self.assertEqual(communication_doc.bcc, bcc_recipient)
 
+    def test_parse_content_swaps_inline_media_src_for_embed(self):
+        """Inline media must carry `embed` and no `src`, so the framework
+        inlines it as a cid attachment instead of shipping a broken
+        /private/files/ link to the recipient (#3421)."""
+        ticket = frappe.new_doc("HD Ticket")
+        html = (
+            '<img src="/private/files/x.png">'
+            '<video src="/private/files/c.mp4"></video>'
+        )
+        parsed = ticket.parse_content(html)
+        # no leftover src would duplicate and win over the cid rewrite
+        self.assertNotIn('src="/private/files/', parsed)
+        self.assertIn('embed="/private/files/x.png"', parsed)
+        self.assertIn('embed="/private/files/c.mp4"', parsed)
+
     def test_reply_via_agent_with_cc_and_bcc_no_to(self):
         """
         reply_via_agent should succeed when both cc and bcc are provided but to is empty


### PR DESCRIPTION
Fixes #3421.

## Problem
When an agent replies with an inline image (pasted/dropped into the editor), the customer receives a broken image. The outgoing email references `/private/files/...`, which the recipient has no permission to load.

## Root cause
`parse_content` sets an `embed` attribute so the framework inlines the file as a `cid:` attachment — but it kept the original `src`. After the framework rewrites `embed` → `src="cid:..."`, the tag ends up with **two** `src` attributes:

```html
<img src="/private/files/x.png" src="cid:abc123">
```

Per HTML, duplicate attributes resolve to the first, so the private URL wins and the working `cid:` reference is discarded — broken image.

This regressed in `b0e4b3be6` ("dont delete src tag"), which dropped the `del tag["src"]` added by the original private-media security fix (`727c9e81b`).

## Fix
Replace `src` with `embed` instead of duplicating it. The image travels embedded in the email as a cid attachment (the framework already reads private files for this) — no files are made public.

## Test
Adds `test_parse_content_swaps_inline_media_src_for_embed`: asserts no `/private/files/` `src` survives and the path moves to `embed`. Fails on the pre-fix code, passes on the fix.
