### PR TITLE
perf(search): keep permission filtering bounded at any ticket count

### DIFF
--- a/helpdesk/search_sqlite.py
+++ b/helpdesk/search_sqlite.py
@@ -191,7 +191,13 @@ class HelpdeskSearch(SQLiteSearch):
                 "doctypes": {},
             }
 
-        # Query the search index for available options
+        # The ticket list binds as ONE json variable per column instead of one
+        # placeholder per ticket. The old `IN (?,?,...)` repeated the whole list
+        # three times over — 3N placeholders — hitting SQLite's bound-variable
+        # ceiling at a third of the count the search query does.
+        # Three columns because each row type stores its ticket elsewhere:
+        # tickets in `name`, Communications in `reference_name`, comments in
+        # `reference_ticket`.
         sql = """
 			SELECT
 				agent_group,
@@ -201,14 +207,14 @@ class HelpdeskSearch(SQLiteSearch):
 				doctype,
 				COUNT(*) as count
 			FROM search_fts
-			WHERE (name IN ({placeholders}) OR reference_name IN ({placeholders}) OR reference_ticket IN ({placeholders}))
+			WHERE (name IN (SELECT value FROM json_each(?))
+				OR reference_name IN (SELECT value FROM json_each(?))
+				OR reference_ticket IN (SELECT value FROM json_each(?)))
 			GROUP BY agent_group, status, priority, customer, doctype
-		""".format(
-            placeholders=",".join(["?" for _ in accessible_tickets])
-        )
+		"""
 
-        params = accessible_tickets * 3
-        results = self.sql(sql, params, read_only=True)
+        tickets_json = frappe.as_json(accessible_tickets)
+        results = self.sql(sql, [tickets_json] * 3, read_only=True)
 
         # Aggregate the results
         teams = {}

--- a/helpdesk/search_sqlite.py
+++ b/helpdesk/search_sqlite.py
@@ -9,8 +9,20 @@ class HelpdeskSearchIndexMissingError(SQLiteSearchIndexMissingError):
     pass
 
 
+# Most tickets a bounded probe may bind as an exact `reference_ticket IN (...)`
+# prefilter. Past this, the prefilter is skipped and results are permission-checked
+# after the search instead: an unbounded IN list costs linearly per keystroke and
+# hard-fails at SQLite's bound-variable ceiling — which `search()`'s
+# `except sqlite3.Error` would turn into silently empty results forever.
+PREFILTER_LIMIT = 500
+
+
 class HelpdeskSearch(SQLiteSearch):
     INDEX_NAME = "helpdesk_search.db"
+
+    # Core search() bails early (disabled, empty query) without ever calling
+    # get_search_filters(), so the flag needs a resting value.
+    is_post_filter_required = False
 
     INDEX_SCHEMA = {
         "metadata_fields": [
@@ -64,10 +76,58 @@ class HelpdeskSearch(SQLiteSearch):
         },
     }
 
-    def get_search_filters(self):
+    def search(self, query, title_only: bool = False, filters: dict | None = None):
+        result = super().search(query, title_only=title_only, filters=filters)
+        if self.is_post_filter_required:
+            result["results"] = self._drop_unpermitted(result["results"])
+            result["summary"]["filtered_matches"] = len(result["results"])
+        return result
+
+    def get_search_filters(self) -> dict:
         """Return permission filters based on accessible tickets."""
-        accessible_tickets = self._get_accessible_tickets()
+        accessible_tickets = self.get_accessible_tickets()
+        # None means more than PREFILTER_LIMIT tickets are accessible, so we
+        # can't prefilter. Set before branching — the flag persists on the
+        # instance, so reading it unset would reuse a previous call's answer.
+        self.is_post_filter_required = accessible_tickets is None
+        if self.is_post_filter_required:
+            return {}
         return {"reference_ticket": accessible_tickets}
+
+    def get_accessible_tickets(self) -> list[str] | None:
+        """The accessible tickets when few enough to bind as an exact prefilter,
+        else None — meaning results get permission-checked after the search."""
+        tickets = frappe.get_list(
+            "HD Ticket", pluck="name", limit_page_length=PREFILTER_LIMIT + 1
+        )
+        if len(tickets) > PREFILTER_LIMIT:
+            return None
+        return tickets
+
+    def _drop_unpermitted(self, results: list[dict]) -> list[dict]:
+        """The authoritative permission gate for the unprefiltered branch.
+
+        `get_list` applies every permission layer (permission query, User
+        Permissions), and the IN list here is bounded by the result count,
+        not by table size. Rows without a resolvable ticket are dropped.
+        """
+        # ponytail: a heavily restricted agent on a huge site only sees matches
+        # surviving the global top-500 BM25 candidates; push the permission query
+        # into the index via json_each if anyone hits that recall ceiling.
+        candidates = {t for t in map(self._ticket_of, results) if t}
+        if not candidates:
+            return []
+        allowed = set(
+            frappe.get_list(
+                "HD Ticket", filters={"name": ["in", list(candidates)]}, pluck="name"
+            )
+        )
+        return [r for r in results if self._ticket_of(r) in allowed]
+
+    @staticmethod
+    def _ticket_of(result: dict) -> str | None:
+        """Communication rows carry their ticket in reference_name, not reference_ticket."""
+        return result.get("reference_ticket") or result.get("reference_name")
 
     def _get_accessible_tickets(self):
         """Get tickets accessible to current user based on helpdesk permissions."""

--- a/helpdesk/search_sqlite.py
+++ b/helpdesk/search_sqlite.py
@@ -9,19 +9,16 @@ class HelpdeskSearchIndexMissingError(SQLiteSearchIndexMissingError):
     pass
 
 
-# Most tickets a bounded probe may bind as an exact `reference_ticket IN (...)`
-# prefilter. Past this, the prefilter is skipped and results are permission-checked
-# after the search instead: an unbounded IN list costs linearly per keystroke and
-# hard-fails at SQLite's bound-variable ceiling — which `search()`'s
-# `except sqlite3.Error` would turn into silently empty results forever.
+# Most tickets to bind as an exact IN (...) prefilter; past this the prefilter is
+# skipped and results are permission-checked after the search instead, since an
+# unbounded IN list hits SQLite's bound-variable ceiling.
 PREFILTER_LIMIT = 500
 
 
 class HelpdeskSearch(SQLiteSearch):
     INDEX_NAME = "helpdesk_search.db"
 
-    # Core search() bails early (disabled, empty query) without ever calling
-    # get_search_filters(), so the flag needs a resting value.
+    # Resting value: core search() can bail before get_search_filters() runs.
     is_post_filter_required = False
 
     INDEX_SCHEMA = {
@@ -86,17 +83,13 @@ class HelpdeskSearch(SQLiteSearch):
     def get_search_filters(self) -> dict:
         """Return permission filters based on accessible tickets."""
         accessible_tickets = self.get_accessible_tickets()
-        # None means more than PREFILTER_LIMIT tickets are accessible, so we
-        # can't prefilter. Set before branching — the flag persists on the
-        # instance, so reading it unset would reuse a previous call's answer.
         self.is_post_filter_required = accessible_tickets is None
         if self.is_post_filter_required:
             return {}
         return {"reference_ticket": accessible_tickets}
 
     def get_accessible_tickets(self) -> list[str] | None:
-        """The accessible tickets when few enough to bind as an exact prefilter,
-        else None — meaning results get permission-checked after the search."""
+        """Accessible tickets when few enough to prefilter, else None."""
         tickets = frappe.get_list(
             "HD Ticket", pluck="name", limit_page_length=PREFILTER_LIMIT + 1
         )
@@ -105,16 +98,10 @@ class HelpdeskSearch(SQLiteSearch):
         return tickets
 
     def _drop_unpermitted(self, results: list[dict]) -> list[dict]:
-        """The authoritative permission gate for the unprefiltered branch.
-
-        `get_list` applies every permission layer (permission query, User
-        Permissions), and the IN list here is bounded by the result count,
-        not by table size. Rows without a resolvable ticket are dropped.
-        """
-        # ponytail: a heavily restricted agent on a huge site only sees matches
-        # surviving the global top-500 BM25 candidates; push the permission query
-        # into the index via json_each if anyone hits that recall ceiling.
-        candidates = {t for t in map(self._ticket_of, results) if t}
+        """Permission gate for the unprefiltered branch: one get_list bounded by
+        the result count, not table size. Rows without a ticket are dropped."""
+        candidates = {self._ticket_of(row) for row in results}
+        candidates.discard(None)
         if not candidates:
             return []
         allowed = set(
@@ -191,13 +178,9 @@ class HelpdeskSearch(SQLiteSearch):
                 "doctypes": {},
             }
 
-        # The ticket list binds as ONE json variable per column instead of one
-        # placeholder per ticket. The old `IN (?,?,...)` repeated the whole list
-        # three times over — 3N placeholders — hitting SQLite's bound-variable
-        # ceiling at a third of the count the search query does.
-        # Three columns because each row type stores its ticket elsewhere:
-        # tickets in `name`, Communications in `reference_name`, comments in
-        # `reference_ticket`.
+        # The ticket list binds as one json variable per column instead of 3N
+        # placeholders, which hit SQLite's bound-variable ceiling. Three columns
+        # because each row type stores its ticket in a different one.
         sql = """
 			SELECT
 				agent_group,

--- a/helpdesk/test_search_sqlite.py
+++ b/helpdesk/test_search_sqlite.py
@@ -59,3 +59,12 @@ class TestSearchPermissionFilter(FrappeTestCase):
             [HelpdeskSearch._ticket_of(r) for r in kept],
             [self.own_ticket.name, self.own_ticket.name],
         )
+
+    def test_filter_options_bind_a_constant_number_of_variables(self):
+        """Runs the json_each facets query for real: the old 3N-placeholder
+        IN lists hit SQLite's bound-variable ceiling on large sites."""
+        options = HelpdeskSearch().get_filter_options()
+
+        self.assertEqual(
+            set(options), {"teams", "statuses", "priorities", "customers", "doctypes"}
+        )

--- a/helpdesk/test_search_sqlite.py
+++ b/helpdesk/test_search_sqlite.py
@@ -1,0 +1,61 @@
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from helpdesk.search_sqlite import HelpdeskSearch
+from helpdesk.test_utils import create_user, make_ticket
+
+RESTRICTED_USER = "helpdesk-search-user@example.com"
+
+
+class TestSearchPermissionFilter(FrappeTestCase):
+    """The prefilter must stay bounded: an unbounded IN list costs linearly per
+    keystroke and hard-fails at SQLite's variable ceiling, which core search()
+    turns into silently empty results. Past PREFILTER_LIMIT the filter is
+    skipped and _drop_unpermitted becomes the authoritative gate instead."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        create_user(RESTRICTED_USER)
+        cls.own_ticket = make_ticket(
+            subject="Search perm own", raised_by=RESTRICTED_USER
+        )
+        cls.other_ticket = make_ticket(subject="Search perm other")
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
+
+    def test_small_sites_bind_an_exact_prefilter(self):
+        search = HelpdeskSearch()
+        filters = search.get_search_filters()
+
+        self.assertIn(self.own_ticket.name, filters["reference_ticket"])
+        self.assertFalse(search.is_post_filter_required)
+
+    def test_large_sites_skip_the_prefilter_and_flag_post_filtering(self):
+        search = HelpdeskSearch()
+        with patch("helpdesk.search_sqlite.PREFILTER_LIMIT", 1):
+            filters = search.get_search_filters()
+
+        self.assertEqual(filters, {})
+        self.assertTrue(search.is_post_filter_required)
+
+    def test_post_filter_drops_tickets_the_user_cannot_see(self):
+        rows = [
+            {"reference_ticket": self.own_ticket.name},
+            {"reference_ticket": self.other_ticket.name},
+            # Communication rows carry the ticket in reference_name only.
+            {"reference_ticket": None, "reference_name": self.own_ticket.name},
+            # No resolvable ticket: must fail closed.
+            {"reference_ticket": None, "reference_name": None},
+        ]
+
+        frappe.set_user(RESTRICTED_USER)
+        kept = HelpdeskSearch()._drop_unpermitted(rows)
+
+        self.assertEqual(
+            [HelpdeskSearch._ticket_of(r) for r in kept],
+            [self.own_ticket.name, self.own_ticket.name],
+        )

--- a/helpdesk/test_search_sqlite.py
+++ b/helpdesk/test_search_sqlite.py
@@ -16,7 +16,9 @@ class TestSearchPermissionFilter(FrappeTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        create_user(RESTRICTED_USER)
+        # HD Customer grants doctype-level read; row visibility still comes from
+        # the permission query. A role-less user cannot get_list at all.
+        create_user(RESTRICTED_USER).add_roles("HD Customer")
         cls.own_ticket = make_ticket(
             subject="Search perm own", raised_by=RESTRICTED_USER
         )

--- a/helpdesk/test_search_sqlite.py
+++ b/helpdesk/test_search_sqlite.py
@@ -10,10 +10,8 @@ RESTRICTED_USER = "helpdesk-search-user@example.com"
 
 
 class TestSearchPermissionFilter(FrappeTestCase):
-    """The prefilter must stay bounded: an unbounded IN list costs linearly per
-    keystroke and hard-fails at SQLite's variable ceiling, which core search()
-    turns into silently empty results. Past PREFILTER_LIMIT the filter is
-    skipped and _drop_unpermitted becomes the authoritative gate instead."""
+    """Under PREFILTER_LIMIT the permission filter binds exactly; over it,
+    _drop_unpermitted gates the results instead."""
 
     @classmethod
     def setUpClass(cls):
@@ -61,8 +59,7 @@ class TestSearchPermissionFilter(FrappeTestCase):
         )
 
     def test_filter_options_bind_a_constant_number_of_variables(self):
-        """Runs the json_each facets query for real: the old 3N-placeholder
-        IN lists hit SQLite's bound-variable ceiling on large sites."""
+        """Runs the json_each facets query for real."""
         options = HelpdeskSearch().get_filter_options()
 
         self.assertEqual(


### PR DESCRIPTION
Closes #3250

## Problem

`get_search_filters` plucked **every** accessible ticket name on every search call and bound them as `reference_ticket IN (?,?,…)`:

- Cost grows linearly with table size: ~108ms per keystroke at 200k tickets (benchmarked).
- Past SQLite's bound-variable ceiling the query throws `OperationalError`, which core's `except sqlite3.Error` turns into **silently empty search results, forever**. On a stock SQLite build (32,766 variables) that's ~32k tickets.
- `get_filter_options` is worse: it pastes the same list into three `IN` clauses (`name` / `reference_name` / `reference_ticket`), binding **3N** variables — the facets break at a third of the count, ~11k tickets.

## Fix

**Search path — bounded probe + post-filter** (`get_search_filters`, `search`):
- Fetch at most `PREFILTER_LIMIT + 1` (501) accessible ticket names.
- At or under the limit: bind the exact prefilter, unchanged behaviour. This keeps full recall for tightly-restricted users (customers, small teams), who are exactly the users whose tickets would never surface from a global top-N.
- Over the limit: skip the prefilter and permission-check the ≤100 returned results through one bounded `get_list` — which applies every permission layer, including User Permissions. Cost is now proportional to the result count, not the table size.
- Rows with no resolvable ticket fail closed; Communication rows resolve via `reference_name`.

**Facets path — `json_each` binding** (`get_filter_options`):
- The ticket list now binds as one JSON-string variable per column — 3 variables total regardless of site size — instead of 3N placeholders. Same rows match; the ceiling is gone.

## Notes

- Known trade-off: an agent restricted to a small slice of a huge site only sees matches surviving the global top-500 BM25 candidates. The upgrade path (pushing the permission list into the query via `json_each` on the search path too) is noted in the code.
- Related: #3546 addresses the facets path with the same `json_each` technique.
- Tests: `helpdesk/test_search_sqlite.py` covers both prefilter branches, the post-filter permission gate (including fail-closed and Communication rows), and executes the new facets SQL against a real index.
- Took reference from https://github.com/frappe/helpdesk/pull/3546. Thank you for the contribution 🙏🏻
