### PR TITLE
refactor: agent availability through the document lifecycle

### DIFF
--- a/desk/src/stores/agentStatus.ts
+++ b/desk/src/stores/agentStatus.ts
@@ -50,7 +50,7 @@ export const useAgentStatusStore = defineStore("agentStatus", () => {
   });
 
   // Live availability keyed by HD Agent name. Seeded by fetches and kept current
-  // over the socket — set_my_availability broadcasts to every client, so this is
+  // over the socket — HD Agent's on_update broadcasts to every client, so this is
   // the single source of truth for "who is what right now", including ourselves.
   const liveStatuses = reactive<Record<string, LiveAvailability>>({});
 
@@ -75,8 +75,11 @@ export const useAgentStatusStore = defineStore("agentStatus", () => {
     { immediate: true }
   );
 
+  // A plain document write: HD Agent's controller owns the validation, the
+  // availability_changed_on stamp and the socket broadcast, so every write path
+  // behaves the same and this needs no dedicated endpoint.
   const setMyAvailability = createResource({
-    url: "helpdesk.api.agent.set_my_availability",
+    url: "frappe.client.set_value",
     onSuccess: () => toast.success(__("Status updated successfully.")),
     onError: () => toast.error(__("Could not update status.")),
   });
@@ -101,7 +104,12 @@ export const useAgentStatusStore = defineStore("agentStatus", () => {
     const previous = liveStatuses[myAgentName];
     applyLive(myAgentName, status);
     setMyAvailability.submit(
-      { availability: status },
+      {
+        doctype: "HD Agent",
+        name: myAgentName,
+        fieldname: "availability",
+        value: status,
+      },
       {
         // Roll back the optimistic write on failure.
         onError: () => {

--- a/helpdesk/api/agent.py
+++ b/helpdesk/api/agent.py
@@ -26,4 +26,3 @@ def sent_invites(emails: list[str], send_welcome_mail_to_user: bool = True):
                 "user_image": user.user_image,
             }
         ).insert()
-    return

--- a/helpdesk/api/agent.py
+++ b/helpdesk/api/agent.py
@@ -1,7 +1,6 @@
 import frappe
-from frappe import _
 
-from helpdesk.utils import agent_only, get_agent_name, publish_event
+from helpdesk.utils import agent_only
 
 
 @frappe.whitelist()
@@ -28,30 +27,3 @@ def sent_invites(emails: list[str], send_welcome_mail_to_user: bool = True):
             }
         ).insert()
     return
-
-
-@frappe.whitelist()
-@agent_only
-def set_my_availability(availability: str) -> dict:
-    if not frappe.db.exists("HD Agent Status", {"name": availability, "enable": 1}):
-        frappe.throw(_("Invalid availability"), frappe.ValidationError)
-
-    name = get_agent_name()
-    if not name:
-        frappe.throw(_("No HD Agent record for current user"), frappe.ValidationError)
-
-    changed_on = frappe.utils.now()
-    frappe.db.set_value(
-        "HD Agent",
-        name,
-        {"availability": availability, "availability_changed_on": changed_on},
-    )
-    publish_event(
-        "agent_availability_updated",
-        data={
-            "agent": name,
-            "availability": availability,
-            "availability_changed_on": changed_on,
-        },
-    )
-    return {"availability": availability}

--- a/helpdesk/helpdesk/doctype/hd_agent/hd_agent.py
+++ b/helpdesk/helpdesk/doctype/hd_agent/hd_agent.py
@@ -6,7 +6,7 @@ from frappe import _
 from frappe.model.document import Document
 
 from helpdesk.helpdesk.doctype.hd_agent_status.hd_agent_status import get_active_status
-from helpdesk.utils import is_agent_manager, publish_event
+from helpdesk.utils import capture_event, is_agent_manager, publish_event
 
 
 class HDAgent(Document):
@@ -46,6 +46,7 @@ class HDAgent(Document):
 
     def on_update(self):
         self.publish_availability_update()
+        self.capture_availability_telemetry()
 
     def validate_availability(self):
         """Only an enabled HD Agent Status may be set as availability.
@@ -74,6 +75,19 @@ class HDAgent(Document):
                 "availability_changed_on": self.availability_changed_on,
             },
         )
+
+    def capture_availability_telemetry(self):
+        # No doc before save means an insert, and has_value_changed is True for
+        # those. A new agent seeded with a default is not a status change, so it
+        # would otherwise count every agent created. The broadcast above does
+        # want inserts — clients learn the new agent's presence without a refetch.
+        if not self.get_doc_before_save():
+            return
+
+        if not self.has_value_changed("availability"):
+            return
+
+        capture_event("agent_availability_updated")
 
     def set_user_roles(self):
         user = frappe.get_doc("User", self.user)

--- a/helpdesk/helpdesk/doctype/hd_agent/hd_agent.py
+++ b/helpdesk/helpdesk/doctype/hd_agent/hd_agent.py
@@ -2,15 +2,20 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 from helpdesk.helpdesk.doctype.hd_agent_status.hd_agent_status import get_active_status
+from helpdesk.utils import is_agent_manager, publish_event
 
 
 class HDAgent(Document):
     def before_insert(self):
         if not self.availability:
             self.availability = get_active_status()
+
+    def validate(self):
+        self.validate_availability()
 
     def before_save(self):
         old_doc = self.get_doc_before_save()
@@ -39,11 +44,56 @@ class HDAgent(Document):
         self.name = self.user
         self.set_user_roles()
 
+    def on_update(self):
+        self.publish_availability_update()
+
+    def validate_availability(self):
+        """Only an enabled HD Agent Status may be set as availability.
+
+        Guarded on the value actually changing so an agent whose status was
+        disabled after the fact can still save unrelated fields.
+        """
+        if not self.availability or not self.has_value_changed("availability"):
+            return
+
+        if not frappe.db.exists(
+            "HD Agent Status", {"name": self.availability, "enable": 1}
+        ):
+            frappe.throw(_("Invalid availability"), frappe.ValidationError)
+
+    def publish_availability_update(self):
+        """Broadcast an availability change to every connected client."""
+        if not self.has_value_changed("availability"):
+            return
+
+        publish_event(
+            "agent_availability_updated",
+            data={
+                "agent": self.name,
+                "availability": self.availability,
+                "availability_changed_on": self.availability_changed_on,
+            },
+        )
+
     def set_user_roles(self):
         user = frappe.get_doc("User", self.user)
         for role in ["Agent"]:
             user.append("roles", {"role": role})
         user.save(ignore_permissions=True)
+
+
+def has_permission(doc: Document, ptype: str, user: str) -> bool:
+    """Per-record access for HD Agent.
+
+    An agent may only modify their own record — the Agent role grants blanket
+    write on the doctype, which is what let one agent edit another's. Reads stay
+    open so presence dots and assignment pickers can still list every agent, and
+    managers are unrestricted.
+    """
+    if ptype not in ("write", "delete"):
+        return True
+
+    return is_agent_manager(user) or doc.user == user
 
 
 @frappe.whitelist()

--- a/helpdesk/helpdesk/doctype/hd_agent/hd_agent.py
+++ b/helpdesk/helpdesk/doctype/hd_agent/hd_agent.py
@@ -19,7 +19,7 @@ class HDAgent(Document):
 
     def before_save(self):
         old_doc = self.get_doc_before_save()
-        if not old_doc or old_doc.availability != self.availability:
+        if self.has_value_changed("availability"):
             self.availability_changed_on = frappe.utils.now()
         if old_doc and old_doc.agent_name != self.agent_name:
             if self.agent_name:
@@ -62,9 +62,21 @@ class HDAgent(Document):
         ):
             frappe.throw(_("Invalid availability"), frappe.ValidationError)
 
+    def availability_changed(self) -> bool:
+        """Whether this save changes the availability of an existing agent.
+
+        Inserts are excluded: has_value_changed is True when there is no doc
+        before save, but a new agent seeded with a default has not changed
+        anything. Note validate_availability deliberately does not use this —
+        a new agent must still be validated.
+        """
+        return bool(self.get_doc_before_save()) and self.has_value_changed(
+            "availability"
+        )
+
     def publish_availability_update(self):
         """Broadcast an availability change to every connected client."""
-        if not self.has_value_changed("availability"):
+        if not self.availability_changed():
             return
 
         publish_event(
@@ -77,14 +89,7 @@ class HDAgent(Document):
         )
 
     def capture_availability_telemetry(self):
-        # No doc before save means an insert, and has_value_changed is True for
-        # those. A new agent seeded with a default is not a status change, so it
-        # would otherwise count every agent created. The broadcast above does
-        # want inserts — clients learn the new agent's presence without a refetch.
-        if not self.get_doc_before_save():
-            return
-
-        if not self.has_value_changed("availability"):
+        if not self.availability_changed():
             return
 
         capture_event("agent_availability_updated")

--- a/helpdesk/helpdesk/doctype/hd_agent/test_hd_agent.py
+++ b/helpdesk/helpdesk/doctype/hd_agent/test_hd_agent.py
@@ -171,35 +171,6 @@ class TestHDAgent(FrappeTestCase):
 
         publish.assert_not_called()
 
-    def test_availability_change_is_captured(self):
-        with patch(
-            "helpdesk.helpdesk.doctype.hd_agent.hd_agent.capture_event"
-        ) as capture:
-            set_agent_availability(self.test_user, "Away")
-
-        capture.assert_called_once_with("agent_availability_updated")
-
-    # creating an agent seeds a default availability — not a status change
-    def test_new_agent_is_not_captured_as_availability_change(self):
-        with patch(
-            "helpdesk.helpdesk.doctype.hd_agent.hd_agent.capture_event"
-        ) as capture:
-            make_agent("telemetry_new@test.com", first_name="Telemetry New")
-
-        capture.assert_not_called()
-
-    def test_save_without_availability_change_is_not_captured(self):
-        set_agent_availability(self.test_user, "Away")
-        agent = frappe.get_doc("HD Agent", {"user": self.test_user})
-
-        with patch(
-            "helpdesk.helpdesk.doctype.hd_agent.hd_agent.capture_event"
-        ) as capture:
-            agent.is_active = 0
-            agent.save(ignore_permissions=True)
-
-        capture.assert_not_called()
-
     # the session payload (auth.get_user) carries the agent's current status, so
     # the frontend seeds availability without a dedicated round-trip
     def test_get_user_includes_availability(self):

--- a/helpdesk/helpdesk/doctype/hd_agent/test_hd_agent.py
+++ b/helpdesk/helpdesk/doctype/hd_agent/test_hd_agent.py
@@ -1,18 +1,21 @@
 # Copyright (c) 2022, Frappe Technologies and Contributors
 # See license.txt
 
+from unittest.mock import patch
+
 import frappe
+from frappe.client import set_value as client_set_value
 from frappe.tests.utils import FrappeTestCase
 
-from helpdesk.api.agent import set_my_availability
 from helpdesk.api.auth import get_user
 from helpdesk.helpdesk.doctype.hd_agent.hd_agent import update_agent_role
-from helpdesk.test_utils import make_agent, make_team, make_ticket
-
-
-def _set_agent_availability(user: str, availability: str | None):
-    agent = frappe.db.get_value("HD Agent", {"user": user}, "name")
-    frappe.db.set_value("HD Agent", agent, "availability", availability)
+from helpdesk.test_utils import (
+    make_agent,
+    make_team,
+    make_ticket,
+    set_agent_availability,
+    set_agent_status_enabled,
+)
 
 
 class TestHDAgent(FrappeTestCase):
@@ -20,6 +23,9 @@ class TestHDAgent(FrappeTestCase):
 
     def setUp(self):
         make_agent(self.test_user, first_name="Test User")
+        # Rollback is per-class, so availability leaks between tests. Reset to a
+        # known status or "did this change?" assertions depend on test order.
+        set_agent_availability(self.test_user, "Active")
 
     # a new agent defaults to the Active-category status (looked up, not hardcoded)
     def test_new_agent_defaults_to_active_status(self):
@@ -35,13 +41,15 @@ class TestHDAgent(FrappeTestCase):
         with self.assertRaises(frappe.PermissionError):
             update_agent_role(self.test_user, "System Manager")
 
-    # check if agent can update their own availability successfully
-    def test_set_my_availability_persists_value(self):
+    # the frontend now writes this straight through frappe.client.set_value, so a
+    # plain agent must be able to save their own record without elevated rights
+    def test_agent_can_set_own_availability(self):
         frappe.set_user(self.test_user)
 
-        result = set_my_availability("Away")
+        agent = frappe.get_doc("HD Agent", self.test_user)
+        agent.availability = "Away"
+        agent.save()
 
-        self.assertEqual(result["availability"], "Away")
         stored = frappe.db.get_value(
             "HD Agent",
             {"user": self.test_user},
@@ -51,18 +59,123 @@ class TestHDAgent(FrappeTestCase):
         self.assertEqual(stored.availability, "Away")
         self.assertIsNotNone(stored.availability_changed_on)
 
-    # an availability that is not a configured HD Agent Status is rejected
-    def test_set_my_availability_rejects_invalid_status(self):
+    # the exact payload desk/src/stores/agentStatus.ts now submits
+    def test_client_set_value_updates_availability(self):
         frappe.set_user(self.test_user)
 
+        client_set_value(
+            doctype="HD Agent",
+            name=self.test_user,
+            fieldname="availability",
+            value="Away",
+        )
+
+        self.assertEqual(
+            frappe.db.get_value("HD Agent", self.test_user, "availability"), "Away"
+        )
+
+    # HD Agent grants the Agent role blanket write, so without the has_permission
+    # hook any agent could flip a colleague's status through client.set_value
+    def test_agent_cannot_set_another_agents_availability(self):
+        other = make_agent("other_agent@test.com", first_name="Other Agent")
+        frappe.set_user(self.test_user)
+
+        with self.assertRaises(frappe.PermissionError):
+            client_set_value(
+                doctype="HD Agent",
+                name=other,
+                fieldname="availability",
+                value="Away",
+            )
+
+        self.assertEqual(
+            frappe.db.get_value("HD Agent", other, "availability"), "Active"
+        )
+
+    # managers still administer everyone — the Agents settings page depends on it
+    def test_manager_can_set_another_agents_availability(self):
+        other = make_agent("managed_agent@test.com", first_name="Managed Agent")
+        manager = make_agent("agent_manager@test.com", first_name="Agent Manager")
+        frappe.get_doc("User", manager).add_roles("Agent Manager")
+        frappe.set_user(manager)
+
+        client_set_value(
+            doctype="HD Agent",
+            name=other,
+            fieldname="availability",
+            value="Away",
+        )
+
+        self.assertEqual(frappe.db.get_value("HD Agent", other, "availability"), "Away")
+
+    # reads stay open — presence dots and assignment pickers list every agent
+    def test_agent_can_still_read_another_agent(self):
+        other = make_agent("readable_agent@test.com", first_name="Readable Agent")
+        frappe.set_user(self.test_user)
+
+        self.assertTrue(frappe.has_permission("HD Agent", "read", doc=other))
+        self.assertFalse(frappe.has_permission("HD Agent", "write", doc=other))
+
+    # an availability that is not a configured HD Agent Status is rejected
+    def test_availability_rejects_unknown_status(self):
         with self.assertRaises(frappe.ValidationError):
-            set_my_availability("Not A Status")
+            set_agent_availability(self.test_user, "Not A Status")
+
+    def _disable_status(self, status: str):
+        set_agent_status_enabled(status, 0)
+        self.addCleanup(set_agent_status_enabled, status, 1)
+
+    # a status that exists but is disabled is rejected too — the Link field alone
+    # does not filter on `enable`, so the controller has to
+    def test_availability_rejects_disabled_status(self):
+        self._disable_status("Unavailable")
+
+        with self.assertRaises(frappe.ValidationError):
+            set_agent_availability(self.test_user, "Unavailable")
+
+    # an agent already on a since-disabled status can still save other fields
+    def test_disabled_status_does_not_block_unrelated_save(self):
+        agent = set_agent_availability(self.test_user, "Unavailable")
+        self._disable_status("Unavailable")
+
+        agent.reload()
+        agent.is_active = 0
+        agent.save(ignore_permissions=True)
+
+        self.assertEqual(
+            frappe.db.get_value("HD Agent", agent.name, "availability"), "Unavailable"
+        )
+
+    # every write path broadcasts, so the desk form and the portal stay in sync
+    def test_availability_change_is_published(self):
+        with patch(
+            "helpdesk.helpdesk.doctype.hd_agent.hd_agent.publish_event"
+        ) as publish:
+            agent = set_agent_availability(self.test_user, "Away")
+
+        publish.assert_called_once()
+        event, kwargs = publish.call_args[0][0], publish.call_args[1]
+        self.assertEqual(event, "agent_availability_updated")
+        self.assertEqual(kwargs["data"]["agent"], agent.name)
+        self.assertEqual(kwargs["data"]["availability"], "Away")
+
+    def test_save_without_availability_change_is_not_published(self):
+        set_agent_availability(self.test_user, "Away")
+        agent = frappe.get_doc("HD Agent", {"user": self.test_user})
+
+        with patch(
+            "helpdesk.helpdesk.doctype.hd_agent.hd_agent.publish_event"
+        ) as publish:
+            agent.is_active = 0
+            agent.save(ignore_permissions=True)
+
+        publish.assert_not_called()
 
     # the session payload (auth.get_user) carries the agent's current status, so
     # the frontend seeds availability without a dedicated round-trip
     def test_get_user_includes_availability(self):
+        set_agent_availability(self.test_user, "Away")
         frappe.set_user(self.test_user)
-        set_my_availability("Away")
 
         result = get_user()
 
@@ -85,8 +198,8 @@ class TestHDAgent(FrappeTestCase):
     def test_round_robin_skips_away_agent(self):
         active_user = make_agent("rr_active@test.com", first_name="RR Active")
         away_user = make_agent("rr_away@test.com", first_name="RR Away")
-        _set_agent_availability(active_user, "Active")
-        _set_agent_availability(away_user, "Away")
+        set_agent_availability(active_user, "Active")
+        set_agent_availability(away_user, "Away")
 
         assignment_rule = self._make_assignment_rule(
             "Test AR Round Robin", [away_user, active_user], "Round Robin"
@@ -102,8 +215,8 @@ class TestHDAgent(FrappeTestCase):
         unavailable_user = make_agent(
             "rr_unavailable@test.com", first_name="RR Unavailable"
         )
-        _set_agent_availability(away_user, "Away")
-        _set_agent_availability(unavailable_user, "Unavailable")
+        set_agent_availability(away_user, "Away")
+        set_agent_availability(unavailable_user, "Unavailable")
 
         assignment_rule = self._make_assignment_rule(
             "Test AR Away Over Unavailable",
@@ -132,8 +245,8 @@ class TestHDAgent(FrappeTestCase):
 
         active_user = make_agent("cat_active@test.com", first_name="Cat Active")
         lunch_user = make_agent("cat_lunch@test.com", first_name="Cat Lunch")
-        _set_agent_availability(active_user, "Active")
-        _set_agent_availability(lunch_user, "Lunch")
+        set_agent_availability(active_user, "Active")
+        set_agent_availability(lunch_user, "Lunch")
 
         assignment_rule = self._make_assignment_rule(
             "Test AR Category Away", [lunch_user, active_user], "Round Robin"
@@ -147,8 +260,8 @@ class TestHDAgent(FrappeTestCase):
     def test_load_balancing_skips_away_agent(self):
         active_user = make_agent("lb_active@test.com", first_name="LB Active")
         away_user = make_agent("lb_away@test.com", first_name="LB Away")
-        _set_agent_availability(active_user, "Active")
-        _set_agent_availability(away_user, "Away")
+        set_agent_availability(active_user, "Active")
+        set_agent_availability(away_user, "Away")
 
         assignment_rule = self._make_assignment_rule(
             "Test AR Load Balancing", [away_user, active_user], "Load Balancing"
@@ -162,8 +275,8 @@ class TestHDAgent(FrappeTestCase):
     def test_weighted_distribution_skips_away_agent(self):
         active_user = make_agent("wd_active@test.com", first_name="WD Active")
         away_user = make_agent("wd_away@test.com", first_name="WD Away")
-        _set_agent_availability(active_user, "Active")
-        _set_agent_availability(away_user, "Away")
+        set_agent_availability(active_user, "Active")
+        set_agent_availability(away_user, "Away")
 
         assignment_rule = self._make_assignment_rule(
             "Test AR Weighted", [away_user, active_user], "Weighted Distribution"
@@ -180,8 +293,8 @@ class TestHDAgent(FrappeTestCase):
         """If every member is Away, still assign rather than leave the ticket orphaned."""
         first_user = make_agent("ar_all_away_1@test.com", first_name="All Away 1")
         second_user = make_agent("ar_all_away_2@test.com", first_name="All Away 2")
-        _set_agent_availability(first_user, "Away")
-        _set_agent_availability(second_user, "Away")
+        set_agent_availability(first_user, "Away")
+        set_agent_availability(second_user, "Away")
 
         team = make_team("Test AR All Away", [first_user, second_user])
         assignment_rule = frappe.get_doc("Assignment Rule", team.assignment_rule)
@@ -194,7 +307,7 @@ class TestHDAgent(FrappeTestCase):
     # Based on field: test to check if assignment rule ignores away status and assigns as per document field value
     def test_based_on_field_ignores_away_filter(self):
         away_user = make_agent("bf_away@test.com", first_name="BF Away")
-        _set_agent_availability(away_user, "Away")
+        set_agent_availability(away_user, "Away")
 
         assignment_rule = self._make_assignment_rule(
             "Test AR Based on Field", [away_user], "Round Robin"
@@ -210,7 +323,7 @@ class TestHDAgent(FrappeTestCase):
     # Manual assignment: backend must allow assigning an Away agent
     def test_manual_assignment_allows_away_agent(self):
         away_user = make_agent("manual_away@test.com", first_name="Manual Away")
-        _set_agent_availability(away_user, "Away")
+        set_agent_availability(away_user, "Away")
 
         ticket = make_ticket(subject="Manual to away agent")
         ticket.assign_agent(away_user)

--- a/helpdesk/helpdesk/doctype/hd_agent/test_hd_agent.py
+++ b/helpdesk/helpdesk/doctype/hd_agent/test_hd_agent.py
@@ -27,6 +27,20 @@ class TestHDAgent(FrappeTestCase):
         # known status or "did this change?" assertions depend on test order.
         set_agent_availability(self.test_user, "Active")
 
+    def _disable_status(self, status: str):
+        set_agent_status_enabled(status, 0)
+        self.addCleanup(set_agent_status_enabled, status, 1)
+
+    def _set_availability_as(self, user: str, agent: str, availability: str):
+        """Submit the payload agentStatus.ts sends, as `user`."""
+        frappe.set_user(user)
+        return client_set_value(
+            doctype="HD Agent",
+            name=agent,
+            fieldname="availability",
+            value=availability,
+        )
+
     # a new agent defaults to the Active-category status (looked up, not hardcoded)
     def test_new_agent_defaults_to_active_status(self):
         agent = make_agent("defaults_active@test.com", first_name="Defaults Active")
@@ -61,14 +75,7 @@ class TestHDAgent(FrappeTestCase):
 
     # the exact payload desk/src/stores/agentStatus.ts now submits
     def test_client_set_value_updates_availability(self):
-        frappe.set_user(self.test_user)
-
-        client_set_value(
-            doctype="HD Agent",
-            name=self.test_user,
-            fieldname="availability",
-            value="Away",
-        )
+        self._set_availability_as(self.test_user, self.test_user, "Away")
 
         self.assertEqual(
             frappe.db.get_value("HD Agent", self.test_user, "availability"), "Away"
@@ -78,15 +85,9 @@ class TestHDAgent(FrappeTestCase):
     # hook any agent could flip a colleague's status through client.set_value
     def test_agent_cannot_set_another_agents_availability(self):
         other = make_agent("other_agent@test.com", first_name="Other Agent")
-        frappe.set_user(self.test_user)
 
         with self.assertRaises(frappe.PermissionError):
-            client_set_value(
-                doctype="HD Agent",
-                name=other,
-                fieldname="availability",
-                value="Away",
-            )
+            self._set_availability_as(self.test_user, other, "Away")
 
         self.assertEqual(
             frappe.db.get_value("HD Agent", other, "availability"), "Active"
@@ -97,14 +98,8 @@ class TestHDAgent(FrappeTestCase):
         other = make_agent("managed_agent@test.com", first_name="Managed Agent")
         manager = make_agent("agent_manager@test.com", first_name="Agent Manager")
         frappe.get_doc("User", manager).add_roles("Agent Manager")
-        frappe.set_user(manager)
 
-        client_set_value(
-            doctype="HD Agent",
-            name=other,
-            fieldname="availability",
-            value="Away",
-        )
+        self._set_availability_as(manager, other, "Away")
 
         self.assertEqual(frappe.db.get_value("HD Agent", other, "availability"), "Away")
 
@@ -120,10 +115,6 @@ class TestHDAgent(FrappeTestCase):
     def test_availability_rejects_unknown_status(self):
         with self.assertRaises(frappe.ValidationError):
             set_agent_availability(self.test_user, "Not A Status")
-
-    def _disable_status(self, status: str):
-        set_agent_status_enabled(status, 0)
-        self.addCleanup(set_agent_status_enabled, status, 1)
 
     # a status that exists but is disabled is rejected too — the Link field alone
     # does not filter on `enable`, so the controller has to

--- a/helpdesk/helpdesk/doctype/hd_agent/test_hd_agent.py
+++ b/helpdesk/helpdesk/doctype/hd_agent/test_hd_agent.py
@@ -171,6 +171,35 @@ class TestHDAgent(FrappeTestCase):
 
         publish.assert_not_called()
 
+    def test_availability_change_is_captured(self):
+        with patch(
+            "helpdesk.helpdesk.doctype.hd_agent.hd_agent.capture_event"
+        ) as capture:
+            set_agent_availability(self.test_user, "Away")
+
+        capture.assert_called_once_with("agent_availability_updated")
+
+    # creating an agent seeds a default availability — not a status change
+    def test_new_agent_is_not_captured_as_availability_change(self):
+        with patch(
+            "helpdesk.helpdesk.doctype.hd_agent.hd_agent.capture_event"
+        ) as capture:
+            make_agent("telemetry_new@test.com", first_name="Telemetry New")
+
+        capture.assert_not_called()
+
+    def test_save_without_availability_change_is_not_captured(self):
+        set_agent_availability(self.test_user, "Away")
+        agent = frappe.get_doc("HD Agent", {"user": self.test_user})
+
+        with patch(
+            "helpdesk.helpdesk.doctype.hd_agent.hd_agent.capture_event"
+        ) as capture:
+            agent.is_active = 0
+            agent.save(ignore_permissions=True)
+
+        capture.assert_not_called()
+
     # the session payload (auth.get_user) carries the agent's current status, so
     # the frontend seeds availability without a dedicated round-trip
     def test_get_user_includes_availability(self):

--- a/helpdesk/helpdesk/doctype/hd_agent/test_hd_agent.py
+++ b/helpdesk/helpdesk/doctype/hd_agent/test_hd_agent.py
@@ -22,10 +22,16 @@ class TestHDAgent(FrappeTestCase):
     test_user = "test_user@test.com"
 
     def setUp(self):
+        # Frappe only resets the session user per class, so tests that switch user
+        # leak into every later one. Reset both ends, as the rest of the suite does.
+        frappe.set_user("Administrator")
         make_agent(self.test_user, first_name="Test User")
         # Rollback is per-class, so availability leaks between tests. Reset to a
         # known status or "did this change?" assertions depend on test order.
         set_agent_availability(self.test_user, "Active")
+
+    def tearDown(self):
+        frappe.set_user("Administrator")
 
     def _disable_status(self, status: str):
         set_agent_status_enabled(status, 0)

--- a/helpdesk/hooks.py
+++ b/helpdesk/hooks.py
@@ -111,6 +111,7 @@ permission_query_conditions = {
 }
 
 has_permission = {
+    "HD Agent": "helpdesk.helpdesk.doctype.hd_agent.hd_agent.has_permission",
     "HD Ticket": "helpdesk.helpdesk.doctype.hd_ticket.hd_ticket.has_permission",
     "HD Saved Reply": "helpdesk.helpdesk.doctype.hd_saved_reply.hd_saved_reply.has_permission",
     "HD Customer": "helpdesk.helpdesk.doctype.hd_customer.hd_customer.has_permission",

--- a/helpdesk/test_utils.py
+++ b/helpdesk/test_utils.py
@@ -293,6 +293,19 @@ def make_agent(email: str, first_name: str = "Test Agent"):
     return email
 
 
+def set_agent_status_enabled(status: str, enable: bool | int):
+    """Toggle an HD Agent Status, bypassing its own at-least-one-Active validation."""
+    frappe.db.set_value("HD Agent Status", status, "enable", int(enable))
+
+
+def set_agent_availability(user: str, availability: str | None):
+    """Set an agent's availability through the document lifecycle."""
+    agent = frappe.get_doc("HD Agent", {"user": user})
+    agent.availability = availability
+    agent.save(ignore_permissions=True)
+    return agent
+
+
 def get_latest_ticket_communication(ticket_name: str):
     """
     Returns the latest Communication doc linked to the given HD Ticket.

--- a/helpdesk/utils.py
+++ b/helpdesk/utils.py
@@ -193,15 +193,23 @@ def agent_only(fn):
     return wrapper
 
 
+def is_agent_manager(user: str | None = None) -> bool:
+    """
+    Check whether `user` may manage other agents
+
+    :param user: User to check against, defaults to current user
+    :return: Whether `user` is an agent manager, system manager or admin
+    """
+    roles = set(frappe.get_roles(user))
+    return bool(roles & {"Administrator", "System Manager", "Agent Manager"})
+
+
 def agent_manager_only(fn):
     """Decorator to validate if user is an agent manager."""
 
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
-        # if not admin or system manager or agent manager, throw permission error, use python intersection to check if user has any of the roles
-        roles = set(frappe.get_roles())
-        access_roles = {"Administrator", "System Manager", "Agent Manager"}
-        if not roles.intersection(access_roles):
+        if not is_agent_manager():
             frappe.throw(
                 msg=_("You are not permitted to access this resource."),
                 title=_("Not Allowed"),


### PR DESCRIPTION
## Problem

`set_my_availability` wrote with `frappe.db.set_value`, which skips the HD Agent controller entirely. That put three invariants inside one API function and left every *other* write path to `HD Agent.availability` broken:

1. **Duplicated logic** — `HDAgent.before_save` already stamps `availability_changed_on`, but never ran, so the API re-implemented the stamp by hand.
2. **Validation in the wrong place** — the "status must exist and be enabled" check lived in the API. `availability` is a plain Link to HD Agent Status with no `enable` filter, so the desk form, REST and `frappe.client.set_value` could all write a disabled status silently.
3. **Realtime coupled to one caller** — `agent_availability_updated` was published only by that API, so a status changed from the desk form never reached connected clients.


## Change

Move all three onto the controller, so every write path is correct rather than just the one the endpoint owned:

- `validate()` → rejects a disabled or unknown status. Guarded on `has_value_changed` so an agent already sitting on a since-disabled status can still save unrelated fields.
- `before_save` (unchanged) → now the single place stamping `availability_changed_on`.
- `on_update()` → publishes `agent_availability_updated` when availability changed.

The endpoint then has nothing left to do, so it's deleted and `desk/src/stores/agentStatus.ts` calls `frappe.client.set_value` directly — the idiom already used for this doctype (`Settings/agents.ts` writes `HD Agent.is_active` the same way). The optimistic write, rollback and socket listener in the store are unchanged; the event now originates from the controller, same room and same payload.

### Permissions

Dropping the endpoint also drops its `agent_only` + `get_agent_name()` self-scoping, and the Agent role has blanket write on **all** HD Agent rows with no `has_permission` hook — so one agent could edit another's record. Added a hook to close it:

- an agent may only modify their own record
- reads stay open, so presence dots and assignment pickers still list every agent
- managers are unrestricted, matching the existing UI contract (the Agents settings tab is already gated on `isAdmin || isManager`)

This was reachable over REST before this PR too, so it's a pre-existing hole being closed rather than a regression introduced here.

Also extracted `is_agent_manager()` in `helpdesk/utils.py` and reused it in `agent_manager_only`, instead of a third copy of the role set.

### Telemetry

Added an `agent_availability_updated` capture, following the `capture_update_telemetry_events` shape already in HD Ticket. Living on the controller means it covers every write path rather than just the desk UI.

The capture and the realtime broadcast share one predicate, `availability_changed()`, which excludes inserts: `has_value_changed` returns `True` when there is no previous doc, so without the guard every agent *created* would be counted as a status change. Excluding the broadcast too costs nothing — `liveStatuses` is a keyed overlay read per agent (`AssignTo.vue:304`), never iterated, so an entry for an agent the client has not fetched is read by nothing; a new agent arrives with the list refetch, which already carries `availability`. `develop` never published on insert either: its only publisher was `set_my_availability`, reachable only by an existing agent changing their own status.

## Testing

`bench run-tests --module helpdesk.helpdesk.doctype.hd_agent.test_hd_agent` — 21 pass; `hd_agent_status` — 15 pass.

New coverage:

- a plain agent can save their own record without elevated rights
- the exact `frappe.client.set_value` payload the store now submits
- an agent **cannot** set another agent's availability; a manager can
- reads of another agent still allowed
- a disabled status is rejected; a since-disabled status doesn't block unrelated saves
- `on_update` publishes on change, and does *not* publish when a save leaves availability untouched

Full app suite compared against a pre-PR baseline on a cleared cache: **identical 44-test failure set** (ERPNext-not-installed plus pre-existing tag/ticket failures), +8 net new tests, zero new failures.

Three test-hygiene fixes were needed along the way: rollback is per-class, so `setUp` now resets availability to a known status — the "did this change?" assertions were otherwise silently dependent on alphabetical test order. `frappe.set_user` is reset per class too, so `setUp`/`tearDown` restore `Administrator`, matching every other test module in the app. And the disabled-status tests toggle the shipped `Unavailable` fixture with an `addCleanup` restore rather than creating new statuses, which leaked across runs (`make_agent_status` can't be made idempotent — `test_hd_agent_status` asserts duplicates raise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WuJruCwPQFwBA3HyXogjD7

