### PR TITLE
fix(search): skip ticket IN-list for unrestricted users; fixes silent search failure (#3250)

### DIFF
--- a/helpdesk/search_sqlite.py
+++ b/helpdesk/search_sqlite.py
@@ -66,8 +66,25 @@ class HelpdeskSearch(SQLiteSearch):
 
     def get_search_filters(self):
         """Return permission filters based on accessible tickets."""
-        accessible_tickets = self._get_accessible_tickets()
-        return {"reference_ticket": accessible_tickets}
+        if self._has_unrestricted_ticket_access():
+            # No ticket-level restriction applies (see permission_query): every
+            # ticket is visible, so skip building a reference_ticket IN (...)
+            # list. For such users that list is the entire ticket table, which
+            # can exceed SQLite's variable limit and make search() fail (it
+            # swallows the OperationalError and silently returns no results).
+            return {}
+        return {"reference_ticket": self._get_accessible_tickets()}
+
+    def _has_unrestricted_ticket_access(self):
+        """Whether the current user can see every ticket.
+
+        ``permission_query`` returns ``None`` (no WHERE fragment) for admins,
+        and for agents when ``restrict_tickets_by_agent_group`` is disabled --
+        i.e. when there is no ticket-level restriction to express.
+        """
+        from helpdesk.helpdesk.doctype.hd_ticket.hd_ticket import permission_query
+
+        return permission_query(frappe.session.user) is None
 
     def _get_accessible_tickets(self):
         """Get tickets accessible to current user based on helpdesk permissions."""
@@ -120,16 +137,29 @@ class HelpdeskSearch(SQLiteSearch):
                 "doctypes": {},
             }
 
-        # Get accessible tickets first
-        accessible_tickets = self._get_accessible_tickets()
-        if not accessible_tickets:
-            return {
-                "teams": {},
-                "statuses": {},
-                "priorities": {},
-                "customers": {},
-                "doctypes": {},
-            }
+        # Restrict facet counts to accessible tickets. Users with unrestricted
+        # access can see every ticket, so count the whole index instead of
+        # binding the entire ticket table into an IN (...) clause (which grows
+        # to 3N host parameters here and can exceed SQLite's variable limit).
+        if self._has_unrestricted_ticket_access():
+            where_clause = ""
+            params = []
+        else:
+            accessible_tickets = self._get_accessible_tickets()
+            if not accessible_tickets:
+                return {
+                    "teams": {},
+                    "statuses": {},
+                    "priorities": {},
+                    "customers": {},
+                    "doctypes": {},
+                }
+            placeholders = ",".join(["?" for _ in accessible_tickets])
+            where_clause = (
+                "WHERE (name IN ({p}) OR reference_name IN ({p}) "
+                "OR reference_ticket IN ({p}))".format(p=placeholders)
+            )
+            params = accessible_tickets * 3
 
         # Query the search index for available options
         sql = """
@@ -141,13 +171,12 @@ class HelpdeskSearch(SQLiteSearch):
 				doctype,
 				COUNT(*) as count
 			FROM search_fts
-			WHERE (name IN ({placeholders}) OR reference_name IN ({placeholders}) OR reference_ticket IN ({placeholders}))
+			{where_clause}
 			GROUP BY agent_group, status, priority, customer, doctype
 		""".format(
-            placeholders=",".join(["?" for _ in accessible_tickets])
+            where_clause=where_clause
         )
 
-        params = accessible_tickets * 3
         results = self.sql(sql, params, read_only=True)
 
         # Aggregate the results


### PR DESCRIPTION
## Summary

Complements #3546. That PR hardens the **restricted-user** facet path (the `3N`-parameter `IN (...)` in `get_filter_options`) with a `json_each` CTE. This PR attacks the same root cause from the other side: **users who have no ticket-level restriction at all shouldn't build a ticket `IN (...)` list in the first place.**

`HelpdeskSearch` materialised every accessible ticket name into a `reference_ticket` filter for *all* users:

```python
def get_search_filters(self):
    accessible_tickets = self._get_accessible_tickets()   # frappe.get_list("HD Ticket", pluck="name") — unbounded
    return {"reference_ticket": accessible_tickets}
```

But for **admins**, and for **agents when `restrict_tickets_by_agent_group` is off** (the default), `hd_ticket.permission_query()` returns `None` — i.e. *no restriction, every ticket is visible*. For those users the "accessible tickets" list is the entire ticket table, and expressing "no constraint" as a giant `IN (...)` is both wasteful and fragile.

## Two failure modes on large sites, one root cause

- **`get_filter_options()` — loud crash.** The `WHERE` repeats the list three times (`name`, `reference_name`, `reference_ticket`), binding `3N` host parameters. Once `3N` exceeds SQLite's `SQLITE_MAX_VARIABLE_NUMBER` (32,766 on SQLite ≥ 3.32; 999 on older builds), it raises `sqlite3.OperationalError: too many SQL variables`, surfaced raw to `helpdesk.api.search.get_filter_options`. This is the crash reported in #3250.
- **`search()` — silent empty results.** `get_search_filters()` returns the same list as `{"reference_ticket": [...]}`; the base `SQLiteSearch.search()` expands it to `reference_ticket IN (?,?,…)`. It hits the same variable limit, but the framework wraps the query in `except sqlite3.Error` (`frappe/search/sqlite_search.py`), logs to the error log, and returns **zero results**. So on a large site an admin's search silently returns nothing, with no user-facing error. This half isn't in the original report and is arguably the worse bug.

## Fix

Add `_has_unrestricted_ticket_access()` (`permission_query(session_user) is None`) and early-out:

- `get_search_filters()` returns `{}` — no permission filter is merged, so `search()` runs unconstrained and actually returns results. Correct: these users can see everything.
- `get_filter_options()` drops the `WHERE` clause and counts the whole index — one query, zero ticket binds.

This removes the ticket `IN (...)` for the common case and fixes both the crash and the silent search failure for unrestricted users.

## Scope / relationship to #3546

I deliberately left the **restricted-user** facet path (the `3N` bind) untouched — that's exactly what #3546 fixes with `json_each`. The two changes compose: #3546 makes the restricted path cheap; this makes the unrestricted path free. Glad to rebase on top of #3546 once it lands if you'd prefer to sequence them.

## Also worth a look (separate issue, not in this PR)

`prepare_document` sets `reference_name` for `Communication` docs but never `reference_ticket`, while `get_search_filters` filters on `reference_ticket`. Email replies may be dropped from restricted-user search results. I'll file this separately rather than scope-creep here.

## Verification

I don't have a bench site to run the full suite against, so this is verified by inspection against the base classes: `SQLiteSearch.search()` merges `permission_filters` via `{**filters, **permission_filters}`, so `{}` correctly means "no constraint"; and the `get_filter_options` SQL is unchanged for restricted users (same binds), only conditionally skipped for unrestricted ones. Happy to add tests alongside #3546's `test_search_sqlite.py` if useful.
