### PR TITLE
fix: ticket SLA policy application

### DIFF
--- a/desk/src/components/Settings/Sla/SlaPolicyView.vue
+++ b/desk/src/components/Settings/Sla/SlaPolicyView.vue
@@ -481,9 +481,9 @@ const toggleEnabled = () => {
   slaData.value.enabled = !slaData.value.enabled;
 };
 
-const toggleDefaultSla = () => {
-  slaData.value.default_sla = !slaData.value.default_sla;
-  if (slaData.value.default_sla) {
+const toggleDefaultSla = (value: boolean) => {
+  slaData.value.default_sla = value;
+  if (value) {
     slaData.value.enabled = true;
   }
 };

--- a/helpdesk/helpdesk/doctype/hd_service_level_agreement/test_hd_service_level_agreement.py
+++ b/helpdesk/helpdesk/doctype/hd_service_level_agreement/test_hd_service_level_agreement.py
@@ -24,3 +24,50 @@ class TestHDServiceLevelAgreement(IntegrationTestCase):
     def test_default_sla_assignment(self):
         ticket = make_ticket(priority="Low")
         self.assertEqual(ticket.sla, SLA_PRIORITY_NAME)
+
+    def test_blank_condition_sla_is_not_a_false_positive(self):
+        # An enabled, non-default SLA with a blank ("" or NULL) condition
+        # must not match tickets; only the default SLA is a catch-all
+        empty = make_sla("Empty Condition SLA")
+        null = make_sla("Null Condition SLA")
+        frappe.db.set_value("HD Service Level Agreement", null.name, "condition", None)
+        for sla in (empty, null):
+            self.addCleanup(
+                frappe.db.set_value,
+                "HD Service Level Agreement",
+                sla.name,
+                "enabled",
+                0,
+            )
+
+        # Medium matches no conditional SLA, so the default SLA must win
+        ticket = make_ticket(priority="Medium")
+        self.assertEqual(ticket.sla, "Default")
+
+    def test_demoted_default_sla_is_not_catch_all(self):
+        # Promoting another SLA as default demotes the seeded "Default" SLA,
+        # which stays enabled with a blank condition. It must not keep
+        # matching every ticket ahead of the new default.
+        new_default = make_sla("New Default SLA").reload()
+        new_default.default_sla = 1
+        new_default.save()
+
+        def restore():
+            default = frappe.get_doc("HD Service Level Agreement", "Default")
+            default.default_sla = 1
+            default.save()
+            frappe.db.set_value(
+                "HD Service Level Agreement", new_default.name, "enabled", 0
+            )
+
+        self.addCleanup(restore)
+
+        # premise: saving the new default actually demoted "Default"
+        self.assertEqual(
+            frappe.db.get_value("HD Service Level Agreement", "Default", "default_sla"),
+            0,
+        )
+
+        # Medium matches no conditional SLA, so the new default must win
+        ticket = make_ticket(priority="Medium")
+        self.assertEqual(ticket.sla, new_default.name)

--- a/helpdesk/helpdesk/doctype/hd_service_level_agreement/utils.py
+++ b/helpdesk/helpdesk/doctype/hd_service_level_agreement/utils.py
@@ -25,6 +25,9 @@ def get_sla(ticket: Document) -> Document:
         .select(QBSla.name, QBSla.condition)
         .where(QBSla.enabled == True)
         .where(QBSla.default_sla == False)
+        # A blank condition should not appear as a false positive
+        .where(QBSla.condition.notnull())
+        .where(QBSla.condition != "")
         .where(Criterion.any([QBSla.start_date.isnull(), QBSla.start_date <= now]))
         .where(Criterion.any([QBSla.end_date.isnull(), QBSla.end_date >= now]))
     )
@@ -37,8 +40,7 @@ def get_sla(ticket: Document) -> Document:
     sla_list = q.run(as_dict=True)
     res = None
     for sla in sla_list:
-        cond = sla.get("condition")
-        if not cond or frappe.safe_eval(cond, None, get_context(ticket)):
+        if frappe.safe_eval(sla.get("condition"), None, get_context(ticket)):
             res = sla
             break
     return res or get_default()


### PR DESCRIPTION
## Summary
- An enabled, non-default SLA with a blank `condition` was matching every ticket ahead of the actual default SLA, because a blank condition short-circuited to "always match" in `get_sla()`'s loop.
- Most visible when the seeded "Default" SLA is demoted (a different SLA gets `default_sla` checked) but keeps its blank condition — it then silently wins for every ticket regardless of which SLA is actually flagged as default.
- Fix: exclude SLAs with a blank/null condition from the conditional-match query, so `default_sla` is the only legitimate catch-all.

## Test plan
- [x] Create SLA "Default" with `default_sla=1`, no condition (matches install fixture)
- [x] Flag a second SLA as default (`default_sla=1`); confirm "Default" is demoted and its condition remains blank
- [x] Create a ticket and confirm it resolves to the newly-flagged default SLA, not "Default"
- [x] Existing `test_hd_service_level_agreement.py` / `test_hd_ticket.py` SLA tests still pass