### PR TITLE
fix: editor link and edit comment

### DIFF
--- a/desk/patches/frappe-ui+1.0.0-beta.24.patch
+++ b/desk/patches/frappe-ui+1.0.0-beta.24.patch
@@ -18,6 +18,25 @@ index 0b7069a..de2a3df 100644
            pluginKey: new PluginKey(options.name),
            items: ({ query }: { query: string }) =>
              typeof options.items === 'function' ? options.items(query) : options.items,
+diff --git a/node_modules/frappe-ui/src/molecules/editor/extensions/link/link-extension.ts b/node_modules/frappe-ui/src/molecules/editor/extensions/link/link-extension.ts
+index 1447ba9..b6aad68 100644
+--- a/node_modules/frappe-ui/src/molecules/editor/extensions/link/link-extension.ts
++++ b/node_modules/frappe-ui/src/molecules/editor/extensions/link/link-extension.ts
+@@ -45,6 +45,14 @@ export const LinkExtension = Link.extend({
+     }
+   },
+ 
++  // tiptap's Link mark is inclusive whenever `autolink` is on, so typing right
++  // after a link extends the mark onto the new text. Keep autolink (URL
++  // detection as you type) but make the mark non-inclusive so the link stops at
++  // its boundary.
++  inclusive() {
++    return false
++  },
++
+   addCommands() {
+     return {
+       ...this.parent?.(),
 diff --git a/node_modules/frappe-ui/src/molecules/editor/extensions/shared/suggestion-renderer.ts b/node_modules/frappe-ui/src/molecules/editor/extensions/shared/suggestion-renderer.ts
 index 8363502..07f4551 100644
 --- a/node_modules/frappe-ui/src/molecules/editor/extensions/shared/suggestion-renderer.ts

--- a/desk/src/components/CommentBox.vue
+++ b/desk/src/components/CommentBox.vue
@@ -43,7 +43,7 @@
     >
       <Editor v-model="_content" :extensions="extensions" :editable="editable">
         <template #default>
-          <EditorBubbleMenu v-if="editable" :items="fullToolbar" />
+          <EditorBubbleMenu :items="fullToolbar" />
           <EditorContent
             :class="[
               'prose-f shrink text-p-sm transition-all duration-300 ease-in-out block w-full content',
@@ -52,8 +52,6 @@
           />
         </template>
       </Editor>
-      <!-- Save/Discard live outside <Editor> so they react to `editable`
-           (the renderless Editor doesn't re-render its slot on prop change). -->
       <div v-if="editable" class="flex flex-row-reverse gap-2">
         <div>
           <Button

--- a/desk/src/index.css
+++ b/desk/src/index.css
@@ -16,6 +16,11 @@
     background-color: var(--surface-gray-2);
     color: var(--ink-gray-9);
   }
+  /* Editor content carries both prose systems: prose-f underlines links via
+     text-decoration, prose-v3 via border-bottom. Keep only the prose-v3 line. */
+  .prose-f.prose-v3 a {
+    text-decoration: none;
+  }
 }
 
 .tiptap input[placeholder="Add caption"] {


### PR DESCRIPTION
1. Editing a comment wouldn't finish saving. When you edited a comment and hit Save, it saved on the backend but the box stayed open with the Save/Discard buttons still showing, as if nothing happened.
2. Links showed a double underline. Any link in a comment had two lines under it instead of one.
3. Typing right after a link joined the link. If you added a link and kept typing immediately after it, the new text became part of the link too (underlined and clickable), instead of being normal text.