### PR TITLE
fix(dashboard): show chart-specific empty states

### DIFF
--- a/desk/src/components/SkeletonLoader.vue
+++ b/desk/src/components/SkeletonLoader.vue
@@ -54,8 +54,18 @@
           :key="`chart-${i}`"
           class="border rounded-md min-h-[300px] p-4 space-y-3"
         >
-          <div class="h-4 w-1/3 bg-surface-gray-3 rounded" />
-          <div class="h-4 w-1/4 bg-surface-gray-1 rounded" />
+          <template v-if="getEmptyState(i).chartTitle">
+            <div class="text-ink-gray-8 text-p-base-medium">
+              {{ __(getEmptyState(i).chartTitle) }}
+            </div>
+            <div class="text-ink-gray-6 text-p-sm">
+              {{ __(getEmptyState(i).chartSubtitle ?? "") }}
+            </div>
+          </template>
+          <template v-else>
+            <div class="h-4 w-1/3 bg-surface-gray-3 rounded" />
+            <div class="h-4 w-1/4 bg-surface-gray-1 rounded" />
+          </template>
 
           <div
             class="h-64 w-full rounded flex items-center justify-center relative overflow-hidden"

--- a/desk/src/components/SkeletonLoader.vue
+++ b/desk/src/components/SkeletonLoader.vue
@@ -58,8 +58,11 @@
             <div class="text-ink-gray-8 text-p-base-medium">
               {{ __(getEmptyState(i).chartTitle) }}
             </div>
-            <div class="text-ink-gray-6 text-p-sm">
-              {{ __(getEmptyState(i).chartSubtitle ?? "") }}
+            <div
+              v-if="getEmptyState(i).chartSubtitle"
+              class="text-ink-gray-6 text-p-sm"
+            >
+              {{ __(getEmptyState(i).chartSubtitle) }}
             </div>
           </template>
           <template v-else>

--- a/desk/src/pages/dashboard/Dashboard.vue
+++ b/desk/src/pages/dashboard/Dashboard.vue
@@ -143,10 +143,10 @@
           </template>
         </div>
 
-        <!-- Tag Charts -->
+        <!-- Tag Charts: org level insight, an agent cannot act on their own tag mix -->
         <div
           class="grid grid-cols-1 md:grid-cols-2 gap-4 w-full mt-4"
-          v-if="!tagData.loading"
+          v-if="isManager && !tagData.loading"
         >
           <template v-for="(chart, index) in tagData.data" :key="index">
             <!-- has data -->
@@ -190,7 +190,7 @@
         <div>
           <SkeletonLoader
             :variants="['bar-chart', 'empty-state']"
-            :bar-chart-count="8"
+            :bar-chart-count="emptyStates.length"
             :empty-states="emptyStates"
             :has-applied-filter="hasAppliedFilter"
           />
@@ -327,8 +327,14 @@ const emptyStateByChart: Record<string, ChartEmptyState> = {
   },
 };
 
+const managerOnlyCharts = ["top_tags", "tag_trend"];
+
 // whole dashboard empty: no chart payload to read titles from, so fall back to ours
-const emptyStates = Object.values(emptyStateByChart);
+const emptyStates = computed(() =>
+  Object.entries(emptyStateByChart)
+    .filter(([key]) => isManager || !managerOnlyCharts.includes(key))
+    .map(([, state]) => state)
+);
 
 function chartEmptyState(chart: any) {
   const state = emptyStateByChart[chart?.key] ?? {
@@ -606,7 +612,7 @@ watch(
     numberCards.reload();
     masterData.reload();
     trendData.reload();
-    tagData.reload();
+    if (isManager) tagData.reload();
   },
   { deep: true }
 );
@@ -620,7 +626,7 @@ onMounted(() => {
   numberCards.reload();
   masterData.reload();
   trendData.reload();
-  tagData.reload();
+  if (isManager) tagData.reload();
 });
 
 usePageMeta(() => {

--- a/desk/src/pages/dashboard/Dashboard.vue
+++ b/desk/src/pages/dashboard/Dashboard.vue
@@ -275,46 +275,63 @@ const colors = [
   "#15CCEF",
   "#A6B1B9",
 ];
-// Chart title (as returned by the dashboard APIs) → empty state copy.
-const emptyStateByChart: Record<string, { title: string; message: string }> = {
-  "Ticket Trend": {
+interface ChartEmptyState {
+  // header of the card, shown untranslated only when the chart itself is missing
+  chartTitle: string;
+  chartSubtitle?: string;
+  title: string;
+  message: string;
+}
+
+// Chart key (stable, untranslated identifier from the dashboard APIs) → empty state copy.
+const emptyStateByChart: Record<string, ChartEmptyState> = {
+  ticket_trend: {
+    chartTitle: "Ticket Trend",
     title: "No ticket activity",
     message: "Ticket trends will appear here once tickets are created.",
   },
-  "Feedback Trend": {
+  feedback_trend: {
+    chartTitle: "Feedback Trend",
     title: "No feedback data",
     message: "Feedback insights will appear once responses are collected.",
   },
-  "Tickets by Team": {
+  tickets_by_team: {
+    chartTitle: "Tickets by Team",
     title: "No team data",
     message: "Tickets will be grouped by team once available.",
   },
-  "Tickets by Type": {
+  tickets_by_type: {
+    chartTitle: "Tickets by Type",
     title: "No ticket type data",
     message: "Tickets will be categorized by type once created.",
   },
-  "Tickets by Priority": {
+  tickets_by_priority: {
+    chartTitle: "Tickets by Priority",
     title: "No priority data",
     message: "Ticket priorities will be reflected here once assigned.",
   },
-  "Tickets by Channel": {
+  tickets_by_channel: {
+    chartTitle: "Tickets by Channel",
     title: "No channel data",
     message: "Tickets will be grouped by channel once received.",
   },
-  "Top Tags": {
+  top_tags: {
+    chartTitle: "Top Tags",
     title: "No tags used yet",
     message: "The most used tags will be ranked here once tickets are tagged.",
   },
-  "Tag Trend": {
+  tag_trend: {
+    chartTitle: "Tag Trend",
     title: "No tag activity",
     message: "Daily tag volume will appear here once tickets are tagged.",
   },
 };
 
+// whole dashboard empty: no chart payload to read titles from, so fall back to ours
 const emptyStates = Object.values(emptyStateByChart);
 
 function chartEmptyState(chart: any) {
-  const state = emptyStateByChart[chart?.title] ?? {
+  const state = emptyStateByChart[chart?.key] ?? {
     title: `No ${String(chart?.title).toLowerCase()} available`,
   };
   return [

--- a/desk/src/pages/dashboard/Dashboard.vue
+++ b/desk/src/pages/dashboard/Dashboard.vue
@@ -117,11 +117,7 @@
               :variants="['bar-chart', 'empty-state']"
               :bar-chart-count="1"
               :has-applied-filter="hasAppliedFilter"
-              :empty-states="[
-                {
-                  title: `No ${(chart?.title).toLowerCase()} available.`,
-                },
-              ]"
+              :empty-states="chartEmptyState(chart)"
             />
           </template>
         </div>
@@ -142,11 +138,7 @@
               :variants="['bar-chart', 'empty-state']"
               :bar-chart-count="1"
               :has-applied-filter="hasAppliedFilter"
-              :empty-states="[
-                {
-                  title: `No ${(chart?.title).toLowerCase()} available.`,
-                },
-              ]"
+              :empty-states="chartEmptyState(chart)"
             />
           </template>
         </div>
@@ -168,11 +160,7 @@
               :variants="['bar-chart', 'empty-state']"
               :bar-chart-count="1"
               :has-applied-filter="hasAppliedFilter"
-              :empty-states="[
-                {
-                  title: `No ${(chart?.title).toLowerCase()} available.`,
-                },
-              ]"
+              :empty-states="chartEmptyState(chart)"
             />
           </template>
         </div>
@@ -287,40 +275,52 @@ const colors = [
   "#15CCEF",
   "#A6B1B9",
 ];
-const emptyStates = [
-  {
+// Chart title (as returned by the dashboard APIs) → empty state copy.
+const emptyStateByChart: Record<string, { title: string; message: string }> = {
+  "Ticket Trend": {
     title: "No ticket activity",
     message: "Ticket trends will appear here once tickets are created.",
   },
-  {
+  "Feedback Trend": {
     title: "No feedback data",
     message: "Feedback insights will appear once responses are collected.",
   },
-  {
+  "Tickets by Team": {
     title: "No team data",
     message: "Tickets will be grouped by team once available.",
   },
-  {
+  "Tickets by Type": {
     title: "No ticket type data",
     message: "Tickets will be categorized by type once created.",
   },
-  {
+  "Tickets by Priority": {
     title: "No priority data",
     message: "Ticket priorities will be reflected here once assigned.",
   },
-  {
+  "Tickets by Channel": {
     title: "No channel data",
     message: "Tickets will be grouped by channel once received.",
   },
-  {
-    title: "No tag data",
-    message: "Tags will be ranked here once tickets are tagged.",
+  "Top Tags": {
+    title: "No tags used yet",
+    message: "The most used tags will be ranked here once tickets are tagged.",
   },
-  {
-    title: "No tag trend",
-    message: "Daily tag volume will appear once tickets are tagged.",
+  "Tag Trend": {
+    title: "No tag activity",
+    message: "Daily tag volume will appear here once tickets are tagged.",
   },
-];
+};
+
+const emptyStates = Object.values(emptyStateByChart);
+
+function chartEmptyState(chart: any) {
+  const state = emptyStateByChart[chart?.title] ?? {
+    title: `No ${String(chart?.title).toLowerCase()} available`,
+  };
+  return [
+    { ...state, chartTitle: chart?.title, chartSubtitle: chart?.subtitle },
+  ];
+}
 
 const tabButtons = computed(() => {
   if (isMobileView.value) {

--- a/helpdesk/api/dashboard.py
+++ b/helpdesk/api/dashboard.py
@@ -300,6 +300,7 @@ class HelpdeskDashboard:
 
         return get_bar_chart_config(
             result,
+            "ticket_trend",
             _("Ticket Trend"),
             subtitle,
             {"key": "date", "type": "time", "title": "Date", "timeGrain": "day"},
@@ -381,6 +382,7 @@ class HelpdeskDashboard:
 
         return get_bar_chart_config(
             result,
+            "feedback_trend",
             _("Feedback Trend"),
             subtitle,
             {"key": "date", "type": "time", "title": "Date", "timeGrain": "day"},
@@ -458,6 +460,7 @@ def get_team_chart_data(
     if len(result) < 7:
         return get_pie_chart_config(
             result,
+            "tickets_by_team",
             _("Tickets by Team"),
             _("Percentage of total tickets by team"),
             "team",
@@ -466,6 +469,7 @@ def get_team_chart_data(
     else:
         return get_bar_chart_config(
             result,
+            "tickets_by_team",
             _("Tickets by Team"),
             _("Total tickets by team"),
             {"key": "team", "type": "category", "title": "Team", "timeGrain": "day"},
@@ -491,6 +495,7 @@ def get_ticket_type_chart_data(
     if len(result) < 7:
         return get_pie_chart_config(
             result,
+            "tickets_by_type",
             _("Tickets by Type"),
             _("Percentage of total tickets by type"),
             "type",
@@ -499,6 +504,7 @@ def get_ticket_type_chart_data(
     else:
         return get_bar_chart_config(
             result,
+            "tickets_by_type",
             _("Tickets by Type"),
             _("Total tickets by type"),
             {"key": "type", "type": "category", "title": "Type", "timeGrain": "day"},
@@ -524,6 +530,7 @@ def get_ticket_priority_chart_data(
     if len(result) < 7:
         return get_pie_chart_config(
             result,
+            "tickets_by_priority",
             _("Tickets by Priority"),
             _("Percentage of total tickets by priority"),
             "priority",
@@ -532,6 +539,7 @@ def get_ticket_priority_chart_data(
     else:
         return get_bar_chart_config(
             result,
+            "tickets_by_priority",
             _("Tickets by Priority"),
             _("Total tickets by priority"),
             {
@@ -564,6 +572,7 @@ def get_ticket_channel_chart_data(
 
     return get_pie_chart_config(
         result,
+        "tickets_by_channel",
         _("Tickets by Channel"),
         _("Percentage of total tickets by channel"),
         "channel",
@@ -573,6 +582,7 @@ def get_ticket_channel_chart_data(
 
 def get_pie_chart_config(
     data: list[dict[str, any]],
+    key: str,
     title: str,
     subtitle: str,
     category_column: str,
@@ -581,6 +591,8 @@ def get_pie_chart_config(
     return {
         "type": "pie",
         "data": data,
+        # stable identifier for the client, `title` is translated and cannot be matched on
+        "key": key,
         "title": title,
         "subtitle": subtitle,
         "categoryColumn": category_column,
@@ -590,6 +602,7 @@ def get_pie_chart_config(
 
 def get_bar_chart_config(
     data: list[dict[str, any]],
+    key: str,
     title: str,
     subtitle: str,
     x_axis_config: dict[str, any],
@@ -600,6 +613,8 @@ def get_bar_chart_config(
     return {
         "type": "axis",
         "data": data,
+        # stable identifier for the client, `title` is translated and cannot be matched on
+        "key": key,
         "title": title,
         "subtitle": subtitle,
         "xAxis": x_axis_config,

--- a/helpdesk/api/dashboard_tags.py
+++ b/helpdesk/api/dashboard_tags.py
@@ -42,6 +42,7 @@ class TagDashboard(HelpdeskDashboard):
         return get_bar_chart_config(
             # bars are drawn bottom-up, so ascending puts the biggest on top
             top_tag_data[::-1],
+            "top_tags",
             _("Top Tags"),
             _("Most used tags in this period"),
             {"key": "tag", "type": "category", "title": _("Tag")},
@@ -67,6 +68,7 @@ class TagDashboard(HelpdeskDashboard):
 
         return get_bar_chart_config(
             self.pivot_by_date(rows, tags),
+            "tag_trend",
             _("Tag Trend"),
             _("Daily volume of the top {0} tags").format(TREND_TAG_COUNT),
             {"key": "date", "type": "time", "title": _("Date"), "timeGrain": "day"},


### PR DESCRIPTION
## Problem

Every empty chart on the dashboard showed the same generic line: *"Dashboard charts will appear here once you start receiving or creating tickets."*

All three call sites (trend charts, master-data charts, tag charts) passed only a `title` override to `SkeletonLoader`, so `message` always fell through to the default. The empty cards also rendered grey skeleton bars where the chart header should be, which looked broken sitting next to real charts.

## What this does

- `Dashboard.vue`: single `emptyStateByChart` map keyed by chart title, with specific copy per chart. `chartEmptyState(chart)` replaces the three duplicated inline objects, and the all-empty dashboard state derives its list from the same map.
- `SkeletonLoader.vue`: renders the real chart title and subtitle when passed, grey placeholder bars otherwise.

Unknown chart titles still fall back to `No <title> available`.

## How to test

1. Open the dashboard on a site with tickets but no tags.
2. The Top Tags and Tag Trend cards should show their real headers plus "No tags used yet. / The most used tags will be ranked here once tickets are tagged." instead of the generic dashboard message.
3. Apply a date range with no tickets. Every chart card should show its own title and the filter message.