### PR TITLE
fix(home): keep the last recent activity row out of the bottom fade

### DIFF
--- a/desk/src/pages/home/components/RecentActivity.vue
+++ b/desk/src/pages/home/components/RecentActivity.vue
@@ -12,7 +12,8 @@
       </Tooltip>
     </div>
     <div class="relative mt-5 grow overflow-hidden">
-      <div class="flex flex-col h-full overflow-auto hide-scrollbar">
+      <!-- pb matches the fade height below, so the last row never sits under it -->
+      <div class="flex flex-col h-full overflow-auto hide-scrollbar pb-8">
         <template v-if="!showSkeleton && activities.length > 0">
           <div
             v-for="activity in activities"


### PR DESCRIPTION
## Problem

In **My Recent Activity** on the agent home page, the last row always renders faded, including its hover background.

The bottom scroll fade is a fixed `absolute inset-x-0 bottom-0 h-8` gradient pinned to the card. It has no notion of scroll position, so whatever content sits in the bottom 32px of the list is permanently washed out. When the list is scrolled to the end, that is the final row.

## What this does

Pads the scroll container by the fade height (`pb-8`), so list content scrolls clear of the gradient and the fade lands on padding instead of a row. The fade still does its job while there is more content below.

No scroll listener needed, so nothing to keep in sync on resize or data refresh.