### PR TITLE
fix: reuse existing contact as customer primary contact & accurate ticket counts

### DIFF
--- a/desk/src/components/customer/NewCustomerDialog.vue
+++ b/desk/src/components/customer/NewCustomerDialog.vue
@@ -63,6 +63,22 @@
           <h3 class="text-base-medium text-ink-gray-8">
             {{ __("Primary Contact") }}
           </h3>
+          <div class="grid grid-cols-2 gap-4">
+            <FormControl
+              class="[&_p]:text-p-xs"
+              type="text"
+              :label="__('First Name')"
+              placeholder="John"
+              v-model="primaryContact.firstName"
+            />
+            <FormControl
+              class="[&_p]:text-p-xs"
+              type="text"
+              :label="__('Last Name')"
+              placeholder="Doe"
+              v-model="primaryContact.lastName"
+            />
+          </div>
           <FormControl
             class="[&_p]:text-p-xs"
             type="email"
@@ -74,83 +90,10 @@
               <LucideMail class="size-4" />
             </template>
           </FormControl>
-          <div
-            class="overflow-hidden transition-[height] duration-200 ease-in-out"
-            :style="{ height: contactSwapHeight }"
-          >
-            <div ref="contactSwapEl" class="flex flex-col gap-3">
-              <div
-                v-if="existingContact"
-                class="flex items-center gap-3 rounded-lg border border-outline-gray-2 p-3"
-              >
-                <Avatar
-                  size="xl"
-                  shape="circle"
-                  :label="existingContactName"
-                  :image="existingContact.image"
-                />
-                <div class="flex min-w-0 flex-col gap-0.5">
-                  <span class="truncate text-p-sm text-ink-gray-8">
-                    {{ existingContactName }}
-                  </span>
-                  <span class="truncate text-p-xs text-ink-gray-5">
-                    {{ existingContactDetail }}
-                  </span>
-                </div>
-                <div class="ml-auto flex shrink-0 items-center gap-1">
-                  <Button
-                    variant="ghost"
-                    :aria-label="__('Open contact in new tab')"
-                    @click="openContact"
-                  >
-                    <template #icon>
-                      <LucideExternalLink class="size-4" />
-                    </template>
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    :aria-label="__('Dismiss')"
-                    @click="dismissExistingContact"
-                  >
-                    <template #icon>
-                      <LucideX class="size-4" />
-                    </template>
-                  </Button>
-                </div>
-              </div>
-              <template v-else>
-                <div class="grid grid-cols-2 gap-4">
-                  <FormControl
-                    class="[&_p]:text-p-xs"
-                    type="text"
-                    :label="__('First Name')"
-                    placeholder="John"
-                    v-model="primaryContact.firstName"
-                  />
-                  <FormControl
-                    class="[&_p]:text-p-xs"
-                    type="text"
-                    :label="__('Last Name')"
-                    placeholder="Doe"
-                    v-model="primaryContact.lastName"
-                  />
-                </div>
-                <PhoneControl
-                  :label="__('Mobile Number')"
-                  v-model="primaryContact.mobileNo"
-                />
-                <div
-                  v-if="primaryContact.email"
-                  class="flex items-center gap-2 text-p-xs text-ink-gray-5"
-                >
-                  <LucideInfo class="size-3.5 shrink-0" />
-                  <span>{{
-                    __("An invitation will be sent to this email")
-                  }}</span>
-                </div>
-              </template>
-            </div>
-          </div>
+          <PhoneControl
+            :label="__('Mobile Number')"
+            v-model="primaryContact.mobileNo"
+          />
         </div>
       </div>
     </template>
@@ -178,63 +121,18 @@ import {
 import { __ } from "@/translation";
 import type { Resource } from "@/types";
 import { getErrorMessage, validateEmailWithZod } from "@/utils";
-import { useElementSize } from "@vueuse/core";
-import {
-  Avatar,
-  Button,
-  Dialog,
-  FormControl,
-  createResource,
-  toast,
-} from "frappe-ui";
-import { computed, ref } from "vue";
+import { Button, Dialog, FormControl, createResource, toast } from "frappe-ui";
 import { useRouter } from "vue-router";
-import LucideExternalLink from "~icons/lucide/external-link";
 import LucideGlobe from "~icons/lucide/globe";
-import LucideInfo from "~icons/lucide/info";
 import LucideMail from "~icons/lucide/mail";
 import LucideMapPin from "~icons/lucide/map-pin";
-import LucideX from "~icons/lucide/x";
 import Link from "../frappe-ui/Link.vue";
 import PhoneControl from "../frappe-ui/PhoneControl/PhoneControl.vue";
 
 const model = defineModel<boolean>({ default: false });
 const router = useRouter();
 
-const {
-  state,
-  primaryContact,
-  existingContact,
-  existingContactName,
-  dismissExistingContact,
-  reset,
-} = useNewCustomerForm();
-
-const contactSwapEl = ref<HTMLElement | null>(null);
-const { height: contactSwapContentHeight } = useElementSize(contactSwapEl);
-const contactSwapHeight = computed(() =>
-  contactSwapContentHeight.value
-    ? `${contactSwapContentHeight.value}px`
-    : "auto"
-);
-
-const existingContactDetail = computed(() => {
-  const contact = existingContact.value;
-  const mobile = contact?.mobile_no || contact?.phone;
-  const note = contact?.user
-    ? __("Will be added as the primary contact")
-    : __("Will be set as primary · an invitation will be sent");
-  return mobile ? `${mobile} · ${note}` : note;
-});
-
-function openContact() {
-  if (!existingContact.value) return;
-  const route = router.resolve({
-    name: "Contact",
-    params: { id: existingContact.value.name },
-  });
-  window.open(route.href, "_blank");
-}
+const { state, primaryContact, reset } = useNewCustomerForm();
 
 const customerResource: Resource = createResource({
   url: "helpdesk.api.customer.create_customer",
@@ -268,23 +166,18 @@ function addCustomer() {
       image: state.image,
       country: state.country,
     },
-    primary_contact: buildPrimaryContactPayload(),
+    primary_contact: hasPrimaryContactData()
+      ? {
+          first_name: primaryContact.firstName,
+          last_name: primaryContact.lastName,
+          email: primaryContact.email,
+          mobile_no: primaryContact.mobileNo,
+        }
+      : null,
   });
 }
 
-function buildPrimaryContactPayload(): Record<string, string> | null {
-  if (existingContact.value) return { email: primaryContact.email };
-  if (!hasPrimaryContactData()) return null;
-  return {
-    first_name: primaryContact.firstName,
-    last_name: primaryContact.lastName,
-    email: primaryContact.email,
-    mobile_no: primaryContact.mobileNo,
-  };
-}
-
 function validatePrimaryContact(): boolean {
-  if (existingContact.value) return true;
   if (!hasPrimaryContactData()) return true;
   if (!primaryContact.firstName) {
     toast.error(__("Enter the primary contact's first name"));

--- a/desk/src/components/customer/NewCustomerDialog.vue
+++ b/desk/src/components/customer/NewCustomerDialog.vue
@@ -63,22 +63,6 @@
           <h3 class="text-base-medium text-ink-gray-8">
             {{ __("Primary Contact") }}
           </h3>
-          <div class="grid grid-cols-2 gap-4">
-            <FormControl
-              class="[&_p]:text-p-xs"
-              type="text"
-              :label="__('First Name')"
-              placeholder="John"
-              v-model="primaryContact.firstName"
-            />
-            <FormControl
-              class="[&_p]:text-p-xs"
-              type="text"
-              :label="__('Last Name')"
-              placeholder="Doe"
-              v-model="primaryContact.lastName"
-            />
-          </div>
           <FormControl
             class="[&_p]:text-p-xs"
             type="email"
@@ -90,10 +74,83 @@
               <LucideMail class="size-4" />
             </template>
           </FormControl>
-          <PhoneControl
-            :label="__('Mobile Number')"
-            v-model="primaryContact.mobileNo"
-          />
+          <div
+            class="overflow-hidden transition-[height] duration-200 ease-in-out"
+            :style="{ height: contactSwapHeight }"
+          >
+            <div ref="contactSwapEl" class="flex flex-col gap-3">
+              <div
+                v-if="existingContact"
+                class="flex items-center gap-3 rounded-lg border border-outline-gray-2 p-3"
+              >
+                <Avatar
+                  size="xl"
+                  shape="circle"
+                  :label="existingContactName"
+                  :image="existingContact.image"
+                />
+                <div class="flex min-w-0 flex-col gap-0.5">
+                  <span class="truncate text-p-sm text-ink-gray-8">
+                    {{ existingContactName }}
+                  </span>
+                  <span class="truncate text-p-xs text-ink-gray-5">
+                    {{ existingContactDetail }}
+                  </span>
+                </div>
+                <div class="ml-auto flex shrink-0 items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    :aria-label="__('Open contact in new tab')"
+                    @click="openContact"
+                  >
+                    <template #icon>
+                      <LucideExternalLink class="size-4" />
+                    </template>
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    :aria-label="__('Dismiss')"
+                    @click="dismissExistingContact"
+                  >
+                    <template #icon>
+                      <LucideX class="size-4" />
+                    </template>
+                  </Button>
+                </div>
+              </div>
+              <template v-else>
+                <div class="grid grid-cols-2 gap-4">
+                  <FormControl
+                    class="[&_p]:text-p-xs"
+                    type="text"
+                    :label="__('First Name')"
+                    placeholder="John"
+                    v-model="primaryContact.firstName"
+                  />
+                  <FormControl
+                    class="[&_p]:text-p-xs"
+                    type="text"
+                    :label="__('Last Name')"
+                    placeholder="Doe"
+                    v-model="primaryContact.lastName"
+                  />
+                </div>
+                <PhoneControl
+                  :label="__('Mobile Number')"
+                  v-model="primaryContact.mobileNo"
+                />
+                <div
+                  v-if="primaryContact.email"
+                  class="flex items-center gap-2 text-p-xs text-ink-gray-5"
+                >
+                  <LucideInfo class="size-3.5 shrink-0" />
+                  <span>{{
+                    __("An invitation will be sent to this email")
+                  }}</span>
+                </div>
+              </template>
+            </div>
+          </div>
         </div>
       </div>
     </template>
@@ -121,25 +178,75 @@ import {
 import { __ } from "@/translation";
 import type { Resource } from "@/types";
 import { getErrorMessage, validateEmailWithZod } from "@/utils";
-import { Button, Dialog, FormControl, createResource, toast } from "frappe-ui";
+import { useElementSize } from "@vueuse/core";
+import {
+  Avatar,
+  Button,
+  Dialog,
+  FormControl,
+  createResource,
+  toast,
+} from "frappe-ui";
+import { computed, ref } from "vue";
 import { useRouter } from "vue-router";
+import LucideExternalLink from "~icons/lucide/external-link";
 import LucideGlobe from "~icons/lucide/globe";
+import LucideInfo from "~icons/lucide/info";
 import LucideMail from "~icons/lucide/mail";
 import LucideMapPin from "~icons/lucide/map-pin";
+import LucideX from "~icons/lucide/x";
 import Link from "../frappe-ui/Link.vue";
 import PhoneControl from "../frappe-ui/PhoneControl/PhoneControl.vue";
 
 const model = defineModel<boolean>({ default: false });
 const router = useRouter();
 
-const { state, primaryContact, reset } = useNewCustomerForm();
+const {
+  state,
+  primaryContact,
+  existingContact,
+  existingContactName,
+  dismissExistingContact,
+  reset,
+} = useNewCustomerForm();
+
+const contactSwapEl = ref<HTMLElement | null>(null);
+const { height: contactSwapContentHeight } = useElementSize(contactSwapEl);
+const contactSwapHeight = computed(() =>
+  contactSwapContentHeight.value
+    ? `${contactSwapContentHeight.value}px`
+    : "auto"
+);
+
+const existingContactDetail = computed(() => {
+  const contact = existingContact.value;
+  const mobile = contact?.mobile_no || contact?.phone;
+  const note = contact?.user
+    ? __("Will be added as the primary contact")
+    : __("Will be set as primary · an invitation will be sent");
+  return mobile ? `${mobile} · ${note}` : note;
+});
+
+function openContact() {
+  if (!existingContact.value) return;
+  const route = router.resolve({
+    name: "Contact",
+    params: { id: existingContact.value.name },
+  });
+  window.open(route.href, "_blank");
+}
 
 const customerResource: Resource = createResource({
   url: "helpdesk.api.customer.create_customer",
   method: "POST",
-  onSuccess: (name: string) => {
-    router.push({ name: "Customer", params: { id: name } });
-    toast.success(__("Customer created"));
+  onSuccess: (data: { name: string; invited_emails: string[] }) => {
+    router.push({ name: "Customer", params: { id: data.name } });
+    const invited = data.invited_emails?.[0];
+    toast.success(
+      invited
+        ? __("Customer created · invitation sent to {0}", invited)
+        : __("Customer created")
+    );
   },
   onError: (error: unknown) => {
     getErrorMessage(error, true);
@@ -161,18 +268,23 @@ function addCustomer() {
       image: state.image,
       country: state.country,
     },
-    primary_contact: hasPrimaryContactData()
-      ? {
-          first_name: primaryContact.firstName,
-          last_name: primaryContact.lastName,
-          email: primaryContact.email,
-          mobile_no: primaryContact.mobileNo,
-        }
-      : null,
+    primary_contact: buildPrimaryContactPayload(),
   });
 }
 
+function buildPrimaryContactPayload(): Record<string, string> | null {
+  if (existingContact.value) return { email: primaryContact.email };
+  if (!hasPrimaryContactData()) return null;
+  return {
+    first_name: primaryContact.firstName,
+    last_name: primaryContact.lastName,
+    email: primaryContact.email,
+    mobile_no: primaryContact.mobileNo,
+  };
+}
+
 function validatePrimaryContact(): boolean {
+  if (existingContact.value) return true;
   if (!hasPrimaryContactData()) return true;
   if (!primaryContact.firstName) {
     toast.error(__("Enter the primary contact's first name"));

--- a/desk/src/components/customer/TicketsTab.vue
+++ b/desk/src/components/customer/TicketsTab.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="flex flex-col focus-visible:border-none" tabindex="0">
-    <!-- Filter bar: sticks below the tablist (46px) while the page scrolls -->
+    <!-- ponytail: top-[46px] hardcodes the frappe-ui tablist height; if the
+         tablist changes size, switch to measuring it (useElementSize) -->
+    <!-- Filter bar: sticks below the tablist while the page scrolls -->
     <div
       class="sticky top-[46px] z-[5] -mt-5 flex items-center justify-between gap-3 bg-surface-base pt-5 pb-3"
     >
@@ -153,17 +155,13 @@
   </div>
 </template>
 
-<script
-  setup
-  lang="ts"
-  generic="T extends Record<string, any> = Record<string, any>"
->
+<script setup lang="ts">
 import Link from "@/components/frappe-ui/Link.vue";
 import { IndicatorIcon } from "@/components/icons";
 import { useScreenSize } from "@/composables/screen";
 import { useTicketStatusStore } from "@/stores/ticketStatus";
 import { __ } from "@/translation";
-import type { DocumentResource, ListResource, Resource } from "@/types";
+import type { ListResource, Resource } from "@/types";
 import type { HDTicket } from "@/types/doctypes";
 import { watchDebounced } from "@vueuse/core";
 import { dayjsLocal, FormControl, LoadingIndicator } from "frappe-ui";
@@ -180,14 +178,13 @@ type TicketFilterField = {
 };
 
 const props = defineProps<{
-  doc: DocumentResource<T>;
   ticketsListResource: ListResource<HDTicket>;
   ticketsCountResource: Resource<number>;
   baseFilter: Record<string, string>;
   additionalFilter?: TicketFilterField;
 }>();
 
-const { doc, ticketsListResource, ticketsCountResource, baseFilter } = props;
+const { ticketsListResource, ticketsCountResource, baseFilter } = props;
 
 const router = useRouter();
 const { isMobileView } = useScreenSize();

--- a/desk/src/components/customer/TicketsTab.vue
+++ b/desk/src/components/customer/TicketsTab.vue
@@ -1,7 +1,9 @@
 <template>
   <div class="flex flex-col focus-visible:border-none" tabindex="0">
-    <!-- Filter bar -->
-    <div class="flex items-center justify-between gap-3 pb-3">
+    <!-- Filter bar: sticks below the tablist (46px) while the page scrolls -->
+    <div
+      class="sticky top-[46px] z-[5] -mt-5 flex items-center justify-between gap-3 bg-surface-base pt-5 pb-3"
+    >
       <FormControl
         v-model="search"
         :placeholder="__('Search by ID or Subject')"
@@ -28,7 +30,9 @@
     <!-- Table -->
     <div class="min-h-0 flex flex-1 flex-col" tabindex="0">
       <!-- Loading -->
-      <template v-if="ticketsListResource.loading">
+      <template
+        v-if="ticketsListResource.loading && !ticketsListResource.data?.length"
+      >
         <div
           class="py-16 text-center text-sm text-ink-gray-4 flex items-center justify-center"
         >
@@ -75,12 +79,7 @@
           </div>
         </div>
         <!-- Rows -->
-        <div
-          class="min-h-0 overflow-y-auto pb-6"
-          :class="
-            isMobileView ? 'max-h-[65vh]' : 'max-h-[65vh] overflow-x-hidden'
-          "
-        >
+        <div class="pb-6" :class="isMobileView ? '' : 'overflow-x-hidden'">
           <template
             v-for="(ticket, i) in ticketsListResource.data"
             :key="ticket.name"
@@ -164,7 +163,7 @@ import { IndicatorIcon } from "@/components/icons";
 import { useScreenSize } from "@/composables/screen";
 import { useTicketStatusStore } from "@/stores/ticketStatus";
 import { __ } from "@/translation";
-import type { DocumentResource, ListResource } from "@/types";
+import type { DocumentResource, ListResource, Resource } from "@/types";
 import type { HDTicket } from "@/types/doctypes";
 import { watchDebounced } from "@vueuse/core";
 import { dayjsLocal, FormControl, LoadingIndicator } from "frappe-ui";
@@ -183,11 +182,12 @@ type TicketFilterField = {
 const props = defineProps<{
   doc: DocumentResource<T>;
   ticketsListResource: ListResource<HDTicket>;
+  ticketsCountResource: Resource<number>;
   baseFilter: Record<string, string>;
   additionalFilter?: TicketFilterField;
 }>();
 
-const { doc, ticketsListResource, baseFilter } = props;
+const { doc, ticketsListResource, ticketsCountResource, baseFilter } = props;
 
 const router = useRouter();
 const { isMobileView } = useScreenSize();
@@ -307,6 +307,7 @@ watchDebounced(
         : undefined,
     });
     ticketsListResource.reload();
+    ticketsCountResource.fetch();
   },
   { debounce: 300 }
 );
@@ -317,6 +318,7 @@ onBeforeUnmount(() => {
     orFilters: {},
   });
   ticketsListResource.reload();
+  ticketsCountResource.fetch();
 });
 </script>
 

--- a/desk/src/composables/customer.ts
+++ b/desk/src/composables/customer.ts
@@ -1,9 +1,10 @@
 import { __ } from "@/translation";
 import { DocumentResource, Error } from "@/types";
 import { HDCustomer } from "@/types/doctypes";
-import { getErrorMessage } from "@/utils";
+import { getErrorMessage, validateEmailWithZod } from "@/utils";
+import { useDebounceFn } from "@vueuse/core";
 import { call, createDocumentResource } from "frappe-ui";
-import { computed, h, markRaw, reactive, watch } from "vue";
+import { computed, h, markRaw, reactive, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import LucideGlobe from "~icons/lucide/globe";
 import LucideMapPin from "~icons/lucide/map-pin";
@@ -109,13 +110,46 @@ function usePrimaryContactState() {
   });
 }
 
+interface ExistingContact {
+  name: string;
+  first_name?: string;
+  last_name?: string;
+  mobile_no?: string;
+  phone?: string;
+  image?: string;
+}
+
 /** Bundles the customer + primary-contact state for the New Customer dialog. */
 export function useNewCustomerForm() {
   const state = useCustomerState();
   const primaryContact = usePrimaryContactState();
+  const existingContact = ref<ExistingContact | null>(null);
   applyDefaults();
 
+  const existingContactName = computed(() => {
+    const contact = existingContact.value;
+    if (!contact) return "";
+    const fullName = [contact.first_name, contact.last_name]
+      .filter(Boolean)
+      .join(" ");
+    return fullName || contact.name;
+  });
+
+  const lookupContact = useDebounceFn(async (email: string) => {
+    const contact = validateEmailWithZod(email)
+      ? await fetchContactByEmail(email)
+      : null;
+    if (email !== primaryContact.email) return;
+    existingContact.value = contact?.name ? contact : null;
+  }, 300);
+
+  function dismissExistingContact() {
+    existingContact.value = null;
+    primaryContact.email = "";
+  }
+
   function reset() {
+    existingContact.value = null;
     Object.assign(state, useCustomerState());
     Object.assign(primaryContact, usePrimaryContactState());
     applyDefaults();
@@ -125,7 +159,24 @@ export function useNewCustomerForm() {
     state.country = window.default_country || "";
   }
 
-  return { state, primaryContact, reset };
+  watch(() => primaryContact.email, lookupContact);
+
+  return {
+    state,
+    primaryContact,
+    existingContact,
+    existingContactName,
+    dismissExistingContact,
+    reset,
+  };
+}
+
+function fetchContactByEmail(email: string): Promise<ExistingContact | null> {
+  return call("frappe.client.get_value", {
+    doctype: "Contact",
+    filters: { email_id: email },
+    fieldname: ["name", "first_name", "last_name", "mobile_no", "phone", "image"],
+  });
 }
 
 type StateKey = "name" | "customerType" | "domain" | "image" | "country";

--- a/desk/src/composables/customer.ts
+++ b/desk/src/composables/customer.ts
@@ -1,10 +1,9 @@
 import { __ } from "@/translation";
 import { DocumentResource, Error } from "@/types";
 import { HDCustomer } from "@/types/doctypes";
-import { getErrorMessage, validateEmailWithZod } from "@/utils";
-import { useDebounceFn } from "@vueuse/core";
+import { getErrorMessage } from "@/utils";
 import { call, createDocumentResource } from "frappe-ui";
-import { computed, h, markRaw, reactive, ref, watch } from "vue";
+import { computed, h, markRaw, reactive, watch } from "vue";
 import { useRouter } from "vue-router";
 import LucideGlobe from "~icons/lucide/globe";
 import LucideMapPin from "~icons/lucide/map-pin";
@@ -110,46 +109,13 @@ function usePrimaryContactState() {
   });
 }
 
-interface ExistingContact {
-  name: string;
-  first_name?: string;
-  last_name?: string;
-  mobile_no?: string;
-  phone?: string;
-  image?: string;
-}
-
 /** Bundles the customer + primary-contact state for the New Customer dialog. */
 export function useNewCustomerForm() {
   const state = useCustomerState();
   const primaryContact = usePrimaryContactState();
-  const existingContact = ref<ExistingContact | null>(null);
   applyDefaults();
 
-  const existingContactName = computed(() => {
-    const contact = existingContact.value;
-    if (!contact) return "";
-    const fullName = [contact.first_name, contact.last_name]
-      .filter(Boolean)
-      .join(" ");
-    return fullName || contact.name;
-  });
-
-  const lookupContact = useDebounceFn(async (email: string) => {
-    const contact = validateEmailWithZod(email)
-      ? await fetchContactByEmail(email)
-      : null;
-    if (email !== primaryContact.email) return;
-    existingContact.value = contact?.name ? contact : null;
-  }, 300);
-
-  function dismissExistingContact() {
-    existingContact.value = null;
-    primaryContact.email = "";
-  }
-
   function reset() {
-    existingContact.value = null;
     Object.assign(state, useCustomerState());
     Object.assign(primaryContact, usePrimaryContactState());
     applyDefaults();
@@ -159,24 +125,7 @@ export function useNewCustomerForm() {
     state.country = window.default_country || "";
   }
 
-  watch(() => primaryContact.email, lookupContact);
-
-  return {
-    state,
-    primaryContact,
-    existingContact,
-    existingContactName,
-    dismissExistingContact,
-    reset,
-  };
-}
-
-function fetchContactByEmail(email: string): Promise<ExistingContact | null> {
-  return call("frappe.client.get_value", {
-    doctype: "Contact",
-    filters: { email_id: email },
-    fieldname: ["name", "first_name", "last_name", "mobile_no", "phone", "image"],
-  });
+  return { state, primaryContact, reset };
 }
 
 type StateKey = "name" | "customerType" | "domain" | "image" | "country";

--- a/desk/src/pages/contact/Contact.vue
+++ b/desk/src/pages/contact/Contact.vue
@@ -69,7 +69,6 @@
             <div class="p-5 flex flex-col flex-1 min-h-0">
               <TicketsTab
                 v-if="tab.label === __('Tickets')"
-                :doc="contact"
                 :ticketsListResource="ticketsListResource"
                 :ticketsCountResource="ticketsCountResource"
                 :baseFilter="{ contact: props.id }"

--- a/desk/src/pages/contact/Contact.vue
+++ b/desk/src/pages/contact/Contact.vue
@@ -66,11 +66,12 @@
             </button>
           </template>
           <template #tab-panel="{ tab }">
-            <div class="p-5 overflow-hidden flex flex-col flex-1 min-h-0">
+            <div class="p-5 flex flex-col flex-1 min-h-0">
               <TicketsTab
                 v-if="tab.label === __('Tickets')"
                 :doc="contact"
                 :ticketsListResource="ticketsListResource"
+                :ticketsCountResource="ticketsCountResource"
                 :baseFilter="{ contact: props.id }"
                 :additionalFilter="
                 (contactInfoResource.data?.customers?.length ?? 0) > 1
@@ -166,13 +167,13 @@ const {
 
 const { feedbackCount } = useContactFeedback(props.id);
 
-const { ticketsListResource } = getTicketListResource();
+const { ticketsListResource, ticketsCountResource } = getTicketListResource();
 
 const tabs = computed(() => [
   {
     label: __("Tickets"),
     hash: "tickets",
-    count: ticketsListResource.data?.length ?? 0,
+    count: ticketsCountResource.data ?? 0,
     icon: h(TicketHashIcon, { class: "size-4" }),
   },
   {
@@ -338,6 +339,7 @@ onMounted(() => {
     },
   });
   ticketsListResource.fetch();
+  ticketsCountResource.fetch();
 });
 
 usePageMeta(() => {
@@ -351,6 +353,11 @@ usePageMeta(() => {
 /* frappe-ui's TabsRoot clips with overflow-hidden, which traps the sticky
    tablist. Let it overflow so the tablist sticks to the page scroll container. */
 .tabs-sticky-header {
+  overflow: visible !important;
+}
+/* Same for the tab panels, so sticky children (e.g. the ticket filter bar)
+   can stick to the page scroll container instead of being clipped. */
+.tabs-sticky-header :deep([role="tabpanel"]) {
   overflow: visible !important;
 }
 .tabs-sticky-header :deep([role="tablist"]) {

--- a/desk/src/pages/customer/Customer.vue
+++ b/desk/src/pages/customer/Customer.vue
@@ -66,7 +66,6 @@
               <div v-if="tab.label === __('Tickets')">
                 <!-- Tickets tab content -->
                 <TicketsTab
-                  :doc="customer"
                   :ticketsListResource="ticketsListResource"
                   :ticketsCountResource="ticketsCountResource"
                   :baseFilter="{ customer: props.id }"

--- a/desk/src/pages/customer/Customer.vue
+++ b/desk/src/pages/customer/Customer.vue
@@ -62,12 +62,13 @@
             </button>
           </template>
           <template #tab-panel="{ tab }">
-            <div class="p-5 overflow-hidden flex flex-col flex-1 min-h-0">
+            <div class="p-5 flex flex-col flex-1 min-h-0">
               <div v-if="tab.label === __('Tickets')">
                 <!-- Tickets tab content -->
                 <TicketsTab
                   :doc="customer"
                   :ticketsListResource="ticketsListResource"
+                  :ticketsCountResource="ticketsCountResource"
                   :baseFilter="{ customer: props.id }"
                   :additionalFilter="contactFilter"
                 />
@@ -138,13 +139,13 @@ const route = useRoute();
 const router = useRouter();
 
 const { isMobileView } = useScreenSize();
-const { ticketsListResource } = getTicketListResource();
+const { ticketsListResource, ticketsCountResource } = getTicketListResource();
 
 const tabs = computed(() => [
   {
     label: __("Tickets"),
     hash: "tickets",
-    count: ticketsListResource.data?.length ?? 0,
+    count: ticketsCountResource.data ?? 0,
     icon: h(TicketHashIcon, { class: "size-4" }),
   },
   {
@@ -257,6 +258,7 @@ onMounted(() => {
     },
   });
   ticketsListResource.fetch();
+  ticketsCountResource.fetch();
 });
 
 usePageMeta(() => {
@@ -270,6 +272,11 @@ usePageMeta(() => {
 /* frappe-ui's TabsRoot clips with overflow-hidden, which traps the sticky
    tablist. Let it overflow so the tablist sticks to the page scroll container. */
 .tabs-sticky-header {
+  overflow: visible !important;
+}
+/* Same for the tab panels, so sticky children (e.g. the ticket filter bar)
+   can stick to the page scroll container instead of being clipped. */
+.tabs-sticky-header :deep([role="tabpanel"]) {
   overflow: visible !important;
 }
 .tabs-sticky-header :deep([role="tablist"]) {

--- a/desk/src/stores/docTickets.ts
+++ b/desk/src/stores/docTickets.ts
@@ -3,36 +3,36 @@ import type { HDTicket } from "@/types/doctypes";
 import { createListResource, createResource } from "frappe-ui";
 
 export function getTicketListResource(): {
-	ticketsListResource: ListResource<HDTicket>;
-	ticketsCountResource: Resource<number>;
+  ticketsListResource: ListResource<HDTicket>;
+  ticketsCountResource: Resource<number>;
 } {
-	const ticketsListResource = createListResource({
-		doctype: "HD Ticket",
-		pageLength: 20,
-		fields: [
-			"name",
-			"subject",
-			"status",
-			"priority",
-			"creation",
-			"modified",
-			"_assign",
-			"response_by",
-			"resolution_by",
-		],
-		orderBy: "modified desc",
-	});
+  const ticketsListResource = createListResource({
+    doctype: "HD Ticket",
+    pageLength: 20,
+    fields: [
+      "name",
+      "subject",
+      "status",
+      "priority",
+      "creation",
+      "modified",
+      "_assign",
+      "response_by",
+      "resolution_by",
+    ],
+    orderBy: "modified desc",
+  });
 
-	// Permission-aware total for the current filters (unlike data.length,
-	// which only counts the fetched pages).
-	const ticketsCountResource = createResource({
-		url: "frappe.desk.reportview.get_count",
-		makeParams: () => ({
-			doctype: "HD Ticket",
-			filters: ticketsListResource.filters,
-			or_filters: ticketsListResource.orFilters,
-		}),
-	});
+  // Permission-aware total for the current filters (unlike data.length,
+  // which only counts the fetched pages).
+  const ticketsCountResource = createResource({
+    url: "frappe.desk.reportview.get_count",
+    makeParams: () => ({
+      doctype: "HD Ticket",
+      filters: ticketsListResource.filters,
+      or_filters: ticketsListResource.orFilters,
+    }),
+  });
 
-	return { ticketsListResource, ticketsCountResource };
+  return { ticketsListResource, ticketsCountResource };
 }

--- a/desk/src/stores/docTickets.ts
+++ b/desk/src/stores/docTickets.ts
@@ -1,26 +1,38 @@
-import type { ListResource } from "@/types";
+import type { ListResource, Resource } from "@/types";
 import type { HDTicket } from "@/types/doctypes";
-import { createListResource } from "frappe-ui";
+import { createListResource, createResource } from "frappe-ui";
 
 export function getTicketListResource(): {
-  ticketsListResource: ListResource<HDTicket>;
+	ticketsListResource: ListResource<HDTicket>;
+	ticketsCountResource: Resource<number>;
 } {
-  return {
-    ticketsListResource: createListResource({
-      doctype: "HD Ticket",
-      pageLength: 20,
-      fields: [
-        "name",
-        "subject",
-        "status",
-        "priority",
-        "creation",
-        "modified",
-        "_assign",
-        "response_by",
-        "resolution_by",
-      ],
-      orderBy: "modified desc",
-    }),
-  };
+	const ticketsListResource = createListResource({
+		doctype: "HD Ticket",
+		pageLength: 20,
+		fields: [
+			"name",
+			"subject",
+			"status",
+			"priority",
+			"creation",
+			"modified",
+			"_assign",
+			"response_by",
+			"resolution_by",
+		],
+		orderBy: "modified desc",
+	});
+
+	// Permission-aware total for the current filters (unlike data.length,
+	// which only counts the fetched pages).
+	const ticketsCountResource = createResource({
+		url: "frappe.desk.reportview.get_count",
+		makeParams: () => ({
+			doctype: "HD Ticket",
+			filters: ticketsListResource.filters,
+			or_filters: ticketsListResource.orFilters,
+		}),
+	});
+
+	return { ticketsListResource, ticketsCountResource };
 }

--- a/helpdesk/api/customer.py
+++ b/helpdesk/api/customer.py
@@ -32,16 +32,24 @@ def create_customer(customer: dict, primary_contact: dict | None = None) -> str:
 
 
 def add_primary_contact(customer_doc: Document, primary_contact: dict) -> None:
-    contact_name = create_contact(
-        {
-            "first_name": primary_contact.get("first_name"),
-            "last_name": primary_contact.get("last_name"),
-            "email": primary_contact.get("email"),
-            "phone": primary_contact.get("mobile_no"),
-            "customer": customer_doc.name,
-        },
-        invite=True,
-    )
+    """Set the primary contact, reusing an existing contact for the email.
+
+    The contact is created first when the email is unknown, so the form's
+    name and phone are kept; add_contacts then adds it directly if it has a
+    linked user and invites it by email otherwise.
+    """
+    email = primary_contact.get("email")
+    contact_name = frappe.db.get_value("Contact", {"email_id": email}, "name")
+    if not contact_name:
+        contact_name = create_contact(
+            {
+                "first_name": primary_contact.get("first_name"),
+                "last_name": primary_contact.get("last_name"),
+                "email": email,
+                "phone": primary_contact.get("mobile_no"),
+            }
+        )
+    customer_doc.add_contacts([contact_name], "HD Customer Manager")
     customer_doc.set_primary(contact_name)
     customer_doc.save()
 

--- a/helpdesk/api/customer.py
+++ b/helpdesk/api/customer.py
@@ -5,11 +5,12 @@ from helpdesk.api.contact import create_contact
 
 
 @frappe.whitelist()
-def create_customer(customer: dict, primary_contact: dict | None = None) -> str:
+def create_customer(customer: dict, primary_contact: dict | None = None) -> dict:
     """Create an HD Customer and optionally invite a primary contact.
 
     The primary contact is created, invited by email and set as the customer's
-    primary contact in a single operation.
+    primary contact in a single operation. Returns the customer name and the
+    emails an invitation was sent to.
     """
     frappe.has_permission("HD Customer", "create", throw=True)
 
@@ -25,13 +26,14 @@ def create_customer(customer: dict, primary_contact: dict | None = None) -> str:
     )
     customer_doc.insert()
 
+    invited_emails: list[str] = []
     if primary_contact and primary_contact.get("email"):
-        add_primary_contact(customer_doc, primary_contact)
+        invited_emails = add_primary_contact(customer_doc, primary_contact)
 
-    return customer_doc.name
+    return {"name": customer_doc.name, "invited_emails": invited_emails}
 
 
-def add_primary_contact(customer_doc: Document, primary_contact: dict) -> None:
+def add_primary_contact(customer_doc: Document, primary_contact: dict) -> list[str]:
     """Set the primary contact, reusing an existing contact for the email.
 
     The contact is created first when the email is unknown, so the form's
@@ -49,9 +51,10 @@ def add_primary_contact(customer_doc: Document, primary_contact: dict) -> None:
                 "phone": primary_contact.get("mobile_no"),
             }
         )
-    customer_doc.add_contacts([contact_name], "HD Customer Manager")
+    result = customer_doc.add_contacts([contact_name], "HD Customer Manager")
     customer_doc.set_primary(contact_name)
     customer_doc.save()
+    return result["invite_result"]["invited_emails"]
 
 
 @frappe.whitelist()

--- a/helpdesk/helpdesk/doctype/hd_customer/test_hd_customer.py
+++ b/helpdesk/helpdesk/doctype/hd_customer/test_hd_customer.py
@@ -225,11 +225,13 @@ class TestHDCustomer(IntegrationTestCase):
         email = "primary-contact-api@example.com"
         cleanup_customer_and_contact("Test Customer API Primary", email)
 
-        name = create_customer_api(
+        result = create_customer_api(
             {"customer_name": "Test Customer API Primary", "customer_type": "Company"},
             {"first_name": "Primary", "last_name": "Contact", "email": email},
         )
 
+        name = result["name"]
+        self.assertEqual(result["invited_emails"], [email])
         customer = frappe.get_doc("HD Customer", name)
         contact = frappe.db.get_value("Contact", {"email_id": email}, "name")
         self.assertEqual(customer.customer_type, "Company")
@@ -249,7 +251,7 @@ class TestHDCustomer(IntegrationTestCase):
         name = create_customer_api(
             {"customer_name": "Test Customer API Accept", "customer_type": "Company"},
             {"first_name": "Primary", "email": email},
-        )
+        )["name"]
         invitation = frappe.get_doc("User Invitation", get_invitation(email).name)
         user = create_user(email)
 
@@ -269,7 +271,7 @@ class TestHDCustomer(IntegrationTestCase):
         cleanup_customer_and_contact("Test Customer API Linked User", email)
         contact = create_contact("LinkedPrimary", email)
 
-        name = create_customer_api(
+        result = create_customer_api(
             {
                 "customer_name": "Test Customer API Linked User",
                 "customer_type": "Company",
@@ -277,7 +279,8 @@ class TestHDCustomer(IntegrationTestCase):
             {"first_name": "LinkedPrimary", "email": email},
         )
 
-        customer = frappe.get_doc("HD Customer", name)
+        self.assertEqual(result["invited_emails"], [])
+        customer = frappe.get_doc("HD Customer", result["name"])
         self.assertEqual(customer.primary_contact, contact["contact"])
         contacts = frappe.db.get_all("Contact", {"email_id": email}, pluck="name")
         self.assertEqual(contacts, [contact["contact"]], "Contact must be reused")
@@ -290,7 +293,7 @@ class TestHDCustomer(IntegrationTestCase):
         cleanup_customer_and_contact("Test Customer API Existing Contact", email)
         contact = create_contact("ExistingPrimary", email, user=False)
 
-        name = create_customer_api(
+        result = create_customer_api(
             {
                 "customer_name": "Test Customer API Existing Contact",
                 "customer_type": "Company",
@@ -298,6 +301,8 @@ class TestHDCustomer(IntegrationTestCase):
             {"first_name": "ExistingPrimary", "email": email},
         )
 
+        name = result["name"]
+        self.assertEqual(result["invited_emails"], [email])
         customer = frappe.get_doc("HD Customer", name)
         self.assertEqual(customer.primary_contact, contact["contact"])
         contacts = frappe.db.get_all("Contact", {"email_id": email}, pluck="name")
@@ -313,7 +318,7 @@ class TestHDCustomer(IntegrationTestCase):
         cleanup_customer_and_contact("Test Customer API User Only", email)
         user = create_user(email)
 
-        name = create_customer_api(
+        result = create_customer_api(
             {
                 "customer_name": "Test Customer API User Only",
                 "customer_type": "Company",
@@ -321,7 +326,8 @@ class TestHDCustomer(IntegrationTestCase):
             {"first_name": "UserOnly", "email": email},
         )
 
-        customer = frappe.get_doc("HD Customer", name)
+        self.assertEqual(result["invited_emails"], [])
+        customer = frappe.get_doc("HD Customer", result["name"])
         contact = frappe.db.get_value("Contact", {"email_id": email}, "name")
         self.assertEqual(customer.primary_contact, contact)
         self.assertEqual(frappe.db.get_value("Contact", contact, "user"), user.name)

--- a/helpdesk/helpdesk/doctype/hd_customer/test_hd_customer.py
+++ b/helpdesk/helpdesk/doctype/hd_customer/test_hd_customer.py
@@ -262,6 +262,71 @@ class TestHDCustomer(IntegrationTestCase):
         member_names = [row.contact_name for row in customer.contacts]
         self.assertEqual(member_names.count(contact), 1)
 
+    def test_primary_contact_with_linked_user_is_not_invited(self) -> None:
+        from helpdesk.api.customer import create_customer as create_customer_api
+
+        email = "primary-linked-user@example.com"
+        cleanup_customer_and_contact("Test Customer API Linked User", email)
+        contact = create_contact("LinkedPrimary", email)
+
+        name = create_customer_api(
+            {
+                "customer_name": "Test Customer API Linked User",
+                "customer_type": "Company",
+            },
+            {"first_name": "LinkedPrimary", "email": email},
+        )
+
+        customer = frappe.get_doc("HD Customer", name)
+        self.assertEqual(customer.primary_contact, contact["contact"])
+        contacts = frappe.db.get_all("Contact", {"email_id": email}, pluck="name")
+        self.assertEqual(contacts, [contact["contact"]], "Contact must be reused")
+        self.assertFalse(get_invitation(email), "No invite for an existing user")
+
+    def test_primary_contact_reuses_existing_contact_without_user(self) -> None:
+        from helpdesk.api.customer import create_customer as create_customer_api
+
+        email = "primary-existing-contact@example.com"
+        cleanup_customer_and_contact("Test Customer API Existing Contact", email)
+        contact = create_contact("ExistingPrimary", email, user=False)
+
+        name = create_customer_api(
+            {
+                "customer_name": "Test Customer API Existing Contact",
+                "customer_type": "Company",
+            },
+            {"first_name": "ExistingPrimary", "email": email},
+        )
+
+        customer = frappe.get_doc("HD Customer", name)
+        self.assertEqual(customer.primary_contact, contact["contact"])
+        contacts = frappe.db.get_all("Contact", {"email_id": email}, pluck="name")
+        self.assertEqual(contacts, [contact["contact"]], "Contact must be reused")
+        invitation = get_invitation(email)
+        self.assertEqual(invitation.customer, name)
+        self.assertEqual(invitation.contact, contact["contact"])
+
+    def test_primary_contact_links_existing_user_without_invite(self) -> None:
+        from helpdesk.api.customer import create_customer as create_customer_api
+
+        email = "primary-user-no-contact@example.com"
+        cleanup_customer_and_contact("Test Customer API User Only", email)
+        user = create_user(email)
+
+        name = create_customer_api(
+            {
+                "customer_name": "Test Customer API User Only",
+                "customer_type": "Company",
+            },
+            {"first_name": "UserOnly", "email": email},
+        )
+
+        customer = frappe.get_doc("HD Customer", name)
+        contact = frappe.db.get_value("Contact", {"email_id": email}, "name")
+        self.assertEqual(customer.primary_contact, contact)
+        self.assertEqual(frappe.db.get_value("Contact", contact, "user"), user.name)
+        self.assertFalse(get_invitation(email), "No invite for an existing user")
+
     def test_delete_customer_unlinks_tickets_and_invitations(self) -> None:
         from helpdesk.api.customer import delete_customer
 
@@ -421,3 +486,5 @@ def cleanup_customer_and_contact(customer_name: str, email: str) -> None:
         frappe.delete_doc("Contact", c, force=True)
     if frappe.db.exists("User", email):
         frappe.delete_doc("User", email, force=True)
+    for inv in frappe.db.get_all("User Invitation", {"email": email}, pluck="name"):
+        frappe.delete_doc("User Invitation", inv, force=True)


### PR DESCRIPTION
## What this does

**1. Don't duplicate / re-invite the primary contact when creating a customer**
- `create_customer` now reuses an existing Contact matching the given email instead of creating a duplicate.
- Routes through `add_contacts`: a contact with a linked user is added directly, others get an invitation.
- The success toast shows when an invitation was actually sent (`create_customer` returns `invited_emails`).

**2. Accurate ticket count on Customer & Contact pages**
- The Tickets tab badge showed the paginated row count (20) instead of the total.
- Now fetched via `frappe.desk.reportview.get_count`, which is permission-aware (respects `permission_query`, verified against the restrict-tickets-by-team setting) and mirrors the list's filters + search (`or_filters`).
- UX: single page scrollbar (removed nested 65vh scroller), filter bar sticks below the tab header, and "Load More" no longer replaces the table with a spinner (scroll position is kept).

## How to test
1. Create a customer with a primary-contact email that already has a Contact → no duplicate contact, no invite if the contact has a user; toast reports the invite otherwise.
2. Open a customer/contact with >20 tickets → the Tickets badge shows the total; apply status/priority/search filters → badge follows.
3. Enable "Restrict Tickets By Team" in HD Settings → as a team-restricted agent the badge only counts visible tickets.

Tests: `test_hd_customer.py` covers contact reuse, invite behavior, and the new `create_customer` return shape (26 tests passing).