### PR TITLE
feat: onboarding persona questionnaire (backport #3538)

### DIFF
--- a/desk/src/App.vue
+++ b/desk/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <FrappeUIProvider>
-    <PortalRoot />
+    <router-view />
   </FrappeUIProvider>
   <Dialogs />
 </template>
@@ -11,10 +11,9 @@ import { useConfigStore } from "@/stores/config";
 import { useFavicon } from "@vueuse/core";
 import { FrappeUIProvider, setConfig, toast, useTheme } from "frappe-ui";
 import { storeToRefs } from "pinia";
-import { computed, defineAsyncComponent, h, onMounted } from "vue";
+import { h, onMounted } from "vue";
 import Wifi from "~icons/lucide/wifi";
 import WifiOff from "~icons/lucide/wifi-off";
-import { useAuthStore } from "./stores/auth";
 import { __ } from "./translation";
 import { isCustomerPortal, getBrowserTimezone } from "./utils";
 
@@ -44,21 +43,5 @@ onMounted(() => {
   });
   !isCustomerPortal.value && setConfig("localTimezone", window.timezone?.user);
   setConfig("systemTimezone", window.timezone?.system || null);
-});
-
-const AgentPortalRoot = defineAsyncComponent(
-  () => import("@/roots/AgentRoot.vue")
-);
-const CustomerPortalRoot = defineAsyncComponent(
-  () => import("@/roots/CustomerPortalRoot.vue")
-);
-
-const PortalRoot = computed(() => {
-  const authStore = useAuthStore();
-  if (authStore.hasDeskAccess && authStore.isAgent) {
-    return AgentPortalRoot;
-  } else {
-    return CustomerPortalRoot;
-  }
 });
 </script>

--- a/desk/src/components/Questionnaire.types.ts
+++ b/desk/src/components/Questionnaire.types.ts
@@ -1,0 +1,35 @@
+export interface Option {
+  label: string;
+  value: string;
+}
+
+// A dropdown rendered beneath a text question (e.g. org name + company size).
+export interface DropdownConfig {
+  key: string;
+  label: string;
+  placeholder: string;
+  options: Option[];
+}
+
+export interface TextQuestion {
+  key: string;
+  title: string;
+  type: "text";
+  label?: string;
+  placeholder?: string;
+  multiline?: boolean;
+  required?: boolean;
+  dropdown?: DropdownConfig;
+}
+
+export interface ChoiceQuestion {
+  key: string;
+  title: string;
+  type: "choice";
+  options: Option[];
+  multiple?: boolean;
+  // Placeholder for the free-text box the "Other" option reveals.
+  otherPlaceholder?: string;
+}
+
+export type Question = TextQuestion | ChoiceQuestion;

--- a/desk/src/components/Questionnaire.vue
+++ b/desk/src/components/Questionnaire.vue
@@ -1,0 +1,278 @@
+<template>
+  <div class="relative mx-auto w-full max-w-md flex flex-col gap-5">
+    <HDLogo class="size-8" />
+
+    <!-- Fixed height keeps the panel from resizing as questions vary in length. -->
+    <div class="relative">
+      <Button
+        v-if="current > 0"
+        variant="ghost"
+        icon="lucide-chevron-left"
+        class="!size-7 shrink-0 !rounded-md absolute -left-11 mt-4"
+        @click="back"
+      />
+      <div
+        :key="question.key"
+        class="mx-0 min-w-0 border-0 p-0 flex gap-5 flex-col"
+      >
+        <div>
+          <p class="p-0 text-p-2xl font-bold text-ink-gray-9">
+            {{ question.title
+            }}<span v-if="titleRequired" class="ms-0.5 text-ink-red-6">*</span>
+          </p>
+
+          <p class="text-base pt-1.5">
+            {{ __("This helps us personalize your Helpdesk experience.") }}
+          </p>
+        </div>
+        <template v-if="question.type === 'text'">
+          <div class="flex flex-col gap-3">
+            <!-- Cap textarea resize: vertical only, between one row block and ~2x default. -->
+            <div
+              class="[&_textarea]:resize-y [&_textarea]:min-h-16 [&_textarea]:max-h-40"
+            >
+              <span
+                v-if="question.label"
+                class="mb-1.5 block text-p-sm text-ink-gray-5"
+              >
+                {{ question.label
+                }}<span v-if="question.required" class="ms-0.5 text-ink-red-6"
+                  >*</span
+                >
+              </span>
+              <Textarea
+                v-if="question.multiline"
+                v-model="answers[question.key]"
+                size="sm"
+                variant="outline"
+                :rows="3"
+                :placeholder="question.placeholder"
+              />
+              <TextInput
+                v-else
+                v-model="answers[question.key]"
+                size="sm"
+                type="text"
+                variant="outline"
+                :placeholder="question.placeholder"
+                @keyup.enter="proceed"
+              />
+            </div>
+            <div v-if="dropdown">
+              <span class="mb-1.5 block text-p-sm text-ink-gray-5">
+                {{ dropdown.label }}
+              </span>
+              <Select
+                v-model="answers[dropdown.key]"
+                class="w-full"
+                size="sm"
+                variant="outline"
+                :placeholder="dropdown.placeholder"
+                :options="dropdown.options"
+              />
+            </div>
+          </div>
+        </template>
+        <template v-else>
+          <div class="flex flex-wrap gap-3 !text-ink-gray-7 text-p-base">
+            <Button
+              v-for="option in choiceOptions"
+              :key="option.value"
+              :label="option.label"
+              :variant="isSelected(option) ? 'subtle' : 'outline'"
+              size="sm"
+              class="!rounded-md border border-solid"
+              :class="
+                isSelected(option)
+                  ? '!bg-surface-gray-3 hover:!bg-surface-gray-4 !border-outline-gray-3'
+                  : 'hover:!bg-surface-alpha-gray-2'
+              "
+              @click="select(option)"
+            />
+          </div>
+          <div
+            class="-mt-5 grid transition-[grid-template-rows,opacity] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]"
+            :class="
+              isOtherSelected
+                ? 'grid-rows-[1fr] opacity-100'
+                : 'grid-rows-[0fr] opacity-0'
+            "
+          >
+            <div class="overflow-hidden">
+              <div
+                class="transition-transform duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] [&_textarea]:resize-y [&_textarea]:min-h-16 [&_textarea]:max-h-40"
+                :class="isOtherSelected ? 'translate-y-0' : '-translate-y-full'"
+              >
+                <Textarea
+                  ref="otherInput"
+                  v-model="answers[otherKey]"
+                  class="mt-5"
+                  variant="outline"
+                  :rows="3"
+                  :placeholder="otherPlaceholder"
+                  :tabindex="isOtherSelected ? 0 : -1"
+                  :error="otherError"
+                  @update:model-value="otherError = ''"
+                />
+              </div>
+            </div>
+          </div>
+        </template>
+      </div>
+    </div>
+
+    <div class="flex flex-col items-center gap-2">
+      <Button
+        class="!h-7 w-full !rounded-lg"
+        variant="solid"
+        :label="isLast ? __('Finish') : __('Next')"
+        :disabled="!canProceed"
+        @click="proceed"
+      />
+    </div>
+  </div>
+  <Button
+    class="mt-auto !bg-transparent !text-ink-gray-5 hover:!text-ink-gray-8"
+    variant="ghost"
+    :label="__('Skip for now')"
+    @click="finish"
+  />
+</template>
+
+<script setup lang="ts">
+import HDLogo from "@/assets/logos/HDLogo.vue";
+import { __ } from "@/translation";
+import { Button, Select, Textarea, TextInput } from "frappe-ui";
+import { computed, nextTick, reactive, ref, watch } from "vue";
+import type { Option, Question } from "./Questionnaire.types";
+
+type Answers = Record<string, string | string[]>;
+
+const props = defineProps<{ questions: Question[] }>();
+const emit = defineEmits<{ submit: [answers: Answers] }>();
+
+const current = ref(0);
+const completed = ref(false);
+const answers = reactive<Answers>({});
+const otherInput = ref<InstanceType<typeof Textarea>>();
+
+const total = computed(() => props.questions.length);
+const question = computed(() => props.questions[current.value] as Question);
+const isLast = computed(() => current.value === total.value - 1);
+
+// Next stays disabled until the current question has an answer.
+const canProceed = computed(() => {
+  const q = question.value;
+  const value = answers[q.key];
+  if (q.type === "text")
+    return !q.required || (typeof value === "string" && value.trim() !== "");
+  if (q.multiple) return Array.isArray(value) && value.length > 0;
+  return typeof value === "string" && value !== "";
+});
+
+// Narrow the discriminated union so the template stays declarative: choice
+// questions render pills, text questions may carry a dropdown beneath them.
+const choiceOptions = computed(() =>
+  question.value.type === "choice" ? question.value.options : []
+);
+const dropdown = computed(() =>
+  question.value.type === "text" ? question.value.dropdown : undefined
+);
+
+// "Other" free-text is stored under a `<key>_other` sibling answer key.
+const OTHER_SUFFIX = "_other";
+const otherKey = computed(() => `${question.value.key}${OTHER_SUFFIX}`);
+const isOtherSelected = computed(() => {
+  const otherOption = choiceOptions.value.find((o) => o.value === "other");
+  return otherOption ? isSelected(otherOption) : false;
+});
+
+const otherPlaceholder = computed(
+  () =>
+    (question.value.type === "choice" && question.value.otherPlaceholder) ||
+    __("Tell us more")
+);
+
+// The asterisk normally rides on the field label; questions whose title is
+// itself the prompt have no label to hang it on.
+const titleRequired = computed(
+  () =>
+    question.value.type === "text" &&
+    !!question.value.required &&
+    !question.value.label
+);
+
+const isOtherFilled = computed(() => {
+  const other = answers[otherKey.value];
+  return typeof other === "string" && other.trim() !== "";
+});
+
+// Cleared on navigation and on toggling "Other" off, so re-opening the box
+// never shows a stale error the user hasn't earned yet.
+const otherError = ref("");
+watch([current, isOtherSelected], () => (otherError.value = ""));
+
+function isSelected(option: Option) {
+  const q = question.value;
+  if (q.type !== "choice") return false;
+  const value = answers[q.key];
+  if (q.multiple) {
+    return Array.isArray(value) && value.includes(option.value);
+  }
+  return value === option.value;
+}
+
+function select(option: Option) {
+  if (completed.value) return;
+  const q = question.value;
+  if (q.type !== "choice") return;
+  const key = q.key;
+  if (q.multiple) {
+    const value = Array.isArray(answers[key])
+      ? [...(answers[key] as string[])]
+      : [];
+    const index = value.indexOf(option.value);
+    if (index === -1) {
+      value.push(option.value);
+    } else {
+      value.splice(index, 1);
+    }
+    answers[key] = value;
+  } else {
+    // A click only sets the selection; advancing is always via the Next button.
+    answers[key] = option.value;
+  }
+
+  if (!isOtherSelected.value) {
+    delete answers[otherKey.value];
+  } else if (option.value === "other") {
+    nextTick(() => otherInput.value?.el?.focus({ preventScroll: true }));
+  }
+}
+
+function advance() {
+  if (current.value < total.value - 1) current.value += 1;
+}
+
+function back() {
+  if (current.value > 0) current.value -= 1;
+}
+
+function proceed() {
+  if (!canProceed.value) return;
+  // "Other" stays selectable with Next enabled; the ask happens on click.
+  if (isOtherSelected.value && !isOtherFilled.value) {
+    otherError.value = __("Add a few words so we can continue");
+    otherInput.value?.el?.focus({ preventScroll: true });
+    return;
+  }
+  if (isLast.value) finish();
+  else advance();
+}
+
+function finish() {
+  if (completed.value) return;
+  completed.value = true;
+  setTimeout(() => emit("submit", { ...answers }), 700);
+}
+</script>

--- a/desk/src/pages/PersonaForm.vue
+++ b/desk/src/pages/PersonaForm.vue
@@ -1,0 +1,237 @@
+<template>
+  <div
+    class="relative flex min-h-screen flex-col overflow-y-auto bg-surface-gray-1 transition-opacity duration-300 ease-out"
+    :class="leaving ? 'opacity-0' : 'opacity-100'"
+  >
+    <div class="flex flex-1 flex-col justify-start pb-8 pt-24">
+      <Questionnaire
+        class="h-full"
+        :questions="questions"
+        @submit="submitPersona"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Questionnaire from "@/components/Questionnaire.vue";
+import type { Question } from "@/components/Questionnaire.types";
+import {
+  setActiveSettingsTab,
+  showSettingsModal,
+} from "@/components/Settings/settingsModal";
+import { markPersonaCaptured } from "@/persona";
+import { capture } from "@/telemetry";
+import { __ } from "@/translation";
+import { call, usePageMeta } from "frappe-ui";
+import { ref } from "vue";
+import { useRouter } from "vue-router";
+
+const router = useRouter();
+const leaving = ref(false);
+const FADE_MS = 300;
+
+// The last question's "first goal" answer maps to a settings tab; other goals
+// route directly (create ticket, explore) or fall through to Home.
+const settingsTabForGoal: Record<
+  string,
+  "Email Accounts" | "Invite Agents" | "General"
+> = {
+  connect_email: "Email Accounts",
+  invite_team: "Invite Agents",
+  setup_portal: "General",
+};
+
+async function finishOnboarding(answers: Record<string, string | string[]>) {
+  leaving.value = true;
+  // Persist and fade in parallel; localStorage is the durable guard.
+  const brandName =
+    typeof answers.company_name === "string" ? answers.company_name : undefined;
+  const fade = new Promise((resolve) => setTimeout(resolve, FADE_MS));
+  await Promise.allSettled([markPersonaCaptured(brandName), fade]);
+  try {
+    await routeToGoal(answers.first_goal);
+  } catch {
+    leaving.value = false; // navigation failed — un-fade so we're not stuck
+  }
+}
+
+// Send the admin to their first goal: new ticket, the seeded welcome ticket,
+// a settings tab over Home, or Home.
+async function routeToGoal(goal?: string | string[]) {
+  if (goal === "create_ticket") {
+    await router.push({ name: "TicketAgentNew" });
+    return;
+  }
+  if (goal === "explore") {
+    const ticket = await call(
+      "helpdesk.api.onboarding.get_welcome_ticket"
+    ).catch(() => null);
+    await router.push(
+      ticket
+        ? { name: "TicketAgent", params: { ticketId: ticket } }
+        : { name: "TicketsAgent" }
+    );
+    return;
+  }
+  await router.push({ name: "Home" });
+  const tab = typeof goal === "string" ? settingsTabForGoal[goal] : undefined;
+  if (tab) {
+    setActiveSettingsTab(tab);
+    showSettingsModal.value = true;
+  }
+}
+
+async function submitPersona(answers: Record<string, string | string[]>) {
+  capture("onboarding_persona_hd", { data: answers });
+  await finishOnboarding(answers);
+}
+
+const questions = [
+  {
+    key: "company_name",
+    title: __("Tell us about your organization"),
+    type: "text",
+    label: __("What is your organization's name?"),
+    placeholder: __("e.g. Acme Inc."),
+    required: true,
+    dropdown: {
+      key: "company_size",
+      label: __("How big is your support team?"),
+      placeholder: __("Select team size"),
+      options: [
+        { label: __("1–5"), value: "1-5" },
+        { label: __("6–10"), value: "6-10" },
+        { label: __("11–25"), value: "11-25" },
+        { label: __("26–50"), value: "26-50" },
+        { label: __("51–100"), value: "51-100" },
+        { label: __("100+"), value: "100+" },
+      ],
+    },
+  },
+  {
+    key: "current_solution",
+    title: __("What do you currently use to manage customer support?"),
+    type: "choice",
+    options: [
+      { label: __("Spreadsheets"), value: "spreadsheets" },
+      { label: __("Notion"), value: "notion" },
+      { label: __("Zendesk"), value: "zendesk" },
+      { label: __("Freshdesk"), value: "freshdesk" },
+      { label: __("Intercom"), value: "intercom" },
+      { label: __("Jira Service Management"), value: "jira" },
+      { label: __("Zoho Desk"), value: "zoho_desk" },
+      { label: __("Salesforce Service Cloud"), value: "salesforce" },
+      { label: __("We don't use any helpdesk yet"), value: "none" },
+      {
+        label: __("Shared email inbox (Gmail, Outlook, etc.)"),
+        value: "shared_inbox",
+      },
+      { label: __("Other"), value: "other" },
+    ],
+    otherPlaceholder: __("Which tool does your team use?"),
+  },
+  {
+    key: "contact_channels",
+    title: __("How do your customers currently contact your support team?"),
+    type: "choice",
+    multiple: true,
+    options: [
+      { label: __("Email"), value: "email" },
+      { label: __("Support portal"), value: "support_portal" },
+      { label: __("WhatsApp"), value: "whatsapp" },
+      { label: __("Phone calls"), value: "phone_calls" },
+      { label: __("Live chat"), value: "live_chat" },
+      { label: __("Web form"), value: "web_form" },
+      { label: __("Social media"), value: "social_media" },
+      { label: __("In person"), value: "in_person" },
+      { label: __("Other"), value: "other" },
+    ],
+    otherPlaceholder: __("Which channel do they use?"),
+  },
+  {
+    key: "preferred_channels",
+    title: __(
+      "How would you like your customers to create support tickets in Frappe Helpdesk?"
+    ),
+    type: "choice",
+    multiple: true,
+    options: [
+      { label: __("Via email"), value: "email" },
+      { label: __("Through a support portal"), value: "support_portal" },
+      { label: __("Via WhatsApp"), value: "whatsapp" },
+      { label: __("Live chat"), value: "live_chat" },
+      { label: __("I'm not sure yet"), value: "not_sure" },
+    ],
+  },
+  {
+    key: "biggest_challenges",
+    title: __("What's your biggest support challenge today?"),
+    type: "choice",
+    multiple: true,
+    options: [
+      {
+        label: __("Managing customer conversations across channels"),
+        value: "omnichannel",
+      },
+      {
+        label: __("Finding past conversations"),
+        value: "finding_conversations",
+      },
+      {
+        label: __("Measuring team performance"),
+        value: "measuring_performance",
+      },
+      { label: __("Scaling support as we grow"), value: "scaling" },
+      { label: __("Missing or delayed responses"), value: "delayed_responses" },
+      {
+        label: __("Keeping track of customer requests"),
+        value: "tracking_requests",
+      },
+      {
+        label: __("Assigning tickets"),
+        value: "assignment",
+      },
+      { label: __("Other"), value: "other" },
+    ],
+    otherPlaceholder: __("What makes support hard right now?"),
+  },
+  {
+    key: "referral_source",
+    title: __("How did you hear about Frappe Helpdesk?"),
+    type: "choice",
+    options: [
+      { label: __("GitHub"), value: "github" },
+      { label: __("Google Ads"), value: "google_ads" },
+      { label: __("YouTube"), value: "youtube" },
+      { label: __("Frappe Discuss"), value: "frappe_discuss" },
+      {
+        label: __("Another Frappe product (ERPNext, Frappe Cloud, etc.)"),
+        value: "frappe_product",
+      },
+      { label: __("LinkedIn"), value: "linkedin" },
+      { label: __("X (Twitter)"), value: "x" },
+      { label: __("Reddit"), value: "reddit" },
+      { label: __("A friend or colleague"), value: "word_of_mouth" },
+      { label: __("A Frappe partner or consultant"), value: "partner" },
+      { label: __("An event or conference"), value: "event" },
+      { label: __("Other"), value: "other" },
+    ],
+    otherPlaceholder: __("Where did you hear about us?"),
+  },
+  {
+    key: "first_goal",
+    title: __("What would you like to do first in Frappe Helpdesk?"),
+    type: "choice",
+    options: [
+      { label: __("Connect my support email"), value: "connect_email" },
+      { label: __("Set up a customer portal"), value: "setup_portal" },
+      { label: __("Create my first ticket"), value: "create_ticket" },
+      { label: __("Invite my support team"), value: "invite_team" },
+      { label: __("Explore the product first"), value: "explore" },
+    ],
+  },
+] satisfies Question[];
+
+usePageMeta(() => ({ title: __("Welcome to Frappe Helpdesk") }));
+</script>

--- a/desk/src/persona.ts
+++ b/desk/src/persona.ts
@@ -1,0 +1,59 @@
+import { call } from "frappe-ui";
+import type { RouteLocationNormalized, RouteLocationRaw } from "vue-router";
+
+const PERSONA_DONE_KEY = "helpdesk_persona_captured";
+
+let personaChecked = false;
+
+// Minimal auth contract, so this module doesn't import the auth store (cycle).
+interface PersonaAuth {
+  isLoggedIn: boolean;
+  hasDeskAccess: boolean;
+  isAdmin: boolean;
+  personaCaptured: boolean;
+}
+
+function isPersonaCaptured(auth: PersonaAuth): boolean {
+  try {
+    if (localStorage.getItem(PERSONA_DONE_KEY)) return true;
+  } catch {
+    // storage blocked — fall through to the server flag
+  }
+  return !!auth.personaCaptured;
+}
+
+// window.telemetry is a boot value injected by www/helpdesk, so this is
+// synchronous and guard-safe.
+export function telemetryEnabled(): boolean {
+  return !!window.telemetry?.enabled;
+}
+
+// Gate for the route's beforeEnter: only an uncaptured desk admin may view
+// the wizard, even via URL.
+export function canViewPersona(auth: PersonaAuth): boolean {
+  return (
+    auth.isLoggedIn &&
+    auth.hasDeskAccess &&
+    auth.isAdmin &&
+    !isPersonaCaptured(auth)
+  );
+}
+
+// Interrupt the first eligible admin navigation, once per session, only if
+// telemetry is on. Returns where to redirect, or undefined to continue.
+export function personaInterrupt(
+  to: RouteLocationNormalized,
+  auth: PersonaAuth
+): RouteLocationRaw | undefined {
+  if (to.name === "Persona" || personaChecked) return;
+  if (!(auth.isLoggedIn && auth.hasDeskAccess && auth.isAdmin)) return;
+  personaChecked = true;
+  if (telemetryEnabled() && canViewPersona(auth)) return { name: "Persona" };
+}
+
+export async function markPersonaCaptured(brandName?: string): Promise<void> {
+  localStorage.setItem(PERSONA_DONE_KEY, "1");
+  await call("helpdesk.api.onboarding.mark_persona_captured", {
+    brand_name: brandName,
+  });
+}

--- a/desk/src/roots/PortalRoot.vue
+++ b/desk/src/roots/PortalRoot.vue
@@ -1,0 +1,26 @@
+<template>
+  <component :is="Root" />
+</template>
+
+<script setup lang="ts">
+import { useAuthStore } from "@/stores/auth";
+import { computed, defineAsyncComponent } from "vue";
+
+const AgentPortalRoot = defineAsyncComponent(
+  () => import("@/roots/AgentRoot.vue")
+);
+const CustomerPortalRoot = defineAsyncComponent(
+  () => import("@/roots/CustomerPortalRoot.vue")
+);
+
+// The chrome follows the session, not the URL: an agent keeps the agent
+// shell even on customer-portal pages.
+const Root = computed(() => {
+  const authStore = useAuthStore();
+  if (authStore.hasDeskAccess && authStore.isAgent) {
+    return AgentPortalRoot;
+  } else {
+    return CustomerPortalRoot;
+  }
+});
+</script>

--- a/desk/src/router/index.ts
+++ b/desk/src/router/index.ts
@@ -1,4 +1,5 @@
 import { useScreenSize } from "@/composables/screen";
+import { canViewPersona, personaInterrupt } from "@/persona";
 import { useAuthStore } from "@/stores/auth";
 import { useUserStore } from "@/stores/user";
 import { isCustomerPortal } from "@/utils";
@@ -19,10 +20,12 @@ declare module "vue-router" {
   }
 }
 
-const routes = [
+// Pages that render inside the portal chrome; PortalRoot picks the agent or
+// customer shell from the session.
+const portalRoutes = [
   // Agent Portal Routes
   {
-    path: "/",
+    path: "",
     redirect: "/home",
   },
   {
@@ -199,6 +202,21 @@ const routes = [
   },
 ];
 
+const routes = [
+  // Renders bare — no portal chrome.
+  {
+    path: "/onboarding",
+    name: "Persona",
+    component: () => import("@/pages/PersonaForm.vue"),
+    beforeEnter: () => canViewPersona(useAuthStore()) || { name: "Home" },
+  },
+  {
+    path: "/",
+    component: () => import("@/roots/PortalRoot.vue"),
+    children: portalRoutes,
+  },
+];
+
 const handleMobileView = (componentName: string) => {
   return isMobileView.value ? `Mobile${componentName}` : componentName;
 };
@@ -214,6 +232,9 @@ router.beforeEach(async (to, _, next) => {
   if (authStore.isLoggedIn) {
     await authStore.init();
   }
+
+  const interrupt = personaInterrupt(to, authStore);
+  if (interrupt) return next(interrupt);
 
   if (!authStore.isLoggedIn) {
     const redirectURL = to.fullPath !== "/" ? to.fullPath : "";

--- a/desk/src/stores/auth.ts
+++ b/desk/src/stores/auth.ts
@@ -55,6 +55,9 @@ export const useAuthStore = defineStore("auth", () => {
   const userTeams: ComputedRef<string[]> = computed(
     () => user__.value.user_teams
   );
+  const personaCaptured: ComputedRef<boolean> = computed(
+    () => !!user__.value.persona_captured
+  );
 
   function sessionUser() {
     const cookies = new URLSearchParams(document.cookie.split("; ").join("&"));
@@ -105,6 +108,7 @@ export const useAuthStore = defineStore("auth", () => {
     timezone,
     language,
     userTeams,
+    personaCaptured,
     user,
     logout,
   };

--- a/desk/src/types.ts
+++ b/desk/src/types.ts
@@ -796,6 +796,7 @@ declare global {
     agent: string | null;
     default_country: string;
     apps: string[];
+    telemetry: { enabled: boolean };
   }
 }
 

--- a/helpdesk/api/auth.py
+++ b/helpdesk/api/auth.py
@@ -52,6 +52,10 @@ def get_user():
     )
     user_team = get_agents_team()
     user_team_names = [team["team_name"] for team in user_team]
+    # Ride the boot so the onboarding guard decides without an extra round-trip.
+    persona_captured = bool(
+        frappe.db.get_single_value("HD Settings", "persona_captured")
+    )
 
     return {
         "has_desk_access": has_desk_access,
@@ -69,6 +73,7 @@ def get_user():
         "user_teams": user_team_names,
         "availability": availability.get("availability"),
         "availability_changed_on": availability.get("availability_changed_on"),
+        "persona_captured": persona_captured,
     }
 
 

--- a/helpdesk/api/onboarding.py
+++ b/helpdesk/api/onboarding.py
@@ -1,5 +1,32 @@
 import frappe
 
+from helpdesk.utils import agent_manager_only
+
+
+@frappe.whitelist(methods=["POST"])
+@agent_manager_only
+def mark_persona_captured(brand_name: str | None = None) -> None:
+    """Flag the onboarding persona questionnaire as done so it never re-prompts,
+    and adopt the org name as the brand name.
+    """
+    frappe.db.set_single_value("HD Settings", "persona_captured", 1)
+    brand_name = (brand_name or "").strip()
+    if brand_name:
+        frappe.db.set_single_value("HD Settings", "brand_name", brand_name)
+        frappe.db.set_single_value("Website Settings", "app_name", brand_name)
+        # Display name in framework emails, e.g. the welcome mail "Welcome to <name>".
+        frappe.db.set_default("site_name", brand_name)
+        # set_single_value skips Website Settings' on_update, so clear the cache
+        # ourselves for the new brand to show up in the desk/PWA/app identity.
+        frappe.clear_cache()
+
+
+@frappe.whitelist()
+@agent_manager_only
+def get_welcome_ticket() -> str | None:
+    """Name of the seeded welcome ticket, if it still exists."""
+    return frappe.db.get_value("HD Ticket", {"subject": "Welcome to Helpdesk"}, "name")
+
 
 @frappe.whitelist()
 def get_first_ticket(ticket: str | None = None):

--- a/helpdesk/api/test_onboarding.py
+++ b/helpdesk/api/test_onboarding.py
@@ -1,0 +1,82 @@
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from helpdesk.api.onboarding import mark_persona_captured
+from helpdesk.overrides.user_invitation import HelpdeskUserInvitation
+
+BRAND = "Acme Support"
+
+
+class TestMarkPersonaCaptured(IntegrationTestCase):
+    def setUp(self) -> None:
+        frappe.set_user("Administrator")
+        frappe.db.set_single_value("HD Settings", "brand_name", "")
+        frappe.db.set_single_value("HD Settings", "persona_captured", 0)
+        frappe.db.set_single_value("Website Settings", "app_name", "")
+        frappe.db.set_default("site_name", "")
+
+    def tearDown(self) -> None:
+        frappe.db.rollback()
+
+    def test_brand_name_written_to_settings(self):
+        mark_persona_captured(brand_name=BRAND)
+        self.assertEqual(frappe.db.get_single_value("HD Settings", "brand_name"), BRAND)
+        self.assertEqual(
+            frappe.db.get_single_value("Website Settings", "app_name"), BRAND
+        )
+
+    def test_site_name_set_for_welcome_email_subject(self):
+        # Frappe builds the welcome email subject as "Welcome to <site_name>".
+        mark_persona_captured(brand_name=BRAND)
+        self.assertEqual(frappe.db.get_default("site_name"), BRAND)
+
+    def test_persona_captured_flag_set(self):
+        mark_persona_captured()
+        self.assertTrue(frappe.db.get_single_value("HD Settings", "persona_captured"))
+
+    def test_blank_brand_leaves_brand_untouched(self):
+        mark_persona_captured(brand_name="   ")
+        self.assertTrue(frappe.db.get_single_value("HD Settings", "persona_captured"))
+        self.assertFalse(frappe.db.get_single_value("HD Settings", "brand_name"))
+
+
+class TestInvitationTitleOverride(IntegrationTestCase):
+    def setUp(self) -> None:
+        frappe.set_user("Administrator")
+        frappe.db.set_single_value("HD Settings", "brand_name", "")
+
+    def tearDown(self) -> None:
+        frappe.db.rollback()
+
+    def _invitation(self) -> HelpdeskUserInvitation:
+        invitation = frappe.new_doc("User Invitation")
+        invitation.app_name = "helpdesk"
+        return invitation
+
+    def test_override_is_registered(self):
+        self.assertIsInstance(frappe.new_doc("User Invitation"), HelpdeskUserInvitation)
+
+    def test_title_uses_brand_name(self):
+        # Subject becomes "You've been invited to join <brand> on <app title>".
+        frappe.db.set_single_value("HD Settings", "brand_name", BRAND)
+        app_title = frappe.get_hooks("app_title", app_name="helpdesk")[0]
+        self.assertEqual(
+            self._invitation()._get_email_title(), f"{BRAND} on {app_title}"
+        )
+
+    def test_title_falls_back_to_app_title(self):
+        self.assertEqual(
+            self._invitation()._get_email_title(),
+            frappe.get_hooks("app_title", app_name="helpdesk")[0],
+        )
+
+    def test_other_apps_keep_their_title(self):
+        # The override is site-wide; a brand name must not leak into other
+        # apps' invitation emails.
+        frappe.db.set_single_value("HD Settings", "brand_name", BRAND)
+        invitation = frappe.new_doc("User Invitation")
+        invitation.app_name = "frappe"
+        self.assertEqual(
+            invitation._get_email_title(),
+            frappe.get_hooks("app_title", app_name="frappe")[0],
+        )

--- a/helpdesk/api/test_onboarding.py
+++ b/helpdesk/api/test_onboarding.py
@@ -1,5 +1,5 @@
 import frappe
-from frappe.tests import IntegrationTestCase
+from frappe.tests.utils import FrappeTestCase
 
 from helpdesk.api.onboarding import mark_persona_captured
 from helpdesk.overrides.user_invitation import HelpdeskUserInvitation
@@ -7,7 +7,7 @@ from helpdesk.overrides.user_invitation import HelpdeskUserInvitation
 BRAND = "Acme Support"
 
 
-class TestMarkPersonaCaptured(IntegrationTestCase):
+class TestMarkPersonaCaptured(FrappeTestCase):
     def setUp(self) -> None:
         frappe.set_user("Administrator")
         frappe.db.set_single_value("HD Settings", "brand_name", "")
@@ -40,7 +40,7 @@ class TestMarkPersonaCaptured(IntegrationTestCase):
         self.assertFalse(frappe.db.get_single_value("HD Settings", "brand_name"))
 
 
-class TestInvitationTitleOverride(IntegrationTestCase):
+class TestInvitationTitleOverride(FrappeTestCase):
     def setUp(self) -> None:
         frappe.set_user("Administrator")
         frappe.db.set_single_value("HD Settings", "brand_name", "")

--- a/helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+++ b/helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -61,6 +61,7 @@
   "setup_complete",
   "initial_helpdesk_name_setup_skipped",
   "show_customer_portal_permission_notice",
+  "persona_captured",
   "column_break_hjfh",
   "search_tab",
   "name_weight",
@@ -153,6 +154,14 @@
    "fieldtype": "Check",
    "hidden": 1,
    "label": "Show Customer Portal Permission Notice"
+  },
+  {
+   "default": "0",
+   "description": "Set once an admin completes the onboarding persona questionnaire",
+   "fieldname": "persona_captured",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Persona Captured"
   },
   {
    "fieldname": "column_break_hjfh",
@@ -532,7 +541,7 @@
  "grid_page_length": 50,
  "issingle": 1,
  "links": [],
- "modified": "2026-07-07 12:30:00.000000",
+ "modified": "2026-07-10 14:58:15.922364",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Settings",

--- a/helpdesk/hooks.py
+++ b/helpdesk/hooks.py
@@ -122,6 +122,7 @@ has_permission = {
 override_doctype_class = {
     "Email Account": "helpdesk.overrides.email_account.CustomEmailAccount",
     "Assignment Rule": "helpdesk.overrides.assignment_rule.HelpdeskAssignmentRule",
+    "User Invitation": "helpdesk.overrides.user_invitation.HelpdeskUserInvitation",
 }
 
 ignore_links_on_delete = [

--- a/helpdesk/overrides/user_invitation.py
+++ b/helpdesk/overrides/user_invitation.py
@@ -1,0 +1,18 @@
+import frappe
+from frappe import _
+from frappe.core.doctype.user_invitation.user_invitation import UserInvitation
+
+
+class HelpdeskUserInvitation(UserInvitation):
+    def _get_email_title(self):
+        # Use the org's brand name (set during onboarding) in the invitation
+        # subject — "You've been invited to join <brand> on Helpdesk" — falling
+        # back to the framework app title when it isn't set. The override class
+        # is registered site-wide, so invitations from other apps (ERPNext,
+        # etc.) must keep their own app title.
+        if self.app_name != "helpdesk":
+            return super()._get_email_title()
+        brand = frappe.db.get_single_value("HD Settings", "brand_name")
+        if not brand:
+            return super()._get_email_title()
+        return _("{0} on {1}").format(brand, super()._get_email_title())

--- a/helpdesk/patches.txt
+++ b/helpdesk/patches.txt
@@ -47,3 +47,4 @@ helpdesk.patches.set_default_customer_type
 helpdesk.patches.add_user_invitation_perms
 helpdesk.patches.enable_auto_set_customer_from_contact
 helpdesk.patches.show_customer_portal_permission_notice
+helpdesk.patches.set_persona_captured_for_existing_sites

--- a/helpdesk/patches/set_persona_captured_for_existing_sites.py
+++ b/helpdesk/patches/set_persona_captured_for_existing_sites.py
@@ -1,0 +1,9 @@
+import frappe
+
+
+def execute():
+    # Existing sites are already set up by upgrade time; skip onboarding for them.
+    # Every site ships one welcome ticket, so >1 means real usage — a site with
+    # only that welcome ticket is effectively fresh and still sees the questionnaire.
+    if frappe.db.count("HD Ticket") > 1:
+        frappe.db.set_single_value("HD Settings", "persona_captured", 1)

--- a/helpdesk/www/helpdesk/index.py
+++ b/helpdesk/www/helpdesk/index.py
@@ -49,9 +49,25 @@ def get_boot():
             "lang": frappe.local.lang,
             "dir": "rtl" if is_rtl() else "ltr",
             "apps": frappe.get_installed_apps(),
+            "telemetry": get_telemetry_boot(),
         }
     )
 
 
 def get_default_route():
     return "/helpdesk"
+
+
+def get_telemetry_boot():
+    """Direct-mode config for the browser telemetry client, as a boot value.
+
+    Telemetry must never break the page: older frappe versions have no pulse
+    module, and any boot_config error degrades to "disabled". The key it
+    ships is a public write-only ingest key (same as desk boot).
+    """
+    try:
+        from frappe.utils.telemetry.pulse.client import boot_config
+
+        return boot_config()
+    except Exception:
+        return {"enabled": False}


### PR DESCRIPTION
Manual backport of #3538 to `main-hotfix` (Mergify did not react to the `backport main-hotfix` label).

## What this does
Cherry-pick of the #3538 merge commit (`29c4dc2f2`): onboarding persona questionnaire — `PersonaForm`/`Questionnaire` components, `persona_captured` flag on HD Settings (rides the boot payload), `mark_persona_captured` API, patch to set the flag for existing sites, and the user-invitation override.

## Conflict resolution notes
Only `helpdesk/api/auth.py` and `desk/src/stores/auth.ts` conflicted — both were additive overlaps with main-hotfix's `user_teams` boot code. Resolved by keeping both; the resolved files are content-identical to develop.

## How to test
- `bench --site <site> run-tests --module helpdesk.api.test_onboarding` — 8 tests pass locally against this branch
- Fresh site (or `persona_captured = 0`): first desk login should show the persona questionnaire; submitting sets the flag and it never reappears
- Existing sites: patch `set_persona_captured_for_existing_sites` marks them as captured on migrate

🤖 Generated with [Claude Code](https://claude.com/claude-code)