### PR TITLE
fix(command-palette): rename saved reply group to Frequent replies

### DIFF
--- a/desk/src/components/command-palette/savedReplyCommands.ts
+++ b/desk/src/components/command-palette/savedReplyCommands.ts
@@ -83,7 +83,7 @@ function topSavedReplyCommands(ticketId: string): Command[] {
       title: reply.title,
       // Subtitle, not title prefix: a bare reply title at root reads as a ticket.
       subtitle: __(SUBTITLE),
-      group: "Most used",
+      group: "Frequent replies",
       icon: LucideMessageSquareQuote,
       hideWhenEmpty: true,
       weight: FLAT_OPTION_WEIGHT,


### PR DESCRIPTION
Renames the command palette group label for top saved replies from "Most used" to "Frequent replies", so the header says what the rows are.

**Test:** open the command palette on a ticket with a saved reply used 5+ times — the group header reads "Frequent replies".

🤖 Generated with [Claude Code](https://claude.com/claude-code)