### PR TITLE
fix: attachment remove button opens file in new tab

### DIFF
--- a/desk/src/components/AttachmentItem.vue
+++ b/desk/src/components/AttachmentItem.vue
@@ -11,7 +11,9 @@
           <component :is="icon" class="h-4 w-4" />
         </template>
         <template #suffix>
-          <slot name="suffix" />
+          <span @click.stop.prevent>
+            <slot name="suffix" />
+          </span>
         </template>
       </Button>
     </a>

--- a/desk/src/components/CommentTextEditor.vue
+++ b/desk/src/components/CommentTextEditor.vue
@@ -25,11 +25,7 @@
           :url="!['MOV', 'MP4'].includes(a.file_type) ? a.file_url : null"
         >
           <template #suffix>
-            <FeatherIcon
-              class="h-3.5"
-              name="x"
-              @click.stop="removeAttachment(a)"
-            />
+            <FeatherIcon class="h-3.5" name="x" @click="removeAttachment(a)" />
           </template>
         </AttachmentItem>
       </div>

--- a/desk/src/components/CompactEditor.vue
+++ b/desk/src/components/CompactEditor.vue
@@ -55,7 +55,7 @@
           <FeatherIcon
             class="h-3.5 cursor-pointer"
             name="x"
-            @click.self.stop="removeAttachment(attachment)"
+            @click="removeAttachment(attachment)"
           />
         </template>
       </AttachmentItem>

--- a/desk/src/components/EmailEditor.vue
+++ b/desk/src/components/EmailEditor.vue
@@ -139,7 +139,7 @@
               <FeatherIcon
                 class="h-3.5"
                 name="x"
-                @click.self.stop="removeAttachment(a)"
+                @click="removeAttachment(a)"
               />
             </template>
           </AttachmentItem>

--- a/desk/src/pages/ticket/TicketTextEditor.vue
+++ b/desk/src/pages/ticket/TicketTextEditor.vue
@@ -19,7 +19,7 @@
           <template #suffix>
             <LucideX
               class="size-4"
-              @click.stop="
+              @click="
                 () => {
                   $emit(
                     'update:attachments',


### PR DESCRIPTION
## Problem
When you upload a file or video in a ticket reply or comment, clicking the X button to remove it also opens the file in a new browser tab.

## Cause
The X button sits inside a link (`<a target="_blank">`). Its click handler used `@click.stop`, which stops the event from bubbling but does not stop the link from opening. So the file still opened in a new tab.

## Fix
Block the link navigation in one place: wrap the remove button slot in `AttachmentItem` with `<span @click.stop.prevent>`. Then remove the now unneeded `.stop`/`.self` on the X handlers in the email, compact, comment, and ticket editors so the click reaches that wrapper.

### Before Fix
[Screencast from 2026-07-22 17-18-05.webm](https://github.com/user-attachments/assets/039fe2e9-de27-40d5-b061-508e9b4f4cd0)


### After Fix
[Screencast from 2026-07-22 17-11-50.webm](https://github.com/user-attachments/assets/03156faf-e242-40c1-979a-95227215d16f)
