### PR TITLE
fix: onboarding questionnaire surface, button sizing and team-size default

### DIFF
--- a/desk/src/components/Questionnaire.vue
+++ b/desk/src/components/Questionnaire.vue
@@ -123,8 +123,9 @@
 
     <div class="flex flex-col items-center gap-2">
       <Button
-        class="!h-7 w-full !rounded-lg"
+        class="w-full"
         variant="solid"
+        size="sm"
         :label="isLast ? __('Finish') : __('Next')"
         :disabled="!canProceed"
         @click="proceed"

--- a/desk/src/pages/PersonaForm.vue
+++ b/desk/src/pages/PersonaForm.vue
@@ -31,6 +31,10 @@ const router = useRouter();
 const leaving = ref(false);
 const FADE_MS = 300;
 
+// Team size is the one optional answer; an untouched dropdown reports this
+// rather than dropping the key, so the answer set is always complete.
+const TEAM_SIZE_UNSPECIFIED = "prefer_not_to_say";
+
 // The last question's "first goal" answer maps to a settings tab; other goals
 // route directly (create ticket, explore) or fall through to Home.
 const settingsTabForGoal: Record<
@@ -83,8 +87,12 @@ async function routeToGoal(goal?: string | string[]) {
 }
 
 async function submitPersona(answers: Record<string, string | string[]>) {
-  capture("onboarding_persona_hd", { data: answers });
-  await finishOnboarding(answers);
+  const data = {
+    ...answers,
+    company_size: answers.company_size || TEAM_SIZE_UNSPECIFIED,
+  };
+  capture("onboarding_persona_hd", { data });
+  await finishOnboarding(data);
 }
 
 const questions = [

--- a/desk/src/pages/PersonaForm.vue
+++ b/desk/src/pages/PersonaForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="relative flex min-h-screen flex-col overflow-y-auto bg-surface-gray-1 transition-opacity duration-300 ease-out"
+    class="relative flex min-h-screen flex-col overflow-y-auto bg-surface-base transition-opacity duration-300 ease-out"
     :class="leaving ? 'opacity-0' : 'opacity-100'"
   >
     <div class="flex flex-1 flex-col justify-start pb-8 pt-24">


### PR DESCRIPTION
Follow-up polish on the onboarding persona questionnaire (#3538).

### Changes

**Onboarding screen sits on the base surface** — `bg-surface-gray-1` rendered an off-white tint behind the questionnaire. Switched to `bg-surface-base`, which is pure white in light mode and still flips with the theme (`bg-white` would not).

**`Next` button uses the `size` prop** — `size="sm"` already resolves to `h-7` plus the theme's button radius, so `!h-7` and `!rounded-lg` were restating the default with `!important`. No visual change; the button is still 28px tall.

**Unanswered team size reports `prefer_not_to_say`** — team size is the only optional answer, so leaving the dropdown untouched dropped `company_size` from the persona event entirely. It now defaults in `submitPersona`, the single point both telemetry and goal routing read, so the answer set is always complete.

### Screenshots

Captured on `/helpdesk/onboarding` in light mode with the organization name filled in, so the `Next` button renders enabled. Before (`0975880`) and after (`535db22`).

**Onboarding surface** — `bg-surface-gray-1` `rgb(248, 248, 248)` → `bg-surface-base` `rgb(255, 255, 255)`

| Before | After |
| --- | --- |
| <img alt="Onboarding questionnaire on bg-surface-gray-1" src="https://github.com/user-attachments/assets/12a8df85-35f0-4d3b-a5c2-4d2c92c6df80" /> | <img alt="Onboarding questionnaire on bg-surface-base" src="https://github.com/user-attachments/assets/ada759e7-b401-4282-8580-c6d6f589581f" /> |

**`Next` button** — zoomed on the button row, enabled and hovered, 28px tall in both

| Before | After |
| --- | --- |
| <img alt="Next button with !h-7 and !rounded-lg" src="https://github.com/user-attachments/assets/7478bd5d-a471-4404-91c0-031b514cc4bc" /> | <img alt="Next button with size=sm" src="https://github.com/user-attachments/assets/ed720134-a5ea-4430-bccb-13d3a68fa1c7" /> |

### Testing

Ran the desk dev server against a local site and loaded `/helpdesk/onboarding`:
- background computes to `rgb(255, 255, 255)` in light mode and to the dark surface when the theme flips
- `Next` renders at `h-7` with the theme radius and no `!important` classes
- no console errors

The `prefer_not_to_say` default is not exercised by an automated test — this component has no frontend test harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
