### PR TITLE
fix: unable to remove attachment

### DIFF
--- a/desk/src/components/AttachmentItem.vue
+++ b/desk/src/components/AttachmentItem.vue
@@ -24,6 +24,12 @@
           {{ content }}
         </div>
         <img v-if="isImage" :src="url" class="m-auto rounded border" />
+        <video
+          v-if="isVideo"
+          :src="url"
+          controls
+          class="m-auto max-h-[70vh] rounded border"
+        />
       </template>
     </Dialog>
   </span>
@@ -80,7 +86,8 @@ const mimeType = getMime(props.label) || "";
 const kind = getKind(mimeType);
 const isImage = kind === "image";
 const isText = kind === "text";
-const isShowable = props.url && (isText || isImage);
+const isVideo = kind === "video";
+const isShowable = props.url && (isText || isImage || isVideo);
 const icon = ICONS[kind];
 const content = ref("");
 

--- a/desk/src/components/AttachmentList.vue
+++ b/desk/src/components/AttachmentList.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="flex flex-wrap gap-2">
+    <AttachmentItem
+      v-for="attachment in attachments"
+      :key="attachment.file_url"
+      :label="attachment.file_name"
+      :url="attachment.file_url"
+    >
+      <template #suffix>
+        <LucideX
+          class="size-3.5 cursor-pointer text-ink-gray-6 transition-colors hover:text-ink-gray-9"
+          @click.stop="emit('remove', attachment)"
+        />
+      </template>
+    </AttachmentItem>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { AttachmentItem } from "@/components";
+import LucideX from "~icons/lucide/x";
+
+interface Attachment {
+  file_url: string;
+  file_name: string;
+}
+
+withDefaults(defineProps<{ attachments?: Attachment[] }>(), {
+  attachments: () => [],
+});
+
+const emit = defineEmits<{ remove: [attachment: Attachment] }>();
+</script>

--- a/desk/src/components/CommentTextEditor.vue
+++ b/desk/src/components/CommentTextEditor.vue
@@ -17,22 +17,11 @@
         ]"
       />
       <!-- Attachments -->
-      <div class="flex flex-wrap gap-2 my-2 ms-5">
-        <AttachmentItem
-          v-for="a in attachments"
-          :key="a.file_url"
-          :label="a.file_name"
-          :url="!['MOV', 'MP4'].includes(a.file_type) ? a.file_url : null"
-        >
-          <template #suffix>
-            <FeatherIcon
-              class="h-3.5"
-              name="x"
-              @click.stop="removeAttachment(a)"
-            />
-          </template>
-        </AttachmentItem>
-      </div>
+      <AttachmentList
+        class="my-2 ms-5"
+        :attachments="attachments"
+        @remove="removeAttachment"
+      />
       <div v-if="editable" class="flex flex-col gap-2 border-t">
         <div class="px-4">
           <!-- Fixed Menu -->
@@ -102,7 +91,7 @@ import { Editor, EditorContent, EditorFixedMenu } from "frappe-ui/editor";
 import { useOnboarding } from "frappe-ui/frappe";
 import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 
-import { AttachmentItem } from "@/components/";
+import { AttachmentList } from "@/components/";
 import { buildEditorExtensions, fullToolbar } from "@/components/editor/config";
 import { AttachmentIcon } from "@/components/icons/";
 import { useTyping } from "@/composables/realtime";

--- a/desk/src/components/CompactEditor.vue
+++ b/desk/src/components/CompactEditor.vue
@@ -55,7 +55,7 @@
           <FeatherIcon
             class="h-3.5 cursor-pointer"
             name="x"
-            @click.self.stop="removeAttachment(attachment)"
+            @click.stop="removeAttachment(attachment)"
           />
         </template>
       </AttachmentItem>

--- a/desk/src/components/CompactEditor.vue
+++ b/desk/src/components/CompactEditor.vue
@@ -41,30 +41,17 @@
         <EditorContent :class="editorClass" />
       </template>
     </Editor>
-    <div
+    <AttachmentList
       v-if="showAttachments && attachments?.length"
-      class="flex flex-wrap gap-2 mt-2"
-    >
-      <AttachmentItem
-        v-for="attachment in attachments ?? []"
-        :key="attachment.file_url"
-        :label="attachment.file_name"
-        :url="attachment.file_url"
-      >
-        <template #suffix>
-          <FeatherIcon
-            class="h-3.5 cursor-pointer"
-            name="x"
-            @click.stop="removeAttachment(attachment)"
-          />
-        </template>
-      </AttachmentItem>
-    </div>
+      class="mt-2"
+      :attachments="attachments ?? []"
+      @remove="removeAttachment"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { AttachmentItem } from "@/components";
+import { AttachmentList } from "@/components";
 import {
   buildEditorExtensions,
   commentToolbar,
@@ -73,7 +60,7 @@ import {
 import { AttachmentIcon } from "@/components/icons";
 import { getUserEmailInfo } from "@/composables/useUserEmailInfo";
 import { isContentEmpty } from "@/utils";
-import { FeatherIcon, FileUploader, type UploadedFile } from "frappe-ui";
+import { FileUploader, type UploadedFile } from "frappe-ui";
 import {
   Editor,
   EditorBubbleMenu,

--- a/desk/src/components/EmailEditor.vue
+++ b/desk/src/components/EmailEditor.vue
@@ -128,22 +128,11 @@
         </div>
 
         <!-- Attachments -->
-        <div class="flex flex-wrap gap-2 px-5 my-2">
-          <AttachmentItem
-            v-for="a in attachments"
-            :key="a.file_url"
-            :label="a.file_name"
-            :url="!['MOV', 'MP4'].includes(a.file_type) ? a.file_url : null"
-          >
-            <template #suffix>
-              <FeatherIcon
-                class="h-3.5"
-                name="x"
-                @click.stop="removeAttachment(a)"
-              />
-            </template>
-          </AttachmentItem>
-        </div>
+        <AttachmentList
+          class="px-5 my-2"
+          :attachments="attachments"
+          @remove="removeAttachment"
+        />
         <!-- Fixed Menu -->
         <div
           class="flex justify-between overflow-scroll px-4 py-2.5 items-center border-t"
@@ -213,7 +202,7 @@
 </template>
 
 <script setup lang="ts">
-import { AttachmentItem, SavedRepliesSelectorModal } from "@/components";
+import { AttachmentList, SavedRepliesSelectorModal } from "@/components";
 import { buildEditorExtensions, fullToolbar } from "@/components/editor/config";
 import EmailMultiSelect from "@/components/EmailMultiSelect.vue";
 import { AttachmentIcon } from "@/components/icons";

--- a/desk/src/components/EmailEditor.vue
+++ b/desk/src/components/EmailEditor.vue
@@ -139,7 +139,7 @@
               <FeatherIcon
                 class="h-3.5"
                 name="x"
-                @click.self.stop="removeAttachment(a)"
+                @click.stop="removeAttachment(a)"
               />
             </template>
           </AttachmentItem>

--- a/desk/src/components/index.ts
+++ b/desk/src/components/index.ts
@@ -1,5 +1,6 @@
 export { default as BackButton } from "./BackButton.vue";
 export { default as AttachmentItem } from "./AttachmentItem.vue";
+export { default as AttachmentList } from "./AttachmentList.vue";
 export { default as Autocomplete } from "./Autocomplete.vue";
 export { default as CommandPalette } from "./command-palette/CP.vue";
 export { default as CommentBox } from "./CommentBox.vue";


### PR DESCRIPTION
## Issue

Clicking the **x** icon on an attachment did not remove it. The attachment UI was also duplicated across three editors, and video attachments were rendered as dead, non-clickable chips.

## Solution

- **Fixed removal**: the handler used the `.self` event modifier, which only fires when `event.target` is the `FeatherIcon` element itself. Since the icon renders an `<svg>` with inner `<path>` elements, clicks landed on a child `<path>` and the handler never fired. Dropped `.self`.

## More

- **Extracted `AttachmentList`**: the attachment chip list was duplicated in `EmailEditor`, `CompactEditor` and `CommentTextEditor`. Pulled it into one shared component that takes `:attachments` and emits `remove`; each parent keeps its own `v-if`/positioning.
- **Video preview**: `AttachmentItem` now previews video in the dialog via a native `<video controls>`, so video chips are clickable like images. This let us delete the old `MOV`/`MP4` hack that disabled the link for videos; detection is now MIME-based, so `.webm`, `.avi`, etc. work too.
- **Icon**: replaced `FeatherIcon name="x"` with `LucideX`, added a hover state that darkens the x, and squared the icon (`size-3.5`) for even left/right spacing.