### PR TITLE
feat: Recent Activity card on Home dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,8 +157,12 @@ apiCall.submit({ ticket_id: "<id>", agent_id: "<agent>" });
 ### Icons
 
 - **Primary icon system**: Lucide icons via unplugin-icons for consistency and modern design
-- **Secondary**: FeatherIcon component from frappe-ui (legacy usage, prefer Lucide for new components)
-- Use Lucide icons for all new components:
+- **Secondary**: FeatherIcon component from frappe-ui (legacy usage only)
+- **Rule**: Never introduce `FeatherIcon` in new code. New components must use Lucide
+  icons (`<LucideInfo />`, `<LucidePlus />`, …) — no exceptions, including small
+  helper icons like tooltip/info glyphs.
+- Use Lucide icons for all new components. They are globally auto-registered
+  (see `desk/components.d.ts`), so no import is needed when used as a template tag:
   ```vue
   <template>
     <LucidePlus class="size-4" />

--- a/desk/src/components/EmptyState.vue
+++ b/desk/src/components/EmptyState.vue
@@ -52,9 +52,10 @@
         <span
           v-if="descriptionText"
           :class="{
-            'text-center text-xs text-ink-gray-6 mt-1': text === 'sm',
-            'text-center text-sm text-ink-gray-6 mt-1': text === 'md' || !text,
-            'text-center text-base text-ink-gray-6 mt-1': text === 'lg',
+            'text-center text-p-xs text-ink-gray-6 mt-1': text === 'sm',
+            'text-center text-p-sm text-ink-gray-6 mt-1':
+              text === 'md' || !text,
+            'text-center text-p-base text-ink-gray-6 mt-1': text === 'lg',
           }"
         >
           {{ __(descriptionText) }}

--- a/desk/src/components/layouts/AppSidebar.vue
+++ b/desk/src/components/layouts/AppSidebar.vue
@@ -13,13 +13,13 @@
           <SidebarLabel
             v-if="section.label"
             divider
-            class="my-1 select-none"
+            class="mt-4 my-1 select-none"
             :class="section.collapsible && !isCollapsed && 'cursor-pointer'"
             @click="section.collapsible && toggleSection(section.label)"
           >
             <span class="flex items-center gap-1.5 text-sm font-medium">
               <span
-                class="lucide-chevron-right size-4 shrink-0 text-ink-gray-9 transition-transform duration-300 ease-in-out"
+                class="lucide-chevron-right size-4 shrink-0 text-ink-gray-9 transition-transform duration-300 ease-in-out -ml-0.5"
                 :class="{ 'rotate-90': isSectionOpen(section.label) }"
               />
               <span class="truncate">{{ section.label }}</span>

--- a/desk/src/pages/home/Home.vue
+++ b/desk/src/pages/home/Home.vue
@@ -362,7 +362,7 @@ const chartsDropdown = computed(() => {
         }),
     },
     {
-      label: __("Recent Activity"),
+      label: __("My Recent Activity"),
       chart: "recent_activity",
       onClick: () =>
         addChart("recent_activity", {

--- a/desk/src/pages/home/Home.vue
+++ b/desk/src/pages/home/Home.vue
@@ -361,6 +361,18 @@ const chartsDropdown = computed(() => {
           maxH: 32,
         }),
     },
+    {
+      label: __("Recent Activity"),
+      chart: "recent_activity",
+      onClick: () =>
+        addChart("recent_activity", {
+          w: 16,
+          h: 32,
+          minW: 12,
+          minH: 20,
+          maxH: 44,
+        }),
+    },
   ].filter((chart) => {
     return !layout.value.some((item) => item.chart === chart.chart);
   });

--- a/desk/src/pages/home/components/ChartItem.vue
+++ b/desk/src/pages/home/components/ChartItem.vue
@@ -24,6 +24,7 @@
     <RecentFeedback v-if="item.chart == 'recent_feedback'" :data="item.data" />
     <AvgTimeMetrics v-if="item.chart == 'avg_time_metrics'" :data="item.data" />
     <PendingTickets v-if="item.chart == 'pending_tickets'" :data="item.data" />
+    <RecentActivity v-if="item.chart == 'recent_activity'" :data="item.data" />
   </div>
 </template>
 
@@ -34,6 +35,7 @@ import LineChartCard from "../../../components/LineChartCard.vue";
 import AgentTicketsCard from "./AgentTicketsCard.vue";
 import AvgTimeMetrics from "./AvgTimeMetrics.vue";
 import PendingTickets from "./PendingTickets.vue";
+import RecentActivity from "./RecentActivity.vue";
 import RecentFeedback from "./RecentFeedback.vue";
 
 interface Item {

--- a/desk/src/pages/home/components/RecentActivity.vue
+++ b/desk/src/pages/home/components/RecentActivity.vue
@@ -37,7 +37,7 @@
             </span>
           </div>
         </template>
-        <div v-else-if="showSkeleton" class="flex flex-col">
+        <div v-else class="flex flex-col">
           <div v-for="i in 6" :key="i" class="flex items-center gap-3 p-2 py-3">
             <div class="size-4 rounded-sm bg-surface-gray-1 flex-shrink-0" />
             <div class="flex flex-col gap-1 grow">
@@ -46,13 +46,15 @@
             </div>
           </div>
         </div>
-        <EmptyState
-          v-else
-          :title="__('No recent activity')"
-          :description="__('Tickets you act on will show up here')"
-          text="md"
-        />
       </div>
+      <EmptyState
+        v-if="!showSkeleton && activities.length === 0"
+        class="absolute inset-0 z-10"
+        :title="__('No recent activity')"
+        :description="__('Tickets you act on will show up here')"
+        variant="overlay"
+        text="md"
+      />
       <div
         v-if="!showSkeleton && activities.length > 0"
         class="pointer-events-none absolute inset-x-0 bottom-0 h-8"

--- a/desk/src/pages/home/components/RecentActivity.vue
+++ b/desk/src/pages/home/components/RecentActivity.vue
@@ -3,7 +3,7 @@
     class="flex flex-col rounded-md px-2 py-4 grow w-full h-full overflow-hidden"
   >
     <div class="flex items-center gap-2 px-2 text-lg-semibold text-ink-gray-8">
-      {{ __("Recent Activity") }}
+      {{ __("My Recent Activity") }}
       <Tooltip
         :text="__('Tickets you\'ve recently worked on or viewed')"
         placement="top"
@@ -77,11 +77,12 @@ import ActivityIcon from "~icons/lucide/activity";
 import ReplyIcon from "~icons/lucide/corner-up-left";
 import EyeIcon from "~icons/lucide/eye";
 import MessageSquareIcon from "~icons/lucide/message-square";
+import UserPlusIcon from "~icons/lucide/user-plus";
 
 interface RecentActivity {
   name: string;
   subject: string;
-  activity_type: "replied" | "commented" | "status" | "viewed";
+  activity_type: "replied" | "commented" | "updated" | "viewed" | "assigned";
   text: string | null;
   timestamp: string;
   creation: string;
@@ -100,13 +101,15 @@ const typeLabels: Record<string, string> = {
   replied: __("Replied"),
   commented: __("Commented"),
   viewed: __("Viewed"),
+  assigned: __("Assigned"),
 };
 
 const icons = {
   replied: ReplyIcon,
   commented: MessageSquareIcon,
-  status: ActivityIcon,
+  updated: ActivityIcon,
   viewed: EyeIcon,
+  assigned: UserPlusIcon,
 };
 
 const hasLoadedOnce = ref(false);
@@ -131,9 +134,7 @@ function iconFor(type: string) {
 }
 
 function label(activity: RecentActivity) {
-  return activity.activity_type === "status"
-    ? activity.text
-    : typeLabels[activity.activity_type];
+  return activity.text || typeLabels[activity.activity_type];
 }
 
 const goToTicket = (activity: RecentActivity) => {

--- a/desk/src/pages/home/components/RecentActivity.vue
+++ b/desk/src/pages/home/components/RecentActivity.vue
@@ -1,0 +1,149 @@
+<template>
+  <div
+    class="flex flex-col rounded-md px-2 py-4 grow w-full h-full overflow-hidden"
+  >
+    <div class="flex items-center gap-2 px-2 text-lg-semibold text-ink-gray-8">
+      {{ __("Recent Activity") }}
+      <Tooltip
+        :text="__('Tickets you\'ve recently worked on or viewed')"
+        placement="top"
+      >
+        <LucideInfo class="size-3.5 cursor-pointer text-ink-gray-5" />
+      </Tooltip>
+    </div>
+    <div class="relative mt-5 grow overflow-hidden">
+      <div class="flex flex-col h-full overflow-auto hide-scrollbar">
+        <template v-if="!showSkeleton && activities.length > 0">
+          <div
+            v-for="activity in activities"
+            :key="activity.name"
+            @click="goToTicket(activity)"
+            class="flex items-center gap-3 px-2 py-3 text-sm cursor-pointer hover:bg-surface-sidebar rounded"
+          >
+            <component
+              :is="iconFor(activity.activity_type)"
+              class="size-4 flex-shrink-0 text-ink-gray-5"
+            />
+            <div class="flex flex-col min-w-0 grow gap-1">
+              <span class="truncate text-ink-gray-8">
+                {{ activity.subject || __("Untitled") }}
+              </span>
+              <span class="truncate text-ink-gray-5">
+                #{{ activity.name }} · {{ label(activity) }}
+              </span>
+            </div>
+            <span class="text-ink-gray-4 whitespace-nowrap tabular-nums">
+              {{ activity.timestamp }}
+            </span>
+          </div>
+        </template>
+        <div v-else-if="showSkeleton" class="flex flex-col">
+          <div v-for="i in 6" :key="i" class="flex items-center gap-3 p-2 py-3">
+            <div class="size-4 rounded-sm bg-surface-gray-1 flex-shrink-0" />
+            <div class="flex flex-col gap-1 grow">
+              <div class="h-4 w-2/3 rounded-sm bg-surface-gray-1" />
+              <div class="h-3 w-1/3 rounded-sm bg-surface-gray-1" />
+            </div>
+          </div>
+        </div>
+        <EmptyState
+          v-else
+          :title="__('No recent activity')"
+          :description="__('Tickets you act on will show up here')"
+          text="md"
+        />
+      </div>
+      <div
+        v-if="!showSkeleton && activities.length > 0"
+        class="pointer-events-none absolute inset-x-0 bottom-0 h-8"
+        :style="{
+          backgroundImage:
+            'linear-gradient(to top, var(--surface-base), transparent)',
+        }"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import EmptyState from "@/components/EmptyState.vue";
+import { __ } from "@/translation";
+import { createResource, Tooltip } from "frappe-ui";
+import { computed, onMounted, ref, type PropType } from "vue";
+import { useRouter } from "vue-router";
+import ActivityIcon from "~icons/lucide/activity";
+import ReplyIcon from "~icons/lucide/corner-up-left";
+import EyeIcon from "~icons/lucide/eye";
+import MessageSquareIcon from "~icons/lucide/message-square";
+
+interface RecentActivity {
+  name: string;
+  subject: string;
+  activity_type: "replied" | "commented" | "status" | "viewed";
+  text: string | null;
+  timestamp: string;
+  creation: string;
+}
+
+const props = defineProps({
+  data: {
+    type: Array as PropType<RecentActivity[]>,
+    required: true,
+  },
+});
+
+const router = useRouter();
+
+const typeLabels: Record<string, string> = {
+  replied: __("Replied"),
+  commented: __("Commented"),
+  viewed: __("Viewed"),
+};
+
+const icons = {
+  replied: ReplyIcon,
+  commented: MessageSquareIcon,
+  status: ActivityIcon,
+  viewed: EyeIcon,
+};
+
+const hasLoadedOnce = ref(false);
+
+const recentActivityResource = createResource({
+  url: "helpdesk.api.agent_home.agent_home.get_recent_activity",
+  onSuccess() {
+    hasLoadedOnce.value = true;
+  },
+});
+
+const activities = computed<RecentActivity[]>(() =>
+  recentActivityResource.fetched ? recentActivityResource.data : props.data
+);
+
+const showSkeleton = computed(
+  () => recentActivityResource.loading && !hasLoadedOnce.value
+);
+
+function iconFor(type: string) {
+  return icons[type as keyof typeof icons] || ActivityIcon;
+}
+
+function label(activity: RecentActivity) {
+  return activity.activity_type === "status"
+    ? activity.text
+    : typeLabels[activity.activity_type];
+}
+
+const goToTicket = (activity: RecentActivity) => {
+  router.push({
+    name: "TicketAgent",
+    params: { ticketId: String(activity.name) },
+  });
+};
+
+onMounted(() => {
+  if (!Array.isArray(props.data)) {
+    recentActivityResource.fetch();
+  }
+});
+</script>

--- a/helpdesk/api/agent_home/agent_home.py
+++ b/helpdesk/api/agent_home/agent_home.py
@@ -571,10 +571,8 @@ def _get_pending_response_tickets(limit=10):
     return tickets, total_count
 
 
-# Most significant action wins when collapsing a ticket's events to one row.
-ACTIVITY_PRIORITY = {"replied": 4, "commented": 3, "status": 2, "viewed": 1}
-RECENT_ACTIVITY_LIMIT = 10
-OVER_FETCH_PER_SOURCE = 30
+RECENT_ACTIVITY_LIMIT = 20
+RECENT_ACTIVITY_DAYS = 3
 
 # (doctype, user_field, ticket_field, activity_type, extra_filters)
 ACTIVITY_SOURCES = [
@@ -586,13 +584,27 @@ ACTIVITY_SOURCES = [
         {"reference_doctype": "HD Ticket", "sent_or_received": "Sent"},
     ),
     ("HD Ticket Comment", "commented_by", "reference_ticket", "commented", {}),
-    ("HD Ticket Activity", "owner", "ticket", "status", {}),
+    # SLA changes are automated noise, not something the agent chose to do.
+    (
+        "HD Ticket Activity",
+        "owner",
+        "ticket",
+        "updated",
+        {"action": ["not like", "%SLA%"]},
+    ),
     (
         "View Log",
         "viewed_by",
         "reference_name",
         "viewed",
         {"reference_doctype": "HD Ticket"},
+    ),
+    (
+        "ToDo",
+        "assigned_by",
+        "reference_name",
+        "assigned",
+        {"reference_type": "HD Ticket"},
     ),
 ]
 
@@ -601,49 +613,48 @@ def _activity_events(
     doctype: str, filters: dict, ticket_field: str, activity_type: str
 ) -> list[dict]:
     fields = [f"{ticket_field} as ticket", "creation"]
-    if activity_type == "status":
+    if activity_type == "updated":
         fields.append("action")
     rows = frappe.get_all(
         doctype,
         filters={
             **filters,
-            "creation": [">=", frappe.utils.add_days(frappe.utils.nowdate(), -7)],
+            "creation": [
+                ">=",
+                frappe.utils.add_days(frappe.utils.nowdate(), -RECENT_ACTIVITY_DAYS),
+            ],
         },
         fields=fields,
         order_by="creation desc",
-        limit=OVER_FETCH_PER_SOURCE,
+        limit=RECENT_ACTIVITY_LIMIT,
     )
     events = []
     for row in rows:
         if not row.get("ticket"):
             continue
-        text = row.action if activity_type == "status" else None
         events.append(
             {
                 "ticket": row.ticket,
                 "type": activity_type,
-                "text": text,
+                "text": (
+                    _updated_label(row.action) if activity_type == "updated" else None
+                ),
                 "creation": row.creation,
             }
         )
     return events
 
 
-def _collapse_events(events: list[dict]) -> dict[str, dict]:
-    """One event per ticket: highest priority, ties broken by recency."""
-    best: dict[str, dict] = {}
-    for event in sorted(
-        events, key=lambda e: (ACTIVITY_PRIORITY[e["type"]], e["creation"])
-    ):
-        best[event["ticket"]] = event
-    return best
+def _updated_label(action: str) -> str | None:
+    """HD Ticket Activity action text ('set status to Resolved') with a capital first letter."""
+    return action[:1].upper() + action[1:] if action else None
 
 
 @frappe.whitelist()
 @agent_only
 def get_recent_activity() -> list[dict]:
-    """Tickets the current agent recently acted on, one row per ticket showing
-    the most significant action (replied > commented > status change > viewed)."""
+    """The current agent's latest action per ticket (replied, commented, updated,
+    viewed, assigned), one row per ticket, newest first, over the last few days."""
     user = frappe.session.user
 
     events = []
@@ -651,34 +662,36 @@ def get_recent_activity() -> list[dict]:
         events += _activity_events(
             doctype, {**extra, user_field: user}, ticket_field, activity_type
         )
-
-    best = _collapse_events(events)
-    if not best:
+    if not events:
         return []
 
+    events.sort(key=lambda e: e["creation"], reverse=True)
+
+    # One row per ticket: keep only its most recent event.
+    latest_event_per_ticket: dict[str, dict] = {}
+    for event in events:
+        latest_event_per_ticket.setdefault(event["ticket"], event)
+
     # get_list so tickets the agent can no longer access drop out.
-    accessible = frappe.get_list(
+    accessible_tickets = frappe.get_list(
         "HD Ticket",
-        filters=[["name", "in", list(best.keys())]],
+        filters=[["name", "in", list(latest_event_per_ticket.keys())]],
         fields=["name", "subject"],
     )
-    subjects = {t["name"]: t["subject"] for t in accessible}
+    subject_by_ticket = {t["name"]: t["subject"] for t in accessible_tickets}
 
-    activities = []
-    for ticket, event in best.items():
-        if ticket not in subjects:
-            continue
-        activities.append(
-            {
-                "name": ticket,
-                "subject": subjects[ticket],
-                "activity_type": event["type"],
-                "text": event["text"],
-                "timestamp": format_time_difference(event["creation"]),
-                "creation": event["creation"],
-            }
-        )
-
+    activities = [
+        {
+            "name": event["ticket"],
+            "subject": subject_by_ticket[event["ticket"]],
+            "activity_type": event["type"],
+            "text": event["text"],
+            "timestamp": format_time_difference(event["creation"]),
+            "creation": event["creation"],
+        }
+        for event in latest_event_per_ticket.values()
+        if event["ticket"] in subject_by_ticket
+    ]
     activities.sort(key=lambda a: a["creation"], reverse=True)
     return activities[:RECENT_ACTIVITY_LIMIT]
 

--- a/helpdesk/api/agent_home/agent_home.py
+++ b/helpdesk/api/agent_home/agent_home.py
@@ -4,7 +4,7 @@ from datetime import date, timedelta
 import frappe
 from dateutil.relativedelta import relativedelta
 from frappe.query_builder import DocType
-from frappe.query_builder.functions import Avg, Count, Function, Max
+from frappe.query_builder.functions import Avg, Count, Function
 from frappe.utils import add_months, today
 from pypika import Case
 
@@ -571,6 +571,22 @@ def _get_pending_response_tickets(limit=10):
     return tickets, total_count
 
 
+@frappe.whitelist()
+@agent_only
+def get_pending_tickets(ticket_type: str = "upcoming_sla"):
+    if ticket_type == "upcoming_sla":
+        tickets, total_count = _get_upcoming_sla_tickets(limit=6)
+    elif ticket_type == "new_tickets":
+        tickets, total_count = _get_new_tickets(limit=6)
+    elif ticket_type == "pending":
+        tickets, total_count = _get_pending_response_tickets(limit=6)
+
+    return {
+        "tickets": tickets,
+        "total_pending_tickets": total_count,
+    }
+
+
 RECENT_ACTIVITY_LIMIT = 20
 RECENT_ACTIVITY_DAYS = 3
 
@@ -609,140 +625,80 @@ ACTIVITY_SOURCES = [
 ]
 
 
-def _activity_events(
-    doctype: str, filters: dict, ticket_field: str, activity_type: str
-) -> list[dict]:
-    """The latest event per ticket for one source, newest first. Deduping in SQL
-    (one row per ticket via MAX(creation)) keeps a single busy ticket from
-    consuming the limit and starving other eligible tickets."""
-    table = frappe.qb.DocType(doctype)
-    last_activity = Max(table.creation).as_("last_activity")
-    query = (
-        frappe.qb.from_(table)
-        .select(table[ticket_field].as_("ticket"), last_activity)
-        .where(table.creation >= _recent_activity_cutoff())
-        .groupby(table[ticket_field])
-        .orderby(Max(table.creation), order=frappe.qb.desc)
-        .limit(RECENT_ACTIVITY_LIMIT)
-    )
-    for field, condition in filters.items():
-        column = table[field]
-        if isinstance(condition, (list, tuple)):
-            operator, value = condition
-            query = query.where(
-                column.not_like(value) if operator == "not like" else column.like(value)
-            )
-        else:
-            query = query.where(column == condition)
-
-    return [
-        {"ticket": row.ticket, "type": activity_type, "creation": row.last_activity}
-        for row in query.run(as_dict=True)
-        if row.ticket
-    ]
-
-
-def _recent_activity_cutoff() -> str:
-    return frappe.utils.add_days(frappe.utils.nowdate(), -RECENT_ACTIVITY_DAYS)
-
-
-def _updated_label(action: str) -> str | None:
-    """HD Ticket Activity action text ('set status to Resolved') with a capital first letter."""
-    return action[:1].upper() + action[1:] if action else None
-
-
-def _updated_action_text(user: str, tickets: list[str]) -> dict[str, str]:
-    """Latest non-SLA action text per ticket, for tickets whose winning event is
-    an 'updated'. Only these rows carry server text; other types are labelled on
-    the frontend."""
-    if not tickets:
-        return {}
-    rows = frappe.get_all(
-        "HD Ticket Activity",
-        filters={
-            "ticket": ["in", tickets],
-            "owner": user,
-            "action": ["not like", "%SLA%"],
-        },
-        fields=["ticket", "action"],
-        order_by="creation asc",
-    )
-    # Ascending order means the last write per ticket is its most recent action.
-    return {row.ticket: _updated_label(row.action) for row in rows}
-
-
 @frappe.whitelist()
 @agent_only
 def get_recent_activity() -> list[dict]:
     """The current agent's latest action per ticket (replied, commented, updated,
     viewed, assigned), one row per ticket, newest first, over the last few days."""
     user = frappe.session.user
+    cutoff = frappe.utils.add_days(frappe.utils.nowdate(), -RECENT_ACTIVITY_DAYS)
 
     events = []
-    for doctype, user_field, ticket_field, activity_type, extra in ACTIVITY_SOURCES:
-        events += _activity_events(
-            doctype, {**extra, user_field: user}, ticket_field, activity_type
-        )
-    if not events:
-        return []
+    for (
+        doctype,
+        user_field,
+        ticket_field,
+        activity_type,
+        extra_filters,
+    ) in ACTIVITY_SOURCES:
+        filters = {**extra_filters, user_field: user, "creation": [">=", cutoff]}
+        events += _activity_events(doctype, filters, ticket_field, activity_type)
 
     # One row per ticket: keep only its most recent event across all sources.
-    latest_event_per_ticket: dict[str, dict] = {}
+    latest_per_ticket: dict[str, dict] = {}
     for event in sorted(events, key=lambda e: e["creation"]):
-        latest_event_per_ticket[event["ticket"]] = event
+        latest_per_ticket[event["ticket"]] = event
+    if not latest_per_ticket:
+        return []
 
-    # get_list so tickets the agent can no longer access drop out; filter before
-    # limiting so inaccessible tickets don't leave the card underfilled.
-    subject_by_ticket = _ticket_subjects(list(latest_event_per_ticket))
-    filtered_recent_events = [
-        event
-        for event in sorted(
-            latest_event_per_ticket.values(),
-            key=lambda e: e["creation"],
-            reverse=True,
-        )
-        if event["ticket"] in subject_by_ticket
-    ][:RECENT_ACTIVITY_LIMIT]
-
-    action_text = _updated_action_text(
-        user, [e["ticket"] for e in filtered_recent_events if e["type"] == "updated"]
+    # get_list respects permissions, so tickets the agent can't access drop out
+    # here — before the cap, so they can't leave the card underfilled.
+    accessible_tickets = frappe.get_list(
+        "HD Ticket",
+        filters=[["name", "in", list(latest_per_ticket)]],
+        fields=["name", "subject"],
     )
+    subject_by_ticket = {t.name: t.subject for t in accessible_tickets}
+
+    recent = sorted(
+        (e for e in latest_per_ticket.values() if e["ticket"] in subject_by_ticket),
+        key=lambda e: e["creation"],
+        reverse=True,
+    )[:RECENT_ACTIVITY_LIMIT]
 
     return [
         {
-            "name": event["ticket"],
-            "subject": subject_by_ticket[event["ticket"]],
-            "activity_type": event["type"],
-            "text": action_text.get(event["ticket"]),
-            "timestamp": format_time_difference(event["creation"]),
-            "creation": event["creation"],
+            "name": e["ticket"],
+            "subject": subject_by_ticket[e["ticket"]],
+            "activity_type": e["type"],
+            "text": e["text"],
+            "timestamp": format_time_difference(e["creation"]),
+            "creation": e["creation"],
         }
-        for event in filtered_recent_events
+        for e in recent
     ]
 
 
-def _ticket_subjects(tickets: list[str]) -> dict[str, str]:
-    if not tickets:
-        return {}
-    rows = frappe.get_list(
-        "HD Ticket",
-        filters=[["name", "in", tickets]],
-        fields=["name", "subject"],
-    )
-    return {row["name"]: row["subject"] for row in rows}
+def _activity_events(
+    doctype: str, filters: dict, ticket_field: str, activity_type: str
+) -> list[dict]:
+    """Every event of one type the agent performed in the window, tagged with its
+    ticket. Deduping to one row per ticket happens in get_recent_activity."""
+    fields = [f"{ticket_field} as ticket", "creation"]
+    if activity_type == "updated":
+        fields.append("action")
+    return [
+        {
+            "ticket": row.ticket,
+            "type": activity_type,
+            "text": _updated_label(row.action) if activity_type == "updated" else None,
+            "creation": row.creation,
+        }
+        for row in frappe.get_all(doctype, filters=filters, fields=fields)
+        if row.ticket
+    ]
 
 
-@frappe.whitelist()
-@agent_only
-def get_pending_tickets(ticket_type: str = "upcoming_sla"):
-    if ticket_type == "upcoming_sla":
-        tickets, total_count = _get_upcoming_sla_tickets(limit=6)
-    elif ticket_type == "new_tickets":
-        tickets, total_count = _get_new_tickets(limit=6)
-    elif ticket_type == "pending":
-        tickets, total_count = _get_pending_response_tickets(limit=6)
-
-    return {
-        "tickets": tickets,
-        "total_pending_tickets": total_count,
-    }
+def _updated_label(action: str) -> str | None:
+    """HD Ticket Activity action text ('set status to Resolved') with a capital first letter."""
+    return action[:1].upper() + action[1:] if action else None

--- a/helpdesk/api/agent_home/agent_home.py
+++ b/helpdesk/api/agent_home/agent_home.py
@@ -4,7 +4,7 @@ from datetime import date, timedelta
 import frappe
 from dateutil.relativedelta import relativedelta
 from frappe.query_builder import DocType
-from frappe.query_builder.functions import Avg, Count, Function
+from frappe.query_builder.functions import Avg, Count, Function, Max
 from frappe.utils import add_months, today
 from pypika import Case
 
@@ -612,42 +612,63 @@ ACTIVITY_SOURCES = [
 def _activity_events(
     doctype: str, filters: dict, ticket_field: str, activity_type: str
 ) -> list[dict]:
-    fields = [f"{ticket_field} as ticket", "creation"]
-    if activity_type == "updated":
-        fields.append("action")
-    rows = frappe.get_all(
-        doctype,
-        filters={
-            **filters,
-            "creation": [
-                ">=",
-                frappe.utils.add_days(frappe.utils.nowdate(), -RECENT_ACTIVITY_DAYS),
-            ],
-        },
-        fields=fields,
-        order_by="creation desc",
-        limit=RECENT_ACTIVITY_LIMIT,
+    """The latest event per ticket for one source, newest first. Deduping in SQL
+    (one row per ticket via MAX(creation)) keeps a single busy ticket from
+    consuming the limit and starving other eligible tickets."""
+    table = frappe.qb.DocType(doctype)
+    last_activity = Max(table.creation).as_("last_activity")
+    query = (
+        frappe.qb.from_(table)
+        .select(table[ticket_field].as_("ticket"), last_activity)
+        .where(table.creation >= _recent_activity_cutoff())
+        .groupby(table[ticket_field])
+        .orderby(Max(table.creation), order=frappe.qb.desc)
+        .limit(RECENT_ACTIVITY_LIMIT)
     )
-    events = []
-    for row in rows:
-        if not row.get("ticket"):
-            continue
-        events.append(
-            {
-                "ticket": row.ticket,
-                "type": activity_type,
-                "text": (
-                    _updated_label(row.action) if activity_type == "updated" else None
-                ),
-                "creation": row.creation,
-            }
-        )
-    return events
+    for field, condition in filters.items():
+        column = table[field]
+        if isinstance(condition, (list, tuple)):
+            operator, value = condition
+            query = query.where(
+                column.not_like(value) if operator == "not like" else column.like(value)
+            )
+        else:
+            query = query.where(column == condition)
+
+    return [
+        {"ticket": row.ticket, "type": activity_type, "creation": row.last_activity}
+        for row in query.run(as_dict=True)
+        if row.ticket
+    ]
+
+
+def _recent_activity_cutoff() -> str:
+    return frappe.utils.add_days(frappe.utils.nowdate(), -RECENT_ACTIVITY_DAYS)
 
 
 def _updated_label(action: str) -> str | None:
     """HD Ticket Activity action text ('set status to Resolved') with a capital first letter."""
     return action[:1].upper() + action[1:] if action else None
+
+
+def _updated_action_text(user: str, tickets: list[str]) -> dict[str, str]:
+    """Latest non-SLA action text per ticket, for tickets whose winning event is
+    an 'updated'. Only these rows carry server text; other types are labelled on
+    the frontend."""
+    if not tickets:
+        return {}
+    rows = frappe.get_all(
+        "HD Ticket Activity",
+        filters={
+            "ticket": ["in", tickets],
+            "owner": user,
+            "action": ["not like", "%SLA%"],
+        },
+        fields=["ticket", "action"],
+        order_by="creation asc",
+    )
+    # Ascending order means the last write per ticket is its most recent action.
+    return {row.ticket: _updated_label(row.action) for row in rows}
 
 
 @frappe.whitelist()
@@ -665,35 +686,50 @@ def get_recent_activity() -> list[dict]:
     if not events:
         return []
 
-    events.sort(key=lambda e: e["creation"], reverse=True)
-
-    # One row per ticket: keep only its most recent event.
+    # One row per ticket: keep only its most recent event across all sources.
     latest_event_per_ticket: dict[str, dict] = {}
-    for event in events:
-        latest_event_per_ticket.setdefault(event["ticket"], event)
+    for event in sorted(events, key=lambda e: e["creation"]):
+        latest_event_per_ticket[event["ticket"]] = event
 
-    # get_list so tickets the agent can no longer access drop out.
-    accessible_tickets = frappe.get_list(
-        "HD Ticket",
-        filters=[["name", "in", list(latest_event_per_ticket.keys())]],
-        fields=["name", "subject"],
+    # get_list so tickets the agent can no longer access drop out; filter before
+    # limiting so inaccessible tickets don't leave the card underfilled.
+    subject_by_ticket = _ticket_subjects(list(latest_event_per_ticket))
+    filtered_recent_events = [
+        event
+        for event in sorted(
+            latest_event_per_ticket.values(),
+            key=lambda e: e["creation"],
+            reverse=True,
+        )
+        if event["ticket"] in subject_by_ticket
+    ][:RECENT_ACTIVITY_LIMIT]
+
+    action_text = _updated_action_text(
+        user, [e["ticket"] for e in filtered_recent_events if e["type"] == "updated"]
     )
-    subject_by_ticket = {t["name"]: t["subject"] for t in accessible_tickets}
 
-    activities = [
+    return [
         {
             "name": event["ticket"],
             "subject": subject_by_ticket[event["ticket"]],
             "activity_type": event["type"],
-            "text": event["text"],
+            "text": action_text.get(event["ticket"]),
             "timestamp": format_time_difference(event["creation"]),
             "creation": event["creation"],
         }
-        for event in latest_event_per_ticket.values()
-        if event["ticket"] in subject_by_ticket
+        for event in filtered_recent_events
     ]
-    activities.sort(key=lambda a: a["creation"], reverse=True)
-    return activities[:RECENT_ACTIVITY_LIMIT]
+
+
+def _ticket_subjects(tickets: list[str]) -> dict[str, str]:
+    if not tickets:
+        return {}
+    rows = frappe.get_list(
+        "HD Ticket",
+        filters=[["name", "in", tickets]],
+        fields=["name", "subject"],
+    )
+    return {row["name"]: row["subject"] for row in rows}
 
 
 @frappe.whitelist()

--- a/helpdesk/api/agent_home/agent_home.py
+++ b/helpdesk/api/agent_home/agent_home.py
@@ -571,6 +571,118 @@ def _get_pending_response_tickets(limit=10):
     return tickets, total_count
 
 
+# Most significant action wins when collapsing a ticket's events to one row.
+ACTIVITY_PRIORITY = {"replied": 4, "commented": 3, "status": 2, "viewed": 1}
+RECENT_ACTIVITY_LIMIT = 10
+OVER_FETCH_PER_SOURCE = 30
+
+# (doctype, user_field, ticket_field, activity_type, extra_filters)
+ACTIVITY_SOURCES = [
+    (
+        "Communication",
+        "owner",
+        "reference_name",
+        "replied",
+        {"reference_doctype": "HD Ticket", "sent_or_received": "Sent"},
+    ),
+    ("HD Ticket Comment", "commented_by", "reference_ticket", "commented", {}),
+    ("HD Ticket Activity", "owner", "ticket", "status", {}),
+    (
+        "View Log",
+        "viewed_by",
+        "reference_name",
+        "viewed",
+        {"reference_doctype": "HD Ticket"},
+    ),
+]
+
+
+def _activity_events(
+    doctype: str, filters: dict, ticket_field: str, activity_type: str
+) -> list[dict]:
+    fields = [f"{ticket_field} as ticket", "creation"]
+    if activity_type == "status":
+        fields.append("action")
+    rows = frappe.get_all(
+        doctype,
+        filters={
+            **filters,
+            "creation": [">=", frappe.utils.add_days(frappe.utils.nowdate(), -7)],
+        },
+        fields=fields,
+        order_by="creation desc",
+        limit=OVER_FETCH_PER_SOURCE,
+    )
+    events = []
+    for row in rows:
+        if not row.get("ticket"):
+            continue
+        text = row.action if activity_type == "status" else None
+        events.append(
+            {
+                "ticket": row.ticket,
+                "type": activity_type,
+                "text": text,
+                "creation": row.creation,
+            }
+        )
+    return events
+
+
+def _collapse_events(events: list[dict]) -> dict[str, dict]:
+    """One event per ticket: highest priority, ties broken by recency."""
+    best: dict[str, dict] = {}
+    for event in sorted(
+        events, key=lambda e: (ACTIVITY_PRIORITY[e["type"]], e["creation"])
+    ):
+        best[event["ticket"]] = event
+    return best
+
+
+@frappe.whitelist()
+@agent_only
+def get_recent_activity() -> list[dict]:
+    """Tickets the current agent recently acted on, one row per ticket showing
+    the most significant action (replied > commented > status change > viewed)."""
+    user = frappe.session.user
+
+    events = []
+    for doctype, user_field, ticket_field, activity_type, extra in ACTIVITY_SOURCES:
+        events += _activity_events(
+            doctype, {**extra, user_field: user}, ticket_field, activity_type
+        )
+
+    best = _collapse_events(events)
+    if not best:
+        return []
+
+    # get_list so tickets the agent can no longer access drop out.
+    accessible = frappe.get_list(
+        "HD Ticket",
+        filters=[["name", "in", list(best.keys())]],
+        fields=["name", "subject"],
+    )
+    subjects = {t["name"]: t["subject"] for t in accessible}
+
+    activities = []
+    for ticket, event in best.items():
+        if ticket not in subjects:
+            continue
+        activities.append(
+            {
+                "name": ticket,
+                "subject": subjects[ticket],
+                "activity_type": event["type"],
+                "text": event["text"],
+                "timestamp": format_time_difference(event["creation"]),
+                "creation": event["creation"],
+            }
+        )
+
+    activities.sort(key=lambda a: a["creation"], reverse=True)
+    return activities[:RECENT_ACTIVITY_LIMIT]
+
+
 @frappe.whitelist()
 @agent_only
 def get_pending_tickets(ticket_type: str = "upcoming_sla"):

--- a/helpdesk/api/agent_home/test_agent_home.py
+++ b/helpdesk/api/agent_home/test_agent_home.py
@@ -7,7 +7,6 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from helpdesk.api.agent_home.agent_home import (
-    _collapse_events,
     get_agent_tickets,
     get_avg_first_response_time,
     get_avg_resolution_time,
@@ -599,30 +598,9 @@ class TestAgentHome(FrappeTestCase):
             self.assertEqual(t["reason"]["type"], "pending")
             self.assertIn("Pending for", t["reason"]["text"])
 
-    def test_collapse_events_priority_and_recency(self):
-        """One row per ticket: highest-priority action wins, ties broken by
-        recency, and a viewed-only ticket still survives."""
-        # replied (older) beats a later view on the same ticket
-        events = [
-            {"ticket": "T1", "type": "viewed", "creation": 10},
-            {"ticket": "T1", "type": "replied", "creation": 5},
-        ]
-        self.assertEqual(_collapse_events(events)["T1"]["type"], "replied")
-
-        # same type -> most recent wins
-        events = [
-            {"ticket": "T2", "type": "viewed", "creation": 3},
-            {"ticket": "T2", "type": "viewed", "creation": 9},
-        ]
-        self.assertEqual(_collapse_events(events)["T2"]["creation"], 9)
-
-        # a ticket the agent only viewed still shows up
-        events = [{"ticket": "T3", "type": "viewed", "creation": 1}]
-        self.assertEqual(_collapse_events(events)["T3"]["type"], "viewed")
-
-    def test_get_recent_activity_collapses_and_labels(self):
-        """A ticket the agent both viewed and commented on appears once, as the
-        higher-priority action (commented > viewed)."""
+    def test_get_recent_activity_latest_per_ticket(self):
+        """One row per ticket showing its most recent action; SLA changes are
+        filtered out, and updated rows carry the capitalized action text."""
         ticket = self._create_ticket(subject="Recent Activity Ticket")
 
         frappe.get_doc(
@@ -643,11 +621,25 @@ class TestAgentHome(FrappeTestCase):
             }
         ).insert(ignore_permissions=True)
 
+        frappe.get_doc(
+            {
+                "doctype": "HD Ticket Activity",
+                "ticket": ticket.name,
+                "action": "set status to Resolved",
+            }
+        ).insert(ignore_permissions=True)
+
+        # Inserted last (newest) but must be excluded, so it cannot win the row.
+        frappe.get_doc(
+            {
+                "doctype": "HD Ticket Activity",
+                "ticket": ticket.name,
+                "action": "set SLA to Default",
+            }
+        ).insert(ignore_permissions=True)
+
         rows = [r for r in get_recent_activity() if r["name"] == ticket.name]
 
         self.assertEqual(len(rows), 1)
-        self.assertEqual(rows[0]["activity_type"], "commented")
-        self.assertEqual(rows[0]["subject"], "Recent Activity Ticket")
-        # Only status rows carry server-side text (the raw action); the label for
-        # other types is applied on the frontend.
-        self.assertIsNone(rows[0]["text"])
+        self.assertEqual(rows[0]["activity_type"], "updated")
+        self.assertEqual(rows[0]["text"], "Set status to Resolved")

--- a/helpdesk/api/agent_home/test_agent_home.py
+++ b/helpdesk/api/agent_home/test_agent_home.py
@@ -7,6 +7,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from helpdesk.api.agent_home.agent_home import (
+    RECENT_ACTIVITY_LIMIT,
     get_agent_tickets,
     get_avg_first_response_time,
     get_avg_resolution_time,
@@ -643,3 +644,34 @@ class TestAgentHome(FrappeTestCase):
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0]["activity_type"], "updated")
         self.assertEqual(rows[0]["text"], "Set status to Resolved")
+
+    def test_get_recent_activity_dedupes_before_limiting(self):
+        """A single busy ticket must not consume the row limit and starve other
+        eligible tickets: each ticket collapses to one row before the cap applies."""
+        other = self._create_ticket(subject="Quietly commented ticket")
+        frappe.get_doc(
+            {
+                "doctype": "HD Ticket Comment",
+                "reference_ticket": other.name,
+                "commented_by": agent_email,
+                "content": "single note",
+            }
+        ).insert(ignore_permissions=True)
+
+        busy = self._create_ticket(subject="Very busy ticket")
+        for i in range(RECENT_ACTIVITY_LIMIT + 5):
+            frappe.get_doc(
+                {
+                    "doctype": "HD Ticket Comment",
+                    "reference_ticket": busy.name,
+                    "commented_by": agent_email,
+                    "content": f"note {i}",
+                }
+            ).insert(ignore_permissions=True)
+
+        names = [r["name"] for r in get_recent_activity()]
+
+        # The busy ticket's many comments would fill a raw-row limit and drop the
+        # quieter ticket; deduping per ticket first keeps it in the feed.
+        self.assertIn(other.name, names)
+        self.assertEqual(names.count(busy.name), 1)

--- a/helpdesk/api/agent_home/test_agent_home.py
+++ b/helpdesk/api/agent_home/test_agent_home.py
@@ -7,6 +7,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 from helpdesk.api.agent_home.agent_home import (
+    _collapse_events,
     get_agent_tickets,
     get_avg_first_response_time,
     get_avg_resolution_time,
@@ -14,6 +15,7 @@ from helpdesk.api.agent_home.agent_home import (
     get_dashboard,
     get_default_agent_dashboard,
     get_pending_tickets,
+    get_recent_activity,
     get_recent_feedback,
 )
 from helpdesk.test_utils import make_agent, make_sla, make_ticket
@@ -596,3 +598,56 @@ class TestAgentHome(FrappeTestCase):
         for t in result["tickets"]:
             self.assertEqual(t["reason"]["type"], "pending")
             self.assertIn("Pending for", t["reason"]["text"])
+
+    def test_collapse_events_priority_and_recency(self):
+        """One row per ticket: highest-priority action wins, ties broken by
+        recency, and a viewed-only ticket still survives."""
+        # replied (older) beats a later view on the same ticket
+        events = [
+            {"ticket": "T1", "type": "viewed", "creation": 10},
+            {"ticket": "T1", "type": "replied", "creation": 5},
+        ]
+        self.assertEqual(_collapse_events(events)["T1"]["type"], "replied")
+
+        # same type -> most recent wins
+        events = [
+            {"ticket": "T2", "type": "viewed", "creation": 3},
+            {"ticket": "T2", "type": "viewed", "creation": 9},
+        ]
+        self.assertEqual(_collapse_events(events)["T2"]["creation"], 9)
+
+        # a ticket the agent only viewed still shows up
+        events = [{"ticket": "T3", "type": "viewed", "creation": 1}]
+        self.assertEqual(_collapse_events(events)["T3"]["type"], "viewed")
+
+    def test_get_recent_activity_collapses_and_labels(self):
+        """A ticket the agent both viewed and commented on appears once, as the
+        higher-priority action (commented > viewed)."""
+        ticket = self._create_ticket(subject="Recent Activity Ticket")
+
+        frappe.get_doc(
+            {
+                "doctype": "View Log",
+                "reference_doctype": "HD Ticket",
+                "reference_name": ticket.name,
+                "viewed_by": agent_email,
+            }
+        ).insert(ignore_permissions=True)
+
+        frappe.get_doc(
+            {
+                "doctype": "HD Ticket Comment",
+                "reference_ticket": ticket.name,
+                "commented_by": agent_email,
+                "content": "Looking into this",
+            }
+        ).insert(ignore_permissions=True)
+
+        rows = [r for r in get_recent_activity() if r["name"] == ticket.name]
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["activity_type"], "commented")
+        self.assertEqual(rows[0]["subject"], "Recent Activity Ticket")
+        # Only status rows carry server-side text (the raw action); the label for
+        # other types is applied on the frontend.
+        self.assertIsNone(rows[0]["text"])

--- a/helpdesk/api/agent_home/utils.py
+++ b/helpdesk/api/agent_home/utils.py
@@ -4,7 +4,7 @@ from pypika.functions import Count
 
 
 def get_default_agent_dashboard():
-    return '[{"chart":"avg_resolution_time","layout":{"x":33,"y":0,"w":17,"h":10,"minW":16,"minH":10,"maxH":11}},{"chart":"avg_first_response_time","layout":{"x":16,"y":0,"w":17,"h":10,"minW":16,"minH":10,"maxH":11}},{"chart":"agent_tickets","layout":{"x":0,"y":0,"w":16,"h":10,"minW":16,"minH":10,"maxH":11}},{"chart":"pending_tickets","layout":{"x":0,"y":10,"w":50,"h":32,"minW":25,"minH":32,"maxH":32}},{"chart":"recent_feedback","layout":{"x":0,"y":66,"w":50,"h":21,"minW":50,"minH":21,"maxH":21}},{"chart":"avg_time_metrics","layout":{"x":0,"y":42,"w":50,"h":24,"minW":18,"minH":24,"maxH":44}}]'
+    return '[{"chart":"avg_resolution_time","layout":{"x":33,"y":0,"w":17,"h":10,"minW":16,"minH":10,"maxH":11}},{"chart":"avg_first_response_time","layout":{"x":16,"y":0,"w":17,"h":10,"minW":16,"minH":10,"maxH":11}},{"chart":"agent_tickets","layout":{"x":0,"y":0,"w":16,"h":10,"minW":16,"minH":10,"maxH":11}},{"chart":"pending_tickets","layout":{"x":0,"y":10,"w":50,"h":32,"minW":25,"minH":32,"maxH":32}},{"chart":"recent_activity","layout":{"x":0,"y":42,"w":17,"h":29,"minW":12,"minH":20,"maxH":44}},{"chart":"avg_time_metrics","layout":{"x":17,"y":42,"w":33,"h":29,"minW":18,"minH":24,"maxH":44}},{"chart":"recent_feedback","layout":{"x":0,"y":71,"w":50,"h":21,"minW":50,"minH":21,"maxH":21}}]'
 
 
 def calculate_percentage_change(

--- a/helpdesk/helpdesk/doctype/hd_agent/test_hd_agent.py
+++ b/helpdesk/helpdesk/doctype/hd_agent/test_hd_agent.py
@@ -228,3 +228,10 @@ class TestHDAgent(FrappeTestCase):
 
     def tearDown(self):
         frappe.set_user("Administrator")
+        # Delete the teams created here so their auto-created assignment rules (and
+        # the cached Assignment Rule doctype-map) don't leak into other tests and
+        # break ticket creation with a phantom "... - Support Rotation not found".
+        for team in frappe.get_all(
+            "HD Team", filters={"name": ["like", "Test AR%"]}, pluck="name"
+        ):
+            frappe.delete_doc("HD Team", team, force=True, ignore_permissions=True)


### PR DESCRIPTION
## What

Adds a **Recent Activity** card to the agent Home dashboard. It shows the tickets you recently acted on — one row per ticket, displaying that ticket's **most recent** action with an icon, the ticket subject, `#id · <action>`, and relative time. Clicking a row opens the ticket.

Each row reflects one of five action types:

| Type | Source | Meaning |
|------|--------|---------|
| Replied | Communication (sent by you) | You replied on the ticket |
| Commented | HD Ticket Comment | You left an internal note |
| *action text* (e.g. "Set status to Resolved") | HD Ticket Activity | You changed status / priority / team / type / contact |
| Viewed | View Log | You opened the ticket |
| Assigned | ToDo | You assigned someone to the ticket |

- Sources are existing tables (Communication, HD Ticket Comment, HD Ticket Activity, core View Log, core ToDo) — **no new doctype**.
- One row per ticket: only the ticket's latest action is shown, so a busy ticket doesn't flood the feed. Rows are ordered by recency, most recent first.
- Scope: **your own** actions, over the **last 3 days**, capped at **20** tickets.
- Automated **SLA** changes are filtered out of the "updated" rows — they're noise, not something the agent chose to do.
- Ticket subjects are fetched via `get_list`, so tickets the agent can no longer access are dropped from the feed.
- Available from the Home **New** dropdown and included in the default dashboard layout.

## Screenshots

<img width="410" height="406" alt="image" src="https://github.com/user-attachments/assets/79c7de16-48ab-4284-b57d-bd0dce71e0a6" />

<img width="1463" height="831" alt="image" src="https://github.com/user-attachments/assets/239707fa-fd05-419c-bb24-bdd91e1109b9" />

<img width="402" height="401" alt="image" src="https://github.com/user-attachments/assets/025996a0-60f3-458d-bcf6-6cb0aa76f51e" />

