### PR TITLE
fix: set default portal settings for existing sites

### DIFF
--- a/helpdesk/patches.txt
+++ b/helpdesk/patches.txt
@@ -48,3 +48,4 @@ helpdesk.patches.enable_auto_set_customer_from_contact
 helpdesk.patches.show_customer_portal_permission_notice
 helpdesk.patches.set_persona_captured_for_existing_sites
 helpdesk.patches.backfill_priority_level
+helpdesk.patches.set_default_portal_settings

--- a/helpdesk/patches/set_default_portal_settings.py
+++ b/helpdesk/patches/set_default_portal_settings.py
@@ -1,0 +1,15 @@
+import frappe
+
+
+def execute():
+    portal_settings = frappe.get_single("Portal Settings")
+
+    defaults = {
+        "default_role": "HD Customer",
+        "default_portal_home": "/helpdesk",
+    }
+    for field, value in defaults.items():
+        if not portal_settings.get(field):
+            portal_settings.set(field, value)
+
+    portal_settings.save()


### PR DESCRIPTION
### Problem

On a **fresh install**, Helpdesk sets Portal Settings so customer portal users land in the right place:

- `default_role` → `HD Customer`
- `default_portal_home` → `/helpdesk`

Existing sites that upgrade never got these, since the code only runs under `fresh_install` in `install.py`.

### Change

Adds a patch that sets both values on existing sites, **only when they are not already set** — so any custom value an admin configured is left untouched.

docs: https://docs.frappe.io/helpdesk/customers-contacts#update-on-permissions