### PR TITLE
fix: attachment upload feedback + uploads while editing comments

### DIFF
--- a/desk/src/components/CommentBox.vue
+++ b/desk/src/components/CommentBox.vue
@@ -42,6 +42,7 @@
       @keydown.meta.enter.capture.stop="handleSaveComment"
     >
       <Editor
+        :key="editable ? 'edit' : 'view'"
         v-model="_content"
         :extensions="extensions"
         :editable="editable"

--- a/desk/src/components/CommentBox.vue
+++ b/desk/src/components/CommentBox.vue
@@ -41,7 +41,12 @@
       @keydown.ctrl.enter.capture.stop="handleSaveComment"
       @keydown.meta.enter.capture.stop="handleSaveComment"
     >
-      <Editor v-model="_content" :extensions="extensions" :editable="editable">
+      <Editor
+        v-model="_content"
+        :extensions="extensions"
+        :editable="editable"
+        :upload-function="(file:any) => uploadFunction(file, 'HD Ticket', ticketId)"
+      >
         <template #default>
           <EditorBubbleMenu :items="fullToolbar" />
           <EditorContent
@@ -157,6 +162,7 @@ import {
   getFontFamily,
   isContentEmpty,
   timeAgo,
+  uploadFunction,
 } from "@/utils";
 import { buildEditorExtensions, fullToolbar } from "@/components/editor/config";
 import {
@@ -169,8 +175,10 @@ import {
 } from "frappe-ui";
 import { Editor, EditorBubbleMenu, EditorContent } from "frappe-ui/editor";
 import { PropType, computed, onMounted, ref } from "vue";
+import { useRoute } from "vue-router";
 
 const authStore = useAuthStore();
+const ticketId = useRoute().params.ticketId as string;
 const props = defineProps({
   activity: {
     type: Object as PropType<CommentActivity>,

--- a/desk/src/components/CommentTextEditor.vue
+++ b/desk/src/components/CommentTextEditor.vue
@@ -43,7 +43,9 @@
                       @click="openFileSelector()"
                       :disabled="uploading"
                     >
+                      <LoadingIndicator v-if="uploading" class="h-4 w-4" />
                       <AttachmentIcon
+                        v-else
                         class="h-4 w-4"
                         style="stroke-width: 1.5 !important"
                       />
@@ -86,7 +88,7 @@
   </Editor>
 </template>
 <script setup lang="ts">
-import { FileUploader, createResource } from "frappe-ui";
+import { FileUploader, LoadingIndicator, createResource } from "frappe-ui";
 import { Editor, EditorContent, EditorFixedMenu } from "frappe-ui/editor";
 import { useOnboarding } from "frappe-ui/frappe";
 import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";

--- a/desk/src/components/CompactEditor.vue
+++ b/desk/src/components/CompactEditor.vue
@@ -27,7 +27,9 @@
                   :disabled="uploading"
                   @click="openFileSelector()"
                 >
+                  <LoadingIndicator v-if="uploading" class="h-4 w-4" />
                   <AttachmentIcon
+                    v-else
                     class="h-4 w-4"
                     style="stroke-width: 1.5 !important"
                   />
@@ -60,7 +62,7 @@ import {
 import { AttachmentIcon } from "@/components/icons";
 import { getUserEmailInfo } from "@/composables/useUserEmailInfo";
 import { isContentEmpty } from "@/utils";
-import { FileUploader, type UploadedFile } from "frappe-ui";
+import { FileUploader, LoadingIndicator, type UploadedFile } from "frappe-ui";
 import {
   Editor,
   EditorBubbleMenu,

--- a/desk/src/components/EmailEditor.vue
+++ b/desk/src/components/EmailEditor.vue
@@ -158,7 +158,9 @@
                     @click="openFileSelector()"
                     :disabled="uploading"
                   >
+                    <LoadingIndicator v-if="uploading" class="h-4 w-4" />
                     <AttachmentIcon
+                      v-else
                       class="h-4 w-4"
                       style="stroke-width: 1.5 !important"
                     />
@@ -218,7 +220,12 @@ import {
   validateEmailWithZod,
 } from "@/utils";
 import { useStorage } from "@vueuse/core";
-import { FileUploader, createResource, toast } from "frappe-ui";
+import {
+  FileUploader,
+  LoadingIndicator,
+  createResource,
+  toast,
+} from "frappe-ui";
 import { Editor, EditorContent, EditorFixedMenu } from "frappe-ui/editor";
 import { useOnboarding } from "frappe-ui/frappe";
 import {


### PR DESCRIPTION
## What

Two related attachment fixes on the ticket editors.

### 1. Visual feedback while an attachment uploads (#3616)

The `FileUploader` attach button only disabled itself during an upload — no spinner, no progress — so users had no way to tell why the send button was disabled and assumed the app was frozen. The paperclip now swaps to a `LoadingIndicator` while `uploading`, in the comment, email, and compact editors.

### 2. File uploads while editing a comment (#3617)

The edit-comment `<Editor>` in `CommentBox.vue` had no `upload-function`, unlike the new-comment editor. Pasted/dropped media fell back to the default uploader, producing an **orphaned private file** (no `attached_to`) that 403s for other viewers. It now passes `uploadFunction` bound to the `HD Ticket`, matching the new-comment editor.

## Changes

- `CommentTextEditor.vue`, `EmailEditor.vue`, `CompactEditor.vue` — spinner on the attach button while uploading
- `CommentBox.vue` — wire `upload-function` into the edit-comment editor

## Testing

Manually verified in the agent ticket view: the attach button shows a spinner during upload, and pasting/dropping an image while editing a comment uploads it linked to the ticket.

Closes #3616
Closes #3617



