### PR TITLE
fix: agent reply fails on tickets with no prior communication

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -716,12 +716,10 @@ class HDTicket(Document):
                 sender=reply_to_email,
                 subject=subject,
                 with_container=False,
-                in_reply_to=(
-                    last_communication.name if last_communication.name else None
-                ),
+                in_reply_to=last_communication.name if last_communication else None,
             )
         except Exception as e:
-            frappe.throw(_(e))
+            frappe.throw(str(e))
 
     @frappe.whitelist()
     # flake8: noqa


### PR DESCRIPTION
Replying from the agent portal returns a **500** for tickets with no `Communication` (for example, tickets created from Desk or the REST API without a description).

```text
AttributeError: 'NoneType' object has no attribute 'name'
```

`reply_via_agent` dereferences `last_communication.name` before checking whether `last_communication` exists. The exception handler also masks the original error by calling `frappe.throw(_(e))`, which raises another exception instead of displaying the actual `sendmail` error.

Guard the object instead of its attribute (`last_communication.name if last_communication else None`) and pass `str(e)` to `frappe.throw()` so the original error is surfaced.