### PR TITLE
fix: Customer portal permission banner

### DIFF
--- a/desk/src/components/contact/ContactCustomers.vue
+++ b/desk/src/components/contact/ContactCustomers.vue
@@ -2,7 +2,7 @@
   <div v-if="customers?.length" class="flex items-center gap-1.5">
     <div class="flex items-center">
       <Tooltip
-        v-for="customer in customers"
+        v-for="customer in visibleCustomers"
         :key="customer.name"
         :text="customer.name"
       >
@@ -15,6 +15,12 @@
           @click="goToCustomer(customer.name)"
         />
       </Tooltip>
+      <div
+        v-if="remainingCustomers.length"
+        class="relative -mr-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-surface-gray-2 text-2xs font-medium text-ink-gray-6 ring-2 ring-[var(--surface-white)]"
+      >
+        +{{ remainingCustomers.length }}
+      </div>
     </div>
     <span
       class="text-sm text-ink-gray-8 ml-2"
@@ -46,6 +52,16 @@ const props = defineProps<{
 }>();
 
 const router = useRouter();
+
+const MAX_VISIBLE_AVATARS = 5;
+
+const visibleCustomers = computed(() =>
+  props.customers.slice(0, MAX_VISIBLE_AVATARS)
+);
+
+const remainingCustomers = computed(() =>
+  props.customers.slice(MAX_VISIBLE_AVATARS)
+);
 
 const label = computed(() =>
   props.customers.length === 1

--- a/desk/src/components/contact/EditContactDialog.vue
+++ b/desk/src/components/contact/EditContactDialog.vue
@@ -132,7 +132,7 @@
                 class="flex-1"
                 type="text"
                 :modelValue="customer.name"
-                :disabled="true"
+                readonly
               >
                 <template #prefix>
                   <Avatar

--- a/desk/src/components/layouts/CustomerPortalPermissionBanner.vue
+++ b/desk/src/components/layouts/CustomerPortalPermissionBanner.vue
@@ -1,0 +1,39 @@
+<template>
+  <div
+    v-if="!isSidebarCollapsed"
+    class="flex flex-col gap-3 shadow-sm rounded-lg py-2.5 px-3 bg-surface-modal text-base"
+  >
+    <div class="inline-flex gap-2 text-ink-gray-9">
+      <LucideShieldAlert class="h-4 w-4 my-0.5 shrink-0" />
+      <div class="flex flex-col gap-0.5 text-p-sm">
+        <div class="font-medium">
+          {{ __("Customer portal update") }}
+        </div>
+        <div class="text-ink-gray-7">
+          {{ __("We have changed how customer portal permissions work") }}
+        </div>
+      </div>
+    </div>
+    <Button :label="__('Learn more')" theme="blue" @click="showDialog = true" />
+  </div>
+  <Button v-else @click="showDialog = true">
+    <LucideShieldAlert class="h-4 w-4 shrink-0" />
+  </Button>
+  <CustomerPortalPermissionDialog v-model="showDialog" />
+</template>
+
+<script setup lang="ts">
+import { __ } from "@/translation";
+import { ref } from "vue";
+import LucideShieldAlert from "~icons/lucide/shield-alert";
+import CustomerPortalPermissionDialog from "./CustomerPortalPermissionDialog.vue";
+
+defineProps({
+  isSidebarCollapsed: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const showDialog = ref(false);
+</script>

--- a/desk/src/components/layouts/CustomerPortalPermissionBanner.vue
+++ b/desk/src/components/layouts/CustomerPortalPermissionBanner.vue
@@ -16,7 +16,7 @@
     </div>
     <Button :label="__('Learn more')" theme="blue" @click="showDialog = true" />
   </div>
-  <Button v-else @click="showDialog = true">
+  <Button v-else variant="ghost" @click="showDialog = true">
     <LucideShieldAlert class="h-4 w-4 shrink-0" />
   </Button>
   <CustomerPortalPermissionDialog v-model="showDialog" />

--- a/desk/src/components/layouts/CustomerPortalPermissionDialog.vue
+++ b/desk/src/components/layouts/CustomerPortalPermissionDialog.vue
@@ -13,10 +13,12 @@
           }}
         </p>
         <p>
+          {{ __("Only") }}
+          <span class="font-semibold text-ink-gray-8"
+            >'{{ __("customer managers") }}'</span
+          >
           {{
-            __(
-              "Only customer managers can see every ticket of their company and manage its contacts."
-            )
+            __("can see every ticket of their company and manage its contacts.")
           }}
           {{ __("Learn more in the") }}
           <a

--- a/desk/src/components/layouts/CustomerPortalPermissionDialog.vue
+++ b/desk/src/components/layouts/CustomerPortalPermissionDialog.vue
@@ -1,0 +1,91 @@
+<template>
+  <Dialog
+    v-model:open="show"
+    :title="__('Customer portal permissions have changed')"
+  >
+    <template #default>
+      <div class="flex flex-col gap-3 text-p-base text-ink-gray-7">
+        <p>
+          {{
+            __(
+              "Contacts are now members of a customer, and only customer managers can see all tickets of their customer. Other contacts only see the tickets they have raised themselves."
+            )
+          }}
+        </p>
+        <p>
+          {{
+            __(
+              "Contacts that existed before this update became regular members, so they may no longer see the other tickets of their customer."
+            )
+          }}
+        </p>
+        <FormControl
+          v-model="restoreOldBehaviour"
+          type="checkbox"
+          :label="
+            __(
+              'Restore the previous behaviour by making every existing contact a customer manager'
+            )
+          "
+        />
+        <p class="text-p-sm text-ink-gray-5">
+          {{ __("This notice will not be shown again after you confirm.") }}
+        </p>
+      </div>
+    </template>
+    <template #actions>
+      <Button
+        class="w-full"
+        variant="solid"
+        :label="__('Confirm')"
+        :loading="confirming"
+        @click="confirm"
+      />
+    </template>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { __ } from "@/translation";
+import { createResource, toast } from "frappe-ui";
+import { computed, ref, watch } from "vue";
+
+const show = defineModel<boolean>();
+const restoreOldBehaviour = ref(false);
+
+const dismissResource = createResource({
+  url: "helpdesk.api.customer_portal_notice.dismiss_notice",
+  onSuccess: () => {
+    show.value = false;
+  },
+});
+
+const restoreResource = createResource({
+  url: "helpdesk.api.customer_portal_notice.restore_ticket_access",
+  onSuccess: () => {
+    show.value = false;
+    toast.success(
+      __("Existing contacts are being made customer managers in the background")
+    );
+  },
+});
+
+const confirming = computed(
+  () => dismissResource.loading || restoreResource.loading
+);
+
+function confirm() {
+  if (restoreOldBehaviour.value) {
+    restoreResource.submit();
+  } else {
+    dismissResource.submit();
+  }
+}
+
+watch(
+  () => show.value,
+  (open) => {
+    if (!open) restoreOldBehaviour.value = false;
+  }
+);
+</script>

--- a/desk/src/components/layouts/CustomerPortalPermissionDialog.vue
+++ b/desk/src/components/layouts/CustomerPortalPermissionDialog.vue
@@ -8,14 +8,14 @@
         <p>
           {{
             __(
-              "Contacts are now members of a customer, and only customer managers can see all tickets of their customer. Other contacts only see the tickets they have raised themselves."
+              "Contacts on the portal now only see the tickets they raised themselves."
             )
           }}
         </p>
         <p>
           {{
             __(
-              "Contacts that existed before this update became regular members, so they may no longer see the other tickets of their customer."
+              "Customer managers can see every ticket of their company and manage its contacts. Your existing contacts aren't managers yet, so they may see fewer tickets than before."
             )
           }}
           {{ __("Learn more in the") }}
@@ -31,12 +31,12 @@
           type="checkbox"
           :label="
             __(
-              'Restore the previous behaviour by making every existing contact a customer manager'
+              'Make my existing contacts customer managers so they can still see all tickets of their company'
             )
           "
         />
         <p class="text-p-sm text-ink-gray-5">
-          {{ __("This notice will not be shown again after you confirm.") }}
+          {{ __("You won't see this notice again.") }}
         </p>
       </div>
     </template>
@@ -70,7 +70,7 @@ const dismissResource = createResource({
 const restoreResource = createResource({
   url: "helpdesk.api.customer_portal_notice.restore_ticket_access",
   onSuccess: () => {
-    show.value = false;
+    dismissResource.submit();
     toast.success(
       __("Existing contacts are being made customer managers in the background")
     );

--- a/desk/src/components/layouts/CustomerPortalPermissionDialog.vue
+++ b/desk/src/components/layouts/CustomerPortalPermissionDialog.vue
@@ -13,10 +13,10 @@
           }}
         </p>
         <p>
-          {{ __("Only") }}
+          {{ __("Only users with the role of ") }}
           <span class="font-semibold text-ink-gray-8"
-            >'{{ __("customer managers") }}'</span
-          >
+            >'{{ __("Customer Manager") }}'
+          </span>
           {{
             __("can see every ticket of their company and manage its contacts.")
           }}

--- a/desk/src/components/layouts/CustomerPortalPermissionDialog.vue
+++ b/desk/src/components/layouts/CustomerPortalPermissionDialog.vue
@@ -18,6 +18,13 @@
               "Contacts that existed before this update became regular members, so they may no longer see the other tickets of their customer."
             )
           }}
+          {{ __("Learn more in the") }}
+          <a
+            href="https://docs.frappe.io/helpdesk/customers-contacts#update-on-permissions"
+            target="_blank"
+            class="underline"
+            >{{ __("documentation") }}</a
+          >.
         </p>
         <FormControl
           v-model="restoreOldBehaviour"

--- a/desk/src/components/layouts/CustomerPortalPermissionDialog.vue
+++ b/desk/src/components/layouts/CustomerPortalPermissionDialog.vue
@@ -8,14 +8,14 @@
         <p>
           {{
             __(
-              "Contacts on the portal now only see the tickets they raised themselves."
+              "Earlier, every contact could see all the tickets of their company. Now, contacts only see the tickets they raised themselves."
             )
           }}
         </p>
         <p>
           {{
             __(
-              "Customer managers can see every ticket of their company and manage its contacts. Your existing contacts aren't managers yet, so they may see fewer tickets than before."
+              "Only customer managers can see every ticket of their company and manage its contacts."
             )
           }}
           {{ __("Learn more in the") }}
@@ -29,11 +29,7 @@
         <FormControl
           v-model="restoreOldBehaviour"
           type="checkbox"
-          :label="
-            __(
-              'Make my existing contacts customer managers so they can still see all tickets of their company'
-            )
-          "
+          :label="__('Make all existing contacts customer managers')"
         />
         <p class="text-p-sm text-ink-gray-5">
           {{ __("You won't see this notice again.") }}

--- a/desk/src/components/layouts/Sidebar.vue
+++ b/desk/src/components/layouts/Sidebar.vue
@@ -107,7 +107,7 @@
     </div>
     <div class="grow" />
     <div class="flex flex-col gap-2 pb-2.5">
-      <div class="px-2">
+      <div class="px-2 flex flex-col gap-2">
         <TrialBanner
           v-if="isFCSite && !isCustomerPortal"
           :isSidebarCollapsed="!isExpanded"
@@ -179,9 +179,9 @@
 import HDLogo from "@/assets/logos/HDLogo.vue";
 import { Section, SidebarLink } from "@/components";
 import Apps from "@/components/Apps.vue";
-import CustomerPortalPermissionBanner from "@/components/layouts/CustomerPortalPermissionBanner.vue";
 import CP from "@/components/command-palette/CP.vue";
 import { FrappeCloudIcon, InviteCustomer } from "@/components/icons";
+import CustomerPortalPermissionBanner from "@/components/layouts/CustomerPortalPermissionBanner.vue";
 import ShortcutsModal from "@/components/modals/ShortcutsModal.vue";
 import SettingsModal from "@/components/Settings/SettingsModal.vue";
 import UserMenu from "@/components/UserMenu.vue";
@@ -230,12 +230,12 @@ import LucideBell from "~icons/lucide/bell";
 import FileText from "~icons/lucide/file-text";
 import Globe from "~icons/lucide/globe";
 import LucideKeyboard from "~icons/lucide/keyboard";
-import LucideMoon from "~icons/lucide/moon";
-import LucideSun from "~icons/lucide/sun";
 import LucideMail from "~icons/lucide/mail";
 import MailOpen from "~icons/lucide/mail-open";
 import MessageCircle from "~icons/lucide/message-circle";
+import LucideMoon from "~icons/lucide/moon";
 import LucideSearch from "~icons/lucide/search";
+import LucideSun from "~icons/lucide/sun";
 import Ticket from "~icons/lucide/ticket";
 import Timer from "~icons/lucide/timer";
 import UserPen from "~icons/lucide/user-pen";

--- a/desk/src/components/layouts/Sidebar.vue
+++ b/desk/src/components/layouts/Sidebar.vue
@@ -117,6 +117,10 @@
           :isSidebarCollapsed="!isExpanded"
           appName="helpdesk"
         />
+        <CustomerPortalPermissionBanner
+          v-if="showPermissionNoticeBanner"
+          :isSidebarCollapsed="!isExpanded"
+        />
       </div>
 
       <SidebarLink
@@ -175,6 +179,7 @@
 import HDLogo from "@/assets/logos/HDLogo.vue";
 import { Section, SidebarLink } from "@/components";
 import Apps from "@/components/Apps.vue";
+import CustomerPortalPermissionBanner from "@/components/layouts/CustomerPortalPermissionBanner.vue";
 import CP from "@/components/command-palette/CP.vue";
 import { FrappeCloudIcon, InviteCustomer } from "@/components/icons";
 import ShortcutsModal from "@/components/modals/ShortcutsModal.vue";
@@ -191,6 +196,7 @@ import {
   showEmailBox,
 } from "@/pages/ticket/modalStates";
 import { useAuthStore } from "@/stores/auth";
+import { useConfigStore } from "@/stores/config";
 import { useNotificationStore } from "@/stores/notification";
 import { useSidebarStore } from "@/stores/sidebar";
 import { capture } from "@/telemetry";
@@ -246,6 +252,7 @@ const isRtl = document.documentElement.dir === "rtl";
 const route = useRoute();
 const router = useRouter();
 const authStore = useAuthStore();
+const configStore = useConfigStore();
 const notificationStore = useNotificationStore();
 const { isExpanded, width } = storeToRefs(useSidebarStore());
 const device = useDevice();
@@ -430,6 +437,14 @@ const showOnboardingBanner = computed(() => {
     !isCustomerPortal.value &&
     !isOnboardingStepsCompleted.value &&
     authStore.isManager
+  );
+});
+
+const showPermissionNoticeBanner = computed(() => {
+  return (
+    !isCustomerPortal.value &&
+    authStore.isManager &&
+    configStore.showCustomerPortalPermissionNotice
   );
 });
 

--- a/desk/src/components/layouts/Sidebar.vue
+++ b/desk/src/components/layouts/Sidebar.vue
@@ -443,7 +443,7 @@ const showOnboardingBanner = computed(() => {
 const showPermissionNoticeBanner = computed(() => {
   return (
     !isCustomerPortal.value &&
-    authStore.isManager &&
+    (authStore.isManager || authStore.isAdmin) &&
     configStore.showCustomerPortalPermissionNotice
   );
 });

--- a/desk/src/stores/config.ts
+++ b/desk/src/stores/config.ts
@@ -35,6 +35,9 @@ export const useConfigStore = defineStore("config", () => {
   const enableCommentReactions = computed(
     () => !!parseInt(config.value.enable_comment_reactions)
   );
+  const showCustomerPortalPermissionNotice = computed(
+    () => !!parseInt(config.value.show_customer_portal_permission_notice)
+  );
 
   socket.on("helpdesk:settings-updated", () => configResource.reload());
 
@@ -51,5 +54,6 @@ export const useConfigStore = defineStore("config", () => {
     assignWithinTeam,
     disableGlobalScopeForSavedReplies,
     enableCommentReactions,
+    showCustomerPortalPermissionNotice,
   };
 });

--- a/desk/src/stores/config.ts
+++ b/desk/src/stores/config.ts
@@ -1,9 +1,10 @@
-import { socket } from "@/socket";
 import { createResource } from "frappe-ui";
 import { defineStore } from "pinia";
 import { computed, ComputedRef } from "vue";
+import { globalStore } from "./globalStore";
 
 export const useConfigStore = defineStore("config", () => {
+  const { $socket } = globalStore();
   const configResource = createResource({
     url: "helpdesk.api.config.get_config",
     auto: true,
@@ -39,7 +40,7 @@ export const useConfigStore = defineStore("config", () => {
     () => !!parseInt(config.value.show_customer_portal_permission_notice)
   );
 
-  socket.on("helpdesk:settings-updated", () => configResource.reload());
+  $socket.on("helpdesk:settings-updated", () => configResource.reload());
 
   return {
     configResource,

--- a/desk/src/utils.ts
+++ b/desk/src/utils.ts
@@ -766,7 +766,7 @@ export function isElementInViewport(el: HTMLElement) {
 export function parseApiOptions(
   options: string[] | DropdownOption[]
 ): DropdownOption[] | [] {
-  if (!options.length) return [];
+  if (!options?.length) return [];
   return (
     options
       .filter((o) => Boolean(o))

--- a/helpdesk/api/config.py
+++ b/helpdesk/api/config.py
@@ -1,7 +1,7 @@
 import frappe
 
 
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
 def get_config():
     fields = [
         "brand_name",

--- a/helpdesk/api/config.py
+++ b/helpdesk/api/config.py
@@ -1,7 +1,7 @@
 import frappe
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def get_config():
     fields = [
         "brand_name",

--- a/helpdesk/api/config.py
+++ b/helpdesk/api/config.py
@@ -15,6 +15,7 @@ def get_config():
         "assign_within_team",
         "disable_saved_replies_global_scope",
         "enable_comment_reactions",
+        "show_customer_portal_permission_notice",
     ]
     res = frappe.get_value(doctype="HD Settings", fieldname=fields, as_dict=True)
 

--- a/helpdesk/api/customer_portal_notice.py
+++ b/helpdesk/api/customer_portal_notice.py
@@ -1,16 +1,19 @@
 import frappe
 
+from helpdesk.utils import agent_manager_only
+
 NOTICE_FLAG = "show_customer_portal_permission_notice"
 
 
 @frappe.whitelist(methods=["POST"])
+@agent_manager_only
 def dismiss_notice() -> None:
     """Permanently dismiss the customer portal permission change notice."""
-    only_for_managers()
     disable_notice()
 
 
 @frappe.whitelist(methods=["POST"])
+@agent_manager_only
 def restore_ticket_access() -> None:
     """Restore pre-migration ticket visibility for customer contacts.
 
@@ -18,14 +21,12 @@ def restore_ticket_access() -> None:
     job, so each contact can again see all tickets of their customer.
     Dismisses the notice once the job is queued.
     """
-    only_for_managers()
     frappe.enqueue(
         promote_all_contacts_to_managers,
         queue="long",
         job_id="promote_all_contacts_to_managers",
         deduplicate=True,
     )
-    disable_notice()
 
 
 def disable_notice() -> None:
@@ -60,7 +61,3 @@ def promote_customer_contacts(customer_name: str) -> None:
     for contact in customer.contacts:
         contact.is_manager = True
     customer.save(ignore_permissions=True)
-
-
-def only_for_managers() -> None:
-    frappe.only_for(["Agent Manager", "System Manager"])

--- a/helpdesk/api/customer_portal_notice.py
+++ b/helpdesk/api/customer_portal_notice.py
@@ -1,0 +1,66 @@
+import frappe
+
+NOTICE_FLAG = "show_customer_portal_permission_notice"
+
+
+@frappe.whitelist(methods=["POST"])
+def dismiss_notice() -> None:
+    """Permanently dismiss the customer portal permission change notice."""
+    only_for_managers()
+    disable_notice()
+
+
+@frappe.whitelist(methods=["POST"])
+def restore_ticket_access() -> None:
+    """Restore pre-migration ticket visibility for customer contacts.
+
+    Promotes every customer contact to a customer manager in a background
+    job, so each contact can again see all tickets of their customer.
+    Dismisses the notice once the job is queued.
+    """
+    only_for_managers()
+    frappe.enqueue(
+        promote_all_contacts_to_managers,
+        queue="long",
+        job_id="promote_all_contacts_to_managers",
+        deduplicate=True,
+    )
+    disable_notice()
+
+
+def disable_notice() -> None:
+    """Turn the flag off via the document, so HD Settings notifies
+    connected clients through its on_update realtime event."""
+    settings = frappe.get_doc("HD Settings")
+    settings.set(NOTICE_FLAG, 0)
+    settings.save(ignore_permissions=True)
+
+
+def promote_all_contacts_to_managers() -> None:
+    """Mark every customer contact as manager, syncing roles via HD Customer."""
+    customers = frappe.get_all(
+        "HD Customer Member",
+        filters={"is_manager": 0, "parenttype": "HD Customer"},
+        parent_doctype="HD Customer",
+        pluck="parent",
+        distinct=True,
+    )
+    for customer_name in customers:
+        try:
+            promote_customer_contacts(customer_name)
+        except Exception:
+            frappe.log_error(
+                title="promote_all_contacts_to_managers",
+                message=f"Failed to promote contacts of customer {customer_name}",
+            )
+
+
+def promote_customer_contacts(customer_name: str) -> None:
+    customer = frappe.get_doc("HD Customer", customer_name)
+    for contact in customer.contacts:
+        contact.is_manager = True
+    customer.save(ignore_permissions=True)
+
+
+def only_for_managers() -> None:
+    frappe.only_for(["Agent Manager", "System Manager"])

--- a/helpdesk/api/customer_portal_notice.py
+++ b/helpdesk/api/customer_portal_notice.py
@@ -94,13 +94,37 @@ def grant_manager_roles(users: list[str]) -> None:
         fields=["parent", "role"],
     )
     existing_pairs = {(row.parent, row.role) for row in existing}
+    now = frappe.utils.now()
+    session_user = frappe.session.user
     values = [
-        (frappe.generate_hash(length=10), user, role, "roles", "User")
+        (
+            frappe.generate_hash(length=10),
+            user,
+            role,
+            "roles",
+            "User",
+            now,
+            now,
+            session_user,
+            session_user,
+        )
         for user in users
         for role in roles
         if (user, role) not in existing_pairs
     ]
     if values:
         frappe.db.bulk_insert(
-            "Has Role", ["name", "parent", "role", "parentfield", "parenttype"], values
+            "Has Role",
+            [
+                "name",
+                "parent",
+                "role",
+                "parentfield",
+                "parenttype",
+                "creation",
+                "modified",
+                "owner",
+                "modified_by",
+            ],
+            values,
         )

--- a/helpdesk/api/customer_portal_notice.py
+++ b/helpdesk/api/customer_portal_notice.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe.realtime import get_website_room
 
 from helpdesk.utils import agent_manager_only
 
@@ -30,34 +31,76 @@ def restore_ticket_access() -> None:
 
 
 def disable_notice() -> None:
-    """Turn the flag off via the document, so HD Settings notifies
-    connected clients through its on_update realtime event."""
-    settings = frappe.get_doc("HD Settings")
-    settings.set(NOTICE_FLAG, 0)
-    settings.save(ignore_permissions=True)
+    """Turn the flag off and notify connected clients, publishing the same
+    realtime event HD Settings emits from its on_update."""
+    frappe.db.set_single_value("HD Settings", NOTICE_FLAG, 0)
+    frappe.publish_realtime(
+        "helpdesk:settings-updated", room=get_website_room(), after_commit=True
+    )
 
 
 def promote_all_contacts_to_managers() -> None:
-    """Mark every customer contact as manager, syncing roles via HD Customer."""
-    customers = frappe.get_all(
+    """Mark every customer contact as manager and grant the manager roles."""
+    users = get_users_of_non_manager_contacts()
+    mark_all_members_as_managers()
+    grant_manager_roles(users)
+    for user in users:
+        frappe.clear_cache(user=user)
+
+
+def get_users_of_non_manager_contacts() -> list[str]:
+    """Users linked to contacts that are not managers yet. Contacts without
+    a linked user are skipped, there is no user to grant the role to."""
+    contact_names = frappe.get_all(
         "HD Customer Member",
         filters={"is_manager": 0, "parenttype": "HD Customer"},
         parent_doctype="HD Customer",
-        pluck="parent",
+        pluck="contact_name",
         distinct=True,
     )
-    for customer_name in customers:
-        try:
-            promote_customer_contacts(customer_name)
-        except Exception:
-            frappe.log_error(
-                title="promote_all_contacts_to_managers",
-                message=f"Failed to promote contacts of customer {customer_name}",
-            )
+    if not contact_names:
+        return []
+
+    return frappe.get_all(
+        "Contact",
+        filters={"name": ("in", contact_names), "user": ("is", "set")},
+        pluck="user",
+        distinct=True,
+    )
 
 
-def promote_customer_contacts(customer_name: str) -> None:
-    customer = frappe.get_doc("HD Customer", customer_name)
-    for contact in customer.contacts:
-        contact.is_manager = True
-    customer.save(ignore_permissions=True)
+def mark_all_members_as_managers() -> None:
+    Member = frappe.qb.DocType("HD Customer Member")
+    (
+        frappe.qb.update(Member)
+        .set(Member.is_manager, 1)
+        .where((Member.is_manager == 0) & (Member.parenttype == "HD Customer"))
+    ).run()
+
+
+def grant_manager_roles(users: list[str]) -> None:
+    """Bulk-insert the customer roles for users that are missing them."""
+    roles = ("HD Customer Manager", "HD Customer")
+    if not users:
+        return
+
+    existing = frappe.get_all(
+        "Has Role",
+        filters={
+            "parenttype": "User",
+            "parent": ("in", users),
+            "role": ("in", roles),
+        },
+        fields=["parent", "role"],
+    )
+    existing_pairs = {(row.parent, row.role) for row in existing}
+    values = [
+        (frappe.generate_hash(length=10), user, role, "roles", "User")
+        for user in users
+        for role in roles
+        if (user, role) not in existing_pairs
+    ]
+    if values:
+        frappe.db.bulk_insert(
+            "Has Role", ["name", "parent", "role", "parentfield", "parenttype"], values
+        )

--- a/helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+++ b/helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -60,6 +60,7 @@
   "setup_section",
   "setup_complete",
   "initial_helpdesk_name_setup_skipped",
+  "show_customer_portal_permission_notice",
   "column_break_hjfh",
   "search_tab",
   "name_weight",
@@ -145,6 +146,13 @@
    "fieldname": "initial_helpdesk_name_setup_skipped",
    "fieldtype": "Check",
    "label": "Is name setup skipped"
+  },
+  {
+   "default": "0",
+   "fieldname": "show_customer_portal_permission_notice",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Show Customer Portal Permission Notice"
   },
   {
    "fieldname": "column_break_hjfh",
@@ -524,7 +532,7 @@
  "grid_page_length": 50,
  "issingle": 1,
  "links": [],
- "modified": "2026-06-29 18:07:35.389430",
+ "modified": "2026-07-07 12:30:00.000000",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Settings",

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -271,14 +271,30 @@ class HDTicket(Document):
         if not self.is_new() and not self.has_value_changed("contact"):
             return
 
-        session_contact = frappe.db.get_value(
-            "Contact", {"user": frappe.session.user}
-        ) or frappe.db.get_value("Contact", {"email_id": frappe.session.user})
-        if self.contact != session_contact:
+        if self.contact != self.get_session_contact():
             frappe.throw(
                 _("You can only raise tickets for your own contact."),
                 frappe.PermissionError,
             )
+
+    def get_session_contact(self) -> str | None:
+        """Resolve the Contact owned by the current session user.
+
+        Match strictly on the ``user`` link. Fall back to the email only when
+        it is the session user's own verified email and the Contact is not
+        already linked to a different user, so an unrelated record that merely
+        shares the email can never satisfy the ownership check.
+        """
+        contact = frappe.db.get_value("Contact", {"user": frappe.session.user})
+        if contact:
+            return contact
+
+        user_email = frappe.db.get_value("User", frappe.session.user, "email")
+        if not user_email:
+            return None
+        return frappe.db.get_value(
+            "Contact", {"email_id": user_email, "user": ("in", ("", None))}
+        )
 
     def set_contact(self):
         email_id = parseaddr(self.raised_by)[1]

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -84,6 +84,7 @@ class HDTicket(Document):
         self.set_status_category()
         self.set_sla()
 
+        self.validate_portal_contact()
         self.set_contact()
         self.set_customer()
 
@@ -256,6 +257,28 @@ class HDTicket(Document):
         if self.raised_by:
             return
         self.raised_by = frappe.session.user
+
+    def validate_portal_contact(self) -> None:
+        """Block non-agent users from attributing a ticket to another contact.
+
+        Agents are unrestricted, and so are system channels like email intake,
+        which run as Administrator.
+        """
+        if is_agent():
+            return
+        if not self.contact:
+            return
+        if not self.is_new() and not self.has_value_changed("contact"):
+            return
+
+        session_contact = frappe.db.get_value(
+            "Contact", {"user": frappe.session.user}
+        ) or frappe.db.get_value("Contact", {"email_id": frappe.session.user})
+        if self.contact != session_contact:
+            frappe.throw(
+                _("You can only raise tickets for your own contact."),
+                frappe.PermissionError,
+            )
 
     def set_contact(self):
         email_id = parseaddr(self.raised_by)[1]

--- a/helpdesk/helpdesk/doctype/hd_ticket_template/api.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket_template/api.py
@@ -1,10 +1,11 @@
+import json
 from typing import Literal
 
 import frappe
 from pypika import JoinType
 
 from helpdesk.helpdesk.doctype.hd_form_script.hd_form_script import get_form_script
-from helpdesk.utils import check_permissions, get_customers
+from helpdesk.utils import check_permissions, get_customers, is_agent
 
 DOCTYPE_TEMPLATE = "HD Ticket Template"
 DOCTYPE_TEMPLATE_FIELD = "HD Ticket Template Field"
@@ -21,23 +22,8 @@ def get_one(name: str):
         return {"about": None, "fields": []}
 
     fields = get_fields_meta(name)
-    customers = get_customers()
-
-    auto_set_customer_from_contact = frappe.db.get_single_value(
-        "HD Settings", "auto_set_customer_from_contact"
-    )
-    has_customer_field = any(f.fieldname == "customer" for f in fields)
-    if auto_set_customer_from_contact and len(customers) > 1 and not has_customer_field:
-        fields.append(
-            frappe._dict(
-                fieldname="customer",
-                fieldtype="Select",
-                label="Customer",
-                options="\n".join(customers),
-                required=1,
-                idx=len(fields) + 1,
-            )
-        )
+    if frappe.db.get_single_value("HD Settings", "auto_set_customer_from_contact"):
+        set_customer_field(fields)
 
     return {
         "about": about,
@@ -47,6 +33,41 @@ def get_one(name: str):
             "HD Ticket", apply_on_new_page=True, is_customer_portal=False
         ),
     }
+
+
+def set_customer_field(fields: list) -> None:
+    """Scope the customer field to the session contact's own customers on the
+    customer portal.
+
+    Agents get the template's customer field untouched. Portal contacts get it
+    filtered to their customers; when the template has no customer field and the
+    contact belongs to multiple customers, a required field is injected so they
+    can pick one. Selection is enforced server side in HDTicket.set_customer.
+    """
+    if is_agent():
+        return
+
+    customers = get_customers()
+    link_filters = json.dumps([["HD Customer", "name", "in", list(customers)]])
+    customer_field = next((f for f in fields if f.fieldname == "customer"), None)
+
+    if customer_field:
+        customer_field.link_filters = link_filters
+        if len(customers) > 1:
+            customer_field.required = 1
+            customer_field.hide_from_customer = 0
+    elif len(customers) > 1:
+        fields.append(
+            frappe._dict(
+                fieldname="customer",
+                fieldtype="Link",
+                label="Customer",
+                options="HD Customer",
+                link_filters=link_filters,
+                required=1,
+                idx=len(fields) + 1,
+            )
+        )
 
 
 def get_fields_meta(template: str):

--- a/helpdesk/patches.txt
+++ b/helpdesk/patches.txt
@@ -46,3 +46,4 @@ helpdesk.patches.move_contact_dynamic_link_to_hd_customer
 helpdesk.patches.set_default_customer_type
 helpdesk.patches.add_user_invitation_perms
 helpdesk.patches.enable_auto_set_customer_from_contact
+helpdesk.patches.show_customer_portal_permission_notice

--- a/helpdesk/patches/show_customer_portal_permission_notice.py
+++ b/helpdesk/patches/show_customer_portal_permission_notice.py
@@ -1,0 +1,15 @@
+import frappe
+
+
+def execute():
+    """Enable the one-time customer portal permission change notice.
+
+    Only sites migrated by ``move_contact_dynamic_link_to_hd_customer`` are
+    affected: their contacts became plain customer members (not managers)
+    and lost visibility of their customer's other tickets. Fresh sites with
+    no such members never see the notice.
+    """
+    if frappe.db.exists("HD Customer Member", {"is_manager": 0}):
+        frappe.db.set_single_value(
+            "HD Settings", "show_customer_portal_permission_notice", 1
+        )

--- a/helpdesk/utils.py
+++ b/helpdesk/utils.py
@@ -193,6 +193,26 @@ def agent_only(fn):
     return wrapper
 
 
+def agent_manager_only(fn):
+    """Decorator to validate if user is an agent manager."""
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        # if not admin or system manager or agent manager, throw permission error, use python intersection to check if user has any of the roles
+        roles = set(frappe.get_roles())
+        access_roles = {"Administrator", "System Manager", "Agent Manager"}
+        if not roles.intersection(access_roles):
+            frappe.throw(
+                msg=_("You are not permitted to access this resource."),
+                title=_("Not Allowed"),
+                exc=frappe.PermissionError,
+            )
+
+        return fn(*args, **kwargs)
+
+    return wrapper
+
+
 def get_agents_team():
     Team = frappe.qb.DocType("HD Team")
     TeamMember = frappe.qb.DocType("HD Team Member")


### PR DESCRIPTION
Dialog to revert all the end users to access each other's tickets.

<img width="2938" height="1584" alt="image" src="https://github.com/user-attachments/assets/685992de-7a73-492b-987b-286d47e5bcfc" />

<img width="2936" height="1582" alt="image" src="https://github.com/user-attachments/assets/7c8e98e1-7d17-4ad1-851e-e67eac9b8281" />

Once an "Agent Manager" or "System Manager" confirms the action, the existing contacts (having users) will have the HD Customer Manager role reverting the older style of permissions


docs: [dismiss_notice](https://docs.frappe.io/helpdesk/customers-contacts#update-on-permissions)