### PR TITLE
fix(list): include full end day in 'Assigned on' between filter

### DIFF
--- a/helpdesk/api/doc.py
+++ b/helpdesk/api/doc.py
@@ -643,7 +643,15 @@ def apply_datetime_filter(query, field, filter_value):
         query = query.where(field <= value)
     elif operator == "between":
         if isinstance(value, list) and len(value) == 2:
-            query = query.where(field >= value[0]).where(field <= value[1])
+            from frappe.utils import get_datetime
+
+            # convert to datetime to include the full start and end day, matching
+            # the timespan branch below; otherwise a date-only upper bound like
+            # "2026-07-02" is treated as 2026-07-02 00:00:00 and drops everything
+            # on the end day (and returns nothing when start and end are equal).
+            start_dt = get_datetime(str(value[0])).replace(hour=0, minute=0, second=0)
+            end_dt = get_datetime(str(value[1])).replace(hour=23, minute=59, second=59)
+            query = query.where(field >= start_dt).where(field <= end_dt)
     elif operator == "timespan":
         from frappe.utils import get_datetime, get_timespan_date_range
 


### PR DESCRIPTION
## Summary

The `between` operator in `apply_datetime_filter` bounded a **Datetime** column with the raw filter values, so a date-only upper bound was treated as midnight. This drops results on the end day and returns nothing for a single-day range.

`helpdesk/api/doc.py`:

```python
elif operator == "between":
    if isinstance(value, list) and len(value) == 2:
        query = query.where(field >= value[0]).where(field <= value[1])   # date-only bounds
elif operator == "timespan":
    ...
    start_dt = get_datetime(str(start)).replace(hour=0, minute=0, second=0)
    end_dt   = get_datetime(str(end)).replace(hour=23, minute=59, second=59)  # full day
    query = query.where(field >= start_dt).where(field <= end_dt)
```

The sibling `timespan` branch already normalizes to the full start/end day (*"convert to datetime to include full start and end day"*); the `between` branch does not.

## Where it bites

`__assigned_on` (label **"Assigned on"**) is a filterable **Date** field, so the list UI offers the **Between** operator. Its value flows through `handle_assigned_on_filter` → `apply_datetime_filter(query, ToDo.creation, ["between", [start, end]])`. Because `ToDo.creation` is a Datetime column:

- `field <= "2026-07-02"` means `<= 2026-07-02 00:00:00`, so anything assigned that day after midnight is excluded; and
- selecting a single day (start == end) yields `>= 2026-07-02 00:00:00 AND <= 2026-07-02 00:00:00`, matching only the exact-midnight instant — effectively **no results**.

## Fix

Normalize the bounds to the start and end of the day, mirroring the `timespan` branch:

```python
elif operator == "between":
    if isinstance(value, list) and len(value) == 2:
        from frappe.utils import get_datetime

        start_dt = get_datetime(str(value[0])).replace(hour=0, minute=0, second=0)
        end_dt = get_datetime(str(value[1])).replace(hour=23, minute=59, second=59)
        query = query.where(field >= start_dt).where(field <= end_dt)
```

## Relationship to #3518

This is the same "date **Between** returns no results" class reported in #3518. Note #3518 is specifically about **"Created On"**, which filters through `frappe.get_list` directly (a different path that normalizes datetime `between` bounds itself), so this change does not by itself close #3518 — but it fixes the same failure mode on the **"Assigned on"** filter, which is entirely helpdesk-side. Cross-referencing for context.

## Verification

I don't have a bench site to run the integration suite, so this is verified by inspection: the change mirrors the existing, already-shipped normalization in the `timespan` branch of the same function. Happy to add a unit test for `apply_datetime_filter` if you'd like one.
