### PR TITLE
fix: strip html comments from agent reply email content

### DIFF
--- a/desk/src/pages/ticket/Tickets.vue
+++ b/desk/src/pages/ticket/Tickets.vue
@@ -17,7 +17,7 @@
         >
           <Button
             class="rtl:flex-row-reverse"
-            label="Create"
+            :label="__('Create')"
             theme="gray"
             variant="solid"
           >

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from email.utils import parseaddr
 
 import frappe
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Comment
 from frappe import _
 from frappe.core.page.permission_manager.permission_manager import remove
 from frappe.desk.form.assign_to import add as assign
@@ -1200,6 +1200,11 @@ class HDTicket(Document):
             return ""
 
         soup = BeautifulSoup(content, "html.parser")
+
+        # comments (e.g. Outlook MSO conditionals in quoted replies) get mangled
+        # by the markdown conversion in sendmail and show up as visible text
+        for comment in soup.find_all(string=lambda s: isinstance(s, Comment)):
+            comment.extract()
 
         for tag in soup.find_all(["img", "video"]):
             if tag.name == "img":

--- a/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
@@ -85,6 +85,18 @@ class TestHDTicket(IntegrationTestCase):
         ticket.insert()
         self.assertTrue(ticket.name)
 
+    def test_parse_content_strips_html_comments(self):
+        ticket = frappe.get_doc(get_ticket_obj())
+        ticket.insert()
+        content = (
+            "<blockquote><!--[if !mso]><!--><!--<![endif]-->"
+            "<!--[if gte mso 9]><xml><o:shapedefaults/></xml><![endif]-->"
+            "<p>Dear Admin,</p></blockquote>"
+        )
+        parsed = ticket.parse_content(content)
+        self.assertNotIn("<!--", parsed)
+        self.assertIn("<p>Dear Admin,</p>", parsed)
+
     def test_agent_flow(self):
         ticket = frappe.get_doc(get_ticket_obj())
         ticket.insert()


### PR DESCRIPTION
## Problem

When a customer emails from Outlook, the stored HTML contains MSO conditional comments (`<!--[if !mso]><!-->`, `<!--[if gte mso 9]>...<![endif]-->`). When an agent replies, the quoted original rides along in the message, and `reply_via_agent` sends it via `frappe.sendmail(..., as_markdown=True)`, which pipes the HTML through markdown2. markdown2 escapes any `>` it considers naked — including one preceded by `]` — turning `<!--[if !mso]>` into `<!--[if !mso]&gt;`. The broken comment opener is no longer hidden, so Outlook renders it as visible text in the reply:

`<!--[if !mso]&gt;<!--[if gte mso 9]&gt;<!--[if gte mso 9]&gt;`

## Fix

Strip HTML comment nodes in `parse_content`, which already parses every outgoing agent reply with BeautifulSoup before template rendering and `sendmail`. Comments carry no meaning in an email reply body, and with them gone there is nothing for markdown2 to mangle.

The Communication record is stored before `parse_content` runs, so ticket history in the UI is unchanged; only the outgoing email is affected.