### PR TITLE
fix: correct Created On date range filter behavior

### DIFF
--- a/desk/src/components/conditions-filter/CFCondition.vue
+++ b/desk/src/components/conditions-filter/CFCondition.vue
@@ -302,9 +302,11 @@ function getValueControl() {
 }
 
 function updateValue(value) {
-  value = value.target ? value.target.value : value;
+  value = value?.target ? value.target.value : value;
   if (props.condition[1] === "between") {
-    props.condition[2] = [value.split(",")[0], value.split(",")[1]];
+    props.condition[2] = Array.isArray(value)
+      ? value
+      : [value.split(",")[0]?.trim() ?? "", value.split(",")[1]?.trim() ?? ""];
   } else {
     props.condition[2] = value + "";
   }

--- a/desk/src/components/view-controls/filter/FilterValueEditor.vue
+++ b/desk/src/components/view-controls/filter/FilterValueEditor.vue
@@ -313,9 +313,10 @@ function handleDateRange(emittedRange: any) {
 }
 
 function splitRange(rawRange: any): string[] {
-  if (typeof rawRange !== "string") return rawRange;
-  const [start, end] = rawRange.split(",");
-  return [start, end];
+  if (!Array.isArray(rawRange) && typeof rawRange !== "string") return [];
+  if (Array.isArray(rawRange)) return rawRange;
+  const delimiter = rawRange.includes(" to ") ? " to " : ",";
+  return rawRange.split(delimiter).map((s) => s.trim());
 }
 
 function moveActive(delta: number) {


### PR DESCRIPTION
# Fix: "Created On" `Between` Date Filter Returns No Results (#3518)

## Problem

The **Created On** filter does not work correctly when the **Between** operator is selected. Even when records exist within the selected date range, the ticket list incorrectly displays **"No data available."**

This issue occurs because the front-end does not consistently handle the value emitted by `DateRangePicker` when constructing the filter value.

## Root Cause

`DateRangePicker` emits the selected date range as a `string[]` (`[startDate, endDate]`), while parts of the filtering logic expected a comma-separated string.

As a result:

* The **Between** filter value was not parsed consistently.
* Date range values were processed incorrectly before the filter was applied.
* An invalid filter value was generated, causing records that fall within the selected date range to be excluded from the results.

## Solution

The date range handling has been updated to support both array and string inputs, ensuring the **Between** filter is parsed correctly regardless of the value format returned by `DateRangePicker`.

The implementation now:

* Accepts the `string[]` value emitted by `DateRangePicker`.
* Maintains compatibility with legacy comma-separated string values.
* Safely handles unexpected or empty inputs.
* Generates the correct filter value so records within the selected date range are returned as expected.

This restores the expected behavior for the **Created On → Between** filter while preserving compatibility with existing filter functionality.
<img width="1912" height="917" alt="image" src="https://github.com/user-attachments/assets/1c8ff54f-1afd-4fbe-9d0b-21c1fe4e1f66" />
