### PR TITLE
fix(email): give agent replies their own Message-Id so threads hold

### DIFF
--- a/helpdesk/api/ticket.py
+++ b/helpdesk/api/ticket.py
@@ -8,23 +8,30 @@ from helpdesk.utils import agent_only, is_admin
 @agent_only
 def bulk_reply(ticket_ids: list, message: str, attachments: list | None = None):
 
-    link_attachments_to_tickets(attachments, ticket_ids)
-
     if not ticket_ids:
         return
 
-    ticket_ids = list(set(ticket_ids))  # Remove duplicates
+    # dedupe but keep the order the agent picked. set() orders by hash, which varies
+    # per process, and duplicates would attach the same file to a ticket twice
+    ticket_ids = list(dict.fromkeys(ticket_ids))
 
+    # Check every ticket before writing anything, so one ticket the agent cannot
+    # reply to does not leave the rest of the batch half done
+    tickets = []
     for ticket_id in ticket_ids:
         frappe.has_permission("HD Ticket", "write", doc=ticket_id, throw=True)
-        doc = frappe.get_doc("HD Ticket", ticket_id)
+        tickets.append(frappe.get_doc("HD Ticket", ticket_id))
+
+    link_attachments_to_tickets(attachments, ticket_ids)
+
+    for doc in tickets:
         try:
             doc.reply_via_agent(
                 message, to=doc.raised_by, attachments=attachments or []
             )
         except Exception as e:
             frappe.log_error(
-                title=f"Bulk reply failed for ticket {ticket_id}",
+                title=f"Bulk reply failed for ticket {doc.name}",
                 message=str(e),
             )
 

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -10,10 +10,11 @@ from frappe.core.page.permission_manager.permission_manager import remove
 from frappe.desk.form.assign_to import add as assign
 from frappe.desk.form.assign_to import clear as clear_all_assignments
 from frappe.desk.form.assign_to import get as get_assignees
+from frappe.email.email_body import get_message_id
 from frappe.model.document import Document
 from frappe.permissions import add_permission, update_permission_property
 from frappe.query_builder import DocType, Order
-from frappe.utils import add_to_date, cint, getdate, now_datetime
+from frappe.utils import add_to_date, cint, get_string_between, getdate, now_datetime
 from pypika.functions import Count
 from pypika.queries import Query
 from pypika.terms import Criterion
@@ -614,6 +615,27 @@ class HDTicket(Document):
         except Exception:
             return None
 
+    def get_last_threadable_communication(self):
+        """Newest communication on this ticket that can anchor an email thread.
+
+        Only communications with a stored `message_id` qualify. That column is what
+        frappe resolves `in_reply_to` against when setting the `In-Reply-To` header
+        (see `EmailQueue.prepare_email_content`), so a communication without one
+        cannot be replied to. Portal replies never sent an email and have no id;
+        skipping them keeps the chain intact across a portal message.
+        """
+        return frappe.db.get_value(
+            "Communication",
+            {
+                "reference_doctype": "HD Ticket",
+                "reference_name": str(self.name),
+                "message_id": ["is", "set"],
+            },
+            ["name", "message_id"],
+            order_by="creation desc",
+            as_dict=True,
+        )
+
     def last_communication_email(self):
         if not (communication := self.get_last_communication()):
             return
@@ -717,9 +739,17 @@ class HDTicket(Document):
             }
         )
 
-        last_communication = self.get_last_communication()
-        if last_communication and last_communication.message_id:
+        last_communication = self.get_last_threadable_communication()
+        if last_communication:
             communication.in_reply_to = last_communication.name
+
+        # Give this reply its own Message-Id so the *next* reply can point at it.
+        # frappe builds `In-Reply-To` by looking up `Communication.message_id` of the
+        # doc named in `in_reply_to`, so a reply without one is a dead end and the
+        # thread breaks after a single hop. Must be freshly generated per message —
+        # reusing the parent's id stamped every reply in a ticket with the same
+        # Message-Id, which is what helpdesk#2308 correctly removed.
+        communication.message_id = get_string_between("<", get_message_id(), ">")
 
         communication.insert(ignore_permissions=True)
         capture_event("agent_replied")
@@ -786,6 +816,10 @@ class HDTicket(Document):
                 subject=subject,
                 with_container=False,
                 in_reply_to=last_communication.name if last_communication else None,
+                # Must match what we stored above: the recipient has to actually
+                # receive this Message-Id for the next reply's `In-Reply-To` to
+                # resolve on their side.
+                message_id=communication.message_id,
             )
         except Exception as e:
             frappe.throw(str(e))

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -616,13 +616,10 @@ class HDTicket(Document):
             return None
 
     def _last_threadable_communication(self) -> str | None:
-        """Name of the newest communication that can anchor an email thread.
+        """Name of the newest communication that has a message_id.
 
-        Only communications with a stored `message_id` qualify: that column is what
-        frappe resolves `in_reply_to` against when setting the `In-Reply-To` header
-        (see `EmailQueue.prepare_email_content`), so one without an id is a dead end.
-        A customer's portal reply sent no email and has no id, so stepping over it
-        keeps the chain intact across it.
+        Frappe builds In-Reply-To from that field, so a communication without one
+        cannot be replied to. Portal replies sent no email and have none.
         """
         return frappe.db.get_value(
             "Communication",
@@ -740,10 +737,8 @@ class HDTicket(Document):
 
         communication.in_reply_to = self._last_threadable_communication()
 
-        # Minted per message so the *next* reply has something to point at, and only
-        # when we actually send: an id on a reply nobody received would anchor the
-        # next one to a Message-Id that reached no mailbox. Never reuse the parent's
-        # id - that stamped every reply in a ticket with the same one (helpdesk#2308).
+        # Each reply gets its own id so the next reply can point at it. Only set it
+        # when we really send, or the next reply points at an email nobody received.
         should_send_email = not skip_email_workflow and frappe.db.get_single_value(
             "HD Settings", "enable_reply_email_via_agent"
         )
@@ -812,10 +807,8 @@ class HDTicket(Document):
                 sender=reply_to_email,
                 subject=subject,
                 with_container=False,
-                # in_reply_to resolves through the name of the communication which holds
                 in_reply_to=communication.in_reply_to,
-                # Must match what we stored: the recipient has to receive this exact
-                # Message-Id for the next reply's `In-Reply-To` to resolve for them.
+                # send the id we stored, so the next reply can point back at it
                 message_id=communication.message_id,
             )
         except Exception as e:

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -737,13 +737,22 @@ class HDTicket(Document):
 
         communication.in_reply_to = self._last_threadable_communication()
 
-        # Each reply gets its own id so the next reply can point at it. Only set it
-        # when we really send, or the next reply points at an email nobody received.
+        # Each reply needs its own id so the next reply can point at it. It is saved
+        # further down, once the mail has actually gone out - see the send below.
         should_send_email = not skip_email_workflow and frappe.db.get_single_value(
             "HD Settings", "enable_reply_email_via_agent"
         )
+        message_id = None
         if should_send_email:
-            communication.message_id = get_string_between("<", get_message_id(), ">")
+            # check before writing anything, so a reply we already know we cannot
+            # send is never saved at all
+            if not sender_email:
+                frappe.throw(
+                    _(
+                        "Unable to send email. Please setup default outgoing email account."
+                    )
+                )
+            message_id = get_string_between("<", get_message_id(), ">")
 
         communication.insert(ignore_permissions=True)
         capture_event("agent_replied")
@@ -758,11 +767,6 @@ class HDTicket(Document):
 
         if not should_send_email:
             return
-
-        if not sender_email:
-            frappe.throw(
-                _("Unable to send email. Please setup default outgoing email account.")
-            )
 
         message = self.parse_content(message)
 
@@ -790,7 +794,7 @@ class HDTicket(Document):
             send_now = True
 
         try:
-            frappe.sendmail(
+            queued = frappe.sendmail(
                 attachments=_attachments,
                 bcc=bcc,
                 cc=cc,
@@ -808,11 +812,19 @@ class HDTicket(Document):
                 subject=subject,
                 with_container=False,
                 in_reply_to=communication.in_reply_to,
-                # send the id we stored, so the next reply can point back at it
-                message_id=communication.message_id,
+                message_id=message_id,
             )
         except Exception as e:
             frappe.throw(str(e))
+
+        # Save the id only now that the mail is queued carrying it, so the next reply
+        # can point back at it. A reply we could not hand off keeps no id and so can
+        # never be answered. sendmail returns nothing when it queued nothing at all.
+        # A queued mail that later fails to deliver still keeps its id - undoing that
+        # would need to watch the Email Queue, and a bounce does not make the id
+        # unusable anyway.
+        if queued:
+            communication.db_set("message_id", message_id)
 
     @frappe.whitelist()
     # flake8: noqa

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -737,15 +737,14 @@ class HDTicket(Document):
 
         communication.in_reply_to = self._last_threadable_communication()
 
-        # Each reply needs its own id so the next reply can point at it. It is saved
-        # further down, once the mail has actually gone out - see the send below.
+        # Each reply needs its own id so the next reply can point at it. Saved after
+        # the send below, not here.
         should_send_email = not skip_email_workflow and frappe.db.get_single_value(
             "HD Settings", "enable_reply_email_via_agent"
         )
         message_id = None
         if should_send_email:
-            # check before writing anything, so a reply we already know we cannot
-            # send is never saved at all
+            # fail before writing anything we would have to undo
             if not sender_email:
                 frappe.throw(
                     _(
@@ -794,7 +793,7 @@ class HDTicket(Document):
             send_now = True
 
         try:
-            queued = frappe.sendmail(
+            queued_email = frappe.sendmail(
                 attachments=_attachments,
                 bcc=bcc,
                 cc=cc,
@@ -817,13 +816,9 @@ class HDTicket(Document):
         except Exception as e:
             frappe.throw(str(e))
 
-        # Save the id only now that the mail is queued carrying it, so the next reply
-        # can point back at it. A reply we could not hand off keeps no id and so can
-        # never be answered. sendmail returns nothing when it queued nothing at all.
-        # A queued mail that later fails to deliver still keeps its id - undoing that
-        # would need to watch the Email Queue, and a bounce does not make the id
-        # unusable anyway.
-        if queued:
+        # Save the id now that a mail is queued carrying it. A reply we could not hand
+        # off keeps no id, so it can never become the next reply's parent.
+        if queued_email:
             communication.db_set("message_id", message_id)
 
     @frappe.whitelist()

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -749,7 +749,14 @@ class HDTicket(Document):
         # thread breaks after a single hop. Must be freshly generated per message —
         # reusing the parent's id stamped every reply in a ticket with the same
         # Message-Id, which is what helpdesk#2308 correctly removed.
-        communication.message_id = get_string_between("<", get_message_id(), ">")
+        # Only when this reply is actually emailed: an id stored for a reply nobody
+        # received would anchor the next one to a Message-Id that reached no mailbox,
+        # which fails exactly like storing no id at all.
+        should_send_email = not skip_email_workflow and frappe.db.get_single_value(
+            "HD Settings", "enable_reply_email_via_agent"
+        )
+        if should_send_email:
+            communication.message_id = get_string_between("<", get_message_id(), ">")
 
         communication.insert(ignore_permissions=True)
         capture_event("agent_replied")
@@ -762,9 +769,7 @@ class HDTicket(Document):
             self.attach_file_with_doc("HD Ticket", self.name, file_url)
             _attachments.append({"file_url": file_url})
 
-        if skip_email_workflow or not frappe.db.get_single_value(
-            "HD Settings", "enable_reply_email_via_agent"
-        ):
+        if not should_send_email:
             return
 
         if not sender_email:

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -615,14 +615,14 @@ class HDTicket(Document):
         except Exception:
             return None
 
-    def get_last_threadable_communication(self):
-        """Newest communication on this ticket that can anchor an email thread.
+    def _last_threadable_communication(self) -> str | None:
+        """Name of the newest communication that can anchor an email thread.
 
-        Only communications with a stored `message_id` qualify. That column is what
+        Only communications with a stored `message_id` qualify: that column is what
         frappe resolves `in_reply_to` against when setting the `In-Reply-To` header
-        (see `EmailQueue.prepare_email_content`), so a communication without one
-        cannot be replied to. Portal replies never sent an email and have no id;
-        skipping them keeps the chain intact across a portal message.
+        (see `EmailQueue.prepare_email_content`), so one without an id is a dead end.
+        A customer's portal reply sent no email and has no id, so stepping over it
+        keeps the chain intact across it.
         """
         return frappe.db.get_value(
             "Communication",
@@ -631,9 +631,8 @@ class HDTicket(Document):
                 "reference_name": str(self.name),
                 "message_id": ["is", "set"],
             },
-            ["name", "message_id"],
+            "name",
             order_by="creation desc",
-            as_dict=True,
         )
 
     def last_communication_email(self):
@@ -739,19 +738,12 @@ class HDTicket(Document):
             }
         )
 
-        last_communication = self.get_last_threadable_communication()
-        if last_communication:
-            communication.in_reply_to = last_communication.name
+        communication.in_reply_to = self._last_threadable_communication()
 
-        # Give this reply its own Message-Id so the *next* reply can point at it.
-        # frappe builds `In-Reply-To` by looking up `Communication.message_id` of the
-        # doc named in `in_reply_to`, so a reply without one is a dead end and the
-        # thread breaks after a single hop. Must be freshly generated per message —
-        # reusing the parent's id stamped every reply in a ticket with the same
-        # Message-Id, which is what helpdesk#2308 correctly removed.
-        # Only when this reply is actually emailed: an id stored for a reply nobody
-        # received would anchor the next one to a Message-Id that reached no mailbox,
-        # which fails exactly like storing no id at all.
+        # Minted per message so the *next* reply has something to point at, and only
+        # when we actually send: an id on a reply nobody received would anchor the
+        # next one to a Message-Id that reached no mailbox. Never reuse the parent's
+        # id - that stamped every reply in a ticket with the same one (helpdesk#2308).
         should_send_email = not skip_email_workflow and frappe.db.get_single_value(
             "HD Settings", "enable_reply_email_via_agent"
         )
@@ -820,10 +812,10 @@ class HDTicket(Document):
                 sender=reply_to_email,
                 subject=subject,
                 with_container=False,
-                in_reply_to=last_communication.name if last_communication else None,
-                # Must match what we stored above: the recipient has to actually
-                # receive this Message-Id for the next reply's `In-Reply-To` to
-                # resolve on their side.
+                # in_reply_to resolves through the name of the communication which holds
+                in_reply_to=communication.in_reply_to,
+                # Must match what we stored: the recipient has to receive this exact
+                # Message-Id for the next reply's `In-Reply-To` to resolve for them.
                 message_id=communication.message_id,
             )
         except Exception as e:

--- a/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
@@ -44,20 +44,6 @@ def get_ticket_obj():
     }
 
 
-def get_ticket_communications(ticket_name: str):
-    """Communications on a ticket, oldest first.
-
-    `get_latest_ticket_communication` uses limit=1 with no order_by, so it cannot be
-    used to tell one reply from the next.
-    """
-    return frappe.get_all(
-        "Communication",
-        filters={"reference_doctype": "HD Ticket", "reference_name": ticket_name},
-        fields=["name", "message_id", "in_reply_to"],
-        order_by="creation asc",
-    )
-
-
 non_agent = "non_agent@test.com"
 agent = "agent@test.com"
 agent2 = "agent2@test.com"
@@ -1149,40 +1135,28 @@ class TestHDTicket(IntegrationTestCase):
             self.assertEqual(communication_doc.bcc, bcc_recipient)
 
     def test_agent_reply_stores_unique_message_id_and_threads_onto_previous(self):
-        """Every agent reply needs its own Message-Id and must point at the one before it.
-
-        Regression guard: helpdesk#2308 removed `communication.message_id`, while
-        frappe#32651 builds the `In-Reply-To` header from exactly that column. With the
-        column empty each reply is a dead end, so every reply arrives as a new thread.
-        """
+        """Without this, every agent reply arrives as a new thread."""
         ticket = make_ticket()
 
         ticket.reply_via_agent(message="First reply")
-        first = get_ticket_communications(ticket.name)[-1]
+        first = get_latest_ticket_communication(ticket.name)
 
+        ticket.reload()
         ticket.reply_via_agent(message="Second reply")
-        second = get_ticket_communications(ticket.name)[-1]
+        second = get_latest_ticket_communication(ticket.name)
 
-        self.assertTrue(first.message_id, "reply must store its own Message-Id")
-        self.assertTrue(second.message_id, "reply must store its own Message-Id")
+        self.assertTrue(first.message_id, "reply must store its own id")
+        self.assertTrue(second.message_id, "reply must store its own id")
         self.assertNotEqual(
-            first.message_id,
-            second.message_id,
-            "each message needs a unique Message-Id, never a copy of the parent's",
+            first.message_id, second.message_id, "ids must not be reused"
         )
         self.assertEqual(
-            second.in_reply_to,
-            first.name,
-            "second reply must thread onto the first",
+            second.in_reply_to, first.name, "second reply follows the first"
         )
 
     def test_agent_reply_sends_the_message_id_it_stored(self):
-        """The Message-Id on the wire must equal the one stored on the Communication.
-
-        Storing an id without passing it to sendmail looks correct but fails silently:
-        the recipient receives a queue-generated id while the next reply's `In-Reply-To`
-        names the stored one, which no mail client has ever seen.
-        """
+        """If we store an id but send a different one, the customer never has the id
+        the next reply points at."""
         email_account = frappe.get_doc(
             {
                 "doctype": "Email Account",
@@ -1214,7 +1188,7 @@ class TestHDTicket(IntegrationTestCase):
                 "HD Settings", "enable_reply_email_via_agent", reply_email_enabled
             )
 
-        communication = get_ticket_communications(ticket.name)[-1]
+        communication = get_latest_ticket_communication(ticket.name)
         self.assertTrue(sendmail.called, "reply should have been emailed")
         self.assertEqual(
             sendmail.call_args.kwargs.get("message_id"),
@@ -1223,33 +1197,78 @@ class TestHDTicket(IntegrationTestCase):
         )
 
     def test_portal_reply_does_not_break_agent_reply_threading(self):
-        """A customer's portal reply sent no email, so it cannot anchor a thread.
-
-        It must be skipped when picking a parent, otherwise a single portal message
-        breaks threading for every agent reply after it.
-        """
+        """A portal reply sent no email, so replies after it must skip past it."""
         ticket = make_ticket()
 
         ticket.reply_via_agent(message="First reply")
-        first = get_ticket_communications(ticket.name)[-1]
+        first = get_latest_ticket_communication(ticket.name)
 
         # each of these is its own request in production; replying updates the ticket row
         ticket.reload()
         ticket.create_communication_via_contact(message="Customer portal reply")
-        portal = get_ticket_communications(ticket.name)[-1]
-        self.assertFalse(
-            portal.message_id, "portal replies send no email, so they store no id"
-        )
+        portal = get_latest_ticket_communication(ticket.name)
+        self.assertFalse(portal.message_id, "portal replies store no id")
 
         ticket.reload()
         ticket.reply_via_agent(message="Second reply")
-        second = get_ticket_communications(ticket.name)[-1]
+        second = get_latest_ticket_communication(ticket.name)
 
         self.assertEqual(
-            second.in_reply_to,
-            first.name,
-            "should thread onto the last emailed reply, not the portal message",
+            second.in_reply_to, first.name, "follows the last emailed reply"
         )
+
+    def test_agent_replies_thread_on_a_ticket_created_by_email(self):
+        """A ticket raised by email: the first reply answers the customer's mail,
+        and later replies follow the reply before them."""
+        ticket = make_ticket()
+        customer_email = frappe.get_doc(
+            {
+                "doctype": "Communication",
+                "communication_type": "Communication",
+                "communication_medium": "Email",
+                "sent_or_received": "Received",
+                "reference_doctype": "HD Ticket",
+                "reference_name": ticket.name,
+                "subject": f"Re: {ticket.subject}",
+                # frappe stores incoming ids without the angle brackets
+                "message_id": "customer-mail-1@example.com",
+                "content": "my printer is broken",
+            }
+        ).insert(ignore_permissions=True)
+
+        ticket.reload()
+        ticket.reply_via_agent(message="First reply")
+        first = get_latest_ticket_communication(ticket.name)
+
+        ticket.reload()
+        ticket.reply_via_agent(message="Second reply")
+        second = get_latest_ticket_communication(ticket.name)
+
+        self.assertEqual(
+            first.in_reply_to, customer_email.name, "first reply answers the customer"
+        )
+        self.assertEqual(
+            second.in_reply_to, first.name, "second reply follows the first"
+        )
+        self.assertNotEqual(
+            first.message_id, second.message_id, "ids must not be reused"
+        )
+
+    def test_reply_stores_no_message_id_when_email_is_off(self):
+        """No email was sent, so there is no id the customer could ever reply to."""
+        previous = frappe.db.get_single_value(
+            "HD Settings", "enable_reply_email_via_agent"
+        )
+        frappe.db.set_single_value("HD Settings", "enable_reply_email_via_agent", 0)
+        try:
+            ticket = make_ticket()
+            ticket.reply_via_agent(message="Not emailed")
+            self.assertFalse(get_latest_ticket_communication(ticket.name).message_id)
+        finally:
+            # rollback is per test class, so restore or later tests inherit this
+            frappe.db.set_single_value(
+                "HD Settings", "enable_reply_email_via_agent", previous
+            )
 
     def test_security_unauthorized_reply_via_agent(self):
         ticket = make_ticket()

--- a/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
@@ -2,6 +2,7 @@
 # See license.txt
 
 from datetime import timedelta
+from unittest.mock import patch
 
 import frappe
 from frappe.tests import IntegrationTestCase
@@ -41,6 +42,20 @@ def get_ticket_obj():
         "subject": "Test Ticket",
         "description": "Test Ticket Description",
     }
+
+
+def get_ticket_communications(ticket_name: str):
+    """Communications on a ticket, oldest first.
+
+    `get_latest_ticket_communication` uses limit=1 with no order_by, so it cannot be
+    used to tell one reply from the next.
+    """
+    return frappe.get_all(
+        "Communication",
+        filters={"reference_doctype": "HD Ticket", "reference_name": ticket_name},
+        fields=["name", "message_id", "in_reply_to"],
+        order_by="creation asc",
+    )
 
 
 non_agent = "non_agent@test.com"
@@ -1132,6 +1147,109 @@ class TestHDTicket(IntegrationTestCase):
             self.assertEqual(communication_doc.cc, cc_recipient)
         if hasattr(communication_doc, "bcc") and communication_doc.bcc:
             self.assertEqual(communication_doc.bcc, bcc_recipient)
+
+    def test_agent_reply_stores_unique_message_id_and_threads_onto_previous(self):
+        """Every agent reply needs its own Message-Id and must point at the one before it.
+
+        Regression guard: helpdesk#2308 removed `communication.message_id`, while
+        frappe#32651 builds the `In-Reply-To` header from exactly that column. With the
+        column empty each reply is a dead end, so every reply arrives as a new thread.
+        """
+        ticket = make_ticket()
+
+        ticket.reply_via_agent(message="First reply")
+        first = get_ticket_communications(ticket.name)[-1]
+
+        ticket.reply_via_agent(message="Second reply")
+        second = get_ticket_communications(ticket.name)[-1]
+
+        self.assertTrue(first.message_id, "reply must store its own Message-Id")
+        self.assertTrue(second.message_id, "reply must store its own Message-Id")
+        self.assertNotEqual(
+            first.message_id,
+            second.message_id,
+            "each message needs a unique Message-Id, never a copy of the parent's",
+        )
+        self.assertEqual(
+            second.in_reply_to,
+            first.name,
+            "second reply must thread onto the first",
+        )
+
+    def test_agent_reply_sends_the_message_id_it_stored(self):
+        """The Message-Id on the wire must equal the one stored on the Communication.
+
+        Storing an id without passing it to sendmail looks correct but fails silently:
+        the recipient receives a queue-generated id while the next reply's `In-Reply-To`
+        names the stored one, which no mail client has ever seen.
+        """
+        email_account = frappe.get_doc(
+            {
+                "doctype": "Email Account",
+                "email_account_name": "Threading Test",
+                "email_id": "threading-test@example.com",
+                "enable_outgoing": 1,
+                "smtp_server": "smtp.example.com",
+            }
+        ).insert(ignore_if_duplicate=True)
+
+        reply_email_enabled = frappe.db.get_single_value(
+            "HD Settings", "enable_reply_email_via_agent"
+        )
+        frappe.db.set_single_value("HD Settings", "enable_reply_email_via_agent", 1)
+        try:
+            ticket = make_ticket()
+            with patch("frappe.sendmail") as sendmail:
+                ticket.reply_via_agent(
+                    message="Reply",
+                    to="customer@test.com",
+                    from_email={
+                        "email_account": email_account.name,
+                        "email_id": email_account.email_id,
+                    },
+                )
+        finally:
+            # rollback is per test class, so restore or later tests inherit this
+            frappe.db.set_single_value(
+                "HD Settings", "enable_reply_email_via_agent", reply_email_enabled
+            )
+
+        communication = get_ticket_communications(ticket.name)[-1]
+        self.assertTrue(sendmail.called, "reply should have been emailed")
+        self.assertEqual(
+            sendmail.call_args.kwargs.get("message_id"),
+            communication.message_id,
+            "wire Message-Id must match the one stored on the Communication",
+        )
+
+    def test_portal_reply_does_not_break_agent_reply_threading(self):
+        """A customer's portal reply sent no email, so it cannot anchor a thread.
+
+        It must be skipped when picking a parent, otherwise a single portal message
+        breaks threading for every agent reply after it.
+        """
+        ticket = make_ticket()
+
+        ticket.reply_via_agent(message="First reply")
+        first = get_ticket_communications(ticket.name)[-1]
+
+        # each of these is its own request in production; replying updates the ticket row
+        ticket.reload()
+        ticket.create_communication_via_contact(message="Customer portal reply")
+        portal = get_ticket_communications(ticket.name)[-1]
+        self.assertFalse(
+            portal.message_id, "portal replies send no email, so they store no id"
+        )
+
+        ticket.reload()
+        ticket.reply_via_agent(message="Second reply")
+        second = get_ticket_communications(ticket.name)[-1]
+
+        self.assertEqual(
+            second.in_reply_to,
+            first.name,
+            "should thread onto the last emailed reply, not the portal message",
+        )
 
     def test_security_unauthorized_reply_via_agent(self):
         ticket = make_ticket()

--- a/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
@@ -44,6 +44,20 @@ def get_ticket_obj():
     }
 
 
+def sent_replies(ticket_name: str):
+    """Agent replies saved on a ticket, oldest first."""
+    return frappe.get_all(
+        "Communication",
+        filters={
+            "reference_doctype": "HD Ticket",
+            "reference_name": ticket_name,
+            "sent_or_received": "Sent",
+        },
+        fields=["name", "message_id", "in_reply_to"],
+        order_by="creation asc",
+    )
+
+
 non_agent = "non_agent@test.com"
 agent = "agent@test.com"
 agent2 = "agent2@test.com"
@@ -1138,11 +1152,11 @@ class TestHDTicket(IntegrationTestCase):
         """Without this, every agent reply arrives as a new thread."""
         ticket = make_ticket()
 
-        ticket.reply_via_agent(message="First reply")
+        ticket.reply_via_agent(message="First reply", to="customer@test.com")
         first = get_latest_ticket_communication(ticket.name)
 
         ticket.reload()
-        ticket.reply_via_agent(message="Second reply")
+        ticket.reply_via_agent(message="Second reply", to="customer@test.com")
         second = get_latest_ticket_communication(ticket.name)
 
         self.assertTrue(first.message_id, "reply must store its own id")
@@ -1200,7 +1214,7 @@ class TestHDTicket(IntegrationTestCase):
         """A portal reply sent no email, so replies after it must skip past it."""
         ticket = make_ticket()
 
-        ticket.reply_via_agent(message="First reply")
+        ticket.reply_via_agent(message="First reply", to="customer@test.com")
         first = get_latest_ticket_communication(ticket.name)
 
         # each of these is its own request in production; replying updates the ticket row
@@ -1210,7 +1224,7 @@ class TestHDTicket(IntegrationTestCase):
         self.assertFalse(portal.message_id, "portal replies store no id")
 
         ticket.reload()
-        ticket.reply_via_agent(message="Second reply")
+        ticket.reply_via_agent(message="Second reply", to="customer@test.com")
         second = get_latest_ticket_communication(ticket.name)
 
         self.assertEqual(
@@ -1237,11 +1251,11 @@ class TestHDTicket(IntegrationTestCase):
         ).insert(ignore_permissions=True)
 
         ticket.reload()
-        ticket.reply_via_agent(message="First reply")
+        ticket.reply_via_agent(message="First reply", to="customer@test.com")
         first = get_latest_ticket_communication(ticket.name)
 
         ticket.reload()
-        ticket.reply_via_agent(message="Second reply")
+        ticket.reply_via_agent(message="Second reply", to="customer@test.com")
         second = get_latest_ticket_communication(ticket.name)
 
         self.assertEqual(
@@ -1252,6 +1266,53 @@ class TestHDTicket(IntegrationTestCase):
         )
         self.assertNotEqual(
             first.message_id, second.message_id, "ids must not be reused"
+        )
+
+    def test_reply_that_fails_to_send_stores_no_message_id(self):
+        """The reply stays visible, but with no id it can never be replied to."""
+        ticket = make_ticket()
+
+        with patch("frappe.sendmail", side_effect=Exception("smtp is down")):
+            with self.assertRaises(Exception):
+                ticket.reply_via_agent(message="Never sent", to="customer@test.com")
+
+        replies = sent_replies(ticket.name)
+        self.assertEqual(len(replies), 1, "the attempt stays on the ticket")
+        self.assertFalse(replies[0].message_id, "a reply nobody got has no id")
+
+    def test_reply_stores_no_message_id_when_nothing_was_queued(self):
+        """sendmail returns nothing when it queued nothing, which is not a send."""
+        ticket = make_ticket()
+
+        with patch("frappe.sendmail", return_value=None):
+            ticket.reply_via_agent(message="Queued nothing", to="customer@test.com")
+
+        self.assertFalse(get_latest_ticket_communication(ticket.name).message_id)
+
+    def test_next_reply_threads_onto_the_last_one_that_sent(self):
+        """The bug this guards: a reply that failed to send must not be answered,
+        or the customer gets a reply pointing at an email they never received."""
+        ticket = make_ticket()
+        real_sendmail = frappe.sendmail
+
+        ticket.reply_via_agent(message="First reply", to="customer@test.com")
+        first = get_latest_ticket_communication(ticket.name)
+
+        ticket.reload()
+        with patch("frappe.sendmail", side_effect=Exception("smtp is down")):
+            with self.assertRaises(Exception):
+                ticket.reply_via_agent(
+                    message="Second reply, never sent", to="customer@test.com"
+                )
+
+        ticket.reload()
+        with patch("frappe.sendmail", side_effect=real_sendmail):
+            ticket.reply_via_agent(message="Third reply", to="customer@test.com")
+        third = get_latest_ticket_communication(ticket.name)
+
+        self.assertTrue(first.message_id, "the first reply did send")
+        self.assertEqual(
+            third.in_reply_to, first.name, "skips the reply that never went out"
         )
 
     def test_reply_stores_no_message_id_when_email_is_off(self):
@@ -1651,6 +1712,51 @@ class TestHDTicket(IntegrationTestCase):
         )
         for file in files:
             frappe.delete_doc("File", file)
+
+    def test_bulk_reply_writes_nothing_if_one_ticket_is_off_limits(self):
+        """Everything is checked before anything is written, so a ticket the agent
+        cannot reply to stops the batch instead of half completing it."""
+        frappe.set_user(agent)
+        allowed = make_ticket(raised_by="customer1@test.com")
+        forbidden = make_ticket(raised_by="customer2@test.com")
+
+        def deny_forbidden(*args, **kwargs):
+            if kwargs.get("doc") == forbidden.name:
+                raise frappe.PermissionError
+            return True
+
+        with patch("frappe.has_permission", side_effect=deny_forbidden):
+            with self.assertRaises(frappe.PermissionError):
+                bulk_reply(
+                    ticket_ids=[allowed.name, forbidden.name], message="Test Message"
+                )
+
+        self.assertFalse(
+            sent_replies(allowed.name), "no ticket may be replied to before all pass"
+        )
+
+    def test_bulk_reply_replies_once_per_duplicated_ticket(self):
+        """Ids are deduped before anything is written, so a ticket listed twice gets
+        one reply and one copy of each file."""
+        frappe.set_user(agent)
+        file1 = upload_test_file("outlook.png")
+        ticket = make_ticket(raised_by="customer1@test.com")
+
+        bulk_reply(
+            ticket_ids=[ticket.name, ticket.name],
+            message="Test Message",
+            attachments=[file1],
+        )
+
+        self.assertEqual(len(sent_replies(ticket.name)), 1, "one reply, not two")
+        self.assertEqual(
+            frappe.db.count(
+                "File",
+                {"attached_to_doctype": "HD Ticket", "attached_to_name": ticket.name},
+            ),
+            1,
+            "one copy of the file, not two",
+        )
 
     def test_auto_close_respects_inactivity_cutoff_boundary(self):
         """`close_tickets_after_n_days` closes a ticket whose last communication is


### PR DESCRIPTION
## What's wrong

Every email carries a unique id (`Message-Id`). A reply points back at the previous message's id using an `In-Reply-To` header — that's how Gmail and Outlook keep a conversation together.

Agent replies were going out with no `In-Reply-To` at all. So every reply arrived as a brand new conversation in the customer's mailbox. One ticket with five replies became five separate email threads.

Measured on our own instance over one week, agent replies on HD Tickets:

| | |
|---|---|
| replies sent | 1,911 |
| with a threading header | 159 (8%) |
| carrying an id the next reply could use | ~0 |

> If you try to reproduce this on Gmail you may not see it. Every reply has an identical subject, and Gmail also groups by subject, so it usually still looks like one conversation. Outlook relies on the headers, which is where it was reported.

## Why

Two changes landed 77 minutes apart on 2025-05-23:

- **frappe#32651** made the `In-Reply-To` header come from `Communication.message_id`.
- **#2308** deleted the code that filled `Communication.message_id` in.

Each was correct on its own. Together they left that column always empty, so no reply could ever be the parent of the next one. #2308 was right about what it removed — that code copied the parent's id onto every reply, so all replies in a ticket shared a single id.

It stayed hidden for 14 months because incoming mail still landed on the right ticket (frappe checks the Email Queue for that, not just Communication). Nothing looked broken from the agent side. The damage was only ever visible in the customer's mailbox.

Different from #3215, which fixed the *inbound* direction — matching an arriving email to its ticket. This is the outbound header.

## The fix

- Give every agent reply its own id, and send that same id.
- Save the id only once the mail has actually been handed off. A reply that failed to send keeps no id, so the next reply can never point at an email nobody received.
- Choose the parent from the newest reply that has an id, so a portal message — which sends no email — doesn't break the chain.

Not a revert of #2308: the id is generated fresh per message, never copied from the parent.

### Bulk reply

A single reply that fails cleans itself up — the whole request rolls back. Bulk reply catches the failure and only logs it, so the row would have stayed behind with an id the customer never got, and the next reply would have threaded onto it. Saving the id after the send covers that too.

Two unrelated problems in the same function, fixed while there: attachments were linked to tickets before any permission check ran, and the same ticket sent twice in one request produced duplicate files. It now checks every ticket first, then attaches, then replies.

## Side effect

Sending an explicit id means frappe stops adding its `isnotification` header. That header has one reader in the framework, which sets a flag used only by `notify_unreplied()` — off by default and never enabled by helpdesk. Core already omits it for sent mail. Reversible with one kwarg if it ever matters.

## Tests

Ten added. This path had none, which is how it went unnoticed.

- a ticket raised by email — the first reply answers the customer, later replies follow the one before them
- two replies get different ids, and the second points at the first
- the id we send matches the id we saved
- a portal message in the middle doesn't break the chain
- no id is saved when email is off, when the send failed, or when nothing was queued (three tests)
- a reply that follows a failed one threads onto the last reply that actually sent
- bulk reply to a ticket the agent can't write to writes nothing at all
- bulk reply with the same ticket twice replies once, with no duplicate files

`test_hd_ticket`: **64 of 66**. The two failures are `test_hold_time_resolution_time_with_holiday*`, which depend on today's date and fail the same way without this branch. Each new test was verified failing against the code it guards.

## Not included

`References`, the other threading header, is still never sent — frappe's `add_headers` forces an `X-` prefix, so it can't be injected app-side. `In-Reply-To` alone is a valid chain. Worth measuring against Outlook before adding more.

Still to do: an end-to-end check on a bench with real outgoing mail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
