### PR TITLE
fix(sidebar): render nav items as real links so middle-click works

### DIFF
--- a/desk/src/components/layouts/AppSidebar.vue
+++ b/desk/src/components/layouts/AppSidebar.vue
@@ -35,6 +35,7 @@
               :id="item.id"
               :label="__(item.label)"
               :active="item.isActive"
+              :to="item.to"
               :class="item.spacedTop && 'mt-4'"
               @click="item.onClick && item.onClick()"
             >
@@ -127,8 +128,7 @@ import {
 } from "frappe-ui";
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
-import type { RouteLocationRaw } from "vue-router";
-import { useRoute, useRouter } from "vue-router";
+import { useRoute } from "vue-router";
 import LucideBell from "~icons/lucide/bell";
 import LucideSearch from "~icons/lucide/search";
 import {
@@ -142,7 +142,6 @@ const props = defineProps<{
 }>();
 
 const route = useRoute();
-const router = useRouter();
 const device = useDevice();
 const notificationStore = useNotificationStore();
 const sidebarStore = useSidebarStore();
@@ -188,10 +187,12 @@ function currentRouteKey(): string | null {
   return (route.query.view as string) || (route.name as string) || null;
 }
 
-function selectItem(key: string, to: RouteLocationRaw, onSelect?: () => void) {
+// Items that carry a `to` are rendered as real links by SidebarItem, so the
+// router handles navigation. This only keeps the side effects: highlight the
+// item immediately (before the route settles) and let callers hook in.
+function selectItem(key: string, onSelect?: () => void) {
   activeItem.value = key;
   onSelect?.();
-  router.push(to);
 }
 
 const navItems = computed(() => {
@@ -204,7 +205,8 @@ const navItems = computed(() => {
       label: option.label,
       icon: option.icon,
       isActive: activeItem.value === option.to,
-      onClick: () => selectItem(option.to, { name: option.to }),
+      to: { name: option.to },
+      onClick: () => selectItem(option.to),
       // Separate the nav group from the search/notification tools above it.
       spacedTop: index === 0 && !isCustomerPortal.value,
       key: option.label,
@@ -227,7 +229,8 @@ const notificationItem = computed(() =>
         label: __("Notifications"),
         icon: LucideBell,
         isActive: activeItem.value === "Notifications",
-        onClick: () => selectItem("Notifications", { name: "Notifications" }),
+        to: { name: "Notifications" },
+        onClick: () => selectItem("Notifications"),
         badge: notificationStore.unread,
         key: "notifications",
         id: "notifications-btn",
@@ -274,14 +277,11 @@ function parseViews(views: any[]) {
     label: view.label,
     icon: getIcon(view.icon),
     isActive: activeItem.value === view.name,
+    to: { name: view.route_name, query: { view: view.name } },
     onClick: () =>
-      selectItem(
-        view.name,
-        { name: view.route_name, query: { view: view.name } },
-        () => {
-          currentView.value = { label: view.label, icon: view.icon };
-        }
-      ),
+      selectItem(view.name, () => {
+        currentView.value = { label: view.label, icon: view.icon };
+      }),
     key: view.name,
     view,
   }));


### PR DESCRIPTION
## Problem

Sidebar entries cannot be opened in a new tab. Middle-click, ctrl/cmd-click and the browser's "open link in new tab" all do nothing, because every item renders as a `<button>` — there is no link target for the browser to act on. The entries are also not exposed as links to assistive technology.

## Cause

`frappe-ui`'s `SidebarItem` already renders a `RouterLink` whenever a `to` prop is present and only falls back to `<button>` otherwise. `AppSidebar` never passes `to`, although every navigable item already knows its route target — it just used it inside the click handler (`router.push`).

## Change

Pass the route target through as `to` for the three navigable item groups: nav items, saved views and the mobile notifications entry. Navigation is then performed by the router link itself, so `selectItem()` keeps only its side effects (setting the active item immediately, before the route settles, plus the caller's hook).

Items that have no route target — search and the notifications toggle — are unchanged and keep rendering as buttons.

## Notes

- No visual change; `SidebarItem` renders identical markup in both branches.
- `activeItem` is still set eagerly for instant highlighting, and the existing route watcher keeps it in sync.
- Removes the now-unused `useRouter`/`RouteLocationRaw` imports.

## Testing

Verified in a production Helpdesk instance: middle-click, ctrl-click and the context menu now open tickets, customers, contacts and saved views in a new tab; regular clicks and active-state highlighting are unaffected.