### PR TITLE
fix(session): exclude Website Users from get_users payload (#3335)

### DIFF
--- a/helpdesk/api/session.py
+++ b/helpdesk/api/session.py
@@ -26,10 +26,13 @@ def get_users():
         if priority.get(row.role, 0) > priority.get(roles_map.get(row.parent), 0):
             roles_map[row.parent] = row.role
 
-    # Fetch all active users
+    # Fetch active desk users (agents + system users). Website Users, i.e.
+    # customer contacts, are intentionally excluded: this endpoint only powers
+    # agent/name/avatar lookups in the desk, and on contact-heavy sites the
+    # unfiltered query returned the entire (potentially 100k+ row) User table.
     users = frappe.db.get_all(
         "User",
-        filters={"enabled": 1},
+        filters={"enabled": 1, "user_type": "System User"},
         fields=["name", "email", "enabled", "user_image", "full_name", "user_type"],
         order_by="full_name asc",
     )


### PR DESCRIPTION
## Summary

`helpdesk.api.session.get_users` powers agent/name/avatar lookups in the desk (it feeds the `usersByName` map in `desk/src/stores/user.ts`, fetched on the boot path via the router's `afterEach` guard). Its `User` query filtered only on `enabled = 1`:

```python
users = frappe.db.get_all(
    "User",
    filters={"enabled": 1},
    fields=[...],
    order_by="full_name asc",
)
```

So it returned **every enabled Website User (customer contact)** alongside agents. On a contact-heavy site that is a payload that grows with the number of customers — the 100k-contact case in #3335 — pulled on initial load to resolve a handful of on-screen avatars.

This restricts the query to **System Users**:

```python
filters={"enabled": 1, "user_type": "System User"},
```

Fixes #3335.

## Why this is the right cut

- Agents receive the `Agent` role (`HDAgent.set_user_roles`), which grants desk access — so agents are System Users and are retained. Customer contacts are Website Users and are dropped. The desk itself already draws this exact line: `helpdesk/auth.py` gates access on `user_type == "System User"`.
- No frontend breakage for dropped contacts: `useUserStore.getUser(email)` already synthesises a `{name, email, full_name, user_image, role}` fallback from the email for any user **absent** from the payload, so contacts still render (name derived from email, no avatar) — the same degradation the store already relies on today.

## Note on #3335's earlier closure

#3335 was closed by #3393, but that PR only optimised the **role-fetching** subqueries (one `Has Role` query instead of N). The `User` query itself was left unchanged, so the reported payload bloat — pulling all Website Users — is still present on `develop`. This PR addresses that remaining half.

## Follow-ups (out of scope here, happy to do separately)

- Trim redundant fields: `enabled` is always `1` (it's the filter). `email` duplicates `name` for the `User` doctype, but the store's `formatFullName(user.email)` fallback currently reads it, so dropping it needs a small frontend touch — left out to keep this change safe and self-contained.
- Point `EmailMultiSelect.vue` (scope `"agents"`) at the existing `useAgentStore` rather than the full users list.

## Verification

I don't have a bench site to run the integration suite against, so this is verified by inspection: the change is a single `filters` addition on a whitelisted read, and the frontend fallback path is unchanged. Happy to add a targeted test for `get_users` if you'd like one.
