### PR TITLE
fix(search): avoid SQLite variable limit in filter facets

### DIFF
--- a/helpdesk/search_sqlite.py
+++ b/helpdesk/search_sqlite.py
@@ -131,8 +131,16 @@ class HelpdeskSearch(SQLiteSearch):
                 "doctypes": {},
             }
 
-        # Query the search index for available options
+        accessible_tickets_json = frappe.as_json(
+            accessible_tickets, indent=None, separators=(",", ":")
+        )
+
+        # Query the search index for available options. Binding the accessible
+        # tickets as one JSON value avoids SQLite's statement-wide variable limit.
         sql = """
+			WITH accessible_tickets(ticket) AS (
+				SELECT value FROM json_each(?)
+			)
 			SELECT
 				agent_group,
 				status,
@@ -141,14 +149,15 @@ class HelpdeskSearch(SQLiteSearch):
 				doctype,
 				COUNT(*) as count
 			FROM search_fts
-			WHERE (name IN ({placeholders}) OR reference_name IN ({placeholders}) OR reference_ticket IN ({placeholders}))
+			WHERE (
+				name IN (SELECT ticket FROM accessible_tickets)
+				OR reference_name IN (SELECT ticket FROM accessible_tickets)
+				OR reference_ticket IN (SELECT ticket FROM accessible_tickets)
+			)
 			GROUP BY agent_group, status, priority, customer, doctype
-		""".format(
-            placeholders=",".join(["?" for _ in accessible_tickets])
-        )
+		"""
 
-        params = accessible_tickets * 3
-        results = self.sql(sql, params, read_only=True)
+        results = self.sql(sql, (accessible_tickets_json,), read_only=True)
 
         # Aggregate the results
         teams = {}

--- a/helpdesk/test_search_sqlite.py
+++ b/helpdesk/test_search_sqlite.py
@@ -1,0 +1,171 @@
+import sqlite3
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from helpdesk.search_sqlite import HelpdeskSearch
+
+EMPTY_FILTER_OPTIONS = {
+    "teams": {},
+    "statuses": {},
+    "priorities": {},
+    "customers": {},
+    "doctypes": {},
+}
+
+
+class TestHelpdeskSearch(FrappeTestCase):
+    def setUp(self):
+        self.search = HelpdeskSearch(
+            db_name=f"test_helpdesk_search_{frappe.generate_hash(length=8)}.db"
+        )
+        self.search.drop_index()
+        self.search._ensure_fts_table()
+        self.addCleanup(self.search.drop_index)
+
+    def index_documents(self, *documents):
+        self.search._index_documents(
+            [
+                {
+                    "title": "",
+                    "content": "searchable content",
+                    **document,
+                }
+                for document in documents
+            ]
+        )
+
+    def test_filter_options_supports_access_lists_over_variable_limit(self):
+        accessible_ticket = "HD-TICKET-ACCESSIBLE"
+        inaccessible_ticket = "HD-TICKET-INACCESSIBLE"
+        self.index_documents(
+            {
+                "doctype": "HD Ticket",
+                "name": accessible_ticket,
+                "title": "Accessible ticket",
+                "reference_ticket": accessible_ticket,
+                "agent_group": "Support",
+                "status": "Open",
+                "priority": "High",
+                "customer": "Acme",
+            },
+            {
+                "doctype": "HD Ticket Comment",
+                "name": "HD-COMMENT-ACCESSIBLE",
+                "reference_ticket": accessible_ticket,
+            },
+            {
+                "doctype": "Communication",
+                "name": "HD-COMMUNICATION-ACCESSIBLE",
+                "reference_doctype": "HD Ticket",
+                "reference_name": accessible_ticket,
+            },
+            {
+                "doctype": "HD Ticket",
+                "name": inaccessible_ticket,
+                "title": "Inaccessible ticket",
+                "reference_ticket": inaccessible_ticket,
+                "agent_group": "Restricted",
+                "status": "Closed",
+                "priority": "Low",
+                "customer": "Private",
+            },
+        )
+        accessible_tickets = [
+            accessible_ticket,
+            "value') OR 1=1 --",
+            "日本語-value",
+            *(f"HD-TICKET-MISSING-{index}" for index in range(331)),
+        ]
+        get_connection = self.search._get_connection
+
+        def get_limited_connection(read_only=False):
+            connection = get_connection(read_only)
+            connection.setlimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, 999)
+            return connection
+
+        with (
+            patch.object(
+                self.search,
+                "_get_accessible_tickets",
+                return_value=accessible_tickets,
+            ),
+            patch.object(
+                self.search,
+                "_get_connection",
+                side_effect=get_limited_connection,
+            ),
+        ):
+            options = self.search.get_filter_options()
+
+        self.assertEqual(
+            options,
+            {
+                "teams": {"Support": 1},
+                "statuses": {"Open": 1},
+                "priorities": {"High": 1},
+                "customers": {"Acme": 1},
+                "doctypes": {
+                    "HD Ticket": 1,
+                    "HD Ticket Comment": 1,
+                    "Communication": 1,
+                },
+            },
+        )
+
+    def test_filter_options_handles_duplicate_and_special_ticket_names(self):
+        ticket = "HD-TÍCKET-'quoted' 日本語"
+        self.index_documents(
+            {
+                "doctype": "HD Ticket",
+                "name": ticket,
+                "title": "International ticket",
+                "reference_ticket": ticket,
+                "agent_group": "International",
+                "status": "Open",
+                "priority": "Medium",
+                "customer": "Globál",
+            }
+        )
+
+        with patch.object(
+            self.search,
+            "_get_accessible_tickets",
+            return_value=[ticket, ticket],
+        ):
+            options = self.search.get_filter_options()
+
+        self.assertEqual(options["teams"], {"International": 1})
+        self.assertEqual(options["customers"], {"Globál": 1})
+        self.assertEqual(options["doctypes"], {"HD Ticket": 1})
+
+    def test_filter_options_binds_accessible_tickets_once(self):
+        accessible_tickets = [f"HD-TICKET-{index}" for index in range(10_000)]
+
+        with (
+            patch.object(
+                self.search,
+                "_get_accessible_tickets",
+                return_value=accessible_tickets,
+            ),
+            patch.object(self.search, "index_exists", return_value=True),
+            patch.object(self.search, "sql", return_value=[]) as sql,
+        ):
+            self.search.get_filter_options()
+
+        query, params = sql.call_args.args[:2]
+        self.assertEqual(query.count("?"), 1)
+        self.assertEqual(len(params), 1)
+        self.assertEqual(frappe.parse_json(params[0]), accessible_tickets)
+
+    def test_filter_options_returns_empty_without_index_or_access(self):
+        missing_search = HelpdeskSearch(
+            db_name=f"test_helpdesk_missing_{frappe.generate_hash(length=8)}.db"
+        )
+        missing_search.drop_index()
+        self.addCleanup(missing_search.drop_index)
+        self.assertEqual(missing_search.get_filter_options(), EMPTY_FILTER_OPTIONS)
+
+        with patch.object(self.search, "_get_accessible_tickets", return_value=[]):
+            self.assertEqual(self.search.get_filter_options(), EMPTY_FILTER_OPTIONS)

--- a/helpdesk/test_search_sqlite.py
+++ b/helpdesk/test_search_sqlite.py
@@ -158,6 +158,7 @@ class TestHelpdeskSearch(FrappeTestCase):
         self.assertEqual(query.count("?"), 1)
         self.assertEqual(len(params), 1)
         self.assertEqual(frappe.parse_json(params[0]), accessible_tickets)
+        self.assertEqual(sql.call_args.kwargs, {"read_only": True})
 
     def test_filter_options_returns_empty_without_index_or_access(self):
         missing_search = HelpdeskSearch(


### PR DESCRIPTION
## What this fixes

Helpdesk's SQLite facet query repeated the accessible ticket list in three `IN (...)` clauses (`name`, `reference_name`, and `reference_ticket`). For `N` accessible tickets, that generated `3N` host parameters. A 334-ticket access list therefore produced 1,002 binds and failed when SQLite's variable limit was 999.

This change serializes the access list once, expands it with `json_each(?)` in an `accessible_tickets(ticket)` CTE, and keeps the three access checks as subqueries against that CTE. The query now uses one bound parameter, retains the existing facet semantics, and remains `read_only=True`.

Fixes #3250

## Bug and fix evidence

### Bug — unchanged query

With 334 accessible ticket IDs and SQLite limited to 999 variables, the facet request fails with `sqlite3.OperationalError: too many SQL variables`.

<img width="601" height="1087" alt="Bug: Helpdesk facet request fails with too many SQL variables" src="https://github.com/user-attachments/assets/6155b753-c7b8-438f-ac6f-cea79fbc49e5" />

### Fix — same boundary

After the change, the authenticated Helpdesk search page loads its Status facets under the same forced limit.

<img width="601" height="1087" alt="Fix: Helpdesk Status facets load at the same SQLite boundary" src="https://github.com/user-attachments/assets/fd295eb1-eaa3-4b1e-ad76-d2eaf48499e0" />

The fixed live request returned HTTP 200 with:

```json
{"teams": {}, "statuses": {"Open": 334}, "priorities": {"Medium": 334}, "customers": {}, "doctypes": {"HD Ticket": 334}}
```

Both captures used the same 334 controlled Open tickets and the same forced limit. The temporary tickets and forced-limit instrumentation were removed after capture and are not included in this branch.

## Verification

| Check | Result |
|---|---|
| Focused SQLite search regression suite | 4/4 passed |
| Full Helpdesk suite | 248/248 passed (134 integration + 114 old-Frappe category) |
| Mutation/red proof | Old query fails at 334 IDs / limit 999 with `too many SQL variables` |
| 10,000-ID scale assertion | One bind; `read_only=True` |
| Targeted pre-commit | Black, strict flake8, and isort passed |
| `bench setup requirements` | Passed |
| `bench build` | Passed, including Helpdesk assets |
| `bench --site high-reach.localhost migrate` | Passed |
| Authenticated facet API and search UI | HTTP 200; Status facets rendered |

The regression coverage includes:

- exact Ticket, Comment, and Communication facets at the 334-ID boundary;
- inaccessible results excluded from every facet;
- duplicate IDs, Unicode, and quoted names;
- empty access lists and a missing search index;
- no double count when a result matches more than one reference column;
- 10,000 IDs with one bind and read-only execution.

## Query-size and timing check

Representative local timings for the exact queries against 15,000 indexed rows:

| Accessible IDs | Previous query | JSON/CTE query |
|---:|---:|---:|
| 1,000 | 13.28 ms | 13.98 ms |
| 10,000 | 33.47 ms | 29.16 ms |
| 50,000 | 54.83 ms | 46.89 ms |

At 50,000 IDs, the SQL statement and bind count drop from 300,205 characters / 150,000 binds to 387 characters / 1 bind. The JSON payload itself remains linear in the number of accessible tickets.

## Scope

This PR fixes Helpdesk's SQLite facet-filter path only. [`frappe/frappe#38939`](https://github.com/frappe/frappe/issues/38939) tracks the separate Frappe core search path; this PR does not claim to fix that companion issue.

@RitvikSardana, could you please review this and, if appropriate, assign #3250 to @Dkm0315?
