### PR TITLE
chore: raise upper bound limit for Frappe dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requires = ["flit_core >=3.4,<4"]
 build-backend = "flit_core.buildapi"
 
 [tool.bench.frappe-dependencies]
-frappe = ">=16.0.0-dev,<=17.0.0-dev"
+frappe = ">=16.0.0-dev,<18.0.0"
 telephony = ">=0.0.1,<1.0.0"
 
 [tool.bench.assets]


### PR DESCRIPTION
## Summary
- Raise the allowed Frappe version upper bound from `<=17.0.0-dev` to `<18.0.0` in `pyproject.toml`.

## Test plan
- [x] N/A (dependency constraint change only)