### PR TITLE
fix(assignment): close related ToDo when a ticket resolves

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -246,6 +246,10 @@ class HDTicket(Document):
     def sync_assignment_todos(self):
         """Close assignment ToDos once the ticket resolves, reopen them if it reopens.
 
+        Scoped to allocated ToDos, which is how `ToDo.update_in_reference` defines
+        an assignment, so ToDos merely referencing the ticket are left alone.
+        Cancelled ToDos stay cancelled, a removed assignment must not come back.
+
         Uses `db.set_value` because saving a ToDo drops the agent from `_assign`,
         which Helpdesk treats as the assignee for the ticket's whole lifetime.
         """
@@ -253,15 +257,19 @@ class HDTicket(Document):
             return
 
         resolved = self.status_category == "Resolved"
+        current_status, new_status = (
+            ("Open", "Closed") if resolved else ("Closed", "Open")
+        )
         frappe.db.set_value(
             "ToDo",
             {
                 "reference_type": "HD Ticket",
                 "reference_name": self.name,
-                "status": "Closed" if not resolved else "Open",
+                "allocated_to": ("is", "set"),
+                "status": current_status,
             },
             "status",
-            "Closed" if resolved else "Open",
+            new_status,
         )
 
     def notify_agent(self, agent, notification_type="Assignment"):

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -239,8 +239,30 @@ class HDTicket(Document):
                         self.notify_agent(agent.name, "Reaction")
 
         self.remove_assignment_if_not_in_team()
+        self.sync_assignment_todos()
         self.publish_update()
         self.capture_update_telemetry_events()
+
+    def sync_assignment_todos(self):
+        """Close assignment ToDos once the ticket resolves, reopen them if it reopens.
+
+        Uses `db.set_value` because saving a ToDo drops the agent from `_assign`,
+        which Helpdesk treats as the assignee for the ticket's whole lifetime.
+        """
+        if self.is_new() or not self.has_value_changed("status_category"):
+            return
+
+        resolved = self.status_category == "Resolved"
+        frappe.db.set_value(
+            "ToDo",
+            {
+                "reference_type": "HD Ticket",
+                "reference_name": self.name,
+                "status": "Closed" if not resolved else "Open",
+            },
+            "status",
+            "Closed" if resolved else "Open",
+        )
 
     def notify_agent(self, agent, notification_type="Assignment"):
         frappe.get_doc(

--- a/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
@@ -4,6 +4,7 @@
 from datetime import timedelta
 
 import frappe
+from frappe.desk.form.assign_to import add as assign
 from frappe.tests import IntegrationTestCase
 from frappe.utils import add_to_date, get_datetime, getdate, now_datetime
 
@@ -614,6 +615,39 @@ class TestHDTicket(IntegrationTestCase):
             ticket.status = "Closed"
             ticket.save()
             self.assertEqual(ticket.resolution_time, 30 * 60)
+
+    def test_todo_status_follows_ticket_status_category(self):
+        """Resolving a ticket closes its assignment ToDos, reopening opens them
+        back up, and the assignee stays on `_assign` throughout."""
+        ticket = make_ticket()
+        assign({"doctype": "HD Ticket", "name": ticket.name, "assign_to": [agent]})
+
+        def todo_status():
+            return frappe.db.get_value(
+                "ToDo",
+                {"reference_type": "HD Ticket", "reference_name": ticket.name},
+                "status",
+            )
+
+        def set_status(status):
+            ticket.reload()
+            ticket.status = status
+            ticket.save()
+
+        self.assertEqual(todo_status(), "Open")
+
+        set_status("Resolved")
+        self.assertEqual(todo_status(), "Closed")
+        self.assertIn(
+            agent,
+            frappe.db.get_value("HD Ticket", ticket.name, "_assign"),
+        )
+
+        set_status("Replied")
+        self.assertEqual(todo_status(), "Open")
+
+        set_status("Open")
+        self.assertEqual(todo_status(), "Open")
 
     def test_ticket_merge(self):
         ticket1 = make_ticket(description="Test Desc 1")

--- a/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
@@ -622,10 +622,22 @@ class TestHDTicket(IntegrationTestCase):
         ticket = make_ticket()
         assign({"doctype": "HD Ticket", "name": ticket.name, "assign_to": [agent]})
 
+        # a ToDo that references the ticket without being an assignment
+        unallocated_todo = frappe.get_doc(
+            doctype="ToDo",
+            description="Chase the courier",
+            reference_type="HD Ticket",
+            reference_name=ticket.name,
+        ).insert(ignore_permissions=True)
+
         def todo_status():
             return frappe.db.get_value(
                 "ToDo",
-                {"reference_type": "HD Ticket", "reference_name": ticket.name},
+                {
+                    "reference_type": "HD Ticket",
+                    "reference_name": ticket.name,
+                    "allocated_to": agent,
+                },
                 "status",
             )
 
@@ -641,6 +653,9 @@ class TestHDTicket(IntegrationTestCase):
         self.assertIn(
             agent,
             frappe.db.get_value("HD Ticket", ticket.name, "_assign"),
+        )
+        self.assertEqual(
+            frappe.db.get_value("ToDo", unallocated_todo.name, "status"), "Open"
         )
 
         set_status("Replied")


### PR DESCRIPTION
### Problem

Assignment ToDos are created when an agent is assigned and then never change state. Resolving or closing a ticket leaves its ToDo `Open`, so every ticket an agent has ever handled keeps sitting in their ToDo list.

### Fix

Sync the ToDo status with the ticket's status category on update:

- category `Resolved` (statuses **Resolved**, **Closed**) closes the ToDos
- any other category (`Open`, `Paused`) reopens them, so un-resolving a ticket brings the assignment back

Only fires when `status_category` actually changed, and only flips rows already in the opposite state.

Written via `db.set_value` rather than saving the ToDo: saving drops the agent from `_assign`, and Helpdesk treats `_assign` as the ticket's assignee for its whole lifetime, not just while it is open.

### How to test

1. Assign yourself to a ticket, confirm the ToDo is `Open`.
2. Set the ticket to **Resolved**. The ToDo goes `Closed`, and you are still on `_assign`.
3. Set it back to **Open** or **Replied**. The ToDo goes `Open` again.

Covered by `test_todo_status_follows_ticket_status_category`, which walks Open, Resolved, Replied, Open and asserts `_assign` survives the round trip.

```
bench --site hd-tests run-tests --module helpdesk.helpdesk.doctype.hd_ticket.test_hd_ticket --test test_todo_status_follows_ticket_status_category
✔ test_todo_status_follows_ticket_status_category
```
