### PR TITLE
fix: drop img src after setting embed so inline images render in emails

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -1202,10 +1202,12 @@ class HDTicket(Document):
         soup = BeautifulSoup(content, "html.parser")
 
         for tag in soup.find_all(["img", "video"]):
-            if tag.name == "img":
-                tag["embed"] = tag.get("src")
-            elif tag.name == "video":
-                tag["embed"] = tag.get("src")
+            src = tag.get("src")
+            # only site files can be embedded; external URLs must keep their src
+            if not src or not src.startswith(("/private/files/", "/files/")):
+                continue
+            tag["embed"] = src
+            del tag["src"]
 
         return str(soup)
 

--- a/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
@@ -732,6 +732,29 @@ class TestHDTicket(IntegrationTestCase):
             ticket2_doc.name,
         )
 
+    def test_parse_content_embeds_site_files_only(self):
+        """
+        Site file images must swap src for embed (so the framework inlines them
+        as cid attachments), while external and data URIs keep their src.
+        """
+        ticket = make_ticket()
+
+        parsed = ticket.parse_content('<img src="/private/files/shot.png">')
+        self.assertIn('embed="/private/files/shot.png"', parsed)
+        self.assertNotIn("src=", parsed)
+
+        parsed = ticket.parse_content('<img src="/files/public.png">')
+        self.assertIn('embed="/files/public.png"', parsed)
+        self.assertNotIn("src=", parsed)
+
+        external = '<img src="https://example.com/logo.png"/>'
+        self.assertEqual(ticket.parse_content(external), external)
+
+        data_uri = '<img src="data:image/png;base64,AAA"/>'
+        self.assertEqual(ticket.parse_content(data_uri), data_uri)
+
+        self.assertEqual(ticket.parse_content(""), "")
+
     def test_ticket_inside_working_hours(self):
         inside_working_hour = get_current_week_monday(hours=14)
         with self.freeze_time(inside_working_hour):


### PR DESCRIPTION
## Problem

Fixes #3421. Inline images in agent replies appear broken for some customers.

`parse_content` copies the img `src` into an `embed` attribute. At send time, Frappe replaces `embed="..."` with `src="cid:..."` but keeps the original `src`, which `scrub_urls` has absolutized into a login-gated URL. The email ships with two `src` attributes:

```html
<img src="cid:0TMFHjvb4a" height="317" src="https://site.com/private/files/x.png">
```

Which one wins is undefined. Clients that pick the cid render the image, clients that pick the private URL get a broken icon.

## Fix

Drop `src` after setting `embed` for `/files/` and `/private/files/` paths, so the final tag has only `src="cid:..."`. External URLs and data URIs keep their `src` untouched, since Frappe strips unresolvable embeds and the image would vanish.
