### PR TITLE
fix(customisation): convert link_filters to dict before search_link

### DIFF
--- a/desk/src/composables/formCustomisation.ts
+++ b/desk/src/composables/formCustomisation.ts
@@ -92,7 +92,7 @@ export function parseField(field, doc) {
       field.required ||
       (field.mandatory_depends_on &&
         evaluateDependsOnValue(field.mandatory_depends_on, doc)),
-    filters: field.link_filters && JSON.parse(field.link_filters),
+    filters: field.link_filters && parseLinkFilters(field.link_filters),
     disabled: field.disabled,
     readonly:
       field.readonly ||
@@ -100,6 +100,26 @@ export function parseField(field, doc) {
         evaluateDependsOnValue(field.read_only_depends_on, doc)),
   };
 }
+
+/**
+ * Convert `link_filters` from the stored list format to the dict format that
+ * `frappe.desk.search.search_link` expects. Doctypes with a standard query
+ * @example
+ * // in:  '[["User", "name", "in", ["a@x.com", "b@x.com"]]]'
+ * // out: { name: ["in", ["a@x.com", "b@x.com"]] }
+ */
+export function parseLinkFilters(linkFilters: string) {
+  const conditions = JSON.parse(linkFilters);
+  if (!Array.isArray(conditions)) return conditions;
+  return Object.fromEntries(
+    conditions.map((condition) => {
+      const [fieldname, operator, value] =
+        condition.length === 4 ? condition.slice(1) : condition;
+      return [fieldname, operator === "=" ? value : [operator, value]];
+    })
+  );
+}
+
 export function evaluateDependsOnValue(expression, doc) {
   if (!expression) return true;
   let out = null;

--- a/desk/src/pages/home/components/RecentActivity.vue
+++ b/desk/src/pages/home/components/RecentActivity.vue
@@ -15,11 +15,14 @@
       <!-- pb matches the fade height below, so the last row never sits under it -->
       <div class="flex flex-col h-full overflow-auto hide-scrollbar pb-8">
         <template v-if="!showSkeleton && activities.length > 0">
-          <div
+          <router-link
             v-for="activity in activities"
             :key="activity.name"
-            @click="goToTicket(activity)"
-            class="flex items-center gap-3 px-2 py-3 text-sm cursor-pointer hover:bg-surface-sidebar rounded"
+            :to="{
+              name: 'TicketAgent',
+              params: { ticketId: String(activity.name) },
+            }"
+            class="flex items-center gap-3 px-2 py-3 text-sm hover:bg-surface-sidebar rounded"
           >
             <component
               :is="iconFor(activity.activity_type)"
@@ -36,7 +39,7 @@
             <span class="text-ink-gray-4 whitespace-nowrap tabular-nums">
               {{ activity.timestamp }}
             </span>
-          </div>
+          </router-link>
         </template>
         <div v-else class="flex flex-col">
           <div v-for="i in 6" :key="i" class="flex items-center gap-3 p-2 py-3">
@@ -73,7 +76,6 @@ import EmptyState from "@/components/EmptyState.vue";
 import { __ } from "@/translation";
 import { createResource, Tooltip } from "frappe-ui";
 import { computed, onMounted, ref, type PropType } from "vue";
-import { useRouter } from "vue-router";
 import ActivityIcon from "~icons/lucide/activity";
 import ReplyIcon from "~icons/lucide/corner-up-left";
 import EyeIcon from "~icons/lucide/eye";
@@ -95,8 +97,6 @@ const props = defineProps({
     required: true,
   },
 });
-
-const router = useRouter();
 
 const typeLabels: Record<string, string> = {
   replied: __("Replied"),
@@ -137,13 +137,6 @@ function iconFor(type: string) {
 function label(activity: RecentActivity) {
   return activity.text || typeLabels[activity.activity_type];
 }
-
-const goToTicket = (activity: RecentActivity) => {
-  router.push({
-    name: "TicketAgent",
-    params: { ticketId: String(activity.name) },
-  });
-};
 
 onMounted(() => {
   if (!Array.isArray(props.data)) {


### PR DESCRIPTION
### Problem

Setting **Link Filters** on a Link-to-User field via Customize Form breaks the New Ticket page. Opening the field's dropdown returns a 500:

```
File "apps/frappe/frappe/core/doctype/user/user.py", line 1196, in user_query
    if not (filters.get("ignore_user_type") and frappe.session.data.user_type == "System User"):
builtins.AttributeError: 'list' object has no attribute 'get'
```

Frappe has two filter formats. Customize Form stores `link_filters` as a list of lists (`[[doctype, fieldname, operator, value]]`), while `search_link` expects a dict. Frappe's own desk converts with `frappe.utils.get_filter_from_json()` before calling; `parseField` just did `JSON.parse()` and sent the raw list.

That is harmless for most doctypes, since `search_widget` hands list filters to `frappe.get_list`, which normalizes both formats. But when the target doctype is registered in the `standard_queries` hook, `search_widget` forwards `filters` untouched into that query instead ([search.py:140-160](https://github.com/frappe/frappe/blob/develop/frappe/desk/search.py#L140-L160)), and standard queries are written against dicts. `user_query` calls `filters.get(...)` on line one and dies before fetching a row.

`search_widget` does have a converter behind `query_filters_as_dict`, but `search_link` neither accepts nor forwards that flag, so it is unreachable from the frontend. The conversion has to happen client side.

Vanilla HD Ticket has no Link-to-User field, which is why this only shows up on sites that add one. Sites that register their own standard query (e.g. for Contact) widen the blast radius to the built-in `contact` field.

### Fix

Convert `link_filters` to the dict form in `parseField`, the only consumer of `link_filters` in the frontend, so every Link field is covered including the list `handleLinkFieldUpdate` writes at runtime.

### How to test

1. Customize Form on HD Ticket, add a Link field to User, set Link Filters to `user_type = System User`.
2. Add the field to the Default HD Ticket Template.
3. Open **New Ticket** and click the field's dropdown.

Before: 500 with the traceback above, dropdown stays empty and the ticket cannot be submitted. After: users load.

Verified on both branches of the conversion:

| `link_filters` | Result |
| --- | --- |
| `[["User", "user_type", "=", "System User"]]` | 200, dropdown lists all system users |
| `[["User", "name", "in", ["abc@g.com"]]]` | 200, dropdown narrows to `abc@g.com` |

The second case confirms the non-equality path produces `{name: ["in", [...]]}` and that the filter is genuinely applied server side, not merely no longer crashing.
