### PR TITLE
feat: rtl support (backport #3174)

### DIFF
--- a/desk/index.html
+++ b/desk/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ boot.lang or 'en' }}" dir="{{ boot.dir or 'ltr' }}">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/desk/package.json
+++ b/desk/package.json
@@ -29,6 +29,7 @@
     "pinia": "^2.0.33",
     "sanitize-html": "^2.10.0",
     "socket.io-client": "^4.7.2",
+    "tailwindcss-rtl": "^0.9.0",
     "vue": "^3.5.14",
     "vue-router": "^4.2.2",
     "vuedraggable": "^4.1.0",

--- a/desk/src/components/Autocomplete.vue
+++ b/desk/src/components/Autocomplete.vue
@@ -3,7 +3,7 @@
     <Popover v-model:show="showOptions">
       <template #target="{ open: openPopover, togglePopover }">
         <slot name="target" v-bind="{ open: openPopover, togglePopover }">
-          <div class="w-full -ml-0.5">
+          <div class="w-full -ms-0.5">
             <button
               class="flex w-full items-center justify-between focus:outline-none"
               :class="inputClasses"
@@ -42,7 +42,7 @@
             <div class="relative px-1.5 pt-0.5">
               <ComboboxInput
                 ref="search"
-                class="form-input w-full pr-6 bg-transparent"
+                class="form-input w-full pe-6 bg-transparent"
                 type="text"
                 :value="query"
                 autocomplete="off"
@@ -54,7 +54,7 @@
                 "
               />
               <button
-                class="absolute inset-y-0 right-3 top-px flex items-center"
+                class="absolute inset-y-0 end-3 top-px flex items-center"
                 @click="selectedValue = null"
               >
                 <FeatherIcon name="x" class="size-4" />

--- a/desk/src/components/CallArea.vue
+++ b/desk/src/components/CallArea.vue
@@ -7,7 +7,7 @@
           :label="activity?._caller?.label"
           size="md"
         />
-        <span class="font-medium text-ink-gray-8 ml-1">
+        <span class="font-medium text-ink-gray-8 ms-1">
           {{ activity?._caller?.label }}
         </span>
         <span>{{
@@ -16,7 +16,7 @@
             : __("has made a call")
         }}</span>
       </div>
-      <div class="ml-auto whitespace-nowrap">
+      <div class="ms-auto whitespace-nowrap">
         <Tooltip :text="dateFormat(activity.creation, 'MMM D, dddd')">
           <div class="text-sm text-ink-gray-5">
             {{ __(timeAgo(activity.creation)) }}

--- a/desk/src/components/CommentBox.vue
+++ b/desk/src/components/CommentBox.vue
@@ -16,7 +16,7 @@
       </div>
       <div class="flex items-center gap-1">
         <Tooltip :text="dateFormat(creation, dateTooltipFormat)">
-          <span class="pl-0.5 text-sm text-ink-gray-5">
+          <span class="ps-0.5 text-sm text-ink-gray-5">
             {{ timeAgo(creation) }}
           </span>
         </Tooltip>

--- a/desk/src/components/CommentTextEditor.vue
+++ b/desk/src/components/CommentTextEditor.vue
@@ -17,7 +17,7 @@
         ]"
       />
       <!-- Attachments -->
-      <div class="flex flex-wrap gap-2 my-2 ml-5">
+      <div class="flex flex-wrap gap-2 my-2 ms-5">
         <AttachmentItem
           v-for="a in attachments"
           :key="a.file_url"
@@ -61,11 +61,11 @@
                     </button>
                   </template>
                 </FileUploader>
-                <div class="h-4 w-[2px] border-l ml-1" />
+                <div class="h-4 w-[2px] border-s ms-1" />
               </div>
               <EditorFixedMenu :items="fullToolbar" />
             </div>
-            <div class="flex items-center justify-end space-x-2 w-[40%]">
+            <div class="flex items-center justify-end gap-x-2 w-[40%]">
               <Button
                 label="Discard"
                 @click="

--- a/desk/src/components/CompactEditor.vue
+++ b/desk/src/components/CompactEditor.vue
@@ -14,7 +14,7 @@
         >
           <div
             v-if="showAttachments"
-            class="inline-flex items-center gap-1.5 pr-1"
+            class="inline-flex items-center gap-1.5 pe-1"
           >
             <FileUploader
               :upload-args="{ private: true }"
@@ -34,7 +34,7 @@
                 </button>
               </template>
             </FileUploader>
-            <div class="h-4 w-[2px] border-l ml-1" />
+            <div class="h-4 w-[2px] border-s ms-1" />
           </div>
           <EditorFixedMenu :items="fullToolbar" />
         </div>

--- a/desk/src/components/EmailArea.vue
+++ b/desk/src/components/EmailArea.vue
@@ -39,7 +39,7 @@
             :label="__(status.label)"
             variant="subtle"
             :theme="status.color"
-            class="mr-1.5"
+            class="me-1.5"
           />
           <Tooltip
             :text="dateFormat(creation, dateTooltipFormat)"
@@ -89,8 +89,8 @@
         v-for="(val, label) in { To: to, cc: cc, bcc: bcc }"
         :key="label"
       >
-        <span v-if="val" class="mr-1.5">
-          <span class="mr-1 text-ink-gray-7">{{ label }}:</span>
+        <span v-if="val" class="me-1.5">
+          <span class="me-1 text-ink-gray-7">{{ label }}:</span>
           <span> {{ normalizeAndFilter(val).join(", ") }}</span>
         </span>
       </template>

--- a/desk/src/components/HistoryBox.vue
+++ b/desk/src/components/HistoryBox.vue
@@ -7,9 +7,9 @@
         v-if="relatedActivities.length > 1"
         class="inline-flex flex-wrap gap-1.5 text-ink-gray-8 font-medium w-4/5"
       >
-        <span>{{ `${show_others ? "Hide " : "Show "}` }}</span>
+        <span>{{ `${show_others ? __("Hide ") : __("Show ")}` }}</span>
         <span>+{{ relatedActivities.length }} </span>
-        <span>changes from </span>
+        <span>{{ __("changes from") }} </span>
         <span>{{ user }}</span>
 
         <Button

--- a/desk/src/components/LayoutHeader.vue
+++ b/desk/src/components/LayoutHeader.vue
@@ -2,7 +2,7 @@
   <Teleport to="#app-header" v-if="showHeader">
     <slot>
       <header
-        class="flex h-10.5 items-center justify-between mx-4 md:mx-5 md:mr-0"
+        class="flex h-10.5 items-center justify-between mx-4 md:ms-5 md:me-0"
       >
         <div class="flex items-center gap-2 min-w-0 flex-1">
           <slot name="left-header" />

--- a/desk/src/components/ListRows.vue
+++ b/desk/src/components/ListRows.vue
@@ -3,7 +3,7 @@
     <div v-for="group in groupedRows" :key="group.group">
       <ListGroupHeader :group="group">
         <div
-          class="my-2 flex items-center gap-2 text-base-medium text-ink-gray-8 justify-between w-full mr-1"
+          class="my-2 flex items-center gap-2 text-base-medium text-ink-gray-8 justify-between w-full me-1"
         >
           <div class="flex items-center gap-2 w-full">
             <component v-if="group.icon" :is="group.icon" />
@@ -11,7 +11,7 @@
               v-if="group.group.label != ''"
               class="flex items-end gap-1 w-full"
             >
-              <span>{{ group.group.label }}</span>
+              <span>{{ __(group.group.label) }}</span>
               <span class="text-xs text-ink-gray-5"
                 >{{
                   group.rows.length +

--- a/desk/src/components/ListViewBuilder.vue
+++ b/desk/src/components/ListViewBuilder.vue
@@ -8,9 +8,9 @@
     v-if="showViewControls"
   >
     <QuickFilters v-if="!isMobileView" />
-    <div v-if="!isMobileView" class="-ml-2 h-5 border-l"></div>
+    <div v-if="!isMobileView" class="-ms-2 h-5 border-s"></div>
     <div
-      class="flex items-start gap-2 justify-end h-full py-1 pl-0.5"
+      class="flex items-start gap-2 justify-end h-full py-1 ps-0.5"
       v-if="!isMobileView"
     >
       <Button

--- a/desk/src/components/MultipleAvatar.vue
+++ b/desk/src/components/MultipleAvatar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="_avatars?.length" class="mr-1.5 flex cursor-pointer items-center">
+  <div v-if="_avatars?.length" class="me-1.5 flex cursor-pointer items-center">
     <div
       v-if="_avatars?.length == 1"
       class="flex items-center gap-2 text-base line-clamp-1"
@@ -21,7 +21,7 @@
       :text="avatar.name"
     >
       <Avatar
-        class="user-avatar -mr-1.5 ring-2 ring-[var(--surface-base)] transition hover:z-10 hover:scale-110"
+        class="user-avatar -me-1.5 ring-2 ring-[var(--surface-base)] transition hover:z-10 hover:scale-110"
         shape="circle"
         :image="avatar.image"
         :label="avatar.label"

--- a/desk/src/components/Password.vue
+++ b/desk/src/components/Password.vue
@@ -24,7 +24,7 @@
           <component
             v-show="showEye"
             :is="show ? LucideEyeOff : LucideEye"
-            class="h-3 cursor-pointer mr-1"
+            class="h-3 cursor-pointer me-1"
             @click="show = !show"
           />
         </div>

--- a/desk/src/components/SavedRepliesSelectorModal.vue
+++ b/desk/src/components/SavedRepliesSelectorModal.vue
@@ -39,7 +39,7 @@
                 icon="lucide-x"
                 variant="ghost"
                 @click="search = ''"
-                class="absolute right-1 top-1/2 -translate-y-1/2"
+                class="absolute end-1 top-1/2 -translate-y-1/2"
               />
             </div>
             <Dropdown :options="filters" placement="right">
@@ -104,7 +104,7 @@
                   selectedTemplate.name === template.name &&
                   selectedTemplate.isLoading
                 "
-                class="flex items-center justify-center absolute top-0 left-0 w-full h-full bg-surface-gray-10/20 rounded-lg"
+                class="flex items-center justify-center absolute top-0 start-0 w-full h-full bg-surface-gray-10/20 rounded-lg"
               >
                 <LoadingIndicator class="size-4" />
               </div>

--- a/desk/src/components/SearchArticles.vue
+++ b/desk/src/components/SearchArticles.vue
@@ -3,7 +3,7 @@
     v-if="Boolean(articles.data?.length) && query.length > 2"
     class="rounded border p-4 text-base"
   >
-    <div class="mb-2 font-medium pl-2" v-if="!hideViewAll">
+    <div class="mb-2 font-medium ps-2" v-if="!hideViewAll">
       These articles may already cover what you are looking for
       <RouterLink
         class="group cursor-pointer space-x-1 hover:text-ink-gray-9"

--- a/desk/src/components/SearchMultiSelect.vue
+++ b/desk/src/components/SearchMultiSelect.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative inline-block text-left">
+  <div class="relative inline-block text-start">
     <div class="flex">
       <Button
         variant="outline"
@@ -12,7 +12,7 @@
         >
           <template v-if="selectedCount > 0">
             <!-- Stacked Avatars -->
-            <div class="flex -space-x-2 isolate">
+            <div class="flex -space-x-2 rtl:space-x-reverse isolate">
               <div
                 v-for="(option, index) in selectedOptions.slice(0, 3)"
                 :key="`avatar-${option.value}`"
@@ -41,7 +41,7 @@
         </div>
         <template #suffix>
           <LucideChevronDown
-            class="ml-2 h-4 w-4 transition-transform duration-200"
+            class="ms-2 h-4 w-4 transition-transform duration-200"
             :class="{ 'rotate-180': isOpen }"
           />
         </template>
@@ -50,7 +50,7 @@
 
     <div
       v-if="isOpen"
-      class="absolute z-50 mt-2 w-64 divide-y divide-outline-elevation-2 rounded-lg bg-surface-elevation-2 shadow-2xl ring-1 ring-black ring-opacity-5 focus:outline-none left-0 origin-top-left"
+      class="absolute z-50 mt-2 w-64 divide-y divide-outline-elevation-2 rounded-lg bg-surface-elevation-2 shadow-2xl ring-1 ring-black ring-opacity-5 focus:outline-none start-0 origin-top-left"
     >
       <!-- Header -->
       <div class="py-1.5 px-1.5">
@@ -91,7 +91,7 @@
           >
             <Checkbox
               :modelValue="props.modelValue.includes(option.value)"
-              class="mr-2 flex-shrink-0"
+              class="me-2 flex-shrink-0"
             />
 
             <component v-if="option.icon" :is="renderIcon(option.icon)" />
@@ -100,17 +100,17 @@
               v-else-if="hasAnyVisualElements"
               :image="option.image"
               :label="option.label"
-              class="mr-2 flex-shrink-0"
+              class="me-2 flex-shrink-0"
               size="sm"
             />
 
-            <span class="text-ink-gray-7 flex-1 text-left truncate">
+            <span class="text-ink-gray-7 flex-1 text-start truncate">
               {{ option.label }}
             </span>
 
             <span
               v-if="(option.count ?? 0) > 0"
-              class="text-xs text-ink-gray-5 ml-auto"
+              class="text-xs text-ink-gray-5 ms-auto"
             >
               {{ option.count }}
             </span>
@@ -136,7 +136,7 @@
           >
             <Checkbox
               :modelValue="props.modelValue.includes(option.value)"
-              class="mr-2 flex-shrink-0"
+              class="me-2 flex-shrink-0"
             />
 
             <component v-if="option.icon" :is="renderIcon(option.icon)" />
@@ -145,23 +145,23 @@
               v-else-if="option.image"
               :image="option.image"
               :label="option.label"
-              class="mr-2 flex-shrink-0"
+              class="me-2 flex-shrink-0"
               size="sm"
             />
 
             <!-- Spacer for alignment when other options have visual elements -->
             <div
               v-else-if="hasAnyVisualElements"
-              class="mr-2 w-6 h-6 flex-shrink-0"
+              class="me-2 w-6 h-6 flex-shrink-0"
             ></div>
 
-            <span class="text-ink-gray-7 flex-1 text-left truncate">
+            <span class="text-ink-gray-7 flex-1 text-start truncate">
               {{ option.label }}
             </span>
 
             <span
               v-if="(option.count ?? 0) > 0"
-              class="text-xs text-ink-gray-5 ml-auto"
+              class="text-xs text-ink-gray-5 ms-auto"
             >
               {{ option.count }}
             </span>
@@ -391,7 +391,7 @@ function renderIcon(icon: string | any) {
     "span",
     {
       class:
-        "flex-shrink-0 w-4 h-4 inline-flex items-center justify-center mr-2",
+        "flex-shrink-0 w-4 h-4 inline-flex items-center justify-center me-2",
     },
     [iconContent]
   );

--- a/desk/src/components/SelectDropdown.vue
+++ b/desk/src/components/SelectDropdown.vue
@@ -37,7 +37,7 @@
             <FeatherIcon
               v-if="model == option.value"
               name="check"
-              class="size-4 ml-2"
+              class="size-4 ms-2"
             />
           </div>
         </div>

--- a/desk/src/components/Settings/AgentCard.vue
+++ b/desk/src/components/Settings/AgentCard.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex items-center justify-between py-2" v-bind:class="$attrs">
-    <div class="flex items-center space-x-3 w-4/5">
+    <div class="flex items-center gap-x-3 w-4/5">
       <Avatar :image="agent.user_image" :label="agent.agent_name" size="xl" />
       <div>
         <div class="flex items-center gap-2">

--- a/desk/src/components/Settings/Assignment Rules/AssigneeRules.vue
+++ b/desk/src/components/Settings/Assignment Rules/AssigneeRules.vue
@@ -27,7 +27,7 @@
         <Popover placement="bottom-end">
           <template #target="{ togglePopover }">
             <div
-              class="flex items-center justify-between text-base rounded h-7 py-1.5 pl-2 pr-2 border border-[--surface-gray-2] bg-surface-gray-2 placeholder-ink-gray-4 hover:border-outline-elevation-2 hover:bg-surface-gray-3 focus:bg-surface-base focus:border-outline-gray-4 focus:shadow-sm focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3 text-ink-gray-8 transition-colors w-full dark:[color-scheme:dark] select-none min-w-44"
+              class="flex items-center justify-between text-base rounded h-7 py-1.5 ps-2 pe-2 border border-[--surface-gray-2] bg-surface-gray-2 placeholder-ink-gray-4 hover:border-outline-elevation-2 hover:bg-surface-gray-3 focus:bg-surface-base focus:border-outline-gray-4 focus:shadow-sm focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3 text-ink-gray-8 transition-colors w-full dark:[color-scheme:dark] select-none min-w-44"
               @click="togglePopover()"
             >
               <div>

--- a/desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue
+++ b/desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue
@@ -7,6 +7,7 @@
           icon-left="lucide-plus"
           @click="togglePopover()"
           :label="__('Add Assignee')"
+          class="rtl:flex-row-reverse"
         />
       </template>
       <template #body="{ togglePopover }">
@@ -28,7 +29,7 @@
               :placeholder="__('Search')"
             />
             <button
-              class="absolute right-1.5 inline-flex h-7 w-7 items-center justify-center"
+              class="absolute end-1.5 inline-flex h-7 w-7 items-center justify-center"
               @click="query = ''"
             >
               <FeatherIcon name="x" class="w-4" />
@@ -81,7 +82,7 @@
           <div class="border-t p-1.5 pb-0.5">
             <Button
               variant="ghost"
-              class="w-full"
+              class="w-full rtl:flex-row-reverse"
               icon-left="lucide-plus"
               :label="__('Invite agent')"
               @click="inviteAgents"

--- a/desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue
+++ b/desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue
@@ -4,7 +4,7 @@
   >
     <div
       @click="assignmentRulesActiveScreen = { screen: 'view', data: data }"
-      class="w-full pl-2 col-span-7 h-14 flex flex-col justify-center"
+      class="w-full ps-2 col-span-7 h-14 flex flex-col justify-center"
     >
       <div class="text-base-medium text-ink-gray-7">{{ data.name }}</div>
       <div
@@ -16,7 +16,7 @@
     </div>
     <div class="col-span-3">
       <select
-        class="w-full h-7 text-base hover:bg-surface-gray-3 rounded-md p-0 pl-2 pr-5 bg-transparent -ml-2 border-0 text-ink-gray-8 focus-visible:!ring-0 bg-none truncate"
+        class="w-full h-7 text-base hover:bg-surface-gray-3 rounded-md p-0 ps-2 pe-5 bg-transparent -ms-2 border-0 text-ink-gray-8 focus-visible:!ring-0 bg-none truncate"
         v-model="data.priority"
         @update:modelValue="onPriorityChange"
         @change="onPriorityChange"
@@ -30,7 +30,7 @@
         </option>
       </select>
     </div>
-    <div class="flex justify-between items-center w-full pr-2 col-span-2">
+    <div class="flex justify-between items-center w-full pe-2 col-span-2">
       <div>
         <Switch
           size="sm"

--- a/desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue
+++ b/desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue
@@ -1,20 +1,11 @@
 <template>
-  <SettingsLayoutBase>
-    <template #title>
-      <div class="flex items-center gap-2">
-        <Button
-          variant="ghost"
-          icon-left="chevron-left"
-          :label="
-            assignmentRuleData.assignmentRuleName || __('New Assignment Rule')
-          "
-          size="md"
-          @click="goBack()"
-          class="cursor-pointer -ml-4 hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 font-semibold text-lg hover:opacity-70 !pr-0 !max-w-96 !justify-start"
-        />
-        <UnsavedBadge :show="isDirty" />
-      </div>
-    </template>
+  <SettingsLayoutBase
+    :back-label="
+      assignmentRuleData.assignmentRuleName || __('New Assignment Rule')
+    "
+    :on-back="goBack"
+    :dirty="isDirty"
+  >
     <template #header-actions>
       <div class="flex items-center gap-4">
         <div
@@ -69,7 +60,7 @@
             <Popover>
               <template #target="{ togglePopover }">
                 <div
-                  class="flex items-center justify-between text-base rounded h-7 py-1.5 pl-2 pr-2 border border-[--surface-gray-2] bg-surface-gray-2 placeholder-ink-gray-4 hover:border-outline-elevation-2 hover:bg-surface-gray-3 focus:bg-surface-base focus:border-outline-gray-4 focus:shadow-sm focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3 text-ink-gray-8 transition-colors w-full dark:[color-scheme:dark] cursor-default"
+                  class="flex items-center justify-between text-base rounded h-7 py-1.5 ps-2 pe-2 border border-[--surface-gray-2] bg-surface-gray-2 placeholder-ink-gray-4 hover:border-outline-elevation-2 hover:bg-surface-gray-3 focus:bg-surface-base focus:border-outline-gray-4 focus:shadow-sm focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3 text-ink-gray-8 transition-colors w-full dark:[color-scheme:dark] cursor-default"
                   @click="togglePopover()"
                 >
                   <div>
@@ -350,7 +341,6 @@ import { convertToConditions } from "@/utils";
 import { disableSettingModalOutsideClick } from "../settingsModal";
 import { __ } from "@/translation";
 import SettingsLayoutBase from "@/components/layouts/SettingsLayoutBase.vue";
-import UnsavedBadge from "@/components/UnsavedBadge.vue";
 
 const isDirty = ref(false);
 const initialData = ref(null);

--- a/desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue
+++ b/desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue
@@ -21,6 +21,7 @@
         variant="solid"
         @click="goToNew()"
         icon-left="lucide-plus"
+        class="rtl:flex-row-reverse"
       />
     </template>
     <template
@@ -48,7 +49,7 @@
           icon="lucide-x"
           variant="ghost"
           @click="assignmentRuleSearchQuery = ''"
-          class="absolute right-1 top-1/2 -translate-y-1/2"
+          class="absolute end-1 top-1/2 -translate-y-1/2"
         />
       </div>
     </template>

--- a/desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue
+++ b/desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue
@@ -5,7 +5,7 @@
   >
     <LoadingIndicator class="w-4" />
   </div>
-  <div v-else class="-ml-2 grow">
+  <div v-else class="-ms-2 grow">
     <div
       v-if="!assignmentRulesListData.loading && !assignmentRulesList?.length"
       class="flex flex-col items-center justify-center gap-4 h-full"
@@ -26,7 +26,7 @@
     </div>
     <div v-else>
       <div class="grid grid-cols-12 items-center gap-4 text-sm text-ink-gray-5">
-        <div class="col-span-7 ml-2">{{ __("Assignment rule") }}</div>
+        <div class="col-span-7 ms-2">{{ __("Assignment rule") }}</div>
         <div class="col-span-3">{{ __("Priority") }}</div>
         <div class="col-span-2">{{ __("Enabled") }}</div>
       </div>

--- a/desk/src/components/Settings/EmailAccountCard.vue
+++ b/desk/src/components/Settings/EmailAccountCard.vue
@@ -5,12 +5,12 @@
     <!-- avatar and name -->
     <div class="flex justify-between items-center gap-2">
       <EmailProviderIcon :logo="emailIcon[emailAccount.service]" />
-      <div>
+      <div class="rtl:text-right">
         <p class="text-base-medium text-ink-gray-7">
           {{ emailAccount.email_account_name }}
         </p>
-        <div class="text-sm w-full text-ink-gray-5 mt-1">
-          {{ emailAccount.email_id }}
+        <div class="text-p-sm w-full text-ink-gray-5 mt-1">
+          {{ __(emailAccount.email_id) }}
         </div>
       </div>
     </div>

--- a/desk/src/components/Settings/EmailAccountList.vue
+++ b/desk/src/components/Settings/EmailAccountList.vue
@@ -11,6 +11,7 @@
       <Button
         :label="__('New')"
         theme="gray"
+        class="rtl:flex-row-reverse"
         variant="solid"
         @click="emit('update:step', 'email-add')"
         icon-left="lucide-plus"
@@ -19,11 +20,11 @@
     <template #content>
       <!-- list accounts -->
       <div
-        class="-ml-2 grow"
+        class="-ms-2 grow"
         v-if="!emailAccounts.loading && Boolean(emailAccounts.data?.length)"
       >
         <div class="flex text-sm text-ink-gray-5">
-          <div class="ml-2">{{ __("Email account name") }}</div>
+          <div class="ms-2">{{ __("Email account name") }}</div>
         </div>
         <hr class="mx-2 mt-2" />
         <div
@@ -44,7 +45,7 @@
         </div>
       </div>
       <!-- fallback if no email accounts -->
-      <EmptyState
+      <div
         v-else
         variant="badge"
         :icon="EmailIcon"

--- a/desk/src/components/Settings/EmailAdd.vue
+++ b/desk/src/components/Settings/EmailAdd.vue
@@ -135,7 +135,7 @@
                   </p>
                 </div>
               </div>
-              <ErrorMessage v-if="error" class="ml-1" :message="error" />
+              <ErrorMessage v-if="error" class="ms-1" :message="error" />
             </div>
           </div>
         </div>

--- a/desk/src/components/Settings/EmailEdit.vue
+++ b/desk/src/components/Settings/EmailEdit.vue
@@ -126,7 +126,7 @@
                 <p class="text-p-sm text-ink-gray-4">{{ field.description }}</p>
               </div>
             </div>
-            <ErrorMessage v-if="error" class="ml-1" :message="error" />
+            <ErrorMessage v-if="error" class="ms-1" :message="error" />
           </div>
         </div>
 

--- a/desk/src/components/Settings/EmailNotifications/Notification.vue
+++ b/desk/src/components/Settings/EmailNotifications/Notification.vue
@@ -3,15 +3,15 @@
     <template #title>
       <div class="flex items-center">
         <div
-          class="pl-5 pr-2 relative text-ink-gray-7 hover:opacity-70 min-h-8 flex items-center"
+          class="ps-5 pe-2 relative text-ink-gray-7 hover:opacity-70 min-h-8 flex items-center"
         >
           <button
             type="button"
             @click="internalOnBack"
-            class="absolute top-0 -left-[0.375rem] w-full h-full"
+            class="absolute top-0 -start-[0.375rem] w-full h-full"
           >
             <span class="sr-only">{{ __("back to email event list") }}</span>
-            <LucideChevronLeft class="w-4.5 h-4.5" />
+            <LucideChevronLeft class="w-4.5 h-4.5 rtl:rotate-180" />
           </button>
           <h1 class="text-2xl-semibold">
             {{ props.title }}
@@ -32,7 +32,7 @@
           v-model="enabled"
           @update:model-value="(val) => setUnsavedChanges(val)"
           :style="{ background: 'transparent', padding: '0px' }"
-          class="flex-row-reverse gap-x-2 pl-0"
+          class="flex-row-reverse gap-x-2 ps-0"
         />
         <Button
           type="button"

--- a/desk/src/components/Settings/EmailNotifications/NotificationList.vue
+++ b/desk/src/components/Settings/EmailNotifications/NotificationList.vue
@@ -8,7 +8,7 @@
     "
   >
     <template #content>
-      <ul class="isolate -ml-3">
+      <ul class="isolate -ms-3">
         <div
           v-for="(notification, index) in notifications"
           :key="notification.name"
@@ -28,10 +28,10 @@
             </div>
             <FeatherIcon
               name="chevron-right"
-              class="text-ink-gray-7 size-4 relative z-10 pointer-events-none"
+              class="text-ink-gray-7 size-4 relative z-10 pointer-events-none rtl:rotate-180"
             />
             <div
-              class="w-full h-full absolute top-0 left-0 hover:bg-surface-sidebar rounded-[inherit]"
+              class="w-full h-full absolute top-0 start-0 hover:bg-surface-sidebar rounded-[inherit]"
               @click="
                 () => {
                   props.onSelect(notification);

--- a/desk/src/components/Settings/FieldDependency/FieldDependency.vue
+++ b/desk/src/components/Settings/FieldDependency/FieldDependency.vue
@@ -1,18 +1,9 @@
 <template>
-  <SettingsLayoutBase>
-    <template #title>
-      <div class="flex items-center gap-2">
-        <Button
-          variant="ghost"
-          icon-left="chevron-left"
-          :label="dependencyLabel"
-          size="md"
-          @click="handleBackNavigation"
-          class="cursor-pointer -ml-4 hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 font-semibold text-ink-gray-7 text-lg hover:opacity-70 !pr-0"
-        />
-        <UnsavedBadge :show="isDirty" />
-      </div>
-    </template>
+  <SettingsLayoutBase
+    :back-label="dependencyLabel"
+    :on-back="handleBackNavigation"
+    :dirty="isDirty"
+  >
     <template #header-actions>
       <div class="flex gap-4">
         <!-- Switch -->
@@ -98,7 +89,6 @@ import FieldDependencyFieldsSelection from "./FieldDependencyFieldsSelection.vue
 import FieldDependencyValueSelection from "./FieldDependencyValueSelection.vue";
 import { __ } from "@/translation";
 import SettingsLayoutBase from "@/components/layouts/SettingsLayoutBase.vue";
-import UnsavedBadge from "@/components/UnsavedBadge.vue";
 
 const props = defineProps({
   fieldDependencyName: {

--- a/desk/src/components/Settings/FieldDependency/FieldDependencyList.vue
+++ b/desk/src/components/Settings/FieldDependency/FieldDependencyList.vue
@@ -29,6 +29,7 @@
         variant="solid"
         @click="$emit('update:step', 'fd')"
         icon-left="lucide-plus"
+        class="rtl:flex-row-reverse"
       />
     </template>
     <template #content>
@@ -54,7 +55,7 @@
         />
 
         <div
-          class="w-full -ml-2"
+          class="w-full -ms-2"
           v-if="
             !fieldDependenciesList.loading &&
             fieldDependenciesList.data?.length > 0
@@ -64,7 +65,7 @@
             <div
               class="grid grid-cols-11 items-center gap-4 text-sm text-ink-gray-5"
             >
-              <div class="col-span-7 ml-2">{{ __("Name") }}</div>
+              <div class="col-span-7 ms-2">{{ __("Name") }}</div>
               <div class="col-span-2">{{ __("Created by") }}</div>
               <div class="col-span-2">{{ __("Enabled") }}</div>
             </div>
@@ -78,7 +79,7 @@
               >
                 <div
                   @click.stop="$emit('update:step', 'fd', row.name)"
-                  class="w-full py-3 pl-2 col-span-7 text-base text-ink-gray-7"
+                  class="w-full py-3 ps-2 col-span-7 text-base text-ink-gray-7"
                 >
                   <span>{{ getFieldDependencyLabel(row.name) }}</span>
                 </div>
@@ -89,7 +90,7 @@
                   }}</span>
                 </div>
                 <div
-                  class="flex justify-between items-center w-full pr-2 col-span-2"
+                  class="flex justify-between items-center w-full pe-2 col-span-2"
                 >
                   <div>
                     <Switch

--- a/desk/src/components/Settings/FieldDependency/FieldDependencyValueSelection.vue
+++ b/desk/src/components/Settings/FieldDependency/FieldDependencyValueSelection.vue
@@ -7,7 +7,7 @@
       <span class="block text-xs text-ink-gray-5">
         Select parent field value
       </span>
-      <div class="border flex-1 border-r-0 rounded-l p-2 flex flex-col gap-2">
+      <div class="border flex-1 border-e-0 rounded-s p-2 flex flex-col gap-2">
         <template v-if="state.selectedParentField">
           <FormControl
             v-model="state.parentSearch"
@@ -35,7 +35,7 @@
                   value
                 }}</span>
                 <LucideChevronRight
-                  class="h-4 w-4 text-ink-gray-6"
+                  class="h-4 w-4 text-ink-gray-6 rtl:rotate-180"
                   v-if="
                     getSelectedChildValueCount(value) === 0 ||
                     state.currentParentSelection === value
@@ -63,10 +63,10 @@
     </div>
     <!-- right box -->
     <div class="flex-1 flex flex-col gap-1.5">
-      <span class="block text-xs text-ink-gray-5 pl-1.5">
+      <span class="block text-xs text-ink-gray-5 ps-1.5">
         Select child field value
       </span>
-      <div class="border flex-1 rounded-r p-2 flex flex-col gap-2">
+      <div class="border flex-1 rounded-e p-2 flex flex-col gap-2">
         <template
           v-if="state.selectedChildField && state.currentParentSelection"
         >
@@ -89,7 +89,7 @@
               <FormControl
                 type="checkbox"
                 :model-value="toggleAllChildValues"
-                class="mr-2"
+                class="me-2"
               />
               <span class="text-base-medium text-ink-gray-8">
                 {{ toggleCheckboxLabel }}
@@ -105,7 +105,7 @@
                 <FormControl
                   type="checkbox"
                   :model-value="isChildValueSelected(value)"
-                  class="mr-2"
+                  class="me-2"
                 />
                 <span class="text-base text-ink-gray-6">{{ value }}</span>
               </li>

--- a/desk/src/components/Settings/General/components/LogoUpload.vue
+++ b/desk/src/components/Settings/General/components/LogoUpload.vue
@@ -29,7 +29,7 @@
         "
       >
         <template v-slot="{ progress, uploading, openFileSelector }">
-          <div class="flex items-end space-x-2">
+          <div class="flex items-end gap-x-2">
             <Button
               @click="openFileSelector"
               :iconLeft="ImageUpIcon"

--- a/desk/src/components/Settings/Holiday/HLCalender.vue
+++ b/desk/src/components/Settings/Holiday/HLCalender.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="w-max mx-auto">
-    <div class="text-base-medium mb-2 text-ink-gray-8 ml-2.5">
+    <div class="text-base-medium mb-2 text-ink-gray-8 ms-2.5">
       {{ formattedMonth }}
     </div>
     <div class="rounded-md text-sm">

--- a/desk/src/components/Settings/Holiday/HolidayList.vue
+++ b/desk/src/components/Settings/Holiday/HolidayList.vue
@@ -5,7 +5,7 @@
   >
     <LoadingIndicator class="w-4" />
   </div>
-  <div v-else class="-ml-2 grow">
+  <div v-else class="-ms-2 grow">
     <div
       v-if="!holidayList.list.loading && !holidayList.list.data?.length"
       class="flex flex-col items-center justify-center gap-4 h-full"
@@ -26,7 +26,7 @@
     </div>
     <div v-else>
       <div class="flex text-sm text-ink-gray-5">
-        <div class="ml-2">{{ __("Schedule name") }}</div>
+        <div class="ms-2">{{ __("Schedule name") }}</div>
       </div>
       <hr class="mx-2 mt-2" />
       <div>

--- a/desk/src/components/Settings/Holiday/HolidayListItem.vue
+++ b/desk/src/components/Settings/Holiday/HolidayListItem.vue
@@ -3,7 +3,7 @@
     class="flex items-center cursor-pointer hover:bg-surface-sidebar rounded"
   >
     <div
-      class="w-full pl-2 flex flex-col justify-center h-14"
+      class="w-full ps-2 flex flex-col justify-center h-14"
       @click="holidayListActiveScreen = { screen: 'view', data: data }"
     >
       <div class="text-base-medium text-ink-gray-7">{{ data.name }}</div>
@@ -14,7 +14,7 @@
         {{ data.description }}
       </div>
     </div>
-    <div class="flex justify-between items-center pr-2">
+    <div class="flex justify-between items-center pe-2">
       <div>
         <Dropdown placement="right" :options="dropdownOptions">
           <Button

--- a/desk/src/components/Settings/Holiday/HolidayView.vue
+++ b/desk/src/components/Settings/Holiday/HolidayView.vue
@@ -1,18 +1,9 @@
 <template>
-  <SettingsLayoutBase>
-    <template #title>
-      <div class="flex items-center gap-2">
-        <Button
-          variant="ghost"
-          icon-left="chevron-left"
-          :label="holidayData?.holiday_list_name || __('New Business Holiday')"
-          size="md"
-          @click="goBack()"
-          class="cursor-pointer -ml-4 hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 font-semibold text-ink-gray-7 text-lg hover:opacity-70 !pr-0"
-        />
-        <UnsavedBadge :show="isDirty" />
-      </div>
-    </template>
+  <SettingsLayoutBase
+    :back-label="holidayData?.holiday_list_name || __('New Business Holiday')"
+    :on-back="goBack"
+    :dirty="isDirty"
+  >
     <template #header-actions>
       <Button
         :label="__('Save')"
@@ -248,7 +239,6 @@ import HolidaysCalendarView from "./HolidaysCalendarView.vue";
 import AddHolidayModal from "./Modals/AddHolidayModal.vue";
 import { __ } from "@/translation";
 import SettingsLayoutBase from "@/components/layouts/SettingsLayoutBase.vue";
-import UnsavedBadge from "@/components/UnsavedBadge.vue";
 import { HolidayListResourceSymbol } from "@/types";
 import { HDServiceHolidayList } from "@/types/doctypes";
 

--- a/desk/src/components/Settings/Holiday/Holidays.vue
+++ b/desk/src/components/Settings/Holiday/Holidays.vue
@@ -14,6 +14,7 @@
         variant="solid"
         @click="goToNew()"
         icon-left="lucide-plus"
+        class="rtl:flex-row-reverse"
       />
     </template>
     <template
@@ -38,7 +39,7 @@
           icon="lucide-x"
           variant="ghost"
           @click="holidaySearchRef = ''"
-          class="absolute right-1 top-1/2 -translate-y-1/2"
+          class="absolute end-1 top-1/2 -translate-y-1/2"
         />
       </div>
     </template>

--- a/desk/src/components/Settings/Holiday/HolidaysCalendarView.vue
+++ b/desk/src/components/Settings/Holiday/HolidaysCalendarView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="p-6.5 px-5 rounded-xl border border-outline-gray-2">
     <div class="mb-6.5 flex justify-between items-center">
-      <div class="ml-1">
+      <div class="ms-1">
         <Popover v-if="startYear !== endYear">
           <template #target="{ togglePopover }">
             <Button

--- a/desk/src/components/Settings/InviteAgents.vue
+++ b/desk/src/components/Settings/InviteAgents.vue
@@ -22,7 +22,7 @@
           <Select :options="roleOptions" v-model="role" required class="w-full">
             <template #suffix>
               <LucideChevronDown
-                class="size-4 shrink-0 text-ink-gray-4 ml-auto"
+                class="size-4 shrink-0 text-ink-gray-4 ms-auto"
               />
             </template>
           </Select>

--- a/desk/src/components/Settings/Profile/UserEmailSettings.vue
+++ b/desk/src/components/Settings/Profile/UserEmailSettings.vue
@@ -1,24 +1,9 @@
 <template>
-  <SettingsLayoutBase>
-    <template #title>
-      <div class="flex gap-1 items-center">
-        <Button
-          variant="ghost"
-          icon-left="chevron-left"
-          :label="__('Email Settings')"
-          size="md"
-          class="cursor-pointer -ml-4 hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 font-semibold text-xl hover:opacity-70 !pr-0 !max-w-96 !justify-start"
-          @click="goBack"
-        />
-        <Transition name="fade">
-          <Badge
-            v-if="isDirty"
-            :label="__('Not Saved')"
-            variant="subtle"
-            theme="orange"
-        /></Transition>
-      </div>
-    </template>
+  <SettingsLayoutBase
+    :back-label="__('Email Settings')"
+    :on-back="goBack"
+    :dirty="isDirty"
+  >
     <template #header-actions>
       <Transition name="fade">
         <div v-if="isDirty">

--- a/desk/src/components/Settings/SavedReplies/SavedRepliesList.vue
+++ b/desk/src/components/Settings/SavedReplies/SavedRepliesList.vue
@@ -14,6 +14,7 @@
         variant="solid"
         @click="goToNew()"
         icon-left="lucide-plus"
+        class="rtl:flex-row-reverse"
       />
     </template>
     <template #header-bottom>
@@ -35,7 +36,7 @@
             icon="lucide-x"
             variant="ghost"
             @click="savedRepliesSearchQuery = ''"
-            class="absolute right-1 top-1/2 -translate-y-1/2"
+            class="absolute end-1 top-1/2 -translate-y-1/2"
           />
         </div>
         <Dropdown :options="filterOptions" placement="right">
@@ -58,11 +59,11 @@
     <template #content>
       <div
         v-if="savedRepliesListResource?.list?.loading"
-        class="flex items-center justify-center h-[stretch] absolute w-[stretch] left-0 top-5.5"
+        class="flex items-center justify-center my-auto"
       >
         <LoadingIndicator class="w-4" />
       </div>
-      <EmptyState
+      <div
         v-if="
           !savedRepliesListResource?.list?.loading &&
           !savedRepliesListResource?.data?.length
@@ -77,10 +78,10 @@
           !savedRepliesListResource?.list?.loading &&
           savedRepliesListResource?.data?.length
         "
-        class="-ml-2"
+        class="-ms-2"
       >
         <div
-          class="grid grid-cols-12 items-center gap-3 text-sm text-ink-gray-5 ml-2"
+          class="grid grid-cols-12 items-center gap-3 text-sm text-ink-gray-5 ms-2"
         >
           <div class="col-span-7">{{ __("Title") }}</div>
           <div class="col-span-2">{{ __("Owner") }}</div>
@@ -123,7 +124,7 @@
               }}</span>
             </div>
             <div
-              class="flex justify-between items-center w-full pr-2 col-span-3"
+              class="flex justify-between items-center w-full pe-2 col-span-3"
             >
               <div class="flex items-center gap-1 text-sm text-ink-gray-7">
                 <component
@@ -140,7 +141,7 @@
                   icon="lucide-more-horizontal"
                   variant="ghost"
                   @click="isConfirmingDelete = false"
-                  class="mr-2"
+                  class="me-2"
                 />
               </Dropdown>
             </div>

--- a/desk/src/components/Settings/SavedReplies/SavedReplyView.vue
+++ b/desk/src/components/Settings/SavedReplies/SavedReplyView.vue
@@ -1,18 +1,9 @@
 <template>
-  <SettingsLayoutBase>
-    <template #title>
-      <div class="flex items-center gap-2">
-        <Button
-          variant="ghost"
-          icon-left="chevron-left"
-          :label="savedReplyData.title || __('New Saved Reply')"
-          size="md"
-          @click="goBack()"
-          class="cursor-pointer -ml-4 hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 font-semibold text-ink-gray-7 text-lg hover:opacity-70 !pr-0"
-        />
-        <UnsavedBadge :show="isDirty" />
-      </div>
-    </template>
+  <SettingsLayoutBase
+    :back-label="savedReplyData.title || __('New Saved Reply')"
+    :on-back="goBack"
+    :dirty="isDirty"
+  >
     <template #header-actions>
       <div class="flex items-center gap-2">
         <Button

--- a/desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue
+++ b/desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue
@@ -38,7 +38,7 @@
             </Editor>
             <div
               v-if="getResponsePreviewResource.loading"
-              class="absolute top-0 right-0 flex items-center justify-center size-full rounded-md bg-surface-gray-10/20"
+              class="absolute top-0 end-0 flex items-center justify-center size-full rounded-md bg-surface-gray-10/20"
             >
               <LoadingIndicator class="size-4" />
             </div>

--- a/desk/src/components/Settings/SettingsModal.vue
+++ b/desk/src/components/Settings/SettingsModal.vue
@@ -11,7 +11,7 @@
         :style="{ height: 'calc(100vh - 8rem)' }"
       >
         <div
-          class="flex-col rounded-l-lg w-56 shrink-0 ps-1 py-1 bg-surface-sidebar overflow-y-auto hide-scrollbar"
+          class="flex-col rounded-s-lg w-56 shrink-0 ps-1 py-1 bg-surface-sidebar overflow-y-auto hide-scrollbar"
         >
           <h1
             class="h-7.5 px-2 py-[7px] my-[3px] flex cursor-pointer gap-1.5 text-xs-medium text-ink-gray-5 transition-all duration-300 ease-in-out sticky top-0 z-10 bg-surface-sidebar"

--- a/desk/src/components/Settings/Sla/SlaPolicies.vue
+++ b/desk/src/components/Settings/Sla/SlaPolicies.vue
@@ -27,6 +27,7 @@
         variant="solid"
         @click="goToNew()"
         icon-left="lucide-plus"
+        class="rtl:flex-row-reverse"
       />
     </template>
     <template
@@ -51,7 +52,7 @@
           icon="lucide-x"
           variant="ghost"
           @click="slaSearchQuery = ''"
-          class="absolute right-1 top-1/2 -translate-y-1/2"
+          class="absolute end-1 top-1/2 -translate-y-1/2"
         />
       </div>
     </template>

--- a/desk/src/components/Settings/Sla/SlaPolicyList.vue
+++ b/desk/src/components/Settings/Sla/SlaPolicyList.vue
@@ -24,9 +24,9 @@
         </div>
       </div>
     </div>
-    <div v-else class="-ml-2">
+    <div v-else class="-ms-2">
       <div
-        class="grid grid-cols-6 items-center gap-3 text-sm text-ink-gray-5 ml-2"
+        class="grid grid-cols-6 items-center gap-3 text-sm text-ink-gray-5 ms-2"
       >
         <div class="col-span-5">
           {{ __("Policy name") }}

--- a/desk/src/components/Settings/Sla/SlaPolicyListItem.vue
+++ b/desk/src/components/Settings/Sla/SlaPolicyListItem.vue
@@ -4,7 +4,7 @@
   >
     <div
       @click="slaActiveScreen = { screen: 'view', data: data, fetchData: true }"
-      class="w-full pl-2 col-span-5 flex flex-col justify-center h-14"
+      class="w-full ps-2 col-span-5 flex flex-col justify-center h-14"
     >
       <div class="text-base-medium text-ink-gray-7 flex items-center gap-2">
         {{ data.name }}
@@ -17,7 +17,7 @@
         {{ data.description }}
       </div>
     </div>
-    <div class="flex justify-between items-center w-full pr-2">
+    <div class="flex justify-between items-center w-full pe-2">
       <div>
         <Switch
           size="sm"

--- a/desk/src/components/Settings/Sla/SlaPolicyView.vue
+++ b/desk/src/components/Settings/Sla/SlaPolicyView.vue
@@ -1,18 +1,9 @@
 <template>
-  <SettingsLayoutBase>
-    <template #title>
-      <div class="flex items-center gap-2">
-        <Button
-          variant="ghost"
-          icon-left="chevron-left"
-          :label="slaData.service_level || __('New SLA Policy')"
-          size="md"
-          @click="goBack()"
-          class="cursor-pointer -ml-4 hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 font-semibold text-ink-gray-7 text-lg hover:opacity-70 !pr-0"
-        />
-        <UnsavedBadge :show="isDirty" />
-      </div>
-    </template>
+  <SettingsLayoutBase
+    :back-label="slaData.service_level || __('New SLA Policy')"
+    :on-back="goBack"
+    :dirty="isDirty"
+  >
     <template #header-actions>
       <div class="flex gap-4 items-center">
         <div
@@ -293,7 +284,6 @@ import { disableSettingModalOutsideClick } from "../settingsModal";
 import { useOnboarding } from "frappe-ui/frappe";
 import { __ } from "@/translation";
 import SettingsLayoutBase from "@/components/layouts/SettingsLayoutBase.vue";
-import UnsavedBadge from "@/components/UnsavedBadge.vue";
 import { SlaPolicyListResourceSymbol } from "@/types";
 import { HDServiceLevelAgreement } from "@/types/doctypes";
 

--- a/desk/src/components/Settings/Sla/SlaPriorityList.vue
+++ b/desk/src/components/Settings/Sla/SlaPriorityList.vue
@@ -12,7 +12,7 @@
         :key="column.key"
         class="text-ink-gray-5 overflow-hidden whitespace-nowrap text-ellipsis"
         :class="{
-          'ml-2':
+          'ms-2':
             column.key === 'priority' ||
             column.key === 'response_time' ||
             column.key === 'resolution_time',

--- a/desk/src/components/Settings/Sla/SlaPriorityListItem.vue
+++ b/desk/src/components/Settings/Sla/SlaPriorityListItem.vue
@@ -37,9 +37,9 @@
           </template>
         </Popover>
       </div>
-      <div v-else class="ml-2">
+      <div v-else class="ms-2">
         <select
-          class="w-full h-7 text-base hover:bg-surface-gray-3 rounded-md p-0 pl-2 pr-5 bg-transparent -ml-2 border-0 text-ink-gray-8 focus-visible:!ring-0 bg-none truncate"
+          class="w-full h-7 text-base hover:bg-surface-gray-3 rounded-md p-0 ps-2 pe-5 bg-transparent -ms-2 border-0 text-ink-gray-8 focus-visible:!ring-0 bg-none truncate"
           v-model="props.row[column.key]"
         >
           <option

--- a/desk/src/components/Settings/Sla/SlaWorkDaysList.vue
+++ b/desk/src/components/Settings/Sla/SlaWorkDaysList.vue
@@ -12,7 +12,7 @@
         :key="column.key"
         class="text-ink-gray-5 overflow-hidden whitespace-nowrap text-ellipsis"
         :class="{
-          'ml-2': column.key === 'workday',
+          'ms-2': column.key === 'workday',
         }"
       >
         {{ column.label }}

--- a/desk/src/components/Settings/Sla/SlaWorkDaysListItem.vue
+++ b/desk/src/components/Settings/Sla/SlaWorkDaysListItem.vue
@@ -13,9 +13,9 @@
       <div v-if="column.key === 'start_time' || column.key === 'end_time'">
         {{ formatTime(props.row[column.key]) }}
       </div>
-      <div v-else class="ml-2">
+      <div v-else class="ms-2">
         <select
-          class="w-full h-7 text-base hover:bg-surface-gray-3 rounded-md p-0 pl-2 pr-5 bg-transparent -ml-2 border-0 text-ink-gray-8 focus-visible:!ring-0 bg-none truncate"
+          class="w-full h-7 text-base hover:bg-surface-gray-3 rounded-md p-0 ps-2 pe-5 bg-transparent -ms-2 border-0 text-ink-gray-8 focus-visible:!ring-0 bg-none truncate"
           v-model="props.row[column.key]"
         >
           <option

--- a/desk/src/components/Settings/Teams/NewTeam.vue
+++ b/desk/src/components/Settings/Teams/NewTeam.vue
@@ -1,18 +1,9 @@
 <template>
-  <SettingsLayoutBase>
-    <template #title>
-      <div class="flex items-center gap-2">
-        <Button
-          variant="ghost"
-          icon-left="chevron-left"
-          :label="teamData.name || __('New Team')"
-          size="md"
-          @click="goBack()"
-          class="cursor-pointer -ml-4 hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 font-semibold text-ink-gray-7 text-lg hover:opacity-70 !pr-0"
-        />
-        <UnsavedBadge :show="isDirty" />
-      </div>
-    </template>
+  <SettingsLayoutBase
+    :back-label="teamData.name || __('New Team')"
+    :on-back="goBack"
+    :dirty="isDirty"
+  >
     <template #header-actions>
       <div class="flex items-center gap-4">
         <div class="flex items-center gap-2 cursor-pointer">

--- a/desk/src/components/Settings/Teams/TeamEdit.vue
+++ b/desk/src/components/Settings/Teams/TeamEdit.vue
@@ -1,19 +1,8 @@
 <template>
-  <SettingsLayoutBase>
-    <template #title>
-      <div class="flex items-center justify-between w-full">
-        <div class="flex items-center gap-1 justify-center -ml-[16px]">
-          <Button
-            variant="ghost"
-            icon-left="chevron-left"
-            :label="teamName"
-            size="md"
-            @click="() => emit('update:step', 'team-list')"
-            class="cursor-pointer hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 font-semibold text-ink-gray-7 text-lg hover:opacity-70 !pr-0"
-          />
-        </div>
-      </div>
-    </template>
+  <SettingsLayoutBase
+    :back-label="teamName"
+    :on-back="() => emit('update:step', 'team-list')"
+  >
     <template #header-actions>
       <div class="flex items-center gap-4">
         <div class="flex items-center justify-between gap-2 cursor-pointer">
@@ -70,7 +59,7 @@
         <hr class="mt-2" />
         <div v-for="(member, idx) in teamMembers" :key="member.name">
           <div class="grid grid-cols-8 items-center gap-4 group">
-            <div class="w-full p-2 pl-0 col-span-8">
+            <div class="w-full p-2 ps-0 col-span-8">
               <AgentCard :agent="member" class="!py-0">
                 <template #right>
                   <Dropdown

--- a/desk/src/components/Settings/Teams/TeamsList.vue
+++ b/desk/src/components/Settings/Teams/TeamsList.vue
@@ -8,6 +8,7 @@
     <template #header-actions>
       <Button
         :label="__('New')"
+        class="rtl:flex-row-reverse"
         theme="gray"
         variant="solid"
         @click="emit('update:step', 'new-team', '')"
@@ -36,7 +37,7 @@
           icon="lucide-x"
           variant="ghost"
           @click="teamsSearchQuery = ''"
-          class="absolute right-1 top-1/2 -translate-y-1/2"
+          class="absolute end-1 top-1/2 -translate-y-1/2"
         />
       </div>
     </template>
@@ -44,10 +45,10 @@
       <!-- List -->
       <div
         v-if="!teams.loading && teams.data?.length > 0"
-        class="w-full h-full -ml-2"
+        class="w-full h-full -ms-2"
       >
         <div class="flex text-sm text-ink-gray-5">
-          <div class="ml-2">{{ __("Team name") }}</div>
+          <div class="ms-2">{{ __("Team name") }}</div>
         </div>
         <hr class="mx-2 mt-2" />
         <div v-for="(team, index) in teams.data" :key="team.name">
@@ -55,7 +56,7 @@
             class="flex items-center cursor-pointer hover:bg-surface-sidebar rounded h-12.5"
           >
             <div
-              class="w-full py-3 pl-2 flex gap-1 items-center"
+              class="w-full py-3 ps-2 flex gap-1 items-center"
               @click="() => emit('update:step', 'team-edit', team.name)"
             >
               <p class="text-base-medium text-ink-gray-7">
@@ -63,7 +64,7 @@
               </p>
               <Badge :label="__('Disabled')" v-if="team.disabled" />
             </div>
-            <div class="flex justify-between items-center pr-2">
+            <div class="flex justify-between items-center pe-2">
               <div>
                 <Dropdown placement="right" :options="dropdownOptions(team)">
                   <Button

--- a/desk/src/components/Settings/Teams/components/AgentSelector.vue
+++ b/desk/src/components/Settings/Teams/components/AgentSelector.vue
@@ -34,7 +34,7 @@
             ref="search"
             :value="query"
             autocomplete="off"
-            class="bg-transparent p-0 outline-none border-0 text-base text-ink-gray-8 h-full placeholder:text-ink-gray-4 focus:outline-none focus:ring-0 focus:border-0 w-full select-none"
+            class="bg-transparent p-0 outline-none border-0 text-base text-ink-gray-8 h-full placeholder:text-ink-gray-4 focus:outline-none focus:ring-0 focus:border-0 w-full select-none rtl:text-right"
             placeholder="Type agent name or email"
             @focus="showOptions = true"
             @click="showOptions = true"
@@ -63,7 +63,7 @@
                 :value="agent.name"
                 class="text-base leading-none text-ink-gray-7 rounded flex items-center px-2 py-1 relative select-none data-[highlighted]:outline-none data-[highlighted]:bg-surface-gray-3 cursor-pointer"
               >
-                <UserAvatar class="mr-1" :name="agent.agent_name" size="lg" />
+                <UserAvatar class="me-1" :name="agent.agent_name" size="lg" />
                 <div class="flex flex-col gap-1 p-1 text-ink-gray-8">
                   <div class="text-base-medium">
                     {{ agent.agent_name }}

--- a/desk/src/components/Settings/Telephony/ExotelSettings.vue
+++ b/desk/src/components/Settings/Telephony/ExotelSettings.vue
@@ -1,20 +1,10 @@
 <template>
   <SettingsLayoutBase
     :description="__('Configure your Exotel settings for Helpdesk.')"
+    :back-label="__('Exotel')"
+    :on-back="goBack"
+    :dirty="isDirty.exotel"
   >
-    <template #title>
-      <div class="flex items-center gap-2">
-        <Button
-          variant="ghost"
-          icon-left="chevron-left"
-          :label="__('Exotel')"
-          size="md"
-          @click="goBack"
-          class="cursor-pointer hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 font-semibold text-ink-gray-7 text-lg hover:opacity-70 !pr-0 !pl-0 -ml-1.5"
-        />
-        <UnsavedBadge :show="isDirty.exotel" />
-      </div>
-    </template>
     <template #header-actions>
       <Button
         :label="__('Save')"
@@ -144,7 +134,6 @@ import { useAuthStore } from "@/stores/auth";
 import { useTelephonyStore } from "@/stores/telephony";
 import { disableSettingModalOutsideClick } from "../settingsModal";
 import SettingsLayoutBase from "@/components/layouts/SettingsLayoutBase.vue";
-import UnsavedBadge from "@/components/UnsavedBadge.vue";
 import ConfirmDialog from "@/components/ConfirmDialog.vue";
 
 import { __ } from "@/translation";

--- a/desk/src/components/Settings/Telephony/Telephony.vue
+++ b/desk/src/components/Settings/Telephony/Telephony.vue
@@ -31,7 +31,7 @@
       </Transition>
     </template>
     <template #content>
-      <div class="-ml-2 grow">
+      <div class="-ms-2 grow">
         <div class="flex-1 flex flex-col">
           <!-- General -->
           <div
@@ -79,7 +79,10 @@
                 }}
               </div>
             </div>
-            <FeatherIcon name="chevron-right" class="size-4 text-ink-gray-5" />
+            <FeatherIcon
+              name="chevron-right"
+              class="size-4 text-ink-gray-5 rtl:rotate-180"
+            />
           </div>
 
           <div class="h-px border-t mx-2 border-outline-elevation-2" />
@@ -100,7 +103,10 @@
                 }}
               </div>
             </div>
-            <FeatherIcon name="chevron-right" class="size-4 text-ink-gray-5" />
+            <FeatherIcon
+              name="chevron-right"
+              class="size-4 text-ink-gray-5 rtl:rotate-180"
+            />
           </div>
         </div>
         <ErrorMessage :message="error" />

--- a/desk/src/components/Settings/Telephony/TwilioSettings.vue
+++ b/desk/src/components/Settings/Telephony/TwilioSettings.vue
@@ -1,20 +1,10 @@
 <template>
   <SettingsLayoutBase
     :description="__('Configure your Twilio settings for Helpdesk.')"
+    :back-label="__('Twilio')"
+    :on-back="goBack"
+    :dirty="isDirty.twilio"
   >
-    <template #title>
-      <div class="flex items-center gap-2">
-        <Button
-          variant="ghost"
-          icon-left="chevron-left"
-          :label="__('Twilio')"
-          size="md"
-          @click="goBack"
-          class="cursor-pointer hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 font-semibold text-ink-gray-7 text-lg hover:opacity-70 !pr-0 !pl-0 -ml-1.5"
-        />
-        <UnsavedBadge :show="isDirty.twilio" />
-      </div>
-    </template>
     <template #header-actions>
       <Button
         :label="__('Save')"
@@ -126,7 +116,6 @@
 <script setup>
 import Password from "@/components/Password.vue";
 import SettingsLayoutBase from "@/components/layouts/SettingsLayoutBase.vue";
-import UnsavedBadge from "@/components/UnsavedBadge.vue";
 import ConfirmDialog from "@/components/ConfirmDialog.vue";
 import {
   Button,

--- a/desk/src/components/SidebarLink.vue
+++ b/desk/src/components/SidebarLink.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="-all flex py-[7px] mx-2 h-7.5 cursor-pointer items-center rounded pl-2 pr-2 text-ink-gray-8 duration-300 ease-in-out"
+    class="-all flex py-[7px] mx-2 h-7.5 cursor-pointer items-center rounded ps-2 pe-2 text-ink-gray-8 duration-300 ease-in-out"
     :class="{
       'w-auto': isExpanded,
       'w-8': !isExpanded,
@@ -33,7 +33,7 @@
     </span>
 
     <div
-      class="-all ml-2 flex min-w-0 items-center justify-between text-sm duration-300 ease-in-out w-full"
+      class="-all ms-2 flex min-w-0 items-center justify-between text-sm duration-300 ease-in-out w-full"
       :class="{
         'opacity-100': isExpanded,
         'opacity-0': !isExpanded,

--- a/desk/src/components/TextEditor.vue
+++ b/desk/src/components/TextEditor.vue
@@ -40,7 +40,7 @@
             </div>
             <div class="flex items-center gap-2">
               <Button
-                label="Discard"
+                :label="__('Discard')"
                 theme="gray"
                 variant="subtle"
                 v-if="!isEmpty"

--- a/desk/src/components/TypingIndicator.vue
+++ b/desk/src/components/TypingIndicator.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="typingUsers.length > 0" class="pl-2">
+  <div v-if="typingUsers.length > 0" class="ps-2">
     <div class="flex items-center gap-2 text-sm text-ink-gray-5">
       <div class="flex items-center gap-1.5">
         <component :is="typingMessage" />

--- a/desk/src/components/UserMenu.vue
+++ b/desk/src/components/UserMenu.vue
@@ -13,7 +13,7 @@
       >
         <BrandLogo />
         <div
-          class="flex flex-1 flex-col text-left duration-300 ease-in-out overflow-hidden"
+          class="flex flex-1 flex-col text-start duration-300 ease-in-out overflow-hidden rtl:items-start pe-2"
           :class="
             collapsed
               ? 'ms-0 w-0 overflow-hidden opacity-0'

--- a/desk/src/components/ViewBreadcrumbs.vue
+++ b/desk/src/components/ViewBreadcrumbs.vue
@@ -2,7 +2,7 @@
   <div class="flex items-center">
     <router-link
       :to="{ name: routeName }"
-      class="px-0.5 pl-0 py-1 text-lg-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3 text-ink-gray-5 hover:text-ink-gray-7 flex items-center justify-center"
+      class="ps-0 pe-0.5 py-1 text-lg-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3 text-ink-gray-5 hover:text-ink-gray-7 flex items-center justify-center"
     >
       {{ isMobileView ? "..." : label }}
     </router-link>
@@ -46,7 +46,7 @@
           <span class="truncate">{{ item.label }}</span>
           <Badge
             v-if="item.is_standard"
-            class="ml-1 flex-shrink-0"
+            class="ms-1 flex-shrink-0"
             size="sm"
             label="Standard"
           />
@@ -66,7 +66,7 @@
             <template #default="{ open }">
               <Button
                 variant="ghost"
-                class="kebab-btn !size-4 ml-0 rounded-sm"
+                class="kebab-btn !size-4 ms-0 rounded-sm"
                 :class="open ? 'inline-flex' : 'hidden'"
                 icon="lucide-more-horizontal"
                 @click.stop

--- a/desk/src/components/command-palette/CP.vue
+++ b/desk/src/components/command-palette/CP.vue
@@ -4,7 +4,7 @@
       <div>
         <Combobox nullable @update:model-value="onSelection">
           <div class="relative">
-            <div class="pl-4.5 absolute inset-y-0 left-0 flex items-center">
+            <div class="ps-4.5 absolute inset-y-0 start-0 flex items-center">
               <LucideSearch class="h-4 w-4" />
             </div>
             <ComboboxInput
@@ -13,7 +13,7 @@
                   'Search tickets, emails, comments, or #234 to navigate to ticket'
                 )
               "
-              class="pl-11.5 pr-4.5 w-full border-none bg-transparent py-3 text-base text-ink-gray-8 placeholder:text-ink-gray-4 focus:ring-0"
+              class="ps-11.5 pe-4.5 w-full border-none bg-transparent py-3 text-base text-ink-gray-8 placeholder:text-ink-gray-4 focus:ring-0"
               autocomplete="off"
               @input="onInput"
             />

--- a/desk/src/components/command-palette/CPGroup.vue
+++ b/desk/src/components/command-palette/CPGroup.vue
@@ -6,14 +6,14 @@
     <component
       :is="item.icon"
       v-if="item.icon"
-      class="mr-3 h-4 w-4 text-ink-gray-7"
+      class="me-3 h-4 w-4 text-ink-gray-6"
     />
     <span class="overflow-hidden text-ellipsis whitespace-nowrap">
-      {{ item.title }}&nbsp;
+      {{ __(item.title) }}&nbsp;
     </span>
     <span
       v-if="item.modified"
-      class="ml-auto whitespace-nowrap pl-2 text-ink-gray-5"
+      class="ms-auto whitespace-nowrap ps-2 text-ink-gray-5"
     >
       {{ dayjs(item.modified).fromNow(true) }}
     </span>

--- a/desk/src/components/command-palette/CPGroupResult.vue
+++ b/desk/src/components/command-palette/CPGroupResult.vue
@@ -6,15 +6,15 @@
     <component
       :is="item.icon"
       v-if="item.icon"
-      class="mr-3 h-4 w-4 text-ink-gray-7"
+      class="me-3 h-4 w-4 text-ink-gray-6"
     />
     <span class="overflow-hidden text-ellipsis whitespace-nowrap">
-      {{ item.subject }}
+      {{ __(item.subject) }}
       <span v-if="item.showName" class="text-sm">(#{{ item.name }})</span>
     </span>
     <span
       v-if="item.modified"
-      class="ml-auto whitespace-nowrap pl-2 text-ink-gray-5"
+      class="ms-auto whitespace-nowrap ps-2 text-ink-gray-5"
     >
       {{ dayjs(item.modified).fromNow(true) }}
     </span>

--- a/desk/src/components/desk/global/AddNewAgentsDialog.vue
+++ b/desk/src/components/desk/global/AddNewAgentsDialog.vue
@@ -9,7 +9,7 @@
       <div class="space-y-3">
         <form
           @submit.prevent="onSubmit"
-          class="flex flex-row items-center space-x-2"
+          class="flex flex-row items-center gap-x-2"
         >
           <TextInput
             id="searchInput"
@@ -39,16 +39,16 @@
         >
           <ul class="flex flex-wrap gap-2 py-2">
             <li
-              class="flex items-center space-x-2 rounded bg-surface-base p-1 shadow"
+              class="flex items-center gap-x-2 rounded bg-surface-base p-1 shadow"
               v-for="email in inviteQueue.slice().reverse()"
               :key="email"
               :title="email"
             >
-              <span class="ml-2 text-base">
+              <span class="ms-2 text-base">
                 {{ email }}
               </span>
               <button
-                class="grid h-4 w-4 place-items-center rounded text-ink-gray-7 hover:bg-surface-gray-4"
+                class="grid h-4 w-4 place-items-center rounded text-ink-gray-6 hover:bg-surface-gray-4"
                 @click="removeEmailFromQueue(email)"
               >
                 <FeatherIcon class="w-3" name="x" />
@@ -64,7 +64,7 @@
           :disabled="inviteQueue.length == 0"
           appearance="primary"
           @click="sendInvites"
-          class="mr-2"
+          class="me-2"
           variant="solid"
           :loading="sentInvitesResource.loading"
           >Send Invites

--- a/desk/src/components/frappe-ui/Autocomplete.vue
+++ b/desk/src/components/frappe-ui/Autocomplete.vue
@@ -44,7 +44,7 @@
             <div class="relative px-1.5 pt-0.5">
               <ComboboxInput
                 ref="search"
-                class="form-input w-full pr-6 bg-transparent"
+                class="form-input w-full pe-6 bg-transparent"
                 type="text"
                 @change="
                   (e) => {
@@ -56,7 +56,7 @@
                 placeholder="Search"
               />
               <button
-                class="absolute inset-y-0 right-3 top-px flex items-center"
+                class="absolute inset-y-0 end-3 top-px flex items-center"
                 @click="selectedValue = null"
               >
                 <FeatherIcon name="x" class="size-4" />

--- a/desk/src/components/frappe-ui/Dropdown.vue
+++ b/desk/src/components/frappe-ui/Dropdown.vue
@@ -1,5 +1,5 @@
 <template>
-  <Menu as="div" class="relative inline-block text-left" v-slot="{ open }">
+  <Menu as="div" class="relative inline-block text-start" v-slot="{ open }">
     <Popover
       :transition="dropdownTransition"
       :show="open"
@@ -19,14 +19,14 @@
           class="mt-2 min-w-40 divide-y divide-outline-elevation-2 rounded-lg bg-surface-elevation-2 shadow-2xl ring-1 ring-black ring-opacity-5 focus:outline-none"
           :class="{
             'mt-2': ['bottom', 'left', 'right'].includes(placement),
-            'ml-2': placement == 'right-start',
+            'ms-2': placement == 'right-start',
           }"
         >
           <MenuItems
             class="min-w-40 divide-y divide-outline-elevation-2"
             :class="{
-              'left-0 origin-top-left': placement == 'left',
-              'right-0 origin-top-right': placement == 'right',
+              'start-0 origin-top-left': placement == 'left',
+              'end-0 origin-top-right': placement == 'right',
               'inset-x-0 origin-top': placement == 'center',
               'mt-0 origin-top-right': placement == 'right-start',
             }"
@@ -60,11 +60,11 @@
                     <FeatherIcon
                       v-if="item.icon && typeof item.icon === 'string'"
                       :name="item.icon"
-                      class="mr-2 h-4 w-4 flex-shrink-0 text-ink-gray-7"
+                      class="me-2 h-4 w-4 flex-shrink-0 text-ink-gray-7"
                       aria-hidden="true"
                     />
                     <component
-                      class="mr-2 h-4 w-4 flex-shrink-0 text-ink-gray-7"
+                      class="me-2 h-4 w-4 flex-shrink-0 text-ink-gray-7"
                       v-else-if="item.icon"
                       :is="item.icon"
                     />

--- a/desk/src/components/frappe-ui/DurationField.vue
+++ b/desk/src/components/frappe-ui/DurationField.vue
@@ -35,7 +35,7 @@
                 @keyup.enter="$event.target.blur()"
               />
               <div
-                class="flex flex-col group-hover:opacity-100 opacity-0 absolute top-1/2 -translate-y-1/2 -right-3"
+                class="flex flex-col group-hover:opacity-100 opacity-0 absolute top-1/2 -translate-y-1/2 -end-3"
               >
                 <button
                   @click="increment('hours')"
@@ -70,7 +70,7 @@
                 @keyup.enter="$event.target.blur()"
               />
               <div
-                class="flex flex-col group-hover:opacity-100 opacity-0 absolute top-1/2 -translate-y-1/2 -right-3"
+                class="flex flex-col group-hover:opacity-100 opacity-0 absolute top-1/2 -translate-y-1/2 -end-3"
               >
                 <button
                   @click="increment('minutes')"
@@ -104,7 +104,7 @@
                 class="w-8 text-sm bg-transparent border-0 p-0 text-center focus:ring-0 focus:outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
               />
               <div
-                class="flex flex-col group-hover:opacity-100 opacity-0 absolute top-1/2 -translate-y-1/2 -right-3"
+                class="flex flex-col group-hover:opacity-100 opacity-0 absolute top-1/2 -translate-y-1/2 -end-3"
               >
                 <button
                   @click="increment('seconds')"

--- a/desk/src/components/frappe-ui/DurationPicker.vue
+++ b/desk/src/components/frappe-ui/DurationPicker.vue
@@ -17,7 +17,7 @@
           @keyup.enter="handleEnter"
         />
         <div
-          class="flex flex-col group-hover:opacity-100 opacity-0 absolute top-1/2 -translate-y-1/2 -right-3"
+          class="flex flex-col group-hover:opacity-100 opacity-0 absolute top-1/2 -translate-y-1/2 -end-3"
         >
           <button
             @mousedown="startAction(() => increment('hours'))"
@@ -61,7 +61,7 @@
           @keyup.enter="handleEnter"
         />
         <div
-          class="flex flex-col group-hover:opacity-100 opacity-0 absolute top-1/2 -translate-y-1/2 -right-3"
+          class="flex flex-col group-hover:opacity-100 opacity-0 absolute top-1/2 -translate-y-1/2 -end-3"
         >
           <button
             @mousedown="startAction(() => increment('minutes'))"
@@ -105,7 +105,7 @@
           @keyup.enter="handleEnter"
         />
         <div
-          class="flex flex-col group-hover:opacity-100 opacity-0 absolute top-1/2 -translate-y-1/2 -right-3"
+          class="flex flex-col group-hover:opacity-100 opacity-0 absolute top-1/2 -translate-y-1/2 -end-3"
         >
           <button
             @mousedown="startAction(() => increment('seconds'))"

--- a/desk/src/components/frappe-ui/MultiSelectCombobox.vue
+++ b/desk/src/components/frappe-ui/MultiSelectCombobox.vue
@@ -39,7 +39,7 @@
                 <slot name="prefix" />
                 <span
                   v-if="selectedValue"
-                  class="flex-1 truncate text-left text-base leading-5"
+                  class="flex-1 truncate text-start text-base leading-5"
                 >
                   {{ displayValue(selectedValue) }}
                 </span>
@@ -86,7 +86,7 @@
                   placeholder="Search"
                 />
                 <button
-                  class="absolute right-0 inline-flex h-7 w-7 items-center justify-center"
+                  class="absolute end-0 inline-flex h-7 w-7 items-center justify-center"
                   @click="selectedValue = null"
                 >
                   <FeatherIcon name="x" class="w-4" />
@@ -145,7 +145,7 @@
 
                       <div
                         v-if="$slots['item-suffix'] || option?.description"
-                        class="ml-2 flex-shrink-0"
+                        class="ms-2 flex-shrink-0"
                       >
                         <slot
                           name="item-suffix"

--- a/desk/src/components/knowledge-base/CategoryFolder.vue
+++ b/desk/src/components/knowledge-base/CategoryFolder.vue
@@ -9,7 +9,7 @@
     }"
   >
     <div>
-      <FeatherIcon name="folder" class="h-6 w-6 text-ink-gray-4 -ml-[2px]" />
+      <FeatherIcon name="folder" class="h-6 w-6 text-ink-gray-4 -ms-[2px]" />
     </div>
     <div class="gap-1 flex flex-col">
       <p class="text-base-medium text-ink-gray-8 truncate">

--- a/desk/src/components/layouts/AppHeader.vue
+++ b/desk/src/components/layouts/AppHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex border-b pr-5">
+  <div class="flex border-b pe-5 rtl:pe-6">
     <div id="app-header" class="flex-1 w-full"></div>
     <div class="flex items-start justify-center">
       <CallUI :userEmail="user" />

--- a/desk/src/components/layouts/MobileAppHeader.vue
+++ b/desk/src/components/layouts/MobileAppHeader.vue
@@ -1,13 +1,13 @@
 <template>
   <div class="flex border-b h-12 items-center">
-    <div class="z-20 -mr-4 ml-1 flex items-center justify-center">
+    <div class="z-20 -me-4 ms-1 flex items-center justify-center">
       <Button variant="ghosted" @click="sidebarOpened = !sidebarOpened">
         <FeatherIcon name="menu" class="size-4" />
       </Button>
     </div>
     <header id="app-header" class="w-full"></header>
   </div>
-  <CallUI class="mr-3 mt-2" :userEmail="user" />
+  <CallUI class="me-3 mt-2" :userEmail="user" />
 </template>
 
 <script setup>

--- a/desk/src/components/layouts/MobileSidebar.vue
+++ b/desk/src/components/layouts/MobileSidebar.vue
@@ -4,11 +4,11 @@
       <TransitionChild
         as="template"
         enter="transition ease-in-out duration-200 transform"
-        enter-from="-translate-x-full"
+        enter-from="-translate-x-full rtl:translate-x-full"
         enter-to="translate-x-0"
         leave="transition ease-in-out duration-200 transform"
         leave-from="translate-x-0"
-        leave-to="-translate-x-full"
+        leave-to="-translate-x-full rtl:translate-x-full"
       >
         <div class="relative z-10 h-full">
           <AppSidebar mobile :profile-settings="profileSettings" />
@@ -23,7 +23,7 @@
         leave-from="opacity-100"
         leave-to="opacity-0"
       >
-        <DialogOverlay class="fixed inset-0 bg-black-overlay-500" />
+        <DialogOverlay class="fixed inset-0 bg-surface-gray-7/50" />
       </TransitionChild>
     </Dialog>
   </TransitionRoot>
@@ -64,7 +64,6 @@ const themeMenuItem = computed(() => ({
 }));
 
 const customerPortalDropdown = computed(() => [
-  themeMenuItem.value,
   {
     label: __("Log out"),
     icon: "lucide-log-out",
@@ -99,7 +98,6 @@ const agentPortalDropdown = computed(() => [
     label: __("Docs"),
     onClick: () => window.open("https://docs.frappe.io/helpdesk"),
   },
-  themeMenuItem.value,
   {
     label: __("Log out"),
     icon: "lucide-log-out",

--- a/desk/src/components/layouts/SettingsLayoutBase.vue
+++ b/desk/src/components/layouts/SettingsLayoutBase.vue
@@ -1,10 +1,21 @@
 <template>
   <div class="flex flex-col h-full w-full pb-8">
-    <div class="px-10 py-8 relative z-10">
+    <div class="px-10 py-8">
       <div class="flex items-start justify-between">
-        <div class="flex flex-col gap-1">
+        <div class="flex flex-col gap-1 text-start">
           <slot name="title">
-            <h1 class="text-lg-semibold text-ink-gray-8">
+            <div v-if="backLabel" class="flex items-center gap-2">
+              <Button
+                variant="ghost"
+                icon-left="chevron-left"
+                :label="backLabel"
+                size="md"
+                @click="onBack"
+                class="cursor-pointer -ms-4 hover:bg-transparent focus:bg-transparent focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:none active:bg-transparent active:outline-none active:ring-0 active:ring-offset-0 active:text-ink-gray-5 font-semibold text-ink-gray-7 text-lg hover:opacity-70 !pe-0 !max-w-96 !justify-start rtl:flex-row-reverse rtl:ps-4"
+              />
+              <UnsavedBadge :show="Boolean(dirty)" />
+            </div>
+            <h1 v-else class="text-lg-semibold text-ink-gray-8">
               {{ title }}
             </h1>
           </slot>
@@ -13,7 +24,7 @@
             v-if="Boolean($slots['description']) || Boolean(description)"
           >
             <p class="text-p-sm max-w-md text-ink-gray-6">
-              {{ description }}
+              {{ __(description) }}
             </p>
           </slot>
         </div>
@@ -23,19 +34,20 @@
         <slot name="header-bottom" />
       </div>
     </div>
-    <div class="px-10 pb-8 overflow-y-auto h-full flex flex-col">
+    <div class="px-10 pb-8 overflow-y-auto h-full flex flex-col text-start">
       <slot name="content" />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-const props = defineProps({
-  title: {
-    type: String,
-  },
-  description: {
-    type: String,
-  },
-});
+import UnsavedBadge from "@/components/UnsavedBadge.vue";
+
+defineProps<{
+  title?: string;
+  description?: string;
+  backLabel?: string;
+  onBack?: () => void;
+  dirty?: boolean;
+}>();
 </script>

--- a/desk/src/components/layouts/Sidebar.vue
+++ b/desk/src/components/layouts/Sidebar.vue
@@ -96,8 +96,6 @@ import { __ } from "@/translation";
 import FileText from "~icons/lucide/file-text";
 import Globe from "~icons/lucide/globe";
 import LucideKeyboard from "~icons/lucide/keyboard";
-import LucideMoon from "~icons/lucide/moon";
-import LucideSun from "~icons/lucide/sun";
 import LucideMail from "~icons/lucide/mail";
 import MailOpen from "~icons/lucide/mail-open";
 import MessageCircle from "~icons/lucide/message-circle";
@@ -130,7 +128,6 @@ const themeMenuItem = computed(() => ({
 const isFCSite = ref(window.is_fc_site);
 
 const customerPortalDropdown = computed(() => [
-  themeMenuItem.value,
   {
     group: __("Danger"),
     hideLabel: true,
@@ -357,11 +354,11 @@ const steps = [
 
 const articles = ref([
   {
-    title: "Introduction",
+    title: __("Introduction"),
     opened: false,
     subArticles: [
-      { name: "introduction", title: "Introduction" },
-      { name: "setting-up", title: "Setting up" },
+      { name: "introduction", title: __("Introduction") },
+      { name: "setting-up", title: __("Setting up") },
     ],
   },
   {
@@ -370,27 +367,27 @@ const articles = ref([
     subArticles: [
       {
         name: "lesson-1-your-first-ticket",
-        title: "Creating a ticket",
+        title: __("Creating a ticket"),
       },
       {
         name: "lesson-2understanding-ticket-view",
-        title: "Understanding ticket view",
+        title: __("Understanding ticket view"),
       },
       {
         name: "lesson-3-agents-teams",
-        title: "Agents & Teams",
+        title: __("Agents & Teams"),
       },
       {
         name: "customers-contacts",
-        title: "Customers & Contacts",
+        title: __("Customers & Contacts"),
       },
       {
         name: "lesson-4-knowledge-base",
-        title: "Knowledge Base",
+        title: __("Knowledge Base"),
       },
       {
         name: "customer-portal",
-        title: "Customer Portal",
+        title: __("Customer Portal"),
       },
     ],
   },
@@ -414,20 +411,20 @@ const articles = ref([
     title: __("Customizations"),
     opened: false,
     subArticles: [
-      { name: "custom-actions", title: "Custom Actions" },
-      { name: "field-dependency", title: "Field Dependency" },
-      { name: "custom-views", title: "Custom Views" },
+      { name: "custom-actions", title: __("Custom Actions") },
+      { name: "field-dependency", title: __("Field Dependency") },
+      { name: "custom-views", title: __("Custom Views") },
       {
         name: "settings",
-        title: "Settings",
+        title: __("Settings"),
       },
     ],
   },
   {
-    title: "Frappe Helpdesk Mobile",
+    title: __("Frappe Helpdesk Mobile"),
     opened: false,
     subArticles: [
-      { name: "pwa-installation", title: "Mobile App Installation" },
+      { name: "pwa-installation", title: __("Mobile App Installation") },
     ],
   },
 ]);

--- a/desk/src/components/modals/ShortcutsModal.vue
+++ b/desk/src/components/modals/ShortcutsModal.vue
@@ -20,7 +20,7 @@
               <div class="text-ink-gray-7 text-base flex-1">
                 {{ shortcut.description }}
               </div>
-              <div class="flex space-x-1 gap-1 justify-end">
+              <div class="flex gap-1 justify-end">
                 <span
                   v-for="(key, kIndex) in shortcut.keys"
                   :key="kIndex"

--- a/desk/src/components/notifications/Notifications.vue
+++ b/desk/src/components/notifications/Notifications.vue
@@ -7,7 +7,7 @@
       'box-shadow': '8px 0px 8px rgba(0, 0, 0, 0.1)',
       'max-width': '350px',
       'min-width': '350px',
-      left: sidebarStore.width,
+      'inset-inline-start': sidebarStore.width,
     }"
   >
     <div
@@ -51,7 +51,7 @@
         <UserAvatar :name="n.user_from" />
         <span>
           <div class="mb-2 leading-5">
-            <span class="space-x-1 text-ink-gray-7">
+            <span class="space-x-1 rtl:space-x-reverse text-ink-gray-6">
               <span
                 class="font-medium text-ink-gray-9"
                 v-if="n.notification_type !== 'Reaction' || !n.message"
@@ -154,3 +154,8 @@ function getRoute(n: Notification) {
   }
 }
 </script>
+<style lang="css">
+[dir="rtl"] .notifications-panel {
+  box-shadow: -8px 0px 8px rgba(0, 0, 0, 0.1) !important;
+}
+</style>

--- a/desk/src/components/telephony/ExotelCallUI.vue
+++ b/desk/src/components/telephony/ExotelCallUI.vue
@@ -2,11 +2,11 @@
   <div>
     <div
       v-show="showSmallCallPopup"
-      class="ml-2 flex cursor-pointer select-none items-center justify-between gap-1 rounded-full bg-surface-gray-10 px-2 py-1 mt-1 text-base !text-ink-gray-2"
+      class="ms-2 flex cursor-pointer select-none items-center justify-between gap-1 rounded-full bg-surface-gray-10 px-2 py-1 mt-1 text-base !text-ink-gray-2"
       @click="toggleCallPopup"
     >
       <div
-        class="flex justify-center items-center size-5 rounded-full bg-surface-gray-9 shrink-0 mr-1"
+        class="flex justify-center items-center size-5 rounded-full bg-surface-gray-9 shrink-0 me-1"
       >
         <Avatar
           v-if="contact?.image"

--- a/desk/src/components/telephony/TwilioCallUI.vue
+++ b/desk/src/components/telephony/TwilioCallUI.vue
@@ -102,7 +102,7 @@
   </div>
   <div
     v-show="showSmallCallWindow"
-    class="ml-2 mt-1 flex cursor-pointer select-none items-center justify-between gap-3 rounded-lg bg-surface-gray-10 px-2 py-1 text-base !text-ink-gray-2"
+    class="ms-2 mt-1 flex cursor-pointer select-none items-center justify-between gap-3 rounded-lg bg-surface-gray-10 px-2 py-1 text-base !text-ink-gray-2"
     @click="toggleCallWindow"
     v-bind="$attrs"
   >

--- a/desk/src/components/ticket-agent/TicketDetailsTab.vue
+++ b/desk/src/components/ticket-agent/TicketDetailsTab.vue
@@ -21,10 +21,10 @@
               :id="field.fieldname"
               :class="section.group ? 'flex-1 min-w-0' : 'w-full'"
               :page-length="10"
-              :label="field.label"
-              :placeholder="field.placeholder"
+              :label="__(field.label)"
+              :placeholder="__(field.placeholder)"
               :doctype="field.doctype"
-              :modelValue="field.value"
+              :modelValue="__(field.value)"
               :required="field.required"
               @update:model-value="
               (val:string) => handleFieldUpdate(field.fieldname, val,true)

--- a/desk/src/components/ticket-agent/TicketHeader.vue
+++ b/desk/src/components/ticket-agent/TicketHeader.vue
@@ -2,12 +2,12 @@
   <LayoutHeader>
     <template #left-header>
       <div class="flex flex-col truncate">
-        <Breadcrumbs :items="breadcrumbs" class="breadcrumbs -ml-0.5">
+        <Breadcrumbs :items="breadcrumbs" class="breadcrumbs -ms-0.5">
           <template #prefix="{ item }">
             <Icon
               v-if="item.icon"
               :icon="item.icon"
-              class="mr-1 h-4 flex items-center justify-center self-center"
+              class="me-1 h-4 flex items-center justify-center self-center"
             />
           </template>
         </Breadcrumbs>
@@ -34,7 +34,7 @@
         <div v-if="groupedWithLabelActions.length">
           <div v-for="g in groupedWithLabelActions" :key="g.label">
             <Dropdown v-slot="{ open }" :options="g.action">
-              <Button :label="g.label">
+              <Button :label="__(g.label)">
                 <template #suffix>
                   <FeatherIcon
                     :name="open ? 'chevron-up' : 'chevron-down'"
@@ -48,7 +48,7 @@
         <!-- Status -->
         <Dropdown :options="statusDropdown" placement="right">
           <template #default="{ open }">
-            <Button :label="ticket.doc.status" ref="statusRef">
+            <Button :label="__(ticket.doc.status)" ref="statusRef">
               <template #prefix>
                 <IndicatorIcon
                   :class="
@@ -149,7 +149,7 @@ const statusDropdown = computed(() => {
   const statuses =
     ticketStatusStore.statuses.data?.filter((s) => s.enabled) || [];
   return statuses.map((o: HDTicketStatus) => ({
-    label: o.label_agent,
+    label: __(o.label_agent),
     value: o.label_agent,
     onClick: () => {
       notifyTicketUpdate("Status", o.label_agent);
@@ -175,7 +175,7 @@ const breadcrumbs = computed(() => {
     const currView: ComputedRef<View> = findView(route.query.view as string);
     if (currView) {
       items.push({
-        label: currView.value?.label,
+        label: __(currView.value?.label),
         icon: getIcon(currView.value?.icon),
         route: { name: "TicketsAgent", query: { view: currView.value?.name } },
       });
@@ -309,7 +309,7 @@ const groupedWithLabelActions = computed(() => {
         _actions[groupIndex].action.push(action);
       } else {
         _actions.push({
-          label: action.buttonLabel,
+          label: __(action.buttonLabel),
           action: [action],
         });
       }
@@ -321,7 +321,7 @@ const groupedActions = computed(() => {
   let _actions = [];
   _actions = _actions.concat(defaultActions.value);
   _actions = _actions.concat(
-    actions.value.filter((action) => action.group && !action.buttonLabel)
+    actions.value.filter((action) => action.group && !__(action.buttonLabel))
   );
   _actions = _actions.concat(deleteAction.value);
   return _actions;

--- a/desk/src/components/ticket-agent/TicketNavigation.vue
+++ b/desk/src/components/ticket-agent/TicketNavigation.vue
@@ -1,5 +1,8 @@
 <template>
-  <div v-if="ticketsToNavigate.data?.length > 1" class="flex gap-1">
+  <div
+    v-if="ticketsToNavigate.data?.length > 1"
+    class="flex gap-1 rtl:flex-row-reverse"
+  >
     <Tooltip
       :text="
         getPreviousTicket()
@@ -9,11 +12,14 @@
       :disabled="disableLeftCondition"
     >
       <Button
-        :icon="LucideChevronLeft"
         variant="ghost"
         :disabled="disableLeftCondition"
         @click="goToPreviousTicket()"
-      />
+      >
+        <template #icon>
+          <LucideChevronLeft class="size-4" />
+        </template>
+      </Button>
     </Tooltip>
     <Tooltip
       :text="
@@ -24,11 +30,14 @@
       :disabled="disableRightCondition"
     >
       <Button
-        :icon="LucideChevronRight"
         variant="ghost"
         :disabled="disableRightCondition"
         @click="goToNextTicket()"
-      />
+      >
+        <template #icon>
+          <LucideChevronRight class="size-4" />
+        </template>
+      </Button>
     </Tooltip>
   </div>
 </template>

--- a/desk/src/components/ticket-agent/TicketSLA.vue
+++ b/desk/src/components/ticket-agent/TicketSLA.vue
@@ -2,7 +2,7 @@
   <!-- Teleport to App Header -->
   <teleport to="#app-header">
     <div
-      class="flex items-center mx-5 md:mr-0 text-p-sm gap-3 text-[14px] mb-[13px]"
+      class="flex items-center ms-5 me-5 md:me-0 text-p-sm gap-3 text-[14px] mb-[13px]"
     >
       <!-- Source -->
       <div class="flex items-center gap-1">
@@ -22,19 +22,19 @@
           v-if="!ticket.doc.via_customer_portal"
           class="text-ink-gray-5 flex items-center"
         >
-          <span class="mr-[4px]">via</span>
-          <EmailIcon class="size-4 inline-block mr-1" />
+          <span class="me-[4px]">via</span>
+          <EmailIcon class="size-4 inline-block me-1" />
           <span>Email</span>
         </div>
         <!-- Via Portal -->
         <div v-else class="text-ink-gray-5 flex items-center">
-          <span class="mr-[4px]">via</span>
-          <GlobeIcon class="size-4 inline-block mr-1" />
+          <span class="me-[4px]">via</span>
+          <GlobeIcon class="size-4 inline-block me-1" />
           <span>Portal</span>
         </div>
       </div>
       <!-- divider -->
-      <div class="border-l border-outline-gray-2 h-[13px]" />
+      <div class="border-s border-outline-gray-2 h-[13px]" />
       <!-- First Response -->
       <div class="flex items-center gap-1">
         <span>First Response</span>
@@ -53,7 +53,7 @@
         </Tooltip>
       </div>
       <!-- divider -->
-      <div class="border-l border-outline-gray-2 h-[13px]" />
+      <div class="border-s border-outline-gray-2 h-[13px]" />
       <!-- Resolution by -->
       <div class="flex items-center gap-1">
         <span>Resolution </span>

--- a/desk/src/components/ticket-agent/TicketSidebar.vue
+++ b/desk/src/components/ticket-agent/TicketSidebar.vue
@@ -1,5 +1,5 @@
 <template>
-  <Resizer class="flex flex-col border-l h-full" side="right">
+  <Resizer class="flex flex-col border-s h-full" side="right">
     <TicketDetailsTab />
   </Resizer>
 </template>

--- a/desk/src/components/ticket/TicketAgentActivities.vue
+++ b/desk/src/components/ticket/TicketAgentActivities.vue
@@ -17,7 +17,7 @@
           class="w-full px-6 md:px-5 grid grid-cols-[30px_minmax(auto,_1fr)] gap-2 sm:gap-4"
         >
           <div
-            class="relative flex justify-center after:absolute after:left-[50%] after:top-3 after:-z-10 after:border-l after:border-outline-elevation-2"
+            class="relative flex justify-center after:absolute after:start-[50%] after:top-3 after:-z-10 after:border-s after:border-outline-elevation-2"
             :class="[
               i != activities.length - 1 && 'after:h-full',
               !['email', 'feedback', 'call', 'comment'].includes(
@@ -41,11 +41,11 @@
                 size="lg"
                 :label="activity.sender?.full_name"
                 :image="getUser(activity.sender?.name).user_image"
-                class="bg-surface-base absolute left-[0.7px]"
+                class="bg-surface-base absolute start-[0.7px]"
               />
               <CommentIcon
                 v-else-if="activity.type === 'comment'"
-                class="text-ink-gray-5 absolute left-[7.5px]"
+                class="text-ink-gray-5 absolute start-[7.5px]"
               />
               <FeatherIcon
                 v-else-if="activity.type === 'call'"
@@ -54,11 +54,11 @@
                     ? 'phone-incoming'
                     : 'phone-outgoing'
                 "
-                class="text-ink-gray-5 left-[7.5px] size-4"
+                class="text-ink-gray-5 start-[7.5px] size-4"
               />
               <DotIcon
                 v-else
-                class="text-ink-gray-5 absolute left-[7.5px] top-[6px]"
+                class="text-ink-gray-5 absolute start-[7.5px] top-[6px]"
               />
             </div>
           </div>

--- a/desk/src/components/ticket/TicketAgentDetails.vue
+++ b/desk/src/components/ticket/TicketAgentDetails.vue
@@ -13,7 +13,7 @@
         <Tooltip :text="s.tooltipValue">
           <Badge
             v-if="s.badgeText"
-            class="-ml-1"
+            class="-ms-1"
             :label="s.badgeText"
             variant="subtle"
             :theme="s.badgeColor"

--- a/desk/src/components/ticket/TicketAgentSidebar.vue
+++ b/desk/src/components/ticket/TicketAgentSidebar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex !w-[382px] flex-col justify-between border-l">
+  <div class="flex !w-[382px] flex-col justify-between border-s">
     <div
       class="flex h-10.5 items-center border-b px-5 py-2.5 text-lg-medium text-ink-gray-9 justify-between"
     >

--- a/desk/src/components/ticket/TicketCustomerSidebar.vue
+++ b/desk/src/components/ticket/TicketCustomerSidebar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex w-[382px] flex-col border-l gap-4">
+  <div class="flex w-[382px] flex-col border-s gap-4">
     <!-- Ticket ID -->
     <div class="flex items-center justify-between border-b px-5 py-3">
       <span class="cursor-copy text-lg-semibold">Ticket details</span>

--- a/desk/src/components/ticket/TicketMergeModal.vue
+++ b/desk/src/components/ticket/TicketMergeModal.vue
@@ -29,18 +29,25 @@
                       __("Tickets must meet the following conditions:")
                     }}</span
                   >
-                  <ul class="list-disc pl-4 mt-1 space-y-1">
-                    <li
-                      v-for="(condition, index) in mergeConditions"
-                      :key="index"
-                    >
-                      {{ __(condition.text) }}
-                      <code
-                        v-if="condition.code"
-                        class="bg-surface-gray-2 rounded-md px-1 py-0.5"
+                  <ul class="list-disc ps-4 mt-1 space-y-1">
+                    <li>
+                      {{ __("Ticket must be Open or Paused.") }}
+                      <code class="bg-surface-gray-2 rounded-md px-1 py-0.5">
+                        {{ __("status_category in ['Open', 'Paused']") }}</code
                       >
-                        {{ __(condition.code) }}
-                      </code>
+                    </li>
+                    <li>
+                      {{ __("Ticket must not already be merged.") }}
+                      <code class="bg-surface-gray-2 rounded-md px-1 py-0.5">
+                        {{ __("is_merged === 0") }}</code
+                      >
+                    </li>
+                    <li>
+                      {{
+                        __(
+                          "Source and target tickets which are to be merged cannot be the same."
+                        )
+                      }}
                     </li>
                   </ul>
                 </div>
@@ -52,7 +59,7 @@
         <Link
           class="form-control"
           doctype="HD Ticket"
-          placeholder="Select Ticket"
+          :placeholder="__('Select Ticket')"
           :filters="getDefaultFilters()"
           :label="__('Ticket')"
           :page-length="10"
@@ -75,7 +82,7 @@
             class="h-6 w-5 w-min-5 w-max-5 min-h-5 max-w-5 text-ink-yellow-5"
           />
 
-          <div class="text-wrap text-sm text-ink-gray-7">
+          <div class="text-wrap text-sm text-ink-gray-6">
             {{ __("This action is irreversible.") }}
           </div>
         </div>

--- a/desk/src/components/view-controls/ColumnSettings.vue
+++ b/desk/src/components/view-controls/ColumnSettings.vue
@@ -28,7 +28,7 @@
               >
                 <div class="flex items-center gap-2">
                   <DragIcon class="h-3.5" />
-                  <div>{{ element.label }}</div>
+                  <div>{{ __(element.label) }}</div>
                 </div>
                 <div class="flex cursor-pointer items-center gap-1">
                   <Button
@@ -62,7 +62,7 @@
                   class="w-full !justify-start !text-ink-gray-5"
                   variant="ghost"
                   @click="togglePopover()"
-                  label="Add Column"
+                  :label="__('Add Column')"
                 >
                   <template #prefix>
                     <FeatherIcon name="plus" class="h-4" />
@@ -86,7 +86,7 @@
               class="w-full !justify-start !text-ink-gray-5"
               variant="ghost"
               @click="resetToDefault(close)"
-              label="Reset to Default"
+              :label="__('Reset to Default')"
             >
               <template #prefix>
                 <ReloadIcon class="h-4" />

--- a/desk/src/components/view-controls/Filter.vue
+++ b/desk/src/components/view-controls/Filter.vue
@@ -3,8 +3,8 @@
     <template #target="{ togglePopover, close }">
       <div class="flex items-center w-fit">
         <Button
-          :label="'Filter'"
-          :class="filters?.size ? 'rounded-r-none' : ''"
+          :label="__('Filter')"
+          :class="filters?.size ? 'rounded-e-none' : ''"
           @click="togglePopover"
         >
           <template #prefix><FilterIcon class="h-4" /></template>
@@ -19,7 +19,7 @@
         <Tooltip v-if="filters?.size" :text="'Clear all Filter'">
           <div>
             <Button
-              class="rounded-l-none border-l"
+              class="rounded-s-none border-s"
               icon="lucide-x"
               @click.stop="clearfilter(close)"
             />
@@ -80,7 +80,7 @@
             </div>
             <div v-else class="flex items-center justify-between gap-2">
               <div class="flex items-center gap-2 flex-1">
-                <div class="w-13 pl-2 text-end text-base text-ink-gray-5">
+                <div class="w-13 ps-2 text-end text-base text-ink-gray-5">
                   {{ i == 0 ? "Where" : "And" }}
                 </div>
                 <div id="fieldname" class="!min-w-[140px]">
@@ -125,7 +125,7 @@
             v-else
             class="mb-3 flex h-7 items-center px-3 text-sm text-ink-gray-5"
           >
-            {{ "Empty - Choose a field to filter by" }}
+            {{ __("Empty - Choose a field to filter by") }}
           </div>
           <div class="flex items-center justify-between gap-2">
             <Autocomplete
@@ -138,7 +138,7 @@
                   class="!text-ink-gray-5"
                   variant="ghost"
                   @click="togglePopover()"
-                  :label="'Add Filter'"
+                  :label="__('Add Filter')"
                 >
                   <template #prefix>
                     <FeatherIcon name="plus" class="h-4" />
@@ -165,7 +165,6 @@ import FilterIcon from "@/components/icons/FilterIcon.vue";
 import { useScreenSize } from "@/composables/screen";
 import { useDebounceFn } from "@vueuse/core";
 import {
-  Autocomplete,
   Button,
   Combobox,
   DatePicker,
@@ -176,6 +175,7 @@ import {
   Popover,
   Tooltip,
 } from "frappe-ui";
+import Autocomplete from "@/components/frappe-ui/Autocomplete.vue";
 import { computed, h, inject } from "vue";
 
 const props = defineProps({

--- a/desk/src/components/view-controls/SortBy.vue
+++ b/desk/src/components/view-controls/SortBy.vue
@@ -35,7 +35,7 @@
       <div v-else class="flex items-center justify-center">
         <Button
           v-if="sortValues.size"
-          class="rounded-r-none border-r"
+          class="rounded-e-none border-e"
           @click.stop="
             () => {
               Array.from(sortValues)[0].direction =
@@ -52,7 +52,7 @@
         </Button>
         <Button
           :label="getSortLabel()"
-          :class="sortValues.size ? 'rounded-l-none' : ''"
+          :class="sortValues.size ? 'rounded-s-none' : ''"
         >
           <template v-if="!hideLabel && !sortValues?.size" #prefix>
             <SortIcon class="h-4" />
@@ -87,7 +87,7 @@
               <div class="flex">
                 <Button
                   size="md"
-                  class="rounded-r-none border-r"
+                  class="rounded-e-none border-e"
                   @click="
                     () => {
                       sort.direction = sort.direction == 'asc' ? 'desc' : 'asc';
@@ -109,11 +109,11 @@
                     #target="{ togglePopover, selectedValue, displayValue }"
                   >
                     <Button
-                      class="flex w-full items-center justify-between rounded-l-none !text-ink-gray-5 text-xs"
+                      class="flex w-full items-center justify-between rounded-s-none !text-ink-gray-5 text-xs"
                       size="md"
                       @click="togglePopover()"
                     >
-                      {{ displayValue(selectedValue) }}
+                      {{ __(displayValue(selectedValue)) }}
                       <template #suffix>
                         <FeatherIcon
                           name="chevron-down"
@@ -131,7 +131,7 @@
             v-else
             class="mb-3 flex h-7 items-center px-3 text-sm text-ink-gray-5"
           >
-            {{ "Empty - Choose a field to sort by" }}
+            {{ __("Empty - Choose a field to sort by") }}
           </div>
           <div class="flex items-center justify-between gap-2">
             <Autocomplete
@@ -145,7 +145,7 @@
                   class="!text-ink-gray-5"
                   variant="ghost"
                   @click="togglePopover()"
-                  :label="'Add Sort'"
+                  :label="__('Add Sort')"
                 >
                   <template #prefix>
                     <FeatherIcon name="plus" class="h-4" />
@@ -157,7 +157,7 @@
               v-if="sortValues?.size"
               class="!text-ink-gray-5"
               variant="ghost"
-              :label="'Clear Sort'"
+              :label="__('Clear Sort')"
               @click="clearSort(close)"
             />
           </div>
@@ -228,13 +228,13 @@ const sortSortable = useSortable("#sort-list", sortValues, {
 });
 
 function getSortLabel() {
-  if (!sortValues.value.size) return "Sort";
+  if (!sortValues.value.size) return __("Sort");
   let values = Array.from(sortValues.value);
   let label = sortOptions.data?.find(
     (option) => option.value === values[0].fieldname
   )?.label;
 
-  return label || sort.fieldname;
+  return __(label) || __(sort.fieldname);
 }
 
 function setSort(data) {

--- a/desk/src/main.js
+++ b/desk/src/main.js
@@ -84,6 +84,8 @@ if (import.meta.env.DEV) {
     for (let key in values) {
       window[key] = values[key];
     }
+    if (window.dir) document.documentElement.dir = window.dir;
+    if (window.lang) document.documentElement.lang = window.lang;
     socket = initSocket();
     app.config.globalProperties.$socket = socket;
     app.mount("#app");

--- a/desk/src/pages/SearchAgent.vue
+++ b/desk/src/pages/SearchAgent.vue
@@ -9,7 +9,7 @@
         </template>
       </LayoutHeader>
       <div class="mx-auto mt-6 max-w-4xl px-4 sm:px-5">
-        <div class="flex items-center space-x-2 px-2.5">
+        <div class="flex items-center gap-x-2 px-2.5">
           <TextInput
             ref="searchInput"
             class="flex-1"
@@ -80,7 +80,7 @@
             <Button
               v-if="hasActiveFilters()"
               size="sm"
-              class="ml-auto text-ink-gray-5"
+              class="ms-auto text-ink-gray-5"
               variant="gray-ghost"
               @click="clearFilters"
               :label="__('Clear all filters')"
@@ -135,7 +135,7 @@
                   class="text-ink-gray-6"
                 >
                   <span class="text-ink-gray-5">{{ __("Searched for:") }}</span>
-                  <span class="ml-1 font-medium text-primary">
+                  <span class="ms-1 font-medium text-primary">
                     {{ searchResponse.summary.corrected_query }}
                   </span>
                 </p>
@@ -148,9 +148,9 @@
           <template v-for="item in searchResponse?.results" :key="item.id">
             <router-link
               :to="getItemRoute(item)"
-              class="flex space-x-2 overflow-hidden rounded px-2.5 py-3 hover:bg-surface-gray-2"
+              class="flex gap-x-2 overflow-hidden rounded px-2.5 py-3 hover:bg-surface-gray-2"
             >
-              <div class="flex items-start space-x-2">
+              <div class="flex items-start gap-x-2">
                 <div class="flex-shrink-0">
                   <LucideTicket
                     v-if="item.doctype === 'HD Ticket'"
@@ -188,7 +188,7 @@
                   <span class="px-1 leading-none text-sm text-ink-gray-5">
                     &middot; #{{ getTicketNumber(item) }}
                   </span>
-                  <div class="ml-auto text-sm text-ink-gray-5">
+                  <div class="ms-auto text-sm text-ink-gray-5">
                     {{ formatDate(item.modified) }}
                   </div>
                 </div>

--- a/desk/src/pages/call-logs/CallLogDetailModal.vue
+++ b/desk/src/pages/call-logs/CallLogDetailModal.vue
@@ -43,19 +43,19 @@
                   :label="field.value.caller.label"
                   size="sm"
                 />
-                <div class="ml-1 flex flex-col gap-1">
+                <div class="ms-1 flex flex-col gap-1">
                   {{ field.value.caller.label }}
                 </div>
                 <FeatherIcon
                   name="arrow-right"
-                  class="mx-1 h-4 w-4 text-ink-gray-5"
+                  class="mx-1 h-4 w-4 text-ink-gray-5 rtl:rotate-180"
                 />
                 <Avatar
                   :image="field.value.receiver.image"
                   :label="field.value.receiver.label"
                   size="sm"
                 />
-                <div class="ml-1 flex flex-col gap-1">
+                <div class="ms-1 flex flex-col gap-1">
                   {{ field.value.receiver.label }}
                 </div>
               </div>

--- a/desk/src/pages/customer/Customers.vue
+++ b/desk/src/pages/customer/Customers.vue
@@ -11,6 +11,7 @@
           :label="__('Create')"
           theme="gray"
           variant="solid"
+          class="rtl:flex-row-reverse"
           @click="isDialogVisible = !isDialogVisible"
         >
           <template #prefix>

--- a/desk/src/pages/dashboard/Dashboard.vue
+++ b/desk/src/pages/dashboard/Dashboard.vue
@@ -30,7 +30,7 @@
               class="flex justify-between !min-w-48 items-center border border-outline-gray-2 rounded text-ink-gray-8 px-2 py-1.5 hover:border-outline-gray-3 hover:shadow-sm focus:border-outline-gray-4 focus:shadow-sm focus:ring-0 focus-visible:ring-0 transition-colors h-7 cursor-pointer"
             >
               <div class="flex items-center">
-                <LucideCalendar class="size-4 text-ink-gray-5 mr-2" />
+                <LucideCalendar class="size-4 text-ink-gray-5 me-2" />
                 <span class="text-base whitespace-nowrap">{{ preset }}</span>
               </div>
               <LucideChevronDown class="size-4 text-ink-gray-5" />
@@ -47,7 +47,7 @@
           :format="'MMM D'"
         >
           <template #prefix>
-            <LucideCalendar class="size-4 text-ink-gray-5 mr-2" />
+            <LucideCalendar class="size-4 text-ink-gray-5 me-2" />
           </template>
         </DateRangePicker>
         <Link
@@ -60,7 +60,7 @@
           :hide-me="true"
         >
           <template #prefix>
-            <LucideUsers class="size-4 text-ink-gray-5 mr-2" />
+            <LucideUsers class="size-4 text-ink-gray-5 me-2" />
           </template>
         </Link>
         <Link
@@ -74,7 +74,7 @@
           :hide-me="true"
         >
           <template #prefix>
-            <LucideUser class="size-4 text-ink-gray-5 mr-2" />
+            <LucideUser class="size-4 text-ink-gray-5 me-2" />
           </template>
         </Link>
       </div>
@@ -299,12 +299,12 @@ const tabButtons = computed(() => {
     {
       value: "organization",
       iconLeft: h(LucideBuilding2, { class: "size-4" }),
-      label: "My Organization",
+      label: __("My Organization"),
     },
     {
       value: "my_stats",
       iconLeft: h(LucideUser, { class: "size-4" }),
-      label: "My Stats",
+      label: __("My Stats"),
     },
   ];
 });

--- a/desk/src/pages/home/Home.vue
+++ b/desk/src/pages/home/Home.vue
@@ -69,18 +69,18 @@
         <LoadingIndicator :scale="8" />
       </div>
       <div
-        class="flex flex-col p-1 pt-4 md:p-4 md:pl-3 mx-auto max-w-[1500px] w-full grow relative h-full"
+        class="flex flex-col p-1 pt-4 md:p-4 md:ps-3 mx-auto max-w-[1500px] w-full grow relative h-full"
       >
         <div class="grow pb-12">
           <div
             v-if="!agentDashboard.loading && layout.length > 0"
-            class="text-2xl-semibold text-ink-gray-8 pl-2"
+            class="text-2xl-semibold text-ink-gray-8 ps-2"
           >
             {{ __("Hey") }}, {{ userName }}
           </div>
           <div
             v-if="!agentDashboard.loading && layout.length === 0"
-            class="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"
+            class="absolute top-1/2 start-1/2 transform -translate-x-1/2 rtl:translate-x-1/2 -translate-y-1/2"
           >
             <div class="flex flex-col items-center justify-center gap-1">
               <FeatherIcon name="layout" class="size-12 text-ink-gray-4" />
@@ -119,7 +119,7 @@
                   </div>
                   <div
                     v-if="editing"
-                    class="flex absolute right-0 top-0 bg-surface-gray-9 rounded cursor-pointer opacity-0 group-hover:opacity-100"
+                    class="flex absolute end-0 top-0 bg-surface-gray-9 rounded cursor-pointer opacity-0 group-hover:opacity-100"
                   >
                     <div
                       class="rounded p-1 hover:bg-surface-gray-8"

--- a/desk/src/pages/home/components/PendingTickets.vue
+++ b/desk/src/pages/home/components/PendingTickets.vue
@@ -20,22 +20,22 @@
       >
         <thead v-if="!showSkeleton && chartConfig?.tickets?.length > 0">
           <tr class="text-sm text-ink-gray-5">
-            <th class="p-2 text-left font-normal whitespace-nowrap">
+            <th class="p-2 text-start font-normal whitespace-nowrap">
               {{ __("ID") }}
             </th>
-            <th class="p-2 text-left font-normal w-full">
+            <th class="p-2 text-start font-normal w-full">
               {{ __("Subject") }}
             </th>
-            <th class="p-2 text-left font-normal min-w-20 whitespace-nowrap">
+            <th class="p-2 text-start font-normal min-w-20 whitespace-nowrap">
               {{ __("Status") }}
             </th>
-            <th class="p-2 text-left font-normal min-w-20 whitespace-nowrap">
+            <th class="p-2 text-start font-normal min-w-20 whitespace-nowrap">
               {{ __("Priority") }}
             </th>
-            <th class="p-2 text-left font-normal min-w-32 whitespace-nowrap">
+            <th class="p-2 text-start font-normal min-w-32 whitespace-nowrap">
               {{ __("Team") }}
             </th>
-            <th class="p-2 text-left font-normal min-w-40 whitespace-nowrap">
+            <th class="p-2 text-start font-normal min-w-40 whitespace-nowrap">
               {{ __("Reason") }}
             </th>
           </tr>
@@ -84,7 +84,7 @@
                   v-else-if="ticket.reason.type === 'pending'"
                   class="size-4 flex-shrink-0"
                 />
-                <span class="truncate pr-2">{{ ticket.reason.text }}</span>
+                <span class="truncate pe-2">{{ ticket.reason.text }}</span>
               </div>
               <span
                 v-else
@@ -133,7 +133,7 @@
         </tbody>
       </table>
       <div
-        class="flex justify-between items-center text-sm mt-auto text-ink-gray-5 pl-2 pb-2"
+        class="flex justify-between items-center text-sm mt-auto text-ink-gray-5 ps-2 pb-2"
       >
         <div>
           <div
@@ -144,7 +144,7 @@
             {{
               __("See all {0} tickets", chartConfig?.totalPendingTickets + "")
             }}
-            <FeatherIcon name="arrow-right" class="size-4" />
+            <FeatherIcon name="arrow-right" class="size-4 rtl:rotate-180" />
           </div>
         </div>
         <div v-if="chartConfig?.tickets?.length > 0" class="mt-3 mb-0.5">

--- a/desk/src/pages/home/components/RecentFeedback.vue
+++ b/desk/src/pages/home/components/RecentFeedback.vue
@@ -44,7 +44,7 @@
                 @click="redirectToSeeAllReviews"
               >
                 {{ __("{0} reviews", chartConfig.totalFeedbacks) }}
-                <FeatherIcon name="arrow-up-right" class="size-3.5 ml-0.5" />
+                <FeatherIcon name="arrow-up-right" class="size-3.5 ms-0.5" />
               </div>
             </div>
             <div v-if="chartConfig.totalFeedbacks > 0" class="text-sm">
@@ -115,7 +115,7 @@
             </Dropdown>
 
             <!-- Period dropdown second -->
-            <div class="flex items-center gap-2 ml-auto">
+            <div class="flex items-center gap-2 ms-auto">
               <Dropdown
                 v-if="!showDatePicker && currentPeriod !== 'custom_range'"
                 :options="periodOptions"
@@ -182,7 +182,7 @@
               <!-- Rating & Title -->
               <div class="flex items-center gap-2 mb-2">
                 <div
-                  class="flex items-center gap-1 p-1 pl-0 rounded"
+                  class="flex items-center gap-1 p-1 ps-0 rounded"
                   :class="[getRatingColor(currentFeedback.star_rating).text]"
                 >
                   <LucideStar
@@ -232,7 +232,10 @@
                     @click="prevFeedback"
                     :disabled="currentIndex === 0"
                   >
-                    <FeatherIcon name="chevron-left" class="size-4" />
+                    <FeatherIcon
+                      name="chevron-left"
+                      class="size-4 rtl:rotate-180"
+                    />
                   </Button>
                   <Button
                     variant="ghost"
@@ -240,7 +243,10 @@
                     @click="nextFeedback"
                     :disabled="currentIndex >= chartConfig.feedbacks.length - 1"
                   >
-                    <FeatherIcon name="chevron-right" class="size-4" />
+                    <FeatherIcon
+                      name="chevron-right"
+                      class="size-4 rtl:rotate-180"
+                    />
                   </Button>
                 </div>
               </div>
@@ -309,8 +315,8 @@ import EmptyState from "@/components/EmptyState.vue";
 
 const router = useRouter();
 const chartTabs = [
-  { label: "Rating", value: "rating" },
-  { label: "Feedback", value: "feedback" },
+  { label: __("Rating"), value: "rating" },
+  { label: __("Feedback"), value: "feedback" },
 ];
 const currentTab = ref("rating");
 const { views } = useView("HD Ticket");

--- a/desk/src/pages/knowledge-base/Article.vue
+++ b/desk/src/pages/knowledge-base/Article.vue
@@ -82,7 +82,7 @@
                 v-if="!editable && !isCustomerPortal && !isMobileView"
                 class="text-p-sm text-ink-gray-4 items-center"
               >
-                <span>{{ views }} views</span>
+                <span>{{ views }} {{ __("views") }}</span>
               </div>
             </div>
             <div class="flex gap-4 justify-between sm:items-start">
@@ -173,7 +173,7 @@
             <EditorContent :class="editorClass" />
             <EditorFixedMenu
               v-if="editable"
-              class="-ml-1 overflow-x-auto w-full"
+              class="-ms-1 overflow-x-auto w-full"
               :items="fullToolbar"
             />
           </template>
@@ -195,7 +195,7 @@
                 {{ article.data.author.name }}
               </p>
               <div class="flex items-center gap-1">
-                <span class="text-p-xs text-ink-gray-7">
+                <span class="text-p-xs text-ink-gray-6">
                   {{
                     dayjsLocal(article.data.modified).format("MMM D, h:mm A")
                   }}
@@ -662,7 +662,7 @@ const articleActions = computed(() => [
 const breadcrumbs = computed(() => {
   const items: Breadcrumb[] = [
     {
-      label: isMobileView.value ? "" : __("Knowledge Base"),
+      label: isMobileView.value ? __("KB") : __("Knowledge Base"),
       route: {
         name: isCustomerPortal.value
           ? "CustomerKnowledgeBase"

--- a/desk/src/pages/knowledge-base/Articles.vue
+++ b/desk/src/pages/knowledge-base/Articles.vue
@@ -2,7 +2,7 @@
   <div class="p-5 pb-5 md:pb-10 px-10 w-full overflow-scroll items-center">
     <LayoutHeader>
       <template #left-header>
-        <Breadcrumbs :items="breadcrumbs" class="-ml-0.5" />
+        <Breadcrumbs :items="breadcrumbs" class="-ms-0.5" />
       </template>
     </LayoutHeader>
     <div

--- a/desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue
+++ b/desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue
@@ -8,7 +8,11 @@
       </template>
       <template #right-header>
         <Dropdown :options="headerOptions">
-          <Button :label="__('Create')" variant="solid">
+          <Button
+            :label="__('Create')"
+            variant="solid"
+            class="rtl:flex-row-reverse"
+          >
             <template #prefix>
               <LucidePlus class="h-4 w-4" />
             </template>

--- a/desk/src/pages/knowledge-base/KnowledgeBaseCustomer.vue
+++ b/desk/src/pages/knowledge-base/KnowledgeBaseCustomer.vue
@@ -21,7 +21,7 @@
       <!-- Categories Folder -->
       <section class="flex flex-col gap-3">
         <!-- Heading -->
-        <p class="text-lg text-ink-gray-9">Categories</p>
+        <p class="text-lg text-ink-gray-9">{{ __("Categories") }}</p>
         <CategoryFolderContainer />
       </section>
     </div>

--- a/desk/src/pages/knowledge-base/NewArticle.vue
+++ b/desk/src/pages/knowledge-base/NewArticle.vue
@@ -10,7 +10,7 @@
       <div class="flex flex-col gap-3 rounded-lg border w-full p-4">
         <div class="flex justify-between items-center mb-3">
           <!-- Author Info -->
-          <div class="flex gap-1 items-center flex-1 mr-7 max-w-fit">
+          <div class="flex gap-1 items-center flex-1 me-7 max-w-fit">
             <UserAvatar :name="user.name" :expand="true" />
             <span>{{ __("in") }}</span>
             <Link
@@ -60,7 +60,7 @@
               class="rounded-b-lg max-w-[unset] prose-sm h-[calc(100vh-340px)] sm:h-[calc(100vh-250px)] overflow-auto"
             />
             <EditorFixedMenu
-              class="-ml-1 overflow-x-auto w-full"
+              class="-ms-1 overflow-x-auto w-full"
               :items="fullToolbar"
             />
           </template>

--- a/desk/src/pages/ticket/MobileTicketAgent.vue
+++ b/desk/src/pages/ticket/MobileTicketAgent.vue
@@ -5,7 +5,7 @@
         <Breadcrumbs :items="breadcrumbs" />
       </template>
       <template #right-header>
-        <div class="absolute right-0 pr-2">
+        <div class="absolute end-0 pe-2">
           <Dropdown :options="dropdownOptions">
             <template #default="{ open }">
               <Button :label="ticket.doc.status">
@@ -153,7 +153,7 @@
         >
           {{ __("Confirm") }}
         </Button>
-        <Button class="ml-2" @click="showSubjectDialog = false">
+        <Button class="ms-2" @click="showSubjectDialog = false">
           {{ __("Close") }}
         </Button>
       </template>

--- a/desk/src/pages/ticket/TicketConversation.vue
+++ b/desk/src/pages/ticket/TicketConversation.vue
@@ -17,7 +17,7 @@
         class="w-full activity grid grid-cols-[30px_minmax(auto,_1fr)] gap-2 sm:gap-4 h-full"
       >
         <div
-          class="relative flex justify-center after:absolute after:left-[50%] after:top-3 after:-z-10 after:border-l after:border-outline-gray-modals"
+          class="relative flex justify-center after:absolute after:start-[50%] after:top-3 after:-z-10 after:border-s after:border-outline-gray-1"
           :class="[
             i != communications.length - 1 ? 'after:h-full' : 'after:h-5',
           ]"

--- a/desk/src/pages/ticket/TicketCustomer.vue
+++ b/desk/src/pages/ticket/TicketCustomer.vue
@@ -2,7 +2,7 @@
   <div v-if="ticket.data" class="flex flex-col">
     <LayoutHeader>
       <template #left-header>
-        <Breadcrumbs :items="breadcrumbs" class="-ml-0.5" />
+        <Breadcrumbs :items="breadcrumbs" class="-ms-0.5" />
       </template>
       <template #right-header>
         <CustomActions

--- a/desk/src/pages/ticket/TicketNew.vue
+++ b/desk/src/pages/ticket/TicketNew.vue
@@ -59,7 +59,7 @@
         :class="(subject.length >= 2 || description.length) && 'gap-5'"
       >
         <div class="flex flex-col gap-2">
-          <span class="block text-sm text-ink-gray-7">
+          <span class="block text-sm text-ink-gray-6">
             {{ __("Subject") }}
             <span class="place-self-center text-ink-red-5"> * </span>
           </span>
@@ -78,7 +78,7 @@
         <div v-if="isCustomerPortal">
           <h4
             v-show="subject.length <= 2 && description.length === 0"
-            class="text-p-sm text-ink-gray-4 ml-1"
+            class="text-p-sm text-ink-gray-4 ms-1"
           >
             {{ __("Please enter a subject to continue") }}
           </h4>

--- a/desk/tailwind.config.js
+++ b/desk/tailwind.config.js
@@ -27,6 +27,7 @@ export default {
   },
   plugins: [
     require("@tailwindcss/typography"),
+    require("tailwindcss-rtl"),
     function ({ addUtilities }) {
       addUtilities({
         ".hide-scrollbar": {

--- a/desk/tsconfig.json
+++ b/desk/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"esModuleInterop": true,
 		"allowSyntheticDefaultImports": true,
 		"allowUnreachableCode": false,
 		"target": "es2022",

--- a/helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.py
@@ -151,9 +151,9 @@ def notify_reaction(doc, emoji, user):
 
     count = len(reacting_users)
     if count == 1:
-        message = "1 person reacted to your comment"
+        message = _("1 person reacted to your comment")
     else:
-        message = "{} people reacted to your comment".format(count)
+        message = _("{} people reacted to your comment").format(count)
 
     existing = frappe.db.get_value(
         "HD Notification",


### PR DESCRIPTION
Backport of #3174 (RTL support) onto `main-hotfix`.

`main-hotfix` already carried the RTL boot infrastructure (`is_rtl()`, `boot.dir`/`boot.lang`, `<html dir>`). This adds the frontend sweep that was missing: physical → logical Tailwind utilities (`ms/me`, `ps/pe`, `start/end`, `border-s/e`, `rounded-s/e`, `space-x` → `gap-x`), `rtl:` variants, and directional-icon rotations.

### Conflict resolution

`main-hotfix` had diverged substantially from #3174's base, so conflicts were resolved by **keeping main-hotfix's code and layering the RTL sweep on top**, rather than taking the PR's older markup:

- Kept main-hotfix's refactors: `Sidebar` → `AppSidebar`, `EmptyState`, the `Dialog` API, the color-token migration, and `lucide-*` icon naming.
- Applied the physical → logical swaps onto main-hotfix's versions of those lines.
- Dropped the three files main-hotfix had already removed or relocated (`MultiSelectInput`, `desk/global/New{Contact,Customer}Dialog`).
- Reconciled `SettingsLayoutBase` so its `back-label` / `on-back` / `dirty` API matches the 10 settings views that auto-merged onto it — without this the back button silently disappears across those views.

### Verification

- `rtl:` occurrence count matches `develop` (38), and **74** of the touched files are byte-identical to `develop`. The files that differ do so only through genuine `main-hotfix` ↔ `develop` divergence, not RTL.
- Production build passes (`vite build`, 3371 modules). Note this requires frappe-ui **beta.24**; against older frappe-ui the build fails on pre-existing `bg-surface-base` usage unrelated to this change.

### Known limitation

Sidebar rows do **not** mirror in RTL. frappe-ui's `ScrollArea` renders reka-ui's `ScrollAreaRoot` without forwarding `dir`; reka-ui defaults that prop to `ltr` and stamps it on the DOM, so every row inside `AppSidebar`'s `ScrollArea` computes `direction: ltr` inside an otherwise RTL document, and flexbox never mirrors them. Verified in the browser: `html[dir=rtl]` but sidebar item `direction: ltr`.

This is an upstream frappe-ui issue rather than something this backport introduces — `develop`'s `AppSidebar` has no RTL either, because #3174's sidebar work targeted the older inline `SidebarLink` markup that the `AppSidebar` refactor replaced. It is best fixed in frappe-ui by providing reka-ui's direction context (`ConfigProvider`), which would fix all of its reka-ui-backed components at once. Deliberately left out of this backport to keep it to the sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)