### PR TITLE
feat: First Ticket tag and tag charts on the dashboard

### DIFF
--- a/desk/src/components/TicketPriority.vue
+++ b/desk/src/components/TicketPriority.vue
@@ -12,7 +12,7 @@
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <rect width="14" height="14" rx="4" class="fill-ink-gray-5" />
+        <rect width="14" height="14" rx="4" class="fill-ink-gray-6" />
         <rect
           x="6.25"
           y="3"
@@ -82,6 +82,6 @@ const level = computed(() => getLevel(props.priority ?? ""));
 
 function barClass(barIndexFromTop: number): string {
   const faded = FADED_BARS[level.value] ?? 0;
-  return barIndexFromTop < faded ? "fill-ink-gray-3" : "fill-ink-gray-5";
+  return barIndexFromTop < faded ? "fill-ink-gray-3" : "fill-ink-gray-6";
 }
 </script>

--- a/desk/src/components/ticket-agent/TicketSLA.vue
+++ b/desk/src/components/ticket-agent/TicketSLA.vue
@@ -103,7 +103,7 @@ function cardValue(card: SLACard): string {
 // "Due" is the resting state of every open ticket, so it stays gray; colour
 // only appears when something changed (fulfilled, overdue, failed, hold).
 function valueInk(card: SLACard): string {
-  if (card.metric.state === "due") return "text-ink-gray-6";
+  if (card.metric.state === "due") return "text-ink-gray-7";
   return inkClass[card.metric.color];
 }
 

--- a/desk/src/pages/dashboard/Dashboard.vue
+++ b/desk/src/pages/dashboard/Dashboard.vue
@@ -150,6 +150,32 @@
             />
           </template>
         </div>
+
+        <!-- Tag Charts -->
+        <div
+          class="grid grid-cols-1 md:grid-cols-2 gap-4 w-full mt-4"
+          v-if="!tagData.loading"
+        >
+          <template v-for="(chart, index) in tagData.data" :key="index">
+            <!-- has data -->
+            <div v-if="!isChartEmpty(chart)" class="border rounded-md min-h-80">
+              <component :is="getChartType(chart)" />
+            </div>
+
+            <!-- chart with no data -->
+            <SkeletonLoader
+              v-else
+              :variants="['bar-chart', 'empty-state']"
+              :bar-chart-count="1"
+              :has-applied-filter="hasAppliedFilter"
+              :empty-states="[
+                {
+                  title: `No ${(chart?.title).toLowerCase()} available.`,
+                },
+              ]"
+            />
+          </template>
+        </div>
       </div>
 
       <!-- Skeleton Loading State -->
@@ -176,7 +202,7 @@
         <div>
           <SkeletonLoader
             :variants="['bar-chart', 'empty-state']"
-            :bar-chart-count="6"
+            :bar-chart-count="8"
             :empty-states="emptyStates"
             :has-applied-filter="hasAppliedFilter"
           />
@@ -286,6 +312,14 @@ const emptyStates = [
     title: "No channel data",
     message: "Tickets will be grouped by channel once received.",
   },
+  {
+    title: "No tag data",
+    message: "Tags will be ranked here once tickets are tagged.",
+  },
+  {
+    title: "No tag trend",
+    message: "Daily tag volume will appear once tickets are tagged.",
+  },
 ];
 
 const tabButtons = computed(() => {
@@ -358,6 +392,14 @@ const trendData = createResource({
   url: "helpdesk.api.dashboard.get_dashboard_data",
   makeParams: () => ({
     dashboard_type: "trend",
+    filters: parseFilters(filters),
+  }),
+});
+
+const tagData = createResource({
+  url: "helpdesk.api.dashboard.get_dashboard_data",
+  makeParams: () => ({
+    dashboard_type: "tags",
     filters: parseFilters(filters),
   }),
 });
@@ -547,6 +589,7 @@ watch(
     numberCards.reload();
     masterData.reload();
     trendData.reload();
+    tagData.reload();
   },
   { deep: true }
 );
@@ -560,6 +603,7 @@ onMounted(() => {
   numberCards.reload();
   masterData.reload();
   trendData.reload();
+  tagData.reload();
 });
 
 usePageMeta(() => {

--- a/helpdesk/api/dashboard.py
+++ b/helpdesk/api/dashboard.py
@@ -68,6 +68,10 @@ def get_dashboard_data(
         )
     elif dashboard_type == "trend":
         return dashboard.get_trend_data()
+    elif dashboard_type == "tags":
+        from helpdesk.api.dashboard_tags import TagDashboard
+
+        return TagDashboard(_filters).get_tag_chart_data()
 
 
 class HelpdeskDashboard:
@@ -599,7 +603,10 @@ def get_bar_chart_config(
         "title": title,
         "subtitle": subtitle,
         "xAxis": x_axis_config,
-        "yAxis": {"title": y_axis_title},
+        # every bar chart here counts tickets, so keep the value axis on whole
+        # steps; half a ticket is not a thing. y2 axes (% SLA, rating) are
+        # fractional and are left alone.
+        "yAxis": {"title": y_axis_title, "echartOptions": {"minInterval": 1}},
         "series": series,
         **kwargs,
     }

--- a/helpdesk/api/dashboard_tags.py
+++ b/helpdesk/api/dashboard_tags.py
@@ -1,0 +1,116 @@
+"""Tag charts for the dashboard.
+
+1. Top Tags   - what is being tagged most (volume)
+2. Tag Trend  - when tags spike (emerging issues)
+
+Tags live in `Tag Link`, not in a scalar column, so these cannot reuse the
+group-by helpers the other master charts use.
+"""
+
+import frappe
+from frappe import _
+from frappe.query_builder import DocType
+from frappe.query_builder.functions import Count, Function
+from pypika import Order
+
+from helpdesk.api.dashboard import HD_TICKET, HelpdeskDashboard, get_bar_chart_config
+
+TOP_TAG_COUNT = 10
+TREND_TAG_COUNT = 5
+
+
+class TagDashboard(HelpdeskDashboard):
+    """Tag charts, reusing the dashboard's date / team / agent conditions."""
+
+    def __init__(self, filters):
+        super().__init__(filters)
+        self.tag_link = DocType("Tag Link")
+
+    def get_tag_chart_data(self) -> list[dict[str, any]]:
+        return [
+            self.get_top_tags_chart(),
+            self.get_tag_trend_chart(),
+        ]
+
+    def get_top_tags_chart(self) -> dict[str, any]:
+        """Horizontal bars: the label is the value here, so give it the long axis."""
+        tickets = "Tickets"
+        top_tag_data = self.get_tag_counts(TOP_TAG_COUNT)
+        for tag_row in top_tag_data:
+            tag_row[tickets] = tag_row.pop("count")
+
+        return get_bar_chart_config(
+            # bars are drawn bottom-up, so ascending puts the biggest on top
+            top_tag_data[::-1],
+            _("Top Tags"),
+            _("Most used tags in this period"),
+            {"key": "tag", "type": "category", "title": _("Tag")},
+            _("Tickets"),
+            [{"name": tickets, "type": "bar", "showDataLabels": True}],
+            swapXY=True,
+        )
+
+    def get_tag_trend_chart(self) -> dict[str, any]:
+        """Daily stack of the busiest tags, so a spike in one is visible."""
+        tags = [tag_row.tag for tag_row in self.get_tag_counts(TREND_TAG_COUNT)]
+        date = Function("DATE", self.ticket.creation)
+        rows = (
+            self.get_tagged_tickets()
+            .select(
+                date.as_("date"),
+                self.tag_link.tag,
+                Count(self.ticket.name).as_("count"),
+            )
+            .where(self.tag_link.tag.isin(tags or [""]))
+            .groupby(date, self.tag_link.tag)
+        ).run(as_dict=True)
+
+        return get_bar_chart_config(
+            self.pivot_by_date(rows, tags),
+            _("Tag Trend"),
+            _("Daily volume of the top {0} tags").format(TREND_TAG_COUNT),
+            {"key": "date", "type": "time", "title": _("Date"), "timeGrain": "day"},
+            _("Tickets"),
+            [{"name": tag, "type": "bar", "stackName": "tags"} for tag in tags],
+            stacked=True,
+        )
+
+    def get_tag_counts(self, limit: int | None = None) -> list[dict[str, any]]:
+        """Ticket count per tag, busiest first.
+        Top 10 tags for the duration of the dashboard's date filter.
+        """
+
+        count = Count(self.ticket.name)
+        query = (
+            self.get_tagged_tickets()
+            .select(self.tag_link.tag, count.as_("count"))
+            .groupby(self.tag_link.tag)
+            .orderby(count, order=Order.desc)
+        )
+        if limit:
+            query = query.limit(limit)
+        return query.run(as_dict=True)
+
+    def get_tagged_tickets(self):
+        """`Tag Link` joined to the tickets this dashboard is scoped to."""
+        query = (
+            frappe.qb.from_(self.tag_link)
+            .inner_join(self.ticket)
+            .on(self.tag_link.document_name == self.ticket.name)
+            .where(self.tag_link.document_type == HD_TICKET)
+            .where(self.ticket.creation >= self.from_date)
+            .where(self.ticket.creation < self.to_date_next)
+        )
+        return query.where(self.combined_cond) if self.combined_cond else query
+
+    @staticmethod
+    def pivot_by_date(
+        rows: list[dict[str, any]], tags: list[str]
+    ) -> list[dict[str, any]]:
+        """One row per date with a column per tag, zero filled so bars stack."""
+        by_date = {}
+        for row in rows:
+            day = by_date.setdefault(row.date, dict.fromkeys(tags, 0))
+            day["date"] = row.date
+            day[row.tag] = row.count
+        return [by_date[date] for date in sorted(by_date)]

--- a/helpdesk/api/tags.py
+++ b/helpdesk/api/tags.py
@@ -44,7 +44,8 @@ def update_tags(
 def apply_tag(doctype: str, name: str, label: str, color: str = "Gray") -> str:
     """Link a tag to a document, creating the helpdesk Tag master if needed.
 
-    ``color`` applies only on create or claim; an existing tag keeps its colour.
+    ``color`` applies on create, on claim, and to a tag that has no colour
+    yet; a tag that already has one keeps it.
     """
     label = label.strip()
     if not label:
@@ -63,9 +64,10 @@ def apply_tag(doctype: str, name: str, label: str, color: str = "Gray") -> str:
                 "color": color,
             }
         ).insert(ignore_permissions=True, ignore_if_duplicate=True)
-    elif existing.app != "helpdesk":
+    elif existing.app != "helpdesk" or not existing.color:
         # Desk's tag sidebar mints tags with no app/color; claim them for
-        # helpdesk so they list in the picker
+        # helpdesk so they list in the picker, and fill a missing colour so
+        # they stop rendering gray
         frappe.db.set_value(
             "Tag",
             label,

--- a/helpdesk/api/tags.py
+++ b/helpdesk/api/tags.py
@@ -7,6 +7,9 @@ from helpdesk.helpdesk.doctype.hd_ticket_activity.hd_ticket_activity import (
 )
 from helpdesk.utils import agent_only
 
+FIRST_TICKET_TAG = "First Ticket"
+FIRST_TICKET_TAG_COLOR = "Blue"
+
 
 @frappe.whitelist()
 @agent_only

--- a/helpdesk/api/test_tags.py
+++ b/helpdesk/api/test_tags.py
@@ -2,7 +2,7 @@ import frappe
 from frappe.desk.doctype.tag.tag import add_tag
 from frappe.tests.utils import FrappeTestCase
 
-from helpdesk.api.tags import apply_tag, update_tags
+from helpdesk.api.tags import FIRST_TICKET_TAG, apply_tag, update_tags
 from helpdesk.test_utils import create_agent, make_ticket
 
 AGENT_EMAIL = "helpdesk-tag-agent@example.com"
@@ -138,6 +138,20 @@ class TestTicketTags(FrappeTestCase):
 
         # empty batches are a no-op, not an error
         update_tags("HD Ticket", self.ticket.name)
+
+    def test_first_ticket_is_tagged(self):
+        requester = "helpdesk-first-timer@example.com"
+        first = make_ticket("First one", raised_by=requester)
+        second = make_ticket("Second one", raised_by=requester)
+
+        self.assertIn(
+            FIRST_TICKET_TAG,
+            frappe.db.get_value("HD Ticket", first.name, "_user_tags"),
+        )
+        self.assertNotIn(
+            FIRST_TICKET_TAG,
+            frappe.db.get_value("HD Ticket", second.name, "_user_tags") or "",
+        )
 
     def test_tags_apply_to_any_doctype(self):
         # the endpoint takes doctype/name, so tags are not a ticket feature;

--- a/helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
+++ b/helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -56,7 +56,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-06-02 01:18:56.023594",
+ "modified": "2026-07-27 16:57:56.129699",
  "modified_by": "Administrator",
  "module": "Helpdesk",
  "name": "HD Agent",
@@ -92,5 +92,6 @@
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],
- "title_field": "agent_name"
+ "title_field": "agent_name",
+ "track_changes": 1
 }

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -174,6 +174,7 @@ class HDTicket(Document):
         # Telemetry Event
         self.capture_ticket_created_telemetry_events()
         publish_event("helpdesk:new-ticket")
+        self.tag_first_ticket()
 
         if self.get("description"):
             self.create_communication_via_contact(self.description, new_ticket=True)
@@ -205,6 +206,21 @@ class HDTicket(Document):
                 "split the ticket from #{0}".format(self.ticket_split_from),
             )
             capture_event("ticket_split")
+
+    def tag_first_ticket(self):
+        """Tag the first ticket a requester ever raises.
+
+        A tag (not a field) so it filters, reports and slices like every other
+        tag. Runs after insert, so a count of one means this is the first.
+        """
+        from helpdesk.api.tags import FIRST_TICKET_TAG, FIRST_TICKET_TAG_COLOR
+
+        if not self.raised_by:
+            return
+        if frappe.db.count("HD Ticket", {"raised_by": self.raised_by}) > 1:
+            return
+
+        self.add_tag(FIRST_TICKET_TAG, FIRST_TICKET_TAG_COLOR)
 
     def on_update(self):
         # flake8: noqa

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -210,14 +210,16 @@ class HDTicket(Document):
     def tag_first_ticket(self):
         """Tag the first ticket a requester ever raises.
 
-        A tag (not a field) so it filters, reports and slices like every other
-        tag. Runs after insert, so a count of one means this is the first.
+        This is a one-time tag, so it only applies to the first ticket a requester raises.
         """
         from helpdesk.api.tags import FIRST_TICKET_TAG, FIRST_TICKET_TAG_COLOR
 
         if not self.raised_by:
             return
-        if frappe.db.count("HD Ticket", {"raised_by": self.raised_by}) > 1:
+        earlier_ticket = frappe.db.exists(
+            "HD Ticket", {"raised_by": self.raised_by, "name": ["!=", self.name]}
+        )
+        if earlier_ticket:
             return
 
         self.add_tag(FIRST_TICKET_TAG, FIRST_TICKET_TAG_COLOR)


### PR DESCRIPTION
Part of #3127.

Two things on top of the tags work: a first-ticket tag applied automatically, and the first two tag charts on the dashboard.

## First Ticket tag

The first ticket a requester ever raises is tagged `First Ticket` in `after_insert`. A tag rather than a custom field, so it filters, sits in saved views, and reports through the same paths as every other tag, with no new column and no new UI.

<img width="2916" height="1528" alt="image" src="https://github.com/user-attachments/assets/261efe98-93f3-43a8-a93e-374c87248bdd" />

It runs after insert, where a count of one on `raised_by` means this is the first, and goes through `apply_tag` so the `Tag` master is claimed for helpdesk and shows up in the picker with its colour.

## Top Tags and Tag Trend

Two charts on the dashboard, under the existing master charts. Both honour the date, team and agent filters already on the page.

![Top Tags and Tag Trend on the dashboard](https://raw.githubusercontent.com/RitvikSardana/helpdesk/pr-assets-tag-analytics/dashboard-tag-charts.png)

**Top Tags** ranks the busiest tags. Horizontal, because tag names are long and the label deserves the long axis.

**Tag Trend** stacks the top five tags per day, so a spike in one is visible. That is the chart that answers "what are people suddenly writing in about", which is the reason to have tag reporting at all.

Tags live in `Tag Link` rather than a scalar column, so these join instead of reusing the group-by helpers behind the other master charts. `TagDashboard` subclasses `HelpdeskDashboard` to inherit the date, team and agent conditions rather than rebuilding them.

## Two fixes that came out of this

**Whole-number axes.** Bar chart value axes stepped in halves at low volume, so the y axis read `0.5, 1, 1.5` tickets. Fixed in the shared `get_bar_chart_config`, so Ticket Trend and Feedback Trend get it too. `y2Axis` is untouched, since % SLA and rating are genuinely fractional.

**Tags stuck on gray.** A `Tag` master minted by desk's tag sidebar, or before colours existed, keeps a null colour and renders gray forever, because `apply_tag` only set a colour on create or on claim. A missing colour is now filled in; a tag that already has one still keeps it.

