### PR TITLE
chore: sync locale files from develop to main-hotfix

### DIFF
--- a/helpdesk/locale/ar.po
+++ b/helpdesk/locale/ar.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-15 18:50\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-29 21:57\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Arabic\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr ""
@@ -108,14 +108,6 @@ msgstr ""
 msgid "A workday with this name already exists"
 msgstr ""
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr "واجهة برمجة التطبيقات"
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr ""
@@ -132,7 +124,7 @@ msgstr ""
 msgid "Account"
 msgstr "حساب"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr ""
 
@@ -152,11 +144,9 @@ msgstr "حدث"
 msgid "Action Required"
 msgstr ""
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr ""
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "الإجراءات"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr ""
 msgid "Active"
 msgstr "نشط"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr ""
 
@@ -175,7 +165,7 @@ msgid "Active: The agent is available and working.<br>\n"
 "Unavailable: The agent is off and unavailable."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "نشاط"
@@ -193,10 +183,11 @@ msgid "Add Column"
 msgstr "إضافة عمود"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "إضافة تصفية..."
 
@@ -206,6 +197,10 @@ msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
 msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:148
@@ -244,7 +239,7 @@ msgstr "إضافة الشرط"
 msgid "Add condition group"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "إضافة عامل تصفية"
 
@@ -278,6 +273,12 @@ msgstr ""
 msgid "Add to Holidays"
 msgstr "أضف إلى الإجازات"
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr ""
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr ""
@@ -295,17 +296,14 @@ msgid "Administrator"
 msgstr "مدير"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -316,6 +314,7 @@ msgstr "مدير"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -335,6 +334,7 @@ msgstr ""
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -342,6 +342,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -376,18 +377,9 @@ msgstr ""
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "الكل"
 
@@ -508,6 +500,14 @@ msgstr ""
 msgid "Are you sure you want to delete these articles?"
 msgstr ""
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr ""
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr ""
@@ -543,6 +543,10 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
 msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
@@ -595,16 +599,11 @@ msgstr ""
 msgid "Assign ticket"
 msgstr ""
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr ""
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -618,7 +617,7 @@ msgstr "المُحال إليه"
 msgid "Assignee Rules"
 msgstr "قواعد المكلف إليه"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr ""
 
@@ -626,14 +625,14 @@ msgstr ""
 msgid "Assignees"
 msgstr "المكلفين"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "Assignment"
-msgstr "مهمة"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:122
 msgid "Assignment Condition"
@@ -692,10 +691,6 @@ msgstr ""
 msgid "Assignment rule {0} updated successfully."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -711,10 +706,6 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
-msgstr ""
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
 msgstr ""
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
@@ -766,7 +757,7 @@ msgid "Automation"
 msgstr "التشغيل الآلي"
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr ""
@@ -802,7 +793,7 @@ msgstr "متوسط وقت الاستجابة"
 msgid "Average Time Metrics"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr ""
 
@@ -810,24 +801,36 @@ msgstr ""
 msgid "Average response and resolution metrics not available"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
 msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
@@ -840,11 +843,11 @@ msgstr ""
 msgid "Avg. resolution time"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr ""
 
@@ -867,11 +870,6 @@ msgstr ""
 msgid "Base Support Rotation"
 msgstr ""
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "الرابط الأساسي"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -885,11 +883,11 @@ msgstr "بناءً على سياسة الموارد البشرية الخاصة 
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr "بناءً على سياسة الموارد البشرية الخاصة بك، حدد تاريخ بدء فترة تخصيص الإجازة الخاصة بك"
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr ""
 
@@ -944,11 +942,6 @@ msgstr ""
 msgid "Busy"
 msgstr "مشغول"
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "زر"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr "ملف CSV"
@@ -973,19 +966,31 @@ msgstr ""
 msgid "Caller"
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr "مكالمات هاتفية"
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr ""
 
@@ -1025,7 +1030,7 @@ msgstr ""
 msgid "Cannot merge General category"
 msgstr ""
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr ""
 
@@ -1050,7 +1055,7 @@ msgstr ""
 #: desk/src/pages/knowledge-base/Article.vue:335
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:266
 msgid "Category created successfully."
-msgstr ""
+msgstr "تم إنشاء الفئة بنجاح."
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:337
 msgid "Category deleted successfully."
@@ -1071,13 +1076,13 @@ msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:305
 msgid "Category updated successfully."
-msgstr ""
+msgstr "تم تحديث الفئة بنجاح."
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr ""
 
@@ -1085,7 +1090,7 @@ msgstr ""
 msgid "Change"
 msgstr "تغيير"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "تغيير كلمة المرور"
@@ -1098,9 +1103,8 @@ msgstr ""
 msgid "Change language of the application."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
@@ -1123,7 +1127,7 @@ msgstr ""
 msgid "Change timezone of the application."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr ""
 
@@ -1136,7 +1140,7 @@ msgstr ""
 msgid "Child field"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr ""
 
@@ -1189,7 +1193,7 @@ msgstr ""
 msgid "Clear Table"
 msgstr "مسح الجدول"
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr ""
 
@@ -1204,6 +1208,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
 msgstr "انقر على \"إضافة إلى العطلات\". سيؤدي هذا إلى ملء جدول العطلات بجميع التواريخ التي تقع ضمن العطلة الأسبوعية المحددة. كرر العملية لإضافة تواريخ جميع عطلاتك الأسبوعية."
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:47
@@ -1223,7 +1231,7 @@ msgstr ""
 msgid "Closed"
 msgstr "مغلق"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr ""
 
@@ -1250,7 +1258,7 @@ msgstr "الأعمدة"
 msgid "Comma separated emails to invite."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr ""
 
@@ -1283,7 +1291,7 @@ msgstr ""
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "تعليقات"
@@ -1296,6 +1304,11 @@ msgstr "الاتصالات"
 msgid "Communication ID is required"
 msgstr ""
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
+msgstr "شركة"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
 msgstr "أكتمل"
@@ -1307,7 +1320,7 @@ msgstr "أكتمل"
 msgid "Condition"
 msgstr "الحالة"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr ""
 
@@ -1331,6 +1344,10 @@ msgstr ""
 msgid "Configure your telephony settings."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1356,10 +1373,11 @@ msgstr ""
 msgid "Connect your support email"
 msgstr ""
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1373,26 +1391,30 @@ msgstr "اتصال"
 msgid "Contact HTML"
 msgstr "الاتصال HTML"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
 msgstr ""
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
 msgstr "جهات الاتصال"
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
+msgstr ""
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
 #. Label of the content (Text Editor) field in DocType 'HD Article'
@@ -1415,7 +1437,7 @@ msgstr ""
 msgid "Copy ticket id"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr ""
 
@@ -1423,7 +1445,11 @@ msgstr ""
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr ""
 
@@ -1431,11 +1457,20 @@ msgstr ""
 msgid "Could not send feedback email,due to: {0}"
 msgstr ""
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "الدولة"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1446,9 +1481,13 @@ msgstr "انشاء"
 msgid "Create & invite a contact"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
-msgstr "إنشاء اتصال جديد"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
 msgid "Create View"
@@ -1482,12 +1521,6 @@ msgstr ""
 msgid "Creating a ticket"
 msgstr ""
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr ""
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr ""
@@ -1512,12 +1545,21 @@ msgid "Custom Views"
 msgstr ""
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
 msgstr "العميل"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
+msgstr ""
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1528,17 +1570,33 @@ msgstr "اسم العميل"
 msgid "Customer Portal"
 msgstr ""
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
-msgstr "تم إنشاء الحرفاء بنجاح."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr "نوع العميل"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
 msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
+msgstr "العملاء"
 
 #: desk/src/components/layouts/Sidebar.vue:595
 msgid "Customers & Contacts"
@@ -1565,6 +1623,8 @@ msgstr "أزرق سماوي"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "خطر"
@@ -1665,18 +1725,26 @@ msgstr ""
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr ""
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "حذف"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1692,6 +1760,10 @@ msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
+msgstr ""
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
 msgstr ""
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
@@ -1740,7 +1812,7 @@ msgstr ""
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1826,7 +1898,12 @@ msgstr ""
 msgid "Document Type"
 msgstr "نوع الوثيقة"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr ""
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "شبكة النطاق"
@@ -1867,6 +1944,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
@@ -1917,7 +1998,8 @@ msgstr ""
 msgid "Easily invite new agents, managers, or admins."
 msgstr ""
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1925,6 +2007,14 @@ msgstr "تصحيح"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
 msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:70
@@ -1944,10 +2034,10 @@ msgstr ""
 msgid "Edit your email account"
 msgstr ""
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "البريد الإلكتروني"
 
@@ -1975,9 +2065,10 @@ msgstr ""
 msgid "Email Content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
-msgstr "البريد الإلكتروني"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
+msgstr "عنوان الايميل"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
 #. Settings'
@@ -2002,22 +2093,22 @@ msgstr ""
 msgid "Email account updated successfully"
 msgstr ""
 
-#: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
-msgid "Email settings updated successfully."
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr ""
+#: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
+msgid "Email settings updated successfully."
+msgstr "تم تحديث إعدادات البريد الإلكتروني بنجاح."
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "رسائل البريد الإلكتروني"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr ""
 
@@ -2055,8 +2146,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr ""
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2081,8 +2170,6 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2105,20 +2192,24 @@ msgstr ""
 msgid "Enter a name for this HD Service Holiday List."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr ""
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr ""
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
 msgstr ""
 
 #: helpdesk/api/knowledge_base.py:86
@@ -2129,22 +2220,18 @@ msgstr ""
 msgid "Error processing email at index {0}, message: {1}"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr ""
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "حدث خطأ أثناء الاتصال بحساب البريد الإلكتروني {0}"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr ""
 
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
 msgstr "تفوق"
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
+msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
 #: desk/src/components/Settings/Telephony/Telephony.vue:96
@@ -2172,11 +2259,6 @@ msgstr ""
 msgid "Export Type"
 msgstr "نوع التصدير"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr ""
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2184,6 +2266,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "باءت بالفشل"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2218,11 +2304,11 @@ msgstr ""
 msgid "Failed to save Twilio settings"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr ""
 
@@ -2251,6 +2337,7 @@ msgstr ""
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2288,12 +2375,16 @@ msgstr ""
 msgid "Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
+msgstr ""
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
 msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
@@ -2338,13 +2429,14 @@ msgid "Field dependency updated successfully."
 msgstr ""
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "الحقول"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "فلاتر"
@@ -2354,7 +2446,8 @@ msgstr "فلاتر"
 msgid "Find out all of the variables that can be used in the content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "الاسم الأول"
 
@@ -2362,6 +2455,10 @@ msgstr "الاسم الأول"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
 msgstr "أجاب أولا على"
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
+msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -2385,10 +2482,6 @@ msgstr "وقت الاستجابة الأول"
 #. Name of a report
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -2480,6 +2573,10 @@ msgstr ""
 msgid "Go to Ticket #{0}"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr ""
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2509,19 +2606,12 @@ msgid "Group By Field"
 msgstr ""
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr "ضيف"
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
 msgstr ""
 
 #. Name of a DocType
@@ -2554,24 +2644,36 @@ msgstr ""
 msgid "HD Comment Reaction"
 msgstr ""
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr ""
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr ""
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
 msgstr ""
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
 msgstr ""
 
 #. Name of a DocType
@@ -2592,21 +2694,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
 msgstr ""
 
 #. Name of a DocType
@@ -2648,11 +2735,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
 msgstr ""
 
 #. Name of a DocType
@@ -2750,12 +2832,6 @@ msgstr ""
 msgid "Helpdesk"
 msgstr ""
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr ""
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2772,11 +2848,6 @@ msgstr ""
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
 msgstr "إخفاء "
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr ""
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
@@ -2846,15 +2917,8 @@ msgstr ""
 msgid "ID"
 msgstr "هوية شخصية"
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "عنوان IP"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2941,6 +3005,11 @@ msgstr "صندوق الوارد"
 msgid "Incoming"
 msgstr "الوارد"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr "فرد"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr "بدأت"
@@ -2954,7 +3023,7 @@ msgstr ""
 msgid "Instantly send e-mail"
 msgstr ""
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "عدم كفاية الإذن {0}"
 
@@ -2968,12 +3037,12 @@ msgstr ""
 msgid "Introduction"
 msgstr "مقدمة"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
@@ -2982,22 +3051,42 @@ msgstr ""
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr ""
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr ""
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
 msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
@@ -3008,13 +3097,30 @@ msgstr ""
 msgid "Invite agents"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
-msgstr ""
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
+msgstr "دعوة كمستخدم"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
 msgstr "الدعوة عن طريق البريد الإلكتروني"
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr "دعوة"
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
+msgstr ""
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -3030,6 +3136,11 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "افتراضي"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr ""
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3057,6 +3168,10 @@ msgstr ""
 #. Label of the setup_complete (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
 msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:114
@@ -3093,11 +3208,9 @@ msgstr "اختصارات لوحة المفاتيح"
 msgid "Knowledge Base"
 msgstr "قاعدة المعرفة"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3131,9 +3244,9 @@ msgstr ""
 msgid "Last 3 Months"
 msgstr "آخر 3 أشهر"
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr ""
 
@@ -3174,7 +3287,8 @@ msgstr ""
 msgid "Last Month"
 msgstr "الشهر الماضي"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "اسم العائلة"
 
@@ -3183,24 +3297,33 @@ msgstr "اسم العائلة"
 msgid "Last Week"
 msgstr "الاسبوع الماضي"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr ""
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
 msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
+msgstr "اخير"
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -3216,26 +3339,6 @@ msgstr ""
 #. 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
-msgstr ""
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "حلقة الوصل"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr "خيارات الارتباط"
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -3264,6 +3367,8 @@ msgstr ""
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "تحميل المزيد"
 
@@ -3286,6 +3391,8 @@ msgstr ""
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr "شعار"
@@ -3324,7 +3431,7 @@ msgstr ""
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr ""
 
@@ -3334,7 +3441,7 @@ msgstr ""
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:25
 msgid "Manage your email signature."
-msgstr ""
+msgstr "إدارة توقيع البريد الإلكتروني الخاص بك."
 
 #: desk/src/components/Settings/Preferences/Preferences.vue:2
 msgid "Manage your personal preferences."
@@ -3343,6 +3450,10 @@ msgstr ""
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
+msgstr "مدير"
 
 #: desk/src/pages/MobileNotifications.vue:11
 #: desk/src/pages/MobileNotifications.vue:14
@@ -3396,6 +3507,20 @@ msgstr ""
 msgid "Mobile App Installation"
 msgstr ""
 
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr "رقم الجوال"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr "رقم الهاتف المحمول"
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr ""
+
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
 #. List'
@@ -3436,7 +3561,7 @@ msgid "My Tickets"
 msgstr ""
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3447,8 +3572,9 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3457,6 +3583,10 @@ msgstr "اسم"
 #. Label of the name_weight (Int) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
 msgstr ""
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
@@ -3469,10 +3599,18 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "أبداً"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3581,11 +3719,11 @@ msgstr "لا يوجد رد"
 msgid "No Data Found"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr ""
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr ""
 
@@ -3597,8 +3735,14 @@ msgstr ""
 msgid "No SLA found"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
 msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
@@ -3633,19 +3777,27 @@ msgstr ""
 msgid "No changes made"
 msgstr "لم يتم إجراء أي تغييرات"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr ""
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr ""
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr ""
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
@@ -3657,13 +3809,17 @@ msgstr ""
 msgid "No feedback"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:94
 msgid "No members found"
-msgstr ""
+msgstr "لم يتم العثور على أعضاء"
 
 #: desk/src/pages/MobileNotifications.vue:68
 msgid "No new notifications"
@@ -3697,12 +3853,17 @@ msgstr ""
 msgid "No recently assigned tickets"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr ""
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
 msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
@@ -3710,6 +3871,7 @@ msgstr ""
 msgid "No saved replies found"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr ""
@@ -3730,7 +3892,11 @@ msgstr ""
 msgid "No tickets selected"
 msgstr ""
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr ""
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "غير مسموح"
 
@@ -3742,7 +3908,7 @@ msgstr ""
 msgid "Not Saved"
 msgstr "لم يتم الحفظ"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "غير محدد"
 
@@ -3781,11 +3947,6 @@ msgstr ""
 msgid "On Hold Since"
 msgstr "معلق منذ"
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr ""
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr ""
@@ -3815,6 +3976,10 @@ msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
@@ -3904,7 +4069,12 @@ msgstr ""
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr "شراكة"
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "كلمة السر"
 
@@ -3918,7 +4088,7 @@ msgstr ""
 
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:87
 msgid "Password updated successfully."
-msgstr ""
+msgstr "تم تحديث كلمة المرور بنجاح."
 
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:117
 msgid "Passwords do not match"
@@ -3942,6 +4112,7 @@ msgid "Pending"
 msgstr "معلق"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr ""
 
@@ -3951,19 +4122,19 @@ msgstr ""
 msgid "Pending Tickets"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr ""
 
@@ -3984,13 +4155,14 @@ msgstr "الشخصية"
 msgid "Personal mobile no"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "هاتف"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
 msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
@@ -4047,7 +4219,7 @@ msgstr ""
 msgid "Please enter a valid phone number"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr ""
 
@@ -4090,34 +4262,15 @@ msgstr "الرجاء اختيار يوم العطلة الاسبوعي"
 msgid "Policy name"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
 msgstr ""
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr "وظيفة الوصف"
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr "قائمة مفاتيح مسار البريد"
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr "Post Post String"
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
-msgstr "عنوان العنوان الرئيسي"
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:10
@@ -4151,14 +4304,32 @@ msgstr "معاينة"
 msgid "Previous ticket"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "أساسي"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "جهة الاتصال الرئيسية"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr ""
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr "أولويات"
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4166,9 +4337,10 @@ msgstr "أولويات"
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4248,17 +4420,6 @@ msgstr ""
 msgid "Quarterly"
 msgstr "فصلي"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "خيارات الاستعلام"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr "سلسلة مسار الاستعلام"
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "قائمة الانتظار"
@@ -4281,14 +4442,14 @@ msgstr ""
 msgid "Rate this ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr ""
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4384,8 +4545,15 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "حذف"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4395,9 +4563,18 @@ msgstr ""
 msgid "Remove Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr "حذف الصورة"
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
 msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
@@ -4417,6 +4594,15 @@ msgstr ""
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
 msgstr ""
 
 #. Option in a Select field in the tickets Web Form
@@ -4456,16 +4642,13 @@ msgstr ""
 msgid "Reply on a ticket"
 msgstr ""
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr ""
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
 msgstr ""
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
@@ -4486,6 +4669,7 @@ msgid "Reset to Default"
 msgstr ""
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr "قرار"
@@ -4539,18 +4723,6 @@ msgstr "الإستجابة"
 msgid "Response By"
 msgstr "الرد بواسطة"
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr "خيارات الاستجابة"
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr "الاستجابة نتيجة المسار الرئيسي"
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr "لا يمكن أن يكون وقت الاستجابة {0} للأولوية في الصف {1} أكبر من وقت الحل."
@@ -4593,37 +4765,33 @@ msgstr ""
 msgid "Restrict visibility to these teams"
 msgstr ""
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr "حقل معاينة النتيجة"
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr "النتيجة مجال التوجيه"
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr "النتيجة عنوان الحقل"
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
 msgstr "التعليقات"
 
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:215
 msgid "Ringing"
 msgstr "رنين"
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "صلاحية"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr ""
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4722,9 +4890,9 @@ msgstr "السبت"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4800,17 +4968,19 @@ msgstr ""
 msgid "Search Score"
 msgstr ""
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr "Search Param Name"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "حقول البحث..."
 
@@ -4850,6 +5020,7 @@ msgstr "بحث..."
 msgid "Searched for:"
 msgstr ""
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr "جاري البحث..."
@@ -4868,6 +5039,10 @@ msgstr "حدد"
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
 msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
@@ -4890,6 +5065,10 @@ msgstr "حدد أولوية افتراضية."
 msgid "Select a rating"
 msgstr ""
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr ""
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4901,6 +5080,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
+msgstr ""
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
@@ -4927,6 +5110,10 @@ msgstr ""
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
 msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
@@ -4967,13 +5154,17 @@ msgstr "اسم مستوى الخدمة"
 msgid "Service not supported"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "مجموعة"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:4
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
@@ -4984,12 +5175,21 @@ msgstr ""
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr "قم بتعيين وقت الاستجابة للأولوية {0} في الصف {1}."
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr ""
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr ""
 
@@ -4999,9 +5199,9 @@ msgstr ""
 
 #: desk/src/components/Settings/Sla/SlaHolidays.vue:9
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
-msgstr ""
+msgstr "قم بتعيين أيام العمل وساعات العمل والعطلات عن طريق تحديد جدول محدد مسبقًا أو إنشاء جدول جديد."
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr ""
 
@@ -5035,7 +5235,7 @@ msgstr ""
 #: desk/src/components/Settings/EmailNotifications/ReplyViaAgent.vue:47
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:77
 msgid "Settings updated successfully."
-msgstr ""
+msgstr "تم تحديث الإعدادات بنجاح."
 
 #. Label of the setup_section (Section Break) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -5135,23 +5335,6 @@ msgstr ""
 msgid "Sort"
 msgstr ""
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr "المصدر DocType"
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "اسم المصدر"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr "نوع المصدر"
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr ""
@@ -5196,6 +5379,8 @@ msgstr ""
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5262,6 +5447,7 @@ msgstr ""
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5373,21 +5559,16 @@ msgstr "نظام"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5426,8 +5607,6 @@ msgstr ""
 msgid "Teal"
 msgstr ""
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5438,7 +5617,6 @@ msgstr ""
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5544,6 +5722,10 @@ msgstr ""
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr ""
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr ""
@@ -5554,6 +5736,10 @@ msgstr "عطلة على {0} ليست بين من تاريخ وإلى تاريخ"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
@@ -5576,6 +5762,14 @@ msgstr ""
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr ""
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr ""
@@ -5583,6 +5777,10 @@ msgstr ""
 #: desk/src/components/ticket/TicketMergeModal.vue:79
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
 msgstr ""
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
@@ -5652,7 +5850,7 @@ msgstr "الخميس"
 msgid "Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr ""
 
@@ -5666,6 +5864,10 @@ msgstr ""
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
+msgstr ""
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
 msgstr ""
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
@@ -5725,7 +5927,7 @@ msgstr ""
 msgid "Ticket Summary"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr ""
 
@@ -5758,7 +5960,7 @@ msgstr ""
 msgid "Ticket merged successfully."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr ""
 
@@ -5793,12 +5995,6 @@ msgstr ""
 msgid "Ticket to merged with is required"
 msgstr ""
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr ""
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr ""
@@ -5810,12 +6006,15 @@ msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr ""
 
@@ -5827,19 +6026,19 @@ msgstr ""
 msgid "Tickets assigned to you in the last 7 days"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr ""
 
@@ -5856,6 +6055,7 @@ msgid "Tickets that are awaiting your response"
 msgstr ""
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr ""
 
@@ -5945,19 +6145,19 @@ msgstr ""
 msgid "Total Ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr ""
 
@@ -5989,6 +6189,10 @@ msgstr "النوع"
 msgid "Type a message"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr ""
@@ -5998,7 +6202,7 @@ msgstr ""
 msgid "URL/Method"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr ""
 
@@ -6032,6 +6236,8 @@ msgid "Unpublish"
 msgstr "إلغاء النشر"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr ""
 
@@ -6048,6 +6254,10 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:214
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
+msgstr ""
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
@@ -6076,10 +6286,13 @@ msgstr "تحميل"
 msgid "Upload Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
 msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
+msgstr "تحميل صُورة"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
 msgid "Uploading {0}%"
@@ -6088,17 +6301,13 @@ msgstr ""
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6110,6 +6319,10 @@ msgstr "المستعمل"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
 msgstr "وقت قرار المستخدم"
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
+msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
 msgid "User Signup"
@@ -6128,7 +6341,7 @@ msgstr "المستخدمين"
 msgid "Valid From"
 msgstr "صالح من تاريخ"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "القيمة"
 
@@ -6257,19 +6470,23 @@ msgstr "سنويا"
 msgid "Yellow"
 msgstr "أصفر"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr ""
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr ""
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr ""
 
@@ -6297,6 +6514,14 @@ msgstr ""
 msgid "You do not have permission to access Assignment Rules"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr ""
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr ""
@@ -6319,6 +6544,14 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:46
@@ -6349,7 +6582,7 @@ msgstr "أنشأ"
 msgid "customize {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr "أيام"
 
@@ -6371,7 +6604,7 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:475
 msgid "good"
-msgstr ""
+msgstr "جيد"
 
 #. Option for the 'Type' (Select) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -6400,7 +6633,7 @@ msgstr ""
 msgid "here."
 msgstr ""
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr "ساعات"
 
@@ -6408,7 +6641,7 @@ msgstr "ساعات"
 msgid "in"
 msgstr "في"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "الآن فقط"
 
@@ -6428,7 +6661,7 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:479
 msgid "poor"
-msgstr ""
+msgstr "ضعيف"
 
 #: desk/src/pages/knowledge-base/Article.vue:197
 msgid "published by"
@@ -6441,7 +6674,11 @@ msgstr ""
 msgid "purple"
 msgstr "أرجواني"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr "التعليقات"
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr ""
 
@@ -6458,7 +6695,7 @@ msgstr ""
 msgid "to enable this integration."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr ""
 
@@ -6466,12 +6703,32 @@ msgstr ""
 msgid "views"
 msgstr "المشاهدات"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr ""
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
 msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:307
@@ -6498,7 +6755,7 @@ msgstr ""
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr ""
 

--- a/helpdesk/locale/bg.po
+++ b/helpdesk/locale/bg.po
@@ -3,9 +3,9 @@ msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
 "POT-Creation-Date: 2026-06-28 11:13+0000\n"
-"PO-Revision-Date: 2026-06-29 21:58\n"
+"PO-Revision-Date: 2026-06-29 21:57\n"
 "Last-Translator: hello@frappe.io\n"
-"Language-Team: Hindi\n"
+"Language-Team: Bulgarian\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,14 +13,14 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Crowdin-Project: frappe\n"
 "X-Crowdin-Project-ID: 639578\n"
-"X-Crowdin-Language: hi\n"
+"X-Crowdin-Language: bg\n"
 "X-Crowdin-File: /[frappe.helpdesk] develop/helpdesk/locale/main.pot\n"
 "X-Crowdin-File-ID: 118\n"
-"Language: hi_IN\n"
+"Language: bg_BG\n"
 
 #: desk/src/components/CommentBox.vue:14
 msgid " commented"
-msgstr " टिप्पणी की"
+msgstr ""
 
 #: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
@@ -41,7 +41,7 @@ msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:116
 msgid "- Ticket Reopen Status<br>"
-msgstr "- टिकट पुनः खोलने की स्थिति<br>"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:92
 msgid "- {0} as Default Status<br>"
@@ -49,7 +49,7 @@ msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:94
 msgid "- {0} as Reopen Status<br>"
-msgstr "- {0} पुनः खोलने की स्थिति<br> के रूप में"
+msgstr ""
 
 #. Description of the 'Feedback' (Select) field in DocType 'HD Article
 #. Feedback'
@@ -60,7 +60,7 @@ msgstr ""
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:178
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:196
 msgid "1 Year"
-msgstr "1 वर्ष"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.py:154
 msgid "1 person reacted to your comment"
@@ -69,13 +69,13 @@ msgstr ""
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:176
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:188
 msgid "3 Months"
-msgstr "3 महीने"
+msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:177
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:183
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:192
 msgid "6 Months"
-msgstr "6 महीने"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:117
 msgid "<br>Please update HD Settings to use a different status before disabling this status."
@@ -102,7 +102,7 @@ msgstr ""
 
 #: desk/src/pages/ticket/TicketNew.vue:69
 msgid "A short description"
-msgstr "एक संक्षिप्त विवरण"
+msgstr ""
 
 #: desk/src/components/Settings/Sla/Modals/WorkDayModal.vue:268
 msgid "A workday with this name already exists"
@@ -118,15 +118,15 @@ msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:262
 msgid "Access only this team's tickets"
-msgstr "केवल इसी टीम के टिकटों तक पहुंच प्राप्त करें"
+msgstr ""
 
 #: desk/src/components/Settings/SettingsModal.vue:19
 msgid "Account"
-msgstr "खाता"
+msgstr ""
 
 #: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
-msgstr "खाता जानकारी और सुरक्षा"
+msgstr ""
 
 #. Label of the acknowledgement_section (Section Break) field in DocType 'HD
 #. Settings'
@@ -138,21 +138,21 @@ msgstr ""
 #. Label of the action (Small Text) field in DocType 'HD Ticket Activity'
 #: helpdesk/helpdesk/doctype/hd_ticket_activity/hd_ticket_activity.json
 msgid "Action"
-msgstr "कार्रवाई"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.py:24
 msgid "Action Required"
-msgstr "कार्रवाई आवश्यक है"
+msgstr ""
 
 #: desk/src/pages/contact/Contact.vue:303
 msgid "Actions"
-msgstr "कार्रवाई"
+msgstr ""
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 msgid "Active"
-msgstr "सक्रिय"
+msgstr ""
 
 #: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
@@ -176,7 +176,7 @@ msgstr ""
 
 #: desk/src/pages/knowledge-base/Article.vue:643
 msgid "Add Category"
-msgstr "श्रेणी जोड़ना"
+msgstr ""
 
 #: desk/src/components/view-controls/ColumnSettings.vue:69
 msgid "Add Column"
@@ -286,14 +286,14 @@ msgstr ""
 #. Label of the about (Code) field in DocType 'HD Ticket Template'
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Additional Information"
-msgstr "अतिरिक्त जानकारी"
+msgstr ""
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Administrator"
-msgstr "प्रशासक"
+msgstr ""
 
 #. Name of a role
 #. Label of a Link in the Helpdesk Workspace
@@ -320,7 +320,7 @@ msgstr "प्रशासक"
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Agent"
-msgstr "प्रतिनिधि"
+msgstr ""
 
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
@@ -346,12 +346,12 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
-msgstr "एजेंट प्रबंधक"
+msgstr ""
 
 #. Label of the agent_name (Data) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Agent Name"
-msgstr "एजेंट का नाम"
+msgstr ""
 
 #. Label of the agent_status (Data) field in DocType 'HD Agent Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -360,7 +360,7 @@ msgstr ""
 
 #: desk/src/components/Settings/Agents.vue:109
 msgid "Agent name"
-msgstr "एजेंट का नाम"
+msgstr ""
 
 #: desk/src/components/Settings/Agents.vue:3
 msgid "Agents"
@@ -381,7 +381,7 @@ msgstr ""
 #: desk/src/components/ticket/TicketSplitModal.vue:6
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "All"
-msgstr "सभी"
+msgstr ""
 
 #: desk/src/pages/home/components/PendingTickets.vue:253
 msgid "All SLAs on track"
@@ -391,11 +391,11 @@ msgstr ""
 #: desk/src/pages/home/components/RecentFeedback.vue:398
 #: desk/src/pages/home/components/RecentFeedback.vue:406
 msgid "All Time"
-msgstr "पूरे समय"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:293
 msgid "All Views"
-msgstr "सभी दृश्य"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:322
 msgid "All articles from this category will move to General category."
@@ -414,7 +414,7 @@ msgstr ""
 #: desk/src/components/Settings/General/components/TicketSettings.vue:109
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Allow anyone to create tickets"
-msgstr "किसी को भी टिकट बनाने की अनुमति दें"
+msgstr ""
 
 #. Description of the 'Enable comment reactions' (Check) field in DocType 'HD
 #. Settings'
@@ -439,7 +439,7 @@ msgstr ""
 
 #: desk/src/components/Settings/Preferences/Preferences.vue:26
 msgid "Appearance"
-msgstr "उपस्थिति"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:17
 msgid "Appears in the left sidebar. Recommended size is minimum 32x32 px in PNG or SVG."
@@ -458,29 +458,29 @@ msgstr ""
 #. Level Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Apply SLA for Resolution Time"
-msgstr "समाधान समय के लिए SLA लागू करें"
+msgstr ""
 
 #. Label of the apply_to (Select) field in DocType 'HD Form Script'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 msgid "Apply To"
-msgstr "पर लागू"
+msgstr ""
 
 #. Label of the apply_on_new_page (Check) field in DocType 'HD Form Script'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 msgid "Apply on new page"
-msgstr "नए पेज पर आवेदन करें"
+msgstr ""
 
 #. Label of the enable_outside_hours_banner (Check) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Apply outside working hours"
-msgstr "कार्य समय के बाहर आवेदन करें"
+msgstr ""
 
 #. Label of the apply_to_customer_portal (Check) field in DocType 'HD Form
 #. Script'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 msgid "Apply to customer portal"
-msgstr "ग्राहक पोर्टल पर आवेदन करें"
+msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'HD Article'
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:451
@@ -494,7 +494,7 @@ msgstr ""
 
 #: desk/src/pages/ticket/TicketCustomer.vue:314
 msgid "Are you sure you want to close this ticket?"
-msgstr "क्या आप वाकई इस टिकट को बंद करना चाहते हैं?"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:205
 msgid "Are you sure you want to delete these articles?"
@@ -514,15 +514,15 @@ msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:541
 msgid "Are you sure you want to delete this view?"
-msgstr "क्या आप वाकई इस दृश्य को हटाना चाहते हैं?"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/Article.vue:147
 msgid "Are you sure you want to discard changes?"
-msgstr "क्या आप वाकई बदलावों को रद्द करना चाहते हैं?"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:144
 msgid "Are you sure you want to discard this article?"
-msgstr "क्या आप वाकई इस लेख को हटाना चाहते हैं?"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:450
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:103
@@ -543,7 +543,7 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
-msgstr "क्या आप वाकई लोगो हटाना चाहते हैं?"
+msgstr ""
 
 #: desk/src/components/customer/ContactCard.vue:295
 msgid "Are you sure you want to remove this contact from the customer?"
@@ -557,7 +557,7 @@ msgstr ""
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:114
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 msgid "Article"
-msgstr "लेख"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/Article.vue:519
 msgid "Article body cannot be set as empty."
@@ -577,7 +577,7 @@ msgstr ""
 
 #: desk/src/pages/knowledge-base/Article.vue:514
 msgid "Article title cannot be set as empty"
-msgstr "लेख का शीर्षक खाली नहीं रखा जा सकता"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/Article.vue:545
 msgid "Article updated successfully."
@@ -601,17 +601,17 @@ msgstr ""
 
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
-msgstr "स्वयं को नियुक्त करें"
+msgstr ""
 
 #: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
-msgstr "को सौंपना"
+msgstr ""
 
 #: desk/src/components/ticket-agent/AssignTo.vue:11
 msgid "Assignee"
-msgstr "संपत्ति-भागी"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:5
 msgid "Assignee Rules"
@@ -632,7 +632,7 @@ msgstr ""
 #. Option for the 'Type' (Select) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "Assignment"
-msgstr "कार्यभार"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:122
 msgid "Assignment Condition"
@@ -706,19 +706,19 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
-msgstr "कम से कम एक टीम आवश्यक है"
+msgstr ""
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
 msgid "Attachment"
-msgstr "लगाव"
+msgstr ""
 
 #. Label of the author (Link) field in DocType 'HD Article'
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 msgid "Author"
-msgstr "लेखक"
+msgstr ""
 
 #. Label of the auto_update_status (Check) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/TicketSettings.vue:80
@@ -749,7 +749,7 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:145
 msgid "Automatically close stale tickets"
-msgstr "पुराने टिकट अपने आप बंद हो जाते हैं"
+msgstr ""
 
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
@@ -769,24 +769,24 @@ msgstr ""
 
 #: desk/src/pages/home/components/ChartItem.vue:6
 msgid "Average First Response"
-msgstr "औसत प्रथम प्रतिक्रिया"
+msgstr ""
 
 #: desk/src/pages/home/Home.vue:317
 msgid "Average First Response Time"
-msgstr "औसत प्रथम प्रतिक्रिया समय"
+msgstr ""
 
 #: desk/src/pages/home/components/ChartItem.vue:16
 msgid "Average Resolution"
-msgstr "औसत संकल्प"
+msgstr ""
 
 #: desk/src/pages/home/Home.vue:329
 msgid "Average Resolution Time"
-msgstr "औसत समाधान समय"
+msgstr ""
 
 #. Label of the avg_response_time (Duration) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Average Response Time"
-msgstr "औसत प्रतिक्रिया समय"
+msgstr ""
 
 #: desk/src/pages/home/Home.vue:305
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:5
@@ -803,11 +803,11 @@ msgstr ""
 
 #: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
-msgstr "प्रतिदिन टिकटों की औसत संख्या लगभग {0} है"
+msgstr ""
 
 #: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
-msgstr "औसत प्रतिक्रिया रेटिंग"
+msgstr ""
 
 #: desk/src/components/customer/TicketStats.vue:13
 msgid "Avg. Feedback Received"
@@ -815,7 +815,7 @@ msgstr ""
 
 #: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
-msgstr "औसत प्रथम प्रतिक्रिया"
+msgstr ""
 
 #: desk/src/components/customer/TicketStats.vue:49
 msgid "Avg. First Response Time"
@@ -823,7 +823,7 @@ msgstr ""
 
 #: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
-msgstr "औसत संकल्प"
+msgstr ""
 
 #: desk/src/components/customer/TicketStats.vue:62
 msgid "Avg. Resolution Time"
@@ -836,20 +836,20 @@ msgstr ""
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:290
 msgid "Avg. first response time"
-msgstr "औसत प्रथम प्रतिक्रिया समय"
+msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:130
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:298
 msgid "Avg. resolution time"
-msgstr "औसत समाधान समय"
+msgstr ""
 
 #: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
-msgstr "टिकट पर पहली प्रतिक्रिया देने में लगने वाला औसत समय"
+msgstr ""
 
 #: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
-msgstr "किसी टिकट को हल करने में लगने वाला औसत समय"
+msgstr ""
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -859,21 +859,21 @@ msgstr ""
 #: desk/src/components/Settings/EmailAdd.vue:145
 #: desk/src/components/Settings/EmailEdit.vue:134
 msgid "Back"
-msgstr "पीछे"
+msgstr ""
 
 #: desk/src/pages/InvalidPage.vue:25 desk/src/pages/ticket/TicketAgent.vue:44
 msgid "Back to Tickets"
-msgstr "टिकटों पर वापस जाएँ"
+msgstr ""
 
 #. Label of the base_support_rotation (Link) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Base Support Rotation"
-msgstr "आधार समर्थन घूर्णन"
+msgstr ""
 
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
-msgstr "पर आधारित"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:34
 msgid "Based on your HR Policy, select your leave allocation period's end date"
@@ -894,18 +894,18 @@ msgstr ""
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Black"
-msgstr "काला"
+msgstr ""
 
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Blue"
-msgstr "नीला"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:10
 msgid "Brand name"
-msgstr "ब्रांड का नाम"
+msgstr ""
 
 #. Label of the branding_tab (Tab Break) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:4
@@ -936,11 +936,11 @@ msgstr ""
 
 #: desk/src/components/Settings/Holiday/Holidays.vue:3
 msgid "Business Holidays"
-msgstr "व्यावसायिक अवकाश"
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:210
 msgid "Busy"
-msgstr "व्यस्त"
+msgstr ""
 
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
@@ -996,7 +996,7 @@ msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:714 desk/src/pages/home/Home.vue:44
 msgid "Cancel"
-msgstr "रद्द करना"
+msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:63
 msgid "Cancel Invitation"
@@ -1004,7 +1004,7 @@ msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:214
 msgid "Canceled"
-msgstr "रद्द कर दिया गया"
+msgstr ""
 
 #: helpdesk/integrations/erpnext/api.py:47
 msgid "Cannot Sync Customers"
@@ -1046,7 +1046,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Category"
-msgstr "वर्ग"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:175
 msgid "Category '{0}' link copied to clipboard"
@@ -1072,7 +1072,7 @@ msgstr ""
 #: helpdesk/api/knowledge_base.py:78
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.py:65
 msgid "Category must have atleast one article"
-msgstr "श्रेणी में कम से कम एक लेख होना चाहिए"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:305
 msgid "Category updated successfully."
@@ -1088,7 +1088,7 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:40
 msgid "Change"
-msgstr "परिवर्तन"
+msgstr ""
 
 #: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
@@ -1117,7 +1117,7 @@ msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:89
 msgid "Change team"
-msgstr "परिवर्तन टीम"
+msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:87
 msgid "Change ticket type"
@@ -1134,11 +1134,11 @@ msgstr ""
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Channels"
-msgstr "चैनल"
+msgstr ""
 
 #: desk/src/components/Settings/FieldDependency/FieldDependencyFieldsSelection.vue:18
 msgid "Child field"
-msgstr "बाल क्षेत्र"
+msgstr ""
 
 #: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
@@ -1186,7 +1186,7 @@ msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:160
 msgid "Clear Sort"
-msgstr "क्रम साफ़ करें"
+msgstr ""
 
 #. Label of the clear_table (Button) field in DocType 'HD Service Holiday List'
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
@@ -1220,16 +1220,16 @@ msgstr ""
 #: desk/src/pages/ticket/MobileTicketAgent.vue:159
 #: desk/src/pages/ticket/TicketCustomer.vue:14
 msgid "Close"
-msgstr "बंद करना"
+msgstr ""
 
 #: desk/src/pages/ticket/TicketCustomer.vue:313
 msgid "Close Ticket"
-msgstr "टिकट बंद करें"
+msgstr ""
 
 #. Option in a Select field in the tickets Web Form
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
 msgid "Closed"
-msgstr "बंद किया हुआ"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
@@ -1237,7 +1237,7 @@ msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:143
 msgid "Collapse"
-msgstr "गिर जाना"
+msgstr ""
 
 #. Label of the color (Select) field in DocType 'HD Agent Status'
 #. Label of the color (Color) field in DocType 'HD Service Holiday List'
@@ -1246,13 +1246,13 @@ msgstr "गिर जाना"
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Color"
-msgstr "रंग"
+msgstr ""
 
 #. Label of the columns (Code) field in DocType 'HD View'
 #: desk/src/components/view-controls/ColumnSettings.vue:4
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Columns"
-msgstr "कॉलम"
+msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:15
 msgid "Comma separated emails to invite."
@@ -1265,7 +1265,7 @@ msgstr ""
 #. Label of the reference_comment (Link) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "Comment"
-msgstr "टिप्पणी"
+msgstr ""
 
 #: desk/src/components/CommentBox.vue:318
 msgid "Comment cannot be empty."
@@ -1278,7 +1278,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.py:67
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.py:112
 msgid "Comment not found"
-msgstr "टिप्पणी नहीं मिली"
+msgstr ""
 
 #: desk/src/components/CommentBox.vue:334
 msgid "Comment updated successfully."
@@ -1287,18 +1287,18 @@ msgstr ""
 #. Label of the commented_by (Link) field in DocType 'HD Ticket Comment'
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 msgid "Commented By"
-msgstr "द्वारा टिप्पणी की गई"
+msgstr ""
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
 #: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
-msgstr "टिप्पणियाँ"
+msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:97
 msgid "Communication"
-msgstr "संचार"
+msgstr ""
 
 #: desk/src/components/ticket/TicketSplitModal.vue:76
 msgid "Communication ID is required"
@@ -1307,7 +1307,7 @@ msgstr ""
 #. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Company"
-msgstr "कंपनी"
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
@@ -1318,7 +1318,7 @@ msgstr ""
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Condition"
-msgstr "स्थिति"
+msgstr ""
 
 #: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
@@ -1355,11 +1355,11 @@ msgstr ""
 #: desk/src/pages/ticket/Tickets.vue:428 desk/src/pages/ticket/Tickets.vue:550
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.js:27
 msgid "Confirm"
-msgstr "पुष्टि करना"
+msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:698
 msgid "Confirm Changes"
-msgstr "परिवर्तनों की पुष्टि करें"
+msgstr ""
 
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:19
 msgid "Confirm Password"
@@ -1384,7 +1384,7 @@ msgstr ""
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:43
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.py:72
 msgid "Contact"
-msgstr "संपर्क"
+msgstr ""
 
 #. Label of the contact_html (HTML) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1410,7 +1410,7 @@ msgstr ""
 #: desk/src/pages/customer/Customer.vue:151
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
-msgstr "संपर्क"
+msgstr ""
 
 #: desk/src/components/customer/InviteContactDialog.vue:168
 msgid "Contacts added successfully"
@@ -1422,12 +1422,12 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 msgid "Content"
-msgstr "सामग्री"
+msgstr ""
 
 #. Label of the content_type (Data) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Content Type"
-msgstr "सामग्री प्रकार"
+msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:93
 msgid "Copy ticket URL"
@@ -1461,7 +1461,7 @@ msgstr ""
 #: desk/src/components/customer/NewCustomerDialog.vue:36
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Country"
-msgstr "देश"
+msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
@@ -1515,7 +1515,7 @@ msgstr ""
 
 #: desk/src/components/Settings/FieldDependency/FieldDependencyList.vue:69
 msgid "Created by"
-msgstr "के द्वारा बनाई गई"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:583
 msgid "Creating a ticket"
@@ -1554,7 +1554,7 @@ msgstr ""
 #: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
-msgstr "ग्राहक"
+msgstr ""
 
 #: desk/src/components/customer/ContactCard.vue:177
 #: desk/src/components/customer/InviteContactDialog.vue:130
@@ -1564,7 +1564,7 @@ msgstr ""
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Customer Name"
-msgstr "ग्राहक का नाम"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:603
 msgid "Customer Portal"
@@ -1574,7 +1574,7 @@ msgstr ""
 #: desk/src/components/customer/NewCustomerDialog.vue:31
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Customer Type"
-msgstr "ग्राहक प्रकार"
+msgstr ""
 
 #: desk/src/components/customer/NewCustomerDialog.vue:142
 msgid "Customer created"
@@ -1586,7 +1586,7 @@ msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
-msgstr "ग्राहक पोर्टल"
+msgstr ""
 
 #: desk/src/components/customer/EditCustomerDialog.vue:136
 #: desk/src/components/customer/EditCustomerDialog.vue:150
@@ -1596,7 +1596,7 @@ msgstr ""
 #: desk/src/pages/customer/Customer.vue:198
 #: desk/src/pages/customer/Customers.vue:6
 msgid "Customers"
-msgstr "ग्राहकों"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:595
 msgid "Customers & Contacts"
@@ -1641,7 +1641,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_holiday/hd_holiday.json
 #: helpdesk/helpdesk/report/support_hour_distribution/support_hour_distribution.py:77
 msgid "Date"
-msgstr "तारीख"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:29
 msgid "Day count for auto closing tickets cannot be negative or zero"
@@ -1649,7 +1649,7 @@ msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:38
 msgid "Days"
-msgstr "दिन"
+msgstr ""
 
 #: desk/src/components/Settings/EmailAccountCard.vue:53
 msgid "Default Inbox"
@@ -1760,7 +1760,7 @@ msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
-msgstr "{0} को हटाएँ"
+msgstr ""
 
 #: desk/src/components/DeleteWithTicketsDialog.vue:10
 msgid "Delete {0} ticket(s)"
@@ -1790,7 +1790,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
 msgid "Description"
-msgstr "विवरण"
+msgstr ""
 
 #. Label of the description_template (Text Editor) field in DocType 'HD Ticket
 #. Template'
@@ -1801,12 +1801,12 @@ msgstr ""
 #. Label of the description_weight (Int) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Description Weight"
-msgstr "विवरण वजन"
+msgstr ""
 
 #: desk/src/pages/ticket/TicketNew.vue:90
 #: desk/src/pages/ticket/TicketNew.vue:115
 msgid "Detailed explanation"
-msgstr "विस्तृत व्याख्या"
+msgstr ""
 
 #. Label of the details_section (Section Break) field in DocType 'HD
 #. Notification'
@@ -1817,7 +1817,7 @@ msgstr "विस्तृत व्याख्या"
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Details"
-msgstr "विवरण"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:67
 msgid "Disable global saved replies"
@@ -1831,7 +1831,7 @@ msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:47
 msgid "Disable signup"
-msgstr "साइन अप अक्षम करें"
+msgstr ""
 
 #. Label of the disabled (Check) field in DocType 'HD Team'
 #. Label of the disabled (Check) field in DocType 'HD Ticket Feedback Option'
@@ -1843,7 +1843,7 @@ msgstr "साइन अप अक्षम करें"
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "Disabled"
-msgstr "अक्षम"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:29
 msgid "Disables all email notifications for the ticket - including creation, updates, and alerts."
@@ -1853,15 +1853,15 @@ msgstr ""
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:24
 #: desk/src/pages/knowledge-base/NewArticle.vue:27
 msgid "Discard"
-msgstr "खारिज करना"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:143
 msgid "Discard Article"
-msgstr "लेख को त्याग दें"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/Article.vue:146
 msgid "Discard changes?"
-msgstr "परिवर्तनों को निरस्त करें?"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:203
 msgid "Display a customizable banner message when customers raise tickets outside your working hours."
@@ -1887,7 +1887,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "DocType"
-msgstr "दस्तावेज़ प्रकार"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:371
 msgid "Docs"
@@ -1896,7 +1896,7 @@ msgstr ""
 #. Label of the document_type (Link) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 msgid "Document Type"
-msgstr "दस्तावेज़ प्रकार"
+msgstr ""
 
 #: desk/src/components/contact/EditContactDialog.vue:45
 msgid "Doe"
@@ -1910,13 +1910,13 @@ msgstr ""
 
 #: desk/src/components/ticket/ExportModal.vue:32
 msgid "Download"
-msgstr "डाउनलोड करना"
+msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'HD Article'
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:447
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 msgid "Draft"
-msgstr "मसौदा"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:72
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:138
@@ -1953,11 +1953,11 @@ msgstr ""
 #: desk/src/pages/call-logs/CallLogModal.vue:64
 #: desk/src/pages/call-logs/CallLogModal.vue:68
 msgid "Duration"
-msgstr "अवधि"
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:388
 msgid "Duration is required"
-msgstr "अवधि आवश्यक है"
+msgstr ""
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:8
 msgid "ERPNext"
@@ -2003,7 +2003,7 @@ msgstr ""
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
-msgstr "संपादन करना"
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
@@ -2039,7 +2039,7 @@ msgstr ""
 #: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
 msgid "Email"
-msgstr "ईमेल"
+msgstr ""
 
 #. Label of the email_account (Link) field in DocType 'HD Ticket'
 #. Label of a Link in the Helpdesk Workspace
@@ -2047,7 +2047,7 @@ msgstr "ईमेल"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Email Account"
-msgstr "ईमेल खाता"
+msgstr ""
 
 #: desk/src/components/Settings/EmailAccountList.vue:3
 msgid "Email Accounts"
@@ -2063,7 +2063,7 @@ msgstr ""
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:61
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Email Content"
-msgstr "ईमेल सामग्री"
+msgstr ""
 
 #. Label of the email_id (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -2075,7 +2075,7 @@ msgstr ""
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:3
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Email Notifications"
-msgstr "ईमेल सूचनाएं"
+msgstr ""
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:3
 msgid "Email Settings"
@@ -2083,15 +2083,15 @@ msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:309
 msgid "Email account created"
-msgstr "ईमेल खाता बनाया गया"
+msgstr ""
 
 #: desk/src/components/Settings/EmailAccountList.vue:27
 msgid "Email account name"
-msgstr "ईमेल खाते का नाम"
+msgstr ""
 
 #: desk/src/components/Settings/EmailEdit.vue:471
 msgid "Email account updated successfully"
-msgstr "ईमेल खाता सफलतापूर्वक अपडेट हो गया"
+msgstr ""
 
 #. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -2106,11 +2106,11 @@ msgstr ""
 #: desk/src/pages/SearchAgent.vue:352
 #: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
-msgstr "ईमेल"
+msgstr ""
 
 #: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
-msgstr "ईमेल और हस्ताक्षर"
+msgstr ""
 
 #: desk/src/components/Settings/EmailEdit.vue:417
 msgid "Emails pulled successfully"
@@ -2128,7 +2128,7 @@ msgstr ""
 #. Label of the enable (Check) field in DocType 'HD Agent Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 msgid "Enable"
-msgstr "सक्षम"
+msgstr ""
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:36
 msgid "Enable ERPNext Integration"
@@ -2138,7 +2138,7 @@ msgstr ""
 #: desk/src/components/Settings/General/components/TicketSettings.vue:23
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Enable comment reactions"
-msgstr "टिप्पणियों पर प्रतिक्रियाएँ सक्षम करें"
+msgstr ""
 
 #. Label of the is_feedback_mandatory (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2176,17 +2176,17 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Enabled"
-msgstr "सक्रिय"
+msgstr ""
 
 #. Label of the end_date (Date) field in DocType 'HD Service Level Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "End Date"
-msgstr "अंतिम तिथि"
+msgstr ""
 
 #. Label of the end_time (Time) field in DocType 'HD Service Day'
 #: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
 msgid "End Time"
-msgstr "अंत समय"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:22
 msgid "Enter a name for this HD Service Holiday List."
@@ -2194,7 +2194,7 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
-msgstr "ब्रांड का नाम दर्ज करें"
+msgstr ""
 
 #: desk/src/components/customer/InviteContactDialog.vue:12
 msgid "Enter email address"
@@ -2202,7 +2202,7 @@ msgstr ""
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
-msgstr "टीम के लिए नया नाम दर्ज करें"
+msgstr ""
 
 #: desk/src/components/customer/NewCustomerDialog.vue:182
 msgid "Enter the primary contact's email"
@@ -2240,7 +2240,7 @@ msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:143
 msgid "Expand"
-msgstr "बढ़ाना"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:557
 msgid "Explore customer portal"
@@ -2249,7 +2249,7 @@ msgstr ""
 #: desk/src/components/ticket/ExportModal.vue:2
 #: desk/src/pages/ticket/Tickets.vue:130
 msgid "Export"
-msgstr "निर्यात"
+msgstr ""
 
 #: desk/src/components/ticket/ExportModal.vue:26
 msgid "Export All {0} Record(s)"
@@ -2257,7 +2257,7 @@ msgstr ""
 
 #: desk/src/components/ticket/ExportModal.vue:7
 msgid "Export Type"
-msgstr "निर्यात प्रकार"
+msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
@@ -2265,7 +2265,7 @@ msgstr "निर्यात प्रकार"
 #: desk/src/pages/ticket/Tickets.vue:263 desk/src/pages/ticket/Tickets.vue:271
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
-msgstr "असफल"
+msgstr ""
 
 #: desk/src/components/customer/TicketStats.vue:39
 msgid "Failed SLAs"
@@ -2273,7 +2273,7 @@ msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
-msgstr "श्रेणी बनाने में विफल"
+msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:315
 msgid "Failed to create email account, Invalid credentials"
@@ -2291,7 +2291,7 @@ msgstr ""
 
 #: desk/src/components/Settings/EmailEdit.vue:422
 msgid "Failed to pull emails"
-msgstr "ईमेल प्राप्त करने में विफल"
+msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:259
 #: desk/src/components/Settings/Telephony/Telephony.vue:238
@@ -2344,7 +2344,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Feedback"
-msgstr "प्रतिक्रिया"
+msgstr ""
 
 #. Label of the feedback_extra (Small Text) field in DocType 'HD Email
 #. Feedback'
@@ -2352,32 +2352,32 @@ msgstr "प्रतिक्रिया"
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
 msgid "Feedback "
-msgstr "प्रतिक्रिया "
+msgstr ""
 
 #. Label of the feedback_extra (Long Text) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Feedback (Extra)"
-msgstr "प्रतिक्रिया (अतिरिक्त)"
+msgstr ""
 
 #. Label of the feedback (Link) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Feedback (Option)"
-msgstr "प्रतिक्रिया (विकल्प)"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:30
 msgid "Feedback Already Exists"
-msgstr "प्रतिक्रिया पहले से मौजूद है"
+msgstr ""
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Email Feedback'
 #. Label of a field in the email-feedback Web Form
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
 msgid "Feedback Rating"
-msgstr "प्रतिक्रिया रेटिंग"
+msgstr ""
 
 #: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
-msgstr "प्रतिक्रिया प्रवृत्ति"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
@@ -2414,7 +2414,7 @@ msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.py:25
 msgid "Field `{0}` does not exist in Ticket"
-msgstr "टिकट में फ़ील्ड `{0}` मौजूद नहीं है"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.py:41
 msgid "Field `{0}` is not allowed in Ticket Template"
@@ -2432,7 +2432,7 @@ msgstr ""
 #: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
-msgstr "क्षेत्र"
+msgstr ""
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
@@ -2449,12 +2449,12 @@ msgstr ""
 #: desk/src/components/contact/EditContactDialog.vue:35
 #: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
-msgstr "पहला नाम"
+msgstr ""
 
 #. Label of the first_responded_on (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
-msgstr "सबसे पहले जवाब दिया"
+msgstr ""
 
 #: desk/src/components/customer/TicketsTab.vue:224
 msgid "First Response"
@@ -2469,7 +2469,7 @@ msgstr ""
 #. Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Response Failed By"
-msgstr "पहली प्रतिक्रिया विफल रही"
+msgstr ""
 
 #. Label of the response_time (Duration) field in DocType 'HD Service Level
 #. Priority'
@@ -2477,17 +2477,17 @@ msgstr "पहली प्रतिक्रिया विफल रही"
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Response Time"
-msgstr "प्रथम प्रतिक्रिया समय"
+msgstr ""
 
 #. Name of a report
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
-msgstr "टिकटों के लिए प्रथम प्रतिक्रिया समय"
+msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 msgid "Form"
-msgstr "रूप"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:637
 msgid "Frappe Helpdesk Mobile"
@@ -2499,14 +2499,14 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Friday"
-msgstr "शुक्रवार"
+msgstr ""
 
 #. Label of the user_from (Link) field in DocType 'HD Notification'
 #: desk/src/components/EmailEditor.vue:23
 #: desk/src/pages/call-logs/CallLogModal.vue:44
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "From"
-msgstr "से"
+msgstr ""
 
 #. Label of the from_date (Date) field in DocType 'HD Service Holiday List'
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
@@ -2515,28 +2515,28 @@ msgstr "से"
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:17
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:17
 msgid "From Date"
-msgstr "की तिथि से"
+msgstr ""
 
 #: desk/src/components/Settings/Holiday/HolidayView.vue:71
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:140
 msgid "From date"
-msgstr "की तिथि से"
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:374
 msgid "From is required"
-msgstr "से आवश्यक है"
+msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/Tickets.vue:224 desk/src/pages/ticket/Tickets.vue:263
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Fulfilled"
-msgstr "पूरा"
+msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:6
 #: desk/src/components/layouts/Sidebar.vue:528
 #: desk/src/components/modals/ShortcutsModal.vue:76
 msgid "General"
-msgstr "सामान्य"
+msgstr ""
 
 #. Label of a Link in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
@@ -2545,11 +2545,11 @@ msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.py:40
 msgid "General category can't be deleted"
-msgstr "सामान्य श्रेणी को हटाया नहीं जा सकता"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.py:36
 msgid "General category name can't be changed"
-msgstr "सामान्य श्रेणी का नाम बदला नहीं जा सकता"
+msgstr ""
 
 #: helpdesk/api/knowledge_base.py:56
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.py:23
@@ -2558,7 +2558,7 @@ msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:578
 msgid "Getting Started"
-msgstr "शुरू करना"
+msgstr ""
 
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #: desk/src/components/SavedRepliesSelectorModal.vue:180
@@ -2571,7 +2571,7 @@ msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:89
 msgid "Go to Ticket #{0}"
-msgstr "टिकट पर जाएं #{0}"
+msgstr ""
 
 #: desk/src/components/customer/ContactCard.vue:220
 msgid "Grant Manager Access"
@@ -2593,7 +2593,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Green"
-msgstr "हरा"
+msgstr ""
 
 #. Label of the group_by_tab (Tab Break) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -2608,7 +2608,7 @@ msgstr ""
 #. Name of a role
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
-msgstr "अतिथि"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
@@ -2821,16 +2821,16 @@ msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:125
 msgid "Help"
-msgstr "मदद"
+msgstr ""
 
 #: helpdesk/config/desktop.py:11
 msgid "HelpDesk"
-msgstr "सहायता केंद्र"
+msgstr ""
 
 #. Name of a Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk"
-msgstr "सहायता केंद्र"
+msgstr ""
 
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
@@ -2866,7 +2866,7 @@ msgstr ""
 #. Option in a Select field in the tickets Web Form
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
 msgid "Hold"
-msgstr "पकड़ना"
+msgstr ""
 
 #. Label of the holiday_list (Link) field in DocType 'HD Service Level
 #. Agreement'
@@ -2907,7 +2907,7 @@ msgstr ""
 
 #: desk/src/pages/home/Home.vue:5
 msgid "Home"
-msgstr "घर"
+msgstr ""
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:115
 msgid "I understand, add conditions"
@@ -2915,7 +2915,7 @@ msgstr ""
 
 #: desk/src/pages/home/components/PendingTickets.vue:26
 msgid "ID"
-msgstr "पहचान"
+msgstr ""
 
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
@@ -2970,7 +2970,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Image"
-msgstr "छवि"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:80
 msgid "Image removed successfully."
@@ -2987,11 +2987,11 @@ msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:217
 msgid "In Progress"
-msgstr "प्रगति पर है"
+msgstr ""
 
 #: desk/src/components/Settings/Agents.vue:126
 msgid "Inactive"
-msgstr "निष्क्रिय"
+msgstr ""
 
 #: desk/src/components/CallArea.vue:36
 msgid "Inbound Call"
@@ -3003,16 +3003,16 @@ msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:203
 msgid "Incoming"
-msgstr "आने वाली"
+msgstr ""
 
 #. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Individual"
-msgstr "व्यक्ति"
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
-msgstr "शुरू किया"
+msgstr ""
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:59
 msgid "Install the"
@@ -3021,11 +3021,11 @@ msgstr ""
 #. Label of the instantly_send_email (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Instantly send e-mail"
-msgstr "तुरंत ईमेल भेजें"
+msgstr ""
 
 #: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
-msgstr "{0} के लिए अपर्याप्त अनुमति"
+msgstr ""
 
 #. Label of the integer_value (Int) field in DocType 'HD Ticket Priority'
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
@@ -3035,7 +3035,7 @@ msgstr ""
 #: desk/src/components/layouts/Sidebar.vue:570
 #: desk/src/components/layouts/Sidebar.vue:573
 msgid "Introduction"
-msgstr "परिचय"
+msgstr ""
 
 #: helpdesk/api/agent.py:37
 msgid "Invalid availability"
@@ -3043,7 +3043,7 @@ msgstr ""
 
 #: desk/src/components/customer/NewCustomerDialog.vue:186
 msgid "Invalid email address"
-msgstr "अमान्य ईमेल पता"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
 #: desk/src/components/Settings/Holiday/HolidayView.vue:325
@@ -3053,11 +3053,11 @@ msgstr ""
 
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
-msgstr "अमान्य सूचना"
+msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
 msgid "Invalid phone number"
-msgstr "अमान्य फ़ोन नंबर"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
 msgid "Invalid role {0}"
@@ -3065,7 +3065,7 @@ msgstr ""
 
 #: desk/src/pages/contact/Contact.vue:251
 msgid "Invitation Expired"
-msgstr "निमंत्रण की समय सीमा समाप्त हो गई है"
+msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:246
 #: desk/src/components/customer/RevokeInviteButton.vue:40
@@ -3125,12 +3125,12 @@ msgstr ""
 #. Label of the is_active (Check) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Is Active"
-msgstr "सक्रिय है"
+msgstr ""
 
 #. Label of the is_customer_portal (Check) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Customer Portal"
-msgstr "क्या ग्राहक पोर्टल"
+msgstr ""
 
 #. Label of the is_default (Check) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3147,12 +3147,12 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Standard"
-msgstr "मानक है"
+msgstr ""
 
 #. Label of the apply_to_system (Check) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 msgid "Is applied to system"
-msgstr "सिस्टम पर लागू होता है"
+msgstr ""
 
 #. Label of the initial_helpdesk_name_setup_skipped (Check) field in DocType
 #. 'HD Settings'
@@ -3176,7 +3176,7 @@ msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:114
 msgid "Jump to"
-msgstr "करने के लिए कूद"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/Article.vue:672
 msgid "KB"
@@ -3189,7 +3189,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
 msgid "Key"
-msgstr "चाबी"
+msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:2
 msgid "Keyboard Shortcuts"
@@ -3215,72 +3215,72 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Label"
-msgstr "लेबल"
+msgstr ""
 
 #. Label of the label_customer (Data) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Label (customer view)"
-msgstr "लेबल (ग्राहक दृश्य)"
+msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 msgid "Landing Page"
-msgstr "लैंडिंग पृष्ठ"
+msgstr ""
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:6
 msgid "Language"
-msgstr "भाषा"
+msgstr ""
 
 #: desk/src/components/Settings/Preferences/Preferences.vue:36
 msgid "Language & Time"
-msgstr "भाषा और समय"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:102
 msgid "Last"
-msgstr "अंतिम"
+msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:372
 #: desk/src/pages/home/components/RecentFeedback.vue:401
 msgid "Last 3 Months"
-msgstr "पिछले 3 महीने"
+msgstr ""
 
 #: desk/src/components/ChartCardBase.vue:169
 #: desk/src/components/ChartCardBase.vue:171
 #: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
-msgstr "पिछले 3 महीने"
+msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:453
 #: desk/src/pages/dashboard/Dashboard.vue:486
 #: desk/src/pages/dashboard/Dashboard.vue:488
 #: desk/src/pages/dashboard/Dashboard.vue:524
 msgid "Last 30 Days"
-msgstr "पिछले 30 दिन"
+msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:493
 #: desk/src/pages/dashboard/Dashboard.vue:495
 msgid "Last 60 Days"
-msgstr "पिछले 60 दिन"
+msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:479
 #: desk/src/pages/dashboard/Dashboard.vue:481
 msgid "Last 7 Days"
-msgstr "पिछले 7 दिन"
+msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:500
 #: desk/src/pages/dashboard/Dashboard.vue:502
 msgid "Last 90 Days"
-msgstr "पिछले 90 दिन"
+msgstr ""
 
 #. Label of the last_agent_response (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Last Agent Response"
-msgstr "अंतिम एजेंट प्रतिक्रिया"
+msgstr ""
 
 #. Label of the last_customer_response (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Last Customer Response"
-msgstr "अंतिम ग्राहक प्रतिक्रिया"
+msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:368
 #: desk/src/pages/home/components/RecentFeedback.vue:400
@@ -3295,7 +3295,7 @@ msgstr ""
 #: desk/src/pages/home/components/RecentFeedback.vue:364
 #: desk/src/pages/home/components/RecentFeedback.vue:399
 msgid "Last Week"
-msgstr "पिछले सप्ताह"
+msgstr ""
 
 #: desk/src/components/BarChartCard.vue:79
 #: desk/src/components/ChartCardBase.vue:135
@@ -3319,11 +3319,11 @@ msgstr ""
 #: desk/src/components/ChartCardBase.vue:157
 #: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
-msgstr "पिछले सप्ताह"
+msgstr ""
 
 #: desk/src/components/contact/FeedbackList.vue:122
 msgid "Latest"
-msgstr "नवीनतम"
+msgstr ""
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -3333,7 +3333,7 @@ msgstr ""
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:135
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:212
 msgid "Learn about conditions"
-msgstr "स्थितियों के बारे में जानें"
+msgstr ""
 
 #. Description of the 'Apply outside working hours' (Check) field in DocType
 #. 'HD Settings'
@@ -3350,15 +3350,15 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "List"
-msgstr "सूची"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:357
 msgid "List View"
-msgstr "लिस्ट व्यू"
+msgstr ""
 
 #: desk/src/components/CallArea.vue:72
 msgid "Listen"
-msgstr "सुनना"
+msgstr ""
 
 #. Label of the load_default_columns (Check) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3370,11 +3370,11 @@ msgstr ""
 #: desk/src/components/contact/FeedbackList.vue:84
 #: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
-msgstr "और लोड करें"
+msgstr ""
 
 #: desk/src/components/ticket-agent/AssignTo.vue:93
 msgid "Loading..."
-msgstr "लोड हो रहा है..."
+msgstr ""
 
 #: desk/src/components/ticket/ActivityHeader.vue:65
 msgid "Log a Call"
@@ -3383,7 +3383,7 @@ msgstr ""
 #: desk/src/components/layouts/Sidebar.vue:344
 #: desk/src/components/layouts/Sidebar.vue:395
 msgid "Log out"
-msgstr "लॉग आउट"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:375
 msgid "Login to Frappe Cloud"
@@ -3395,7 +3395,7 @@ msgstr ""
 #: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
-msgstr "प्रतीक चिन्ह"
+msgstr ""
 
 #. Description of the 'Integer value' (Int) field in DocType 'HD Ticket
 #. Priority'
@@ -3409,11 +3409,11 @@ msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:501
 msgid "Make Public"
-msgstr "सार्वजनिक करें"
+msgstr ""
 
 #: desk/src/components/ticket/ActivityHeader.vue:60
 msgid "Make a Call"
-msgstr "फोन करें"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:10
 msgid "Make feedback mandatory"
@@ -3453,12 +3453,12 @@ msgstr ""
 
 #: desk/src/components/customer/ContactCard.vue:25
 msgid "Manager"
-msgstr "प्रबंधक"
+msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:11
 #: desk/src/pages/MobileNotifications.vue:14
 msgid "Mark all as read"
-msgstr "सभी को पढ़ा हुआ मार्क करें"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:608
 msgid "Masters"
@@ -3466,16 +3466,16 @@ msgstr ""
 
 #: desk/src/components/Settings/Teams/NewTeam.vue:38
 msgid "Members"
-msgstr "सदस्यों"
+msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:56
 msgid "Members ({0})"
-msgstr "सदस्य ({0})"
+msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "Mention"
-msgstr "उल्लेख"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:158
 msgid "Merge"
@@ -3489,19 +3489,19 @@ msgstr ""
 #. Label of the merged_with (Link) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Merged With"
-msgstr "के साथ विलय हो गया"
+msgstr ""
 
 #. Label of the message (Text) field in DocType 'HD Notification'
 #. Label of the message (Text Editor) field in DocType 'HD Saved Reply'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 msgid "Message"
-msgstr "संदेश"
+msgstr ""
 
 #. Label of the misc_tab (Tab Break) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Misc"
-msgstr "विविध"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:640
 msgid "Mobile App Installation"
@@ -3514,7 +3514,7 @@ msgstr ""
 
 #: desk/src/components/customer/NewCustomerDialog.vue:94
 msgid "Mobile Number"
-msgstr "मोबाइल नंबर"
+msgstr ""
 
 #. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -3527,20 +3527,20 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Monday"
-msgstr "सोमवार"
+msgstr ""
 
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:35
 msgid "Monthly"
-msgstr "महीने के"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/Article.vue:636
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:191
 msgid "Move To"
-msgstr "करने के लिए कदम"
+msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:249
 msgid "My Dashboard"
-msgstr "मेरे यंत्र रखने की जगह"
+msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:302
 msgid "My Organization"
@@ -3553,12 +3553,12 @@ msgstr ""
 #: desk/src/components/SavedRepliesSelectorModal.vue:175
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:337
 msgid "My Team"
-msgstr "मेरी टीम"
+msgstr ""
 
 #: desk/src/pages/home/Home.vue:293
 #: desk/src/pages/home/components/AgentTicketsCard.vue:4
 msgid "My Tickets"
-msgstr "मेरे टिकट"
+msgstr ""
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
 #. Label of the contact_name (Link) field in DocType 'HD Customer Member'
@@ -3578,16 +3578,16 @@ msgstr "मेरे टिकट"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
-msgstr "नाम"
+msgstr ""
 
 #. Label of the name_weight (Int) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
-msgstr "नाम वजन"
+msgstr ""
 
 #: desk/src/components/customer/NewCustomerDialog.vue:151
 msgid "Name is required"
-msgstr "नाम आवश्यक है"
+msgstr ""
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
 #. Ticket Status'
@@ -3597,7 +3597,7 @@ msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:105
 msgid "Navigation"
-msgstr "मार्गदर्शन"
+msgstr ""
 
 #: desk/src/components/contact/FeedbackList.vue:124
 msgid "Negative"
@@ -3606,11 +3606,11 @@ msgstr ""
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
-msgstr "पहले नकारात्मक"
+msgstr ""
 
 #: desk/src/components/customer/ContactCard.vue:137
 msgid "Never"
-msgstr "कभी नहीं"
+msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3623,12 +3623,12 @@ msgstr "कभी नहीं"
 #: desk/src/components/ticket/ActivityHeader.vue:19
 #: desk/src/pages/home/Home.vue:55
 msgid "New"
-msgstr "नया"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:174
 #: desk/src/pages/knowledge-base/NewArticle.vue:181
 msgid "New Article"
-msgstr "नया लेख"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:4
 msgid "New Assignment Rule"
@@ -3640,7 +3640,7 @@ msgstr ""
 
 #: desk/src/components/Settings/Holiday/HolidayView.vue:3
 msgid "New Business Holiday"
-msgstr "नई व्यावसायिक छुट्टी"
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "New Call Log"
@@ -3656,7 +3656,7 @@ msgstr ""
 
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:8
 msgid "New Password"
-msgstr "नया पासवर्ड"
+msgstr ""
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:3
 msgid "New SLA Policy"
@@ -3676,20 +3676,20 @@ msgstr ""
 
 #: desk/src/pages/ticket/MobileTicketAgent.vue:141
 msgid "New Subject"
-msgstr "नया विषय"
+msgstr ""
 
 #: desk/src/components/Settings/Teams/NewTeam.vue:3
 msgid "New Team"
-msgstr "नई टीम"
+msgstr ""
 
 #: desk/src/pages/ticket/TicketNew.vue:302
 #: desk/src/pages/ticket/TicketNew.vue:312
 msgid "New Ticket"
-msgstr "नया टिकट"
+msgstr ""
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:53
 msgid "New and old title cannot be same"
-msgstr "नया और पुराना शीर्षक एक समान नहीं हो सकता"
+msgstr ""
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:86
 msgid "New and updated customers sync automatically between Helpdesk and ERPNext."
@@ -3697,11 +3697,11 @@ msgstr ""
 
 #: desk/src/components/Settings/NewTeamModal.vue:4
 msgid "New team"
-msgstr "नई टीम"
+msgstr ""
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:51
 msgid "New title is required"
-msgstr "नए शीर्षक की आवश्यकता है"
+msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:50
 msgid "New users will have to be manually registered by system managers."
@@ -3709,19 +3709,19 @@ msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:107
 msgid "Next ticket"
-msgstr "अगला टिकट"
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:216
 msgid "No Answer"
-msgstr "कोई जवाब नहीं"
+msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:345
 msgid "No Data Found"
-msgstr "डाटा प्राप्त नहीं हुआ"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
-msgstr "{0} के लिए कोई ईमेल खाता नहीं मिला"
+msgstr ""
 
 #: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
@@ -3729,7 +3729,7 @@ msgstr ""
 
 #: desk/src/components/Settings/Holiday/HolidayList.vue:20
 msgid "No Holiday list found"
-msgstr "कोई अवकाश सूची नहीं मिली"
+msgstr ""
 
 #: desk/src/components/Settings/Sla/SlaPolicyList.vue:20
 msgid "No SLA found"
@@ -3737,7 +3737,7 @@ msgstr ""
 
 #: helpdesk/api/dashboard.py:452
 msgid "No Team"
-msgstr "कोई टीम नहीं"
+msgstr ""
 
 #: desk/src/components/customer/ContactCard.vue:115
 #: desk/src/components/customer/ContactCard.vue:144
@@ -3747,11 +3747,11 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
 msgid "No additional comments"
-msgstr "कोई अतिरिक्त टिप्पणी नहीं"
+msgstr ""
 
 #: desk/src/components/ticket-agent/AssignTo.vue:144
 msgid "No agents found"
-msgstr "कोई एजेंट नहीं मिला"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:425
 msgid "No articles found for the applied filters. Try adjusting or clearing your filters."
@@ -3775,7 +3775,7 @@ msgstr ""
 
 #: desk/src/components/Settings/EmailEdit.vue:344
 msgid "No changes made"
-msgstr "कोई बदलाव नहीं किया गया"
+msgstr ""
 
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
@@ -3807,7 +3807,7 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:283
 msgid "No feedback"
-msgstr "कोई प्रतिक्रिया नहीं"
+msgstr ""
 
 #: desk/src/components/contact/ContactFeedback.vue:16
 msgid "No feedback yet"
@@ -3819,11 +3819,11 @@ msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:94
 msgid "No members found"
-msgstr "कोई सदस्य नहीं मिला"
+msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:68
 msgid "No new notifications"
-msgstr "कोई नए संदेश नहीं"
+msgstr ""
 
 #: desk/src/pages/home/components/PendingTickets.vue:258
 msgid "No new tickets assigned to you in the last 7 days"
@@ -3831,7 +3831,7 @@ msgstr ""
 
 #: desk/src/components/ticket-agent/TicketNavigation.vue:25
 msgid "No next ticket"
-msgstr "अगला टिकट उपलब्ध नहीं है"
+msgstr ""
 
 #: desk/src/components/ticket-agent/AssignTo.vue:33
 msgid "No one"
@@ -3839,15 +3839,15 @@ msgstr ""
 
 #: desk/src/pages/home/components/PendingTickets.vue:261
 msgid "No pending tickets"
-msgstr "कोई लंबित टिकट नहीं"
+msgstr ""
 
 #: desk/src/components/ticket-agent/TicketNavigation.vue:10
 msgid "No previous ticket"
-msgstr "कोई पूर्व टिकट नहीं"
+msgstr ""
 
 #: desk/src/pages/home/components/PendingTickets.vue:94
 msgid "No reason"
-msgstr "कोई कारण नहीं"
+msgstr ""
 
 #: desk/src/pages/home/components/PendingTickets.vue:257
 msgid "No recently assigned tickets"
@@ -3860,7 +3860,7 @@ msgstr ""
 #: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
-msgstr "कोई परिणाम नहीं मिला"
+msgstr ""
 
 #: desk/src/components/contact/FeedbackList.vue:28
 msgid "No reviews found"
@@ -3874,7 +3874,7 @@ msgstr ""
 #: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
-msgstr "कोई टिकट नहीं मिला"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:202
 msgid "No tickets found for the applied filters. Try adjusting or clearing your filters."
@@ -3898,11 +3898,11 @@ msgstr ""
 
 #: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
-msgstr "अनुमति नहीं"
+msgstr ""
 
 #: desk/src/pages/home/components/PendingTickets.vue:69
 msgid "Not Assigned"
-msgstr "सौंपा नहीं गया है"
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:10
 msgid "Not Saved"
@@ -3910,7 +3910,7 @@ msgstr ""
 
 #: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
-msgstr "सेट नहीं"
+msgstr ""
 
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:250
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.py:270
@@ -3931,25 +3931,25 @@ msgstr ""
 #: desk/src/components/notifications/Notifications.vue:16
 #: desk/src/pages/MobileNotifications.vue:6
 msgid "Notifications"
-msgstr "सूचनाएं"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:146
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:227
 msgid "Old Condition"
-msgstr "पुरानी स्थिति"
+msgstr ""
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:88
 msgid "Old Conditions"
-msgstr "पुरानी स्थितियाँ"
+msgstr ""
 
 #. Label of the on_hold_since (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "On Hold Since"
-msgstr "तब से रुका हुआ है"
+msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
-msgstr "टिकट की स्थिति पर"
+msgstr ""
 
 #: helpdesk/api/ticket.py:75
 msgid "Only administrators can delete tickets."
@@ -3968,7 +3968,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
 msgid "Open"
-msgstr "खुला"
+msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:78
 msgid "Open command palette"
@@ -3996,7 +3996,7 @@ msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:79
 msgid "Open settings"
-msgstr "खुली सेटिंग"
+msgstr ""
 
 #. Description of the 'Category' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
@@ -4013,25 +4013,25 @@ msgstr ""
 #. Label of the opening_time (Time) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Opening Time"
-msgstr "खुलने का समय"
+msgstr ""
 
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Orange"
-msgstr "नारंगी"
+msgstr ""
 
 #. Label of the order (Int) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Order"
-msgstr "आदेश"
+msgstr ""
 
 #. Label of the order_by_tab (Tab Break) field in DocType 'HD View'
 #. Label of the order_by (Code) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Order By"
-msgstr "द्वारा आदेश"
+msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:249
 msgid "Organization Dashboard"
@@ -4039,7 +4039,7 @@ msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:50
 msgid "Other"
-msgstr "अन्य"
+msgstr ""
 
 #: desk/src/components/CallArea.vue:37
 msgid "Outbound Call"
@@ -4051,19 +4051,19 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:199
 msgid "Outside working hours notice"
-msgstr "कार्य समय के बाहर की सूचना"
+msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:105
 msgid "Owner"
-msgstr "मालिक"
+msgstr ""
 
 #: desk/src/pages/InvalidPage.vue:11
 msgid "Page not found"
-msgstr "पृष्ठ नहीं मिला"
+msgstr ""
 
 #: desk/src/components/Settings/FieldDependency/FieldDependencyFieldsSelection.vue:5
 msgid "Parent field"
-msgstr "मूल फ़ील्ड"
+msgstr ""
 
 #: helpdesk/api/settings/field_dependency.py:47
 msgid "Parent field, child field, and parent-child mapping are required."
@@ -4072,15 +4072,15 @@ msgstr ""
 #. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Partnership"
-msgstr "साझेदारी"
+msgstr ""
 
 #: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
-msgstr "पासवर्ड"
+msgstr ""
 
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:104
 msgid "Password must be at least 8 characters"
-msgstr "पासवर्ड कम से कम 8 वर्णों का होना चाहिए"
+msgstr ""
 
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:107
 msgid "Password must contain lowercase, uppercase, number, and symbol"
@@ -4092,12 +4092,12 @@ msgstr ""
 
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:117
 msgid "Passwords do not match"
-msgstr "सांकेतिक शब्द मेल नहीं खाते"
+msgstr ""
 
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:36
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:123
 msgid "Passwords match"
-msgstr "पासवर्ड का मेल"
+msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #. Option for the 'Category' (Select) field in DocType 'HD Ticket Status'
@@ -4105,42 +4105,42 @@ msgstr "पासवर्ड का मेल"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Paused"
-msgstr "रुका हुआ"
+msgstr ""
 
 #: desk/src/pages/home/components/PendingTickets.vue:222
 msgid "Pending"
-msgstr "लंबित"
+msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:42
 #: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
-msgstr "लंबित निमंत्रण"
+msgstr ""
 
 #: desk/src/pages/home/Home.vue:353
 #: desk/src/pages/home/components/PendingTickets.vue:234
 #: desk/src/pages/home/components/PendingTickets.vue:238
 msgid "Pending Tickets"
-msgstr "लंबित टिकट"
+msgstr ""
 
 #: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
-msgstr "चैनल के अनुसार कुल टिकटों का प्रतिशत"
+msgstr ""
 
 #: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
-msgstr "प्राथमिकता के आधार पर कुल टिकटों का प्रतिशत"
+msgstr ""
 
 #: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
-msgstr "टीम के अनुसार कुल टिकटों का प्रतिशत"
+msgstr ""
 
 #: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
-msgstr "टिकटों के प्रकार के अनुसार कुल टिकटों का प्रतिशत"
+msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:46
 msgid "Period"
-msgstr "अवधि"
+msgstr ""
 
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #: desk/src/components/SavedRepliesSelectorModal.vue:170
@@ -4149,16 +4149,16 @@ msgstr "अवधि"
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:190
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 msgid "Personal"
-msgstr "निजी"
+msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:54
 msgid "Personal mobile no"
-msgstr "व्यक्तिगत मोबाइल नंबर"
+msgstr ""
 
 #: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
-msgstr "फ़ोन"
+msgstr ""
 
 #: desk/src/components/contact/EditContactDialog.vue:24
 #: desk/src/components/contact/NewContactDialog.vue:42
@@ -4167,7 +4167,7 @@ msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
 msgid "Pick an option"
-msgstr "एक विकल्प चुनें"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:468
 msgid "Pin View"
@@ -4178,7 +4178,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Pink"
-msgstr "गुलाबी"
+msgstr ""
 
 #. Label of the pinned (Check) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4248,7 +4248,7 @@ msgstr ""
 
 #: helpdesk/api/saved_replies.py:11
 msgid "Please provide saved_reply_id"
-msgstr "कृपया saved_reply_id प्रदान करें"
+msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:239
 msgid "Please select at least one restriction option for teams in the settings."
@@ -4256,11 +4256,11 @@ msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.py:41
 msgid "Please select weekly off day"
-msgstr "कृपया साप्ताहिक अवकाश का दिन चुनें"
+msgstr ""
 
 #: desk/src/components/Settings/Sla/SlaPolicyList.vue:32
 msgid "Policy name"
-msgstr "पॉलिसी का नाम"
+msgstr ""
 
 #: desk/src/components/contact/FeedbackList.vue:123
 msgid "Positive"
@@ -4270,13 +4270,13 @@ msgstr ""
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
-msgstr "पहले सकारात्मक"
+msgstr ""
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:10
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Prefer knowledge base"
-msgstr "ज्ञान आधार को प्राथमिकता दें"
+msgstr ""
 
 #: desk/src/components/Settings/Preferences/Preferences.vue:6
 msgid "Preferences"
@@ -4298,23 +4298,23 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:4
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:26
 msgid "Preview"
-msgstr "पूर्व दर्शन"
+msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:108
 msgid "Previous ticket"
-msgstr "पिछला टिकट"
+msgstr ""
 
 #: desk/src/components/contact/ContactInputRow.vue:20
 #: desk/src/components/customer/ContactCard.vue:31
 #: desk/src/components/customer/ContactCard.vue:36
 msgid "Primary"
-msgstr "प्राथमिक"
+msgstr ""
 
 #. Label of the primary_contact (Link) field in DocType 'HD Customer'
 #: desk/src/components/customer/NewCustomerDialog.vue:64
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Primary Contact"
-msgstr "प्राथमिक संपर्क"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
 msgid "Primary contact must be one of the listed contacts"
@@ -4347,7 +4347,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
 msgid "Priority"
-msgstr "प्राथमिकता"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:86
 msgid "Priority <u>{0}</u> must be included in the SLA {1}."
@@ -4360,16 +4360,16 @@ msgstr ""
 #: desk/src/components/layouts/Sidebar.vue:309
 #: desk/src/pages/ticket/Tickets.vue:377
 msgid "Private Views"
-msgstr "निजी दृश्य"
+msgstr ""
 
 #: desk/src/components/Settings/Teams/NewTeam.vue:30
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:11
 msgid "Product Experts"
-msgstr "उत्पाद विशेषज्ञ"
+msgstr ""
 
 #: desk/src/components/Settings/NewTeamModal.vue:20
 msgid "Product experts"
-msgstr "उत्पाद विशेषज्ञ"
+msgstr ""
 
 #: desk/src/components/Settings/Profile/Profile.vue:3
 msgid "Profile"
@@ -4382,27 +4382,27 @@ msgstr ""
 #. Label of the public (Check) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Public"
-msgstr "जनता"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:301
 #: desk/src/pages/ticket/Tickets.vue:392
 msgid "Public Views"
-msgstr "सार्वजनिक विचार"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/Article.vue:21
 msgid "Publish"
-msgstr "प्रकाशित करना"
+msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'HD Article'
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:443
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 msgid "Published"
-msgstr "प्रकाशित"
+msgstr ""
 
 #. Label of the published_on (Datetime) field in DocType 'HD Article'
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 msgid "Published On"
-msgstr "प्रकाशित"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.py:24
 msgid "Published articles must have content."
@@ -4427,11 +4427,11 @@ msgstr ""
 #. Label of the raised_by (Data) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Raised By (Email)"
-msgstr "(ईमेल) द्वारा जुटाया गया"
+msgstr ""
 
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:31
 msgid "Range"
-msgstr "श्रेणी"
+msgstr ""
 
 #. Title of the email-feedback Web Form
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4453,7 +4453,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
-msgstr "रेटिंग"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.py:23
 msgid "Rating must be between 0.2 and 1.0"
@@ -4461,34 +4461,34 @@ msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.py:19
 msgid "Rating {0} is not allowed"
-msgstr "रेटिंग {0} की अनुमति नहीं है"
+msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "Reaction"
-msgstr "प्रतिक्रिया"
+msgstr ""
 
 #. Label of the reactions (Table) field in DocType 'HD Ticket Comment'
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 msgid "Reactions"
-msgstr "प्रतिक्रियाओं"
+msgstr ""
 
 #. Label of the read (Check) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "Read"
-msgstr "पढ़ना"
+msgstr ""
 
 #: desk/src/pages/home/components/PendingTickets.vue:41
 msgid "Reason"
-msgstr "कारण"
+msgstr ""
 
 #: desk/src/pages/home/components/PendingTickets.vue:226
 msgid "Recent"
-msgstr "हाल ही का"
+msgstr ""
 
 #: desk/src/pages/home/components/PendingTickets.vue:233
 msgid "Recent Tickets"
-msgstr "हाल के टिकट"
+msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:30
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:29
@@ -4511,17 +4511,17 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Red"
-msgstr "लाल"
+msgstr ""
 
 #. Label of the reference_tab (Tab Break) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Reference"
-msgstr "संदर्भ"
+msgstr ""
 
 #. Label of the reference_ticket (Link) field in DocType 'HD Ticket Comment'
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 msgid "Reference Ticket"
-msgstr "संदर्भ टिकट"
+msgstr ""
 
 #. Label of the references_tab (Tab Break) field in DocType 'HD Customer'
 #. Label of the references_section (Section Break) field in DocType 'HD
@@ -4529,11 +4529,11 @@ msgstr "संदर्भ टिकट"
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "References"
-msgstr "संदर्भ"
+msgstr ""
 
 #: desk/src/pages/home/Home.vue:11
 msgid "Refresh"
-msgstr "ताज़ा करना"
+msgstr ""
 
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:75
 msgid "Refresh Apps"
@@ -4548,7 +4548,7 @@ msgstr ""
 #: desk/src/components/contact/ContactInputRow.vue:45
 #: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
-msgstr "निकालना"
+msgstr ""
 
 #: desk/src/components/customer/ContactCard.vue:190
 #: desk/src/components/customer/ContactCard.vue:294
@@ -4561,7 +4561,7 @@ msgstr ""
 
 #: desk/src/components/Settings/Profile/Profile.vue:197
 msgid "Remove Photo"
-msgstr "फ़ोटो हटाएँ"
+msgstr ""
 
 #: desk/src/components/view-controls/filter/Filter.vue:66
 #: desk/src/components/view-controls/filter/Filter.vue:67
@@ -4608,44 +4608,44 @@ msgstr ""
 #. Option in a Select field in the tickets Web Form
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
 msgid "Replied"
-msgstr "उत्तर दिया"
+msgstr ""
 
 #: desk/src/components/EmailArea.vue:54
 msgid "Reply"
-msgstr "जवाब"
+msgstr ""
 
 #: desk/src/components/EmailArea.vue:59
 msgid "Reply All"
-msgstr "सभी को उत्तर दें"
+msgstr ""
 
 #. Label of the reply_from_agent_section (Section Break) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Reply From Agent"
-msgstr "एजेंट की ओर से जवाब"
+msgstr ""
 
 #. Label of the reply_from_contact_section (Section Break) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Reply From Contact"
-msgstr "संपर्क से उत्तर"
+msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:84
 msgid "Reply from agent"
-msgstr "एजेंट की ओर से जवाब"
+msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:77
 msgid "Reply from contact"
-msgstr "संपर्क से जवाब"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:494
 msgid "Reply on a ticket"
-msgstr "टिकट पर प्रतिक्रिया दें"
+msgstr ""
 
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
-msgstr "आवश्यक"
+msgstr ""
 
 #: desk/src/pages/contact/Contact.vue:279
 msgid "Resend Invite"
@@ -4672,22 +4672,22 @@ msgstr ""
 #: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
-msgstr "संकल्प"
+msgstr ""
 
 #. Label of the resolution_by (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution By"
-msgstr "संकल्प द्वारा"
+msgstr ""
 
 #. Label of the resolution_date (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution Date"
-msgstr "संकल्प तिथि"
+msgstr ""
 
 #. Label of the resolution_details (Text Editor) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution Details"
-msgstr "संकल्प विवरण"
+msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4697,7 +4697,7 @@ msgstr ""
 #. Label of the resolution_failed_by (Duration) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution Failed By"
-msgstr "संकल्प विफल रहा"
+msgstr ""
 
 #. Label of the resolution_time (Duration) field in DocType 'HD Service Level
 #. Priority'
@@ -4705,23 +4705,23 @@ msgstr "संकल्प विफल रहा"
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution Time"
-msgstr "संकल्प समय"
+msgstr ""
 
 #. Option for the 'Category' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Resolved"
-msgstr "हल किया"
+msgstr ""
 
 #. Label of the response_tab (Tab Break) field in DocType 'HD Ticket'
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:89
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Response"
-msgstr "प्रतिक्रिया"
+msgstr ""
 
 #. Label of the response_by (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Response By"
-msgstr "द्वारा प्रतिक्रिया"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
@@ -4732,11 +4732,11 @@ msgstr ""
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:179
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Response and Resolution"
-msgstr "प्रतिक्रिया और समाधान"
+msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:407
 msgid "Response is required"
-msgstr "उत्तर देना आवश्यक है"
+msgstr ""
 
 #. Label of the assign_within_team (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -4751,11 +4751,11 @@ msgstr ""
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Restrict tickets by Team"
-msgstr "टिकटों को टीम के आधार पर प्रतिबंधित करें"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:35
 msgid "Restrict tickets by team"
-msgstr "टिकटों को टीम के आधार पर प्रतिबंधित करें"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:38
 msgid "Restrict tickets to be viewed and managed by team members only."
@@ -4769,7 +4769,7 @@ msgstr ""
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
-msgstr "समीक्षा"
+msgstr ""
 
 #: desk/src/components/customer/RevokeInviteButton.vue:12
 msgid "Revoke Invite"
@@ -4781,22 +4781,22 @@ msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:215
 msgid "Ringing"
-msgstr "बज"
+msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:19
 #: desk/src/components/customer/ContactCard.vue:165
 #: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
-msgstr "भूमिका"
+msgstr ""
 
 #: desk/src/components/customer/ContactCard.vue:248
 msgid "Role updated successfully"
-msgstr "भूमिका सफलतापूर्वक अपडेट हो गई"
+msgstr ""
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Route Name"
-msgstr "मार्ग का नाम"
+msgstr ""
 
 #. Label of the rows (Code) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4874,7 +4874,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Saturday"
-msgstr "शनिवार"
+msgstr ""
 
 #. Button label of the email-feedback Web Form
 #: desk/src/components/ListViewBuilder.vue:704
@@ -4897,11 +4897,11 @@ msgstr "शनिवार"
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
 msgid "Save"
-msgstr "बचाना"
+msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:17
 msgid "Save Changes"
-msgstr "परिवर्तनों को सुरक्षित करें"
+msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:12
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:3
@@ -4938,12 +4938,12 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:57
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 msgid "Scope"
-msgstr "दायरा"
+msgstr ""
 
 #. Label of the script (Code) field in DocType 'HD Form Script'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 msgid "Script"
-msgstr "लिखी हुई कहानी"
+msgstr ""
 
 #. Label of the search_tab (Tab Break) field in DocType 'HD Settings'
 #: desk/src/components/SavedRepliesSelectorModal.vue:27
@@ -4958,7 +4958,7 @@ msgstr "लिखी हुई कहानी"
 #: desk/src/components/layouts/Sidebar.vue:14 desk/src/pages/SearchAgent.vue:7
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Search"
-msgstr "खोज"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.js:10
 msgid "Search Index Regenerated"
@@ -4966,11 +4966,11 @@ msgstr ""
 
 #: helpdesk/helpdesk/report/ticket_search_analysis/ticket_search_analysis.py:40
 msgid "Search Score"
-msgstr "खोज स्कोर"
+msgstr ""
 
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
-msgstr "खोज एजेंट..."
+msgstr ""
 
 #: desk/src/components/customer/TicketsTab.vue:7
 msgid "Search by ID or Subject"
@@ -4982,11 +4982,11 @@ msgstr ""
 
 #: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
-msgstr "खोज फ़ील्ड..."
+msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:126
 msgid "Search for \"{0}\""
-msgstr "\"{0} \" खोजें"
+msgstr ""
 
 #: desk/src/pages/SearchAgent.vue:100
 msgid "Search index does not exist. Please build the index first."
@@ -5002,32 +5002,32 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:20
 msgid "Search ticket"
-msgstr "टिकट खोजें"
+msgstr ""
 
 #: desk/src/pages/SearchAgent.vue:16
 msgid "Search tickets, comments, and communications..."
-msgstr "टिकट, टिप्पणियां और संदेश खोजें..."
+msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:12
 msgid "Search tickets, emails, comments, or #234 to navigate to ticket"
-msgstr "टिकट, ईमेल, टिप्पणियाँ या #234 खोजें और टिकट पर जाएँ"
+msgstr ""
 
 #: desk/src/components/view-controls/filter/FilterValueEditor.vue:33
 msgid "Search..."
-msgstr "खोज..."
+msgstr ""
 
 #: desk/src/pages/SearchAgent.vue:137
 msgid "Searched for:"
-msgstr "खोज की गई:"
+msgstr ""
 
 #: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
-msgstr "खोज जारी है..."
+msgstr ""
 
 #: desk/src/pages/home/components/PendingTickets.vue:147
 msgid "See all {0} tickets"
-msgstr "सभी टिकट देखें {0}"
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:28
 #: desk/src/pages/call-logs/CallLogModal.vue:57
@@ -5035,11 +5035,11 @@ msgstr "सभी टिकट देखें {0}"
 #: desk/src/pages/call-logs/CallLogModal.vue:92
 #: desk/src/pages/call-logs/CallLogModal.vue:101
 msgid "Select"
-msgstr "चुनना"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
-msgstr "श्रेणी चुनना"
+msgstr ""
 
 #: desk/src/components/contact/EditContactDialog.vue:161
 msgid "Select Customer"
@@ -5063,7 +5063,7 @@ msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:26
 msgid "Select a rating"
-msgstr "रेटिंग चुनें"
+msgstr ""
 
 #: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
 msgid "Select country"
@@ -5072,11 +5072,11 @@ msgstr ""
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
-msgstr "श्रेणी का चयन करें"
+msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:78
 msgid "Select teams"
-msgstr "टीमों का चयन करें"
+msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
@@ -5092,15 +5092,15 @@ msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:41
 msgid "Select your weekly off day"
-msgstr "अपनी साप्ताहिक छुट्टी का दिन चुनें"
+msgstr ""
 
 #: desk/src/pages/ticket/TicketCustomer.vue:78
 msgid "Send"
-msgstr "भेजना"
+msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:37
 msgid "Send Invites"
-msgstr "निमंत्रण भेजें"
+msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:32
 msgid "Send Reply"
@@ -5110,7 +5110,7 @@ msgstr ""
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
-msgstr "प्रतिक्रिया भेजें"
+msgstr ""
 
 #: desk/src/pages/contact/Contact.vue:294
 msgid "Send reset password email"
@@ -5138,7 +5138,7 @@ msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:618
 msgid "Service Level Agreement"
-msgstr "सेवा स्तर समझौता"
+msgstr ""
 
 #: desk/src/components/Settings/Sla/SlaPolicies.vue:5
 msgid "Service Level Agreements (SLAs)"
@@ -5148,7 +5148,7 @@ msgstr ""
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Service Level Name"
-msgstr "सेवा स्तर का नाम"
+msgstr ""
 
 #: helpdesk/api/settings/email.py:14
 msgid "Service not supported"
@@ -5156,12 +5156,12 @@ msgstr ""
 
 #: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
-msgstr "तय करना"
+msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:4
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
-msgstr "फ़ोन नंबर सेट करें"
+msgstr ""
 
 #: desk/src/components/customer/ContactCard.vue:265
 msgid "Set Primary Contact"
@@ -5215,7 +5215,7 @@ msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:574
 msgid "Setting up"
-msgstr "की स्थापना"
+msgstr ""
 
 #. Label of the column_break_feto (Column Break) field in DocType 'HD Team'
 #: desk/src/components/layouts/Sidebar.vue:386
@@ -5240,7 +5240,7 @@ msgstr ""
 #. Label of the setup_section (Section Break) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Setup"
-msgstr "स्थापित करना"
+msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:3
 msgid "Setup Email"
@@ -5253,17 +5253,17 @@ msgstr ""
 #: desk/src/pages/knowledge-base/Article.vue:649
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:167
 msgid "Share"
-msgstr "शेयर करना"
+msgstr ""
 
 #. Label of the share_feedback_section (Section Break) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Share Feedback"
-msgstr "प्रतिक्रिया साझा करें"
+msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:65
 msgid "Share feedback"
-msgstr "प्रतिक्रिया साझा करें"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:381
 msgid "Shortcuts"
@@ -5288,11 +5288,11 @@ msgstr ""
 
 #: desk/src/pages/home/components/PendingTickets.vue:154
 msgid "Showing {0} of {1} {2}"
-msgstr "{1} {2} में से {0} दिखा रहा है"
+msgstr ""
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:22
 msgid "Signature"
-msgstr "हस्ताक्षर"
+msgstr ""
 
 #. Description of the 'Condition' (Code) field in DocType 'HD Service Level
 #. Agreement'
@@ -5333,7 +5333,7 @@ msgstr ""
 #: desk/src/components/view-controls/SortBy.vue:22
 #: desk/src/components/view-controls/SortBy.vue:231
 msgid "Sort"
-msgstr "क्रम से लगाना"
+msgstr ""
 
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
@@ -5345,13 +5345,13 @@ msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket/api.py:335
 msgid "Source ticket does not exist"
-msgstr "स्रोत टिकट मौजूद नहीं है"
+msgstr ""
 
 #. Label of the split_and_merge_section (Section Break) field in DocType 'HD
 #. Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Split and Merge"
-msgstr "विभाजित करें और विलय करें"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.js:9
 msgid "Standard Form Scripts can't be modified, duplicate the script instead."
@@ -5364,12 +5364,12 @@ msgstr ""
 #. Label of the start_date (Date) field in DocType 'HD Service Level Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Start Date"
-msgstr "आरंभ करने की तिथि"
+msgstr ""
 
 #. Label of the start_time (Time) field in DocType 'HD Service Day'
 #: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
 msgid "Start Time"
-msgstr "समय शुरू"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:100
 msgid "Start Time can't be greater than or equal to End Time in row <u>{0}</u>."
@@ -5391,24 +5391,24 @@ msgstr ""
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:31
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
 msgid "Status"
-msgstr "स्थिति"
+msgstr ""
 
 #. Label of the auto_close_status (Link) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Status "
-msgstr "स्थिति "
+msgstr ""
 
 #. Label of the status_category (Data) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Status Category"
-msgstr "स्थिति श्रेणी"
+msgstr ""
 
 #. Label of the status_details (Section Break) field in DocType 'HD Service
 #. Level Agreement'
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:227
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Status Details"
-msgstr "स्थिति विवरण"
+msgstr ""
 
 #. Label of the status_order (Int) field in DocType 'HD Agent Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -5417,7 +5417,7 @@ msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:382
 msgid "Status is required"
-msgstr "स्थिति आवश्यक है"
+msgstr ""
 
 #. Description of the 'Ticket Reopen status' (Link) field in DocType 'HD
 #. Service Level Agreement'
@@ -5454,22 +5454,22 @@ msgstr ""
 #: helpdesk/helpdesk/report/ticket_search_analysis/ticket_search_analysis.py:30
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
 msgid "Subject"
-msgstr "विषय"
+msgstr ""
 
 #. Label of the subject_weight (Int) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Subject Weight"
-msgstr "विषय का वजन"
+msgstr ""
 
 #: desk/src/components/ticket/TicketSplitModal.vue:74
 msgid "Subject is required"
-msgstr "विषय आवश्यक है"
+msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:8
 #: desk/src/pages/ticket/TicketNew.vue:96
 #: desk/src/pages/ticket/TicketNew.vue:120
 msgid "Submit"
-msgstr "जमा करना"
+msgstr ""
 
 #. Label of the summary (Text Editor) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5482,27 +5482,27 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Sunday"
-msgstr "रविवार"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:366
 msgid "Support"
-msgstr "सहायता"
+msgstr ""
 
 #. Name of a report
 #: helpdesk/helpdesk/report/support_hour_distribution/support_hour_distribution.json
 msgid "Support Hour Distribution"
-msgstr "सहायता घंटा वितरण"
+msgstr ""
 
 #. Label of a Link in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Support Policy"
-msgstr "समर्थन नीति"
+msgstr ""
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "Support Team"
-msgstr "सहायता दल"
+msgstr ""
 
 #: desk/src/components/Settings/Preferences/components/ThemeSwitcher.vue:11
 msgid "Switch between light, dark, or system theme"
@@ -5555,7 +5555,7 @@ msgstr ""
 #. Label of the is_system (Check) field in DocType 'HD Ticket Type'
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "System"
-msgstr "प्रणाली"
+msgstr ""
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
@@ -5586,7 +5586,7 @@ msgstr "प्रणाली"
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "System Manager"
-msgstr "सिस्टम प्रबंधक"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.py:12
 msgid "System types can not be deleted"
@@ -5594,7 +5594,7 @@ msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:22
 msgid "Tampered Access"
-msgstr "छेड़छाड़ की गई पहुंच"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket/api.py:337
 msgid "Target ticket does not exist"
@@ -5622,17 +5622,17 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Team"
-msgstr "टीम"
+msgstr ""
 
 #: desk/src/components/Settings/Teams/NewTeam.vue:29
 msgid "Team Name"
-msgstr "टीम का नाम"
+msgstr ""
 
 #. Label of the agent_groups_section (Section Break) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Team Restrictions"
-msgstr "टीम प्रतिबंध"
+msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:269
 msgid "Team can now access all tickets."
@@ -5640,7 +5640,7 @@ msgstr ""
 
 #: desk/src/components/Settings/NewTeamModal.vue:52
 msgid "Team created"
-msgstr "टीम ने बनाया"
+msgstr ""
 
 #: desk/src/components/Settings/Teams/NewTeam.vue:140
 msgid "Team created successfully."
@@ -5661,7 +5661,7 @@ msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamsList.vue:51
 msgid "Team name"
-msgstr "टीम का नाम"
+msgstr ""
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:56
 msgid "Team renamed successfully."
@@ -5676,7 +5676,7 @@ msgstr ""
 #: desk/src/components/Settings/Teams/TeamsList.vue:3
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 msgid "Teams"
-msgstr "टीमें"
+msgstr ""
 
 #: desk/src/components/Settings/Telephony/Telephony.vue:6
 msgid "Telephony"
@@ -5690,7 +5690,7 @@ msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:54
 msgid "Tell us more"
-msgstr "हमें और अधिक बताएँ"
+msgstr ""
 
 #. Label of the template (Link) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5736,7 +5736,7 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
-msgstr "दिनों की संख्या 1 या अधिक होनी चाहिए"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
 msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
@@ -5752,7 +5752,7 @@ msgstr ""
 
 #: desk/src/components/Settings/Preferences/components/ThemeSwitcher.vue:6
 msgid "Theme"
-msgstr "विषय"
+msgstr ""
 
 #: desk/src/components/knowledge-base/CategoryFolderContainer.vue:18
 msgid "There are no categories published at the moment."
@@ -5834,7 +5834,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Thursday"
-msgstr "गुरुवार"
+msgstr ""
 
 #. Label of the ticket (Link) field in DocType 'HD Email Feedback'
 #. Label of the reference_ticket (Link) field in DocType 'HD Notification'
@@ -5848,18 +5848,18 @@ msgstr "गुरुवार"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
 msgid "Ticket"
-msgstr "टिकट"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
-msgstr "टिकट #{0}: हमें आपका अनुरोध प्राप्त हो गया है"
+msgstr ""
 
 #. Name of a report
 #. Label of a Link in the Helpdesk Workspace
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.json
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Analytics"
-msgstr "टिकट विश्लेषण"
+msgstr ""
 
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
@@ -5872,20 +5872,20 @@ msgstr ""
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
 msgid "Ticket Info"
-msgstr "टिकट की जानकारी"
+msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:85
 msgid "Ticket Management"
-msgstr "टिकट प्रबंधन"
+msgstr ""
 
 #. Label of the is_merged (Check) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Ticket Merged"
-msgstr "टिकट विलय हो गया"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:40
 msgid "Ticket Not Found"
-msgstr "टिकट नहीं मिला"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:620
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:50
@@ -5893,7 +5893,7 @@ msgstr "टिकट नहीं मिला"
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:37
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.py:105
 msgid "Ticket Priority"
-msgstr "टिकट प्राथमिकता"
+msgstr ""
 
 #. Label of the ticket_reopen_status (Link) field in DocType 'HD Service Level
 #. Agreement'
@@ -5901,7 +5901,7 @@ msgstr "टिकट प्राथमिकता"
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Ticket Reopen status"
-msgstr "टिकट पुनः खोलने की स्थिति"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:18
 msgid "Ticket Routing"
@@ -5914,7 +5914,7 @@ msgstr ""
 #. Label of the ticket_split_from (Link) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Ticket Split From"
-msgstr "टिकट विभाजन से"
+msgstr ""
 
 #: desk/src/components/ticket/TicketMergeModal.vue:65
 msgid "Ticket Subject"
@@ -5929,7 +5929,7 @@ msgstr ""
 
 #: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
-msgstr "टिकट ट्रेंड"
+msgstr ""
 
 #. Label of the ticket_type_section (Section Break) field in DocType 'HD
 #. Settings'
@@ -5967,7 +5967,7 @@ msgstr ""
 #: desk/src/pages/ticket/TicketAgent.vue:33
 #: helpdesk/helpdesk/doctype/hd_ticket/api.py:63
 msgid "Ticket not found"
-msgstr "टिकट नहीं मिला"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:40
 msgid "Ticket not found for the provided key."
@@ -5981,7 +5981,7 @@ msgstr ""
 #. Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Ticket raised outside working hours"
-msgstr "कार्य समय के बाहर टिकट जारी किया गया"
+msgstr ""
 
 #: desk/src/components/ticket/TicketSplitModal.vue:79
 msgid "Ticket split successfully."
@@ -5989,7 +5989,7 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:155
 msgid "Ticket status"
-msgstr "टिकट की स्थिति"
+msgstr ""
 
 #: desk/src/components/ticket/TicketMergeModal.vue:189
 msgid "Ticket to merged with is required"
@@ -6002,7 +6002,7 @@ msgstr ""
 #. Name of a report
 #: helpdesk/helpdesk/report/ticket_search_analysis/ticket_search_analysis.json
 msgid "Ticket-Search Analysis"
-msgstr "टिकट-खोज विश्लेषण"
+msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
@@ -6016,7 +6016,7 @@ msgstr "टिकट-खोज विश्लेषण"
 #: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
 #: helpdesk/api/dashboard.py:302
 msgid "Tickets"
-msgstr "टिकट"
+msgstr ""
 
 #: desk/src/pages/home/components/PendingTickets.vue:242
 msgid "Tickets approaching or breached SLA"
@@ -6028,7 +6028,7 @@ msgstr ""
 
 #: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
-msgstr "चैनल के अनुसार टिकट"
+msgstr ""
 
 #: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
@@ -6036,11 +6036,11 @@ msgstr ""
 
 #: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
-msgstr "टीम द्वारा टिकट"
+msgstr ""
 
 #: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
-msgstr "टिकट प्रकार के अनुसार"
+msgstr ""
 
 #: helpdesk/api/ticket.py:65
 msgid "Tickets can only be assigned to agents"
@@ -6052,12 +6052,12 @@ msgstr ""
 
 #: desk/src/pages/home/components/PendingTickets.vue:244
 msgid "Tickets that are awaiting your response"
-msgstr "जिन टिकटों पर आपकी प्रतिक्रिया का इंतजार है"
+msgstr ""
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
 #: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
-msgstr "समय क्षेत्र"
+msgstr ""
 
 #. Label of the title (Data) field in DocType 'HD Article'
 #. Label of the title (Data) field in DocType 'HD Saved Reply'
@@ -6069,7 +6069,7 @@ msgstr "समय क्षेत्र"
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 msgid "Title"
-msgstr "शीर्षक"
+msgstr ""
 
 #. Label of the title_slug (Data) field in DocType 'HD Article'
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
@@ -6079,14 +6079,14 @@ msgstr ""
 #: desk/src/components/Settings/NewTeamModal.vue:48
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:397
 msgid "Title is required"
-msgstr "शीर्षक आवश्यक है"
+msgstr ""
 
 #. Label of the user_to (Link) field in DocType 'HD Notification'
 #: desk/src/components/EmailEditor.vue:34
 #: desk/src/pages/call-logs/CallLogModal.vue:33
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "To"
-msgstr "को"
+msgstr ""
 
 #. Label of the to_date (Date) field in DocType 'HD Service Holiday List'
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
@@ -6095,7 +6095,7 @@ msgstr "को"
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:24
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:24
 msgid "To Date"
-msgstr "तारीख तक"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.py:45
 msgid "To Date cannot be before From Date"
@@ -6104,20 +6104,20 @@ msgstr ""
 #: desk/src/components/Settings/Holiday/HolidayView.vue:92
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:157
 msgid "To date"
-msgstr "तारीख तक"
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:366
 msgid "To is required"
-msgstr "की आवश्यकता है"
+msgstr ""
 
 #: desk/src/components/Settings/EmailEdit.vue:268
 msgid "To know more about setting up email accounts, click"
-msgstr "ईमेल खाते सेट अप करने के बारे में अधिक जानने के लिए, क्लिक करें"
+msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:472
 #: desk/src/pages/dashboard/Dashboard.vue:474
 msgid "Today"
-msgstr "आज"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:262
 msgid "Toggle theme"
@@ -6125,41 +6125,41 @@ msgstr ""
 
 #: helpdesk/helpdesk/report/ticket_search_analysis/ticket_search_analysis.py:35
 msgid "Top Result"
-msgstr "शीर्ष परिणाम"
+msgstr ""
 
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:98
 msgid "Total"
-msgstr "कुल"
+msgstr ""
 
 #. Label of the total_hold_time (Duration) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Total Hold Time"
-msgstr "कुल प्रतीक्षा समय"
+msgstr ""
 
 #. Label of the total_holidays (Int) field in DocType 'HD Service Holiday List'
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Total Holidays"
-msgstr "कुल छुट्टियाँ"
+msgstr ""
 
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.py:126
 msgid "Total Ticket"
-msgstr "कुल टिकट"
+msgstr ""
 
 #: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
-msgstr "कुल निर्मित टिकटों की संख्या"
+msgstr ""
 
 #: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
-msgstr "प्राथमिकता के आधार पर कुल टिकट"
+msgstr ""
 
 #: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
-msgstr "टीम के अनुसार कुल टिकट"
+msgstr ""
 
 #: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
-msgstr "प्रकार के अनुसार कुल टिकट"
+msgstr ""
 
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
@@ -6167,7 +6167,7 @@ msgstr "प्रकार के अनुसार कुल टिकट"
 #: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Tuesday"
-msgstr "मंगलवार"
+msgstr ""
 
 #: desk/src/components/Settings/Telephony/Telephony.vue:72
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:4
@@ -6183,11 +6183,11 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Type"
-msgstr "प्रकार"
+msgstr ""
 
 #: desk/src/pages/ticket/TicketCustomer.vue:69
 msgid "Type a message"
-msgstr "एक संदेश टाइप करें"
+msgstr ""
 
 #: desk/src/components/customer/InviteContactDialog.vue:19
 msgid "Type an email address"
@@ -6195,12 +6195,12 @@ msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
-msgstr "टाइप आवश्यक है"
+msgstr ""
 
 #. Label of the url_method (Data) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "URL/Method"
-msgstr "यूआरएल/विधि"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
@@ -6276,7 +6276,7 @@ msgstr ""
 #. Label of the update_status_to (Link) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Update status to"
-msgstr "स्थिति को अपडेट करें"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:41
 msgid "Upload"
@@ -6313,12 +6313,12 @@ msgstr ""
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.py:83
 msgid "User"
-msgstr "उपयोगकर्ता"
+msgstr ""
 
 #. Label of the user_resolution_time (Duration) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
-msgstr "उपयोगकर्ता समाधान समय"
+msgstr ""
 
 #: desk/src/components/contact/FeedbackList.vue:6
 msgid "User Reviews"
@@ -6326,7 +6326,7 @@ msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
 msgid "User Signup"
-msgstr "उपयोगकर्ता पंजीकरण"
+msgstr ""
 
 #. Label of the users (Table MultiSelect) field in DocType 'HD Team'
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
@@ -6339,18 +6339,18 @@ msgstr ""
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:132
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Valid From"
-msgstr "मान्य तिथि से"
+msgstr ""
 
 #: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
-msgstr "कीमत"
+msgstr ""
 
 #. Label of the via_customer_portal (Check) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
 msgid "Via Customer Portal"
-msgstr "ग्राहक पोर्टल के माध्यम से"
+msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:241
 msgid "View Assignment rule"
@@ -6358,12 +6358,12 @@ msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:652
 msgid "View {0}"
-msgstr "दृश्य {0}"
+msgstr ""
 
 #. Label of the views (Int) field in DocType 'HD Article'
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 msgid "Views"
-msgstr "दृश्य"
+msgstr ""
 
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
@@ -6374,7 +6374,7 @@ msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:10
 msgid "Was this article Helpful?"
-msgstr "क्या यह लेख उपयोगी था?"
+msgstr ""
 
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
@@ -6382,18 +6382,18 @@ msgstr "क्या यह लेख उपयोगी था?"
 #: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Wednesday"
-msgstr "बुधवार"
+msgstr ""
 
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:34
 msgid "Weekly"
-msgstr "साप्ताहिक"
+msgstr ""
 
 #. Label of the weekly_off (Check) field in DocType 'HD Holiday'
 #. Label of the weekly_off (Select) field in DocType 'HD Service Holiday List'
 #: helpdesk/helpdesk/doctype/hd_holiday/hd_holiday.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Weekly Off"
-msgstr "साप्ताहिक अवकाश"
+msgstr ""
 
 #. Description of the 'Auto update status' (Check) field in DocType 'HD
 #. Settings'
@@ -6406,7 +6406,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 #: helpdesk/helpdesk/doctype/hd_synonyms/hd_synonyms.json
 msgid "Word"
-msgstr "शब्द"
+msgstr ""
 
 #: desk/src/components/Settings/Sla/SlaHolidays.vue:5
 msgid "Work Schedule and Holidays"
@@ -6444,12 +6444,12 @@ msgstr ""
 #. Level Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Working Hours"
-msgstr "कार्य के घंटे"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/Article.vue:172
 #: desk/src/pages/knowledge-base/NewArticle.vue:55
 msgid "Write your article here..."
-msgstr "अपना लेख यहाँ लिखें..."
+msgstr ""
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:31
 msgid "Write your email signature here."
@@ -6461,14 +6461,14 @@ msgstr ""
 
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:37
 msgid "Yearly"
-msgstr "सालाना"
+msgstr ""
 
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Yellow"
-msgstr "पीला"
+msgstr ""
 
 #: helpdesk/api/ticket_stats.py:35
 msgid "You are not allowed to view another agent's stats."
@@ -6544,7 +6544,7 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
-msgstr "आपका प्रदर्शन है"
+msgstr ""
 
 #: desk/src/components/customer/ContactCard.vue:116
 msgid "active ticket"
@@ -6556,7 +6556,7 @@ msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:46
 msgid "assigned you a ticket"
-msgstr "आपको एक टिकट सौंपा गया है"
+msgstr ""
 
 #: desk/src/components/ticket-agent/AssignTo.vue:29
 msgid "assignees"
@@ -6564,7 +6564,7 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:477
 msgid "average"
-msgstr "औसत"
+msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:13
 msgid "back to email event list"
@@ -6572,11 +6572,11 @@ msgstr ""
 
 #: desk/src/components/HistoryBox.vue:12
 msgid "changes from"
-msgstr "परिवर्तन से"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:651
 msgid "created"
-msgstr "बनाया था"
+msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:42
 msgid "customize {0}"
@@ -6584,19 +6584,19 @@ msgstr ""
 
 #: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
-msgstr "दिन"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:563
 msgid "deleted"
-msgstr "हटाए गए"
+msgstr ""
 
 #: desk/src/components/ticket/TicketSplitModal.vue:7
 msgid "emails/ comments"
-msgstr "ईमेल/टिप्पणियाँ"
+msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:473
 msgid "excellent"
-msgstr "उत्कृष्ट"
+msgstr ""
 
 #: desk/src/components/ticket/TicketSplitModal.vue:8
 msgid "from this email onwards will be moved to new ticket."
@@ -6604,7 +6604,7 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:475
 msgid "good"
-msgstr "अच्छा"
+msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -6613,20 +6613,20 @@ msgstr ""
 
 #: desk/src/components/CallArea.vue:16
 msgid "has made a call"
-msgstr "फोन किया है"
+msgstr ""
 
 #: desk/src/components/CallArea.vue:15
 msgid "has reached out"
-msgstr "संपर्क किया है"
+msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:49
 msgid "has reopened the ticket"
-msgstr "टिकट दोबारा खोल दिया गया है"
+msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:78
 #: desk/src/components/Settings/General/components/TicketSettings.vue:237
 msgid "here"
-msgstr "यहाँ"
+msgstr ""
 
 #: desk/src/components/Settings/FieldDependency/FieldDependencyList.vue:21
 #: desk/src/components/Settings/Sla/SlaPolicies.vue:19
@@ -6635,15 +6635,15 @@ msgstr ""
 
 #: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
-msgstr "घंटे"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:15
 msgid "in"
-msgstr "में"
+msgstr ""
 
 #: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
-msgstr "बस अब"
+msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -6653,11 +6653,11 @@ msgstr ""
 #. Option for the 'Type' (Select) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "list"
-msgstr "सूची"
+msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:43
 msgid "mentioned you in ticket"
-msgstr "टिकट में आपका जिक्र किया गया है"
+msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:479
 msgid "poor"
@@ -6676,11 +6676,11 @@ msgstr ""
 
 #: desk/src/components/customer/TicketStats.vue:32
 msgid "reviews"
-msgstr "समीक्षा"
+msgstr ""
 
 #: helpdesk/api/dashboard.py:242
 msgid "stars"
-msgstr "सितारे"
+msgstr ""
 
 #. Label of the synonym (Data) field in DocType 'HD Synonym'
 #: helpdesk/helpdesk/doctype/hd_synonym/hd_synonym.json
@@ -6689,7 +6689,7 @@ msgstr ""
 
 #: desk/src/pages/home/components/PendingTickets.vue:158
 msgid "ticket"
-msgstr "टिकट"
+msgstr ""
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:68
 msgid "to enable this integration."
@@ -6697,11 +6697,11 @@ msgstr ""
 
 #: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
-msgstr "इसे देखा"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/Article.vue:85
 msgid "views"
-msgstr "दृश्य"
+msgstr ""
 
 #: desk/src/components/contact/ContactCustomers.vue:53
 msgid "{0} Customers"
@@ -6741,11 +6741,11 @@ msgstr ""
 
 #: desk/src/pages/SearchAgent.vue:117
 msgid "{0} matches"
-msgstr "{0} मिलान"
+msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:46
 msgid "{0} reviews"
-msgstr "{0} समीक्षाएँ"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:510
 msgid "{0} view is currently public. Changing it to private will hide it for all the users."

--- a/helpdesk/locale/bs.po
+++ b/helpdesk/locale/bs.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-21 20:28\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-07-11 10:18\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Bosnian\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr " komentirao/la"
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr "% ispunjen Ugovor o Nivou Usluge"
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr "% kreiranih zahtjeva koji su riješeni u okviru Ugovora o Nivou Usluge"
@@ -108,14 +108,6 @@ msgstr "Kratak opis"
 msgid "A workday with this name already exists"
 msgstr "Radni dan s ovim nazivom već postoji"
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr "API"
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr "Pristup svim timskim zahtjevima"
@@ -132,7 +124,7 @@ msgstr "Pristup samo zahtjevima ovog tima"
 msgid "Account"
 msgstr "Račun"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr "Informacije Računa & Sigurnost"
 
@@ -152,11 +144,9 @@ msgstr "Radnja"
 msgid "Action Required"
 msgstr "Radnja je Obavezna"
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr "Radnja koja se izvršava prilikom klika na dugme. Dokument će biti dostupan kao `this`"
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "Radnje"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr "Radnja koja se izvršava prilikom klika na dugme. Dokument će biti dost
 msgid "Active"
 msgstr "Aktivan"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr "Aktivan sada"
 
@@ -177,7 +167,7 @@ msgstr "Aktivan: Agent je dostupan i radi.<br>\n"
 "Odsutan: Agent je privremeno nedostupan.<br>\n"
 "Nedostupan: Agent je isključen i nedostupan."
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "Aktivnost"
@@ -195,10 +185,11 @@ msgid "Add Column"
 msgstr "Dodaj Kolonu"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr "Dodaj E-poštu"
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "Dodaj Filter..."
 
@@ -209,6 +200,10 @@ msgstr "Dodaj praznik"
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
 msgstr "Dodaj novi Članak"
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
+msgstr "Dodaj Telefonski Broj"
 
 #: desk/src/components/view-controls/SortBy.vue:148
 msgid "Add Sort"
@@ -246,7 +241,7 @@ msgstr "Dodaj uslov"
 msgid "Add condition group"
 msgstr "Dodaj grupu uslova"
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "Dodaj filter"
 
@@ -280,6 +275,12 @@ msgstr "Dodajte vremenske ciljeve oko ključnih prekretnica u podršci, kao što
 msgid "Add to Holidays"
 msgstr "Dodaj Praznicima"
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr "Dodaj u primaoce"
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr "Dodaj i upravljaj agentima i dodeljuj im uloge."
@@ -297,17 +298,14 @@ msgid "Administrator"
 msgstr "Administrator"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -318,6 +316,7 @@ msgstr "Administrator"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -337,6 +336,7 @@ msgstr "Nadzorna Tabla Agenta"
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -344,6 +344,7 @@ msgstr "Nadzorna Tabla Agenta"
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -378,18 +379,9 @@ msgstr "Agenti više neće moći pregledavati i kreirati sačuvane odgovore s gl
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "Svi"
 
@@ -445,7 +437,7 @@ msgstr "Ćilibar"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:113
 msgid "Anyone will be able to create tickets without any permission. e.g. from webform."
-msgstr "Bilo ko će moći kreirati zahtjeve bez ikakve dozvole, npr. putem web formulara."
+msgstr "Bilo ko će moći izraditi zahtjeve bez ikakve dozvole, npr. putem web obrasca."
 
 #: desk/src/components/Settings/Preferences/Preferences.vue:26
 msgid "Appearance"
@@ -510,6 +502,14 @@ msgstr "Jeste li sigurni da želite zatvoriti ovaj zahtjev?"
 msgid "Are you sure you want to delete these articles?"
 msgstr "Jeste li sigurni da želite izbrisati ove članke?"
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr "Jeste li sigurni da želite izbrisati ovaj kontakt? Kontakt će biti trajno izbrisan i njegova veza će biti ukinuta sa svim povezanim klijentima i zahtjevima."
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr "Jeste li sigurni da želite izbrisati ovog korisnika? Referenca na ovog korisnika bit će uklonjena iz svih povezanih zahtjeva."
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr "Jeste li sigurni da želite izbrisati ovaj zahtjev? Ovo je nepovratna radnja i ne može se poništiti."
@@ -546,6 +546,10 @@ msgstr "Jeste li sigurni da želite izaći? Nespremljene promjene će biti izgub
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
 msgstr "Jeste li sigurni da želite ukloniti logo?"
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
+msgstr "Jeste li sigurni da želite ukloniti ovaj kontakt od klijenta?"
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
 msgid "Are you sure you want to reset the content? Current content will be overridden."
@@ -597,16 +601,11 @@ msgstr "Dodijelite zahtjev agentu"
 msgid "Assign ticket"
 msgstr "Dodijeli zahtjev"
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr "Dodijeli"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr "Dodijeli sebi"
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -620,7 +619,7 @@ msgstr "Dodijeljeni"
 msgid "Assignee Rules"
 msgstr "Pravila Dodjele"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr "Dodijeljene osobe je uspješno ažurirane."
 
@@ -628,7 +627,7 @@ msgstr "Dodijeljene osobe je uspješno ažurirane."
 msgid "Assignees"
 msgstr "Dodijeljeni"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr "Dodijeljeni su uspješno ažurirani."
 
@@ -694,10 +693,6 @@ msgstr "Pravilo dodjele je uspješno ažurirano."
 msgid "Assignment rule {0} updated successfully."
 msgstr "Pravilo dodjele {0} je uspješno ažurirano."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr "Potrebna je barem jedna e-mail adresa"
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -714,10 +709,6 @@ msgstr "Za ocjenu {0} mora biti omogućena barem jedna opcija povratnih informac
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
 msgstr "Potreban je barem jedan tim"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
-msgstr "Barem jedan od prioriteta, tima i tipa zahtjeva je obavezan"
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
@@ -768,7 +759,7 @@ msgid "Automation"
 msgstr "Automatizacija"
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr "Dostupnost"
@@ -804,7 +795,7 @@ msgstr "Prosječno Vreme Odziva"
 msgid "Average Time Metrics"
 msgstr "Pokazatelji prosječnog vremena"
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr "Prosječna ocjena povratnih informacija po danu je oko {0} zvjezdica"
 
@@ -812,25 +803,37 @@ msgstr "Prosječna ocjena povratnih informacija po danu je oko {0} zvjezdica"
 msgid "Average response and resolution metrics not available"
 msgstr "Prosječne metrike odgovora i rezolucije nisu dostupne"
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr "Prosječan broj zahtjeva dnevno je oko {0}"
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr "Prosječna ocjena povratnih informacija"
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr "Prosječne primljene povratne informacije"
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr "Prosječan prvi odgovor"
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr "Prosječno vrijeme prvog odgovora"
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr "Prosječna Rezolucija"
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
-msgstr "Prosječna ocjena povratnih informacija za riješene zahtjeve"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr "Prosječno vrijeme rješavanja"
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
+msgstr "Prosječna ocjena povratnih informacija za riješene zahtjeva u ovom periodu"
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:290
@@ -842,11 +845,11 @@ msgstr "Prosječno vrijeme prvog odgovora"
 msgid "Avg. resolution time"
 msgstr "Prosječno vrijeme rješavanja"
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr "Prosječno vrijeme potrebno za prvi odgovor na zahtjev"
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr "Prosječno vrijeme potrebno za rješavanje zahtjeva"
 
@@ -869,11 +872,6 @@ msgstr "Nazad na Zahtjeve"
 msgid "Base Support Rotation"
 msgstr "Rotacija Osnovne Podrške"
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "Osnovni URL"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -887,11 +885,11 @@ msgstr "Na osnovu vaših pravila ljudskih resursa, odaberi datum završetka peri
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr "Na osnovu vaših pravila ljudskih resursa, odaberite datum početka perioda raspodjele odmora"
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr "Skrivena kopija"
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr "Skrivena kopija:"
 
@@ -946,11 +944,6 @@ msgstr "Praznici"
 msgid "Busy"
 msgstr "Zauzeto"
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "Dugme"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr "CSV"
@@ -975,19 +968,31 @@ msgstr "Trajanje poziva u sekundama"
 msgid "Caller"
 msgstr "Pozivatelj"
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr "Pozivi"
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr "Može pozivati nove agente, upravljati zahtjevima, kreirati prilagođene prikaze i upravljati javnim prikazima."
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr "Može upravljati svim aspektima Podrške."
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr "Može podići zahtjeve u ime organizacije i upravljati zahtjevima koje su podigli."
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr "Može pregledati sve zahtjeve koje je podigla organizacija i dodijeliti drugim članovima ulogu odgovornog."
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr "Možete pregledati zahtjeve koje su podigli svi kontakti klijenta."
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr "Može raditi na zahtjevima, kreirati prilagođene prikaze i upravljati privatnim prikazima."
 
@@ -1027,7 +1032,7 @@ msgstr "Nije moguće omogućiti pravilo bez dodavanja korisnika"
 msgid "Cannot merge General category"
 msgstr "Nije moguće spojiti Opštu kategoriju"
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr "Ne može se preimenovati: nepovezani {0} '{1}' već postoji na drugoj strani. Prvo ručno riješite konflikt."
 
@@ -1075,11 +1080,11 @@ msgstr "Kategorija mora imati barem jedan članak"
 msgid "Category updated successfully."
 msgstr "Kategorija je uspješno ažurirana."
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr "Kopija"
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr "Kopija:"
 
@@ -1087,7 +1092,7 @@ msgstr "Kopija:"
 msgid "Change"
 msgstr "Promjeni"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "Promjeni Lozinku"
@@ -1100,10 +1105,9 @@ msgstr "Promijeni Sliku"
 msgid "Change language of the application."
 msgstr "Promijenite jezik aplikacije."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
-msgstr "Promijeni sliku"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
+msgstr "Promijeni operatora ({0})"
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
 msgid "Change priority"
@@ -1125,7 +1129,7 @@ msgstr "Promijeni tip zahtjeva"
 msgid "Change timezone of the application."
 msgstr "Promijeni jezik aplikacije."
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr "Promijenite lozinku svog računa radi sigurnosti."
 
@@ -1138,7 +1142,7 @@ msgstr "Kanali"
 msgid "Child field"
 msgstr "Podređeno polje"
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr "Odaberi polje"
 
@@ -1191,7 +1195,7 @@ msgstr "Očisti Sortiranje"
 msgid "Clear Table"
 msgstr "Očisti Tabelu"
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr "Obriši sve"
 
@@ -1206,6 +1210,10 @@ msgstr "Obriši sve filtere"
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
 msgstr "Kliknite na Dodaj Praznicima. Ovo će popuniti tabelu praznika sa svim datumima koji padaju na odabrani slobodan sedmični dan. Ponovite postupak za popunjavanje datuma za sve vaše sedmićne praznike"
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
+msgstr "Kliknite za kopiranje"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:47
@@ -1225,7 +1233,7 @@ msgstr "Zatvori Zahtjev"
 msgid "Closed"
 msgstr "Zatvoreno"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr "Zatvorene ili ocijenjene zahtjeve ne mogu ažurirati osobe koje nisu agenti"
 
@@ -1252,7 +1260,7 @@ msgstr "Kolone"
 msgid "Comma separated emails to invite."
 msgstr "Adrese e-pošte za poziv odvojene zarezima."
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr "Vrijednosti odvojene zarezom"
 
@@ -1285,7 +1293,7 @@ msgstr "Komentirao/la"
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "Komentari"
@@ -1298,6 +1306,11 @@ msgstr "Konverzacija"
 msgid "Communication ID is required"
 msgstr "Obavezan je ID komunikacije"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
+msgstr "Poduzeće"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
 msgstr "Završeno"
@@ -1309,7 +1322,7 @@ msgstr "Završeno"
 msgid "Condition"
 msgstr "Uslov"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr "Konfiguriraj"
 
@@ -1333,6 +1346,10 @@ msgstr "Ovdje konfiguririšite postavke integracije Twilio telefonije"
 msgid "Configure your telephony settings."
 msgstr "Konfigurišite postavke telefonije."
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1358,10 +1375,11 @@ msgstr "Potvrdi prepisivanje"
 msgid "Connect your support email"
 msgstr "Povežite adresu e-pošte za podršku"
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1375,26 +1393,30 @@ msgstr "Kontakt"
 msgid "Contact HTML"
 msgstr "Kontakt HTML"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
-msgstr "Kontakt je uspješno kreiran."
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
-msgstr "Kontakt pozvan."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
+msgstr "Kontakt je uspješno uklonjen"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr "Kontakt je uspješno ažuriran."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
-msgstr "Kontakt s adresom e-pošte već postoji"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
+msgstr "Kontakt {0} nema adresu e-pošte"
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
 msgstr "Kontakti"
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
+msgstr "Kontakti su uspješno dodani"
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
 #. Label of the content (Text Editor) field in DocType 'HD Article'
@@ -1417,7 +1439,7 @@ msgstr "Kopiraj URL zahtjeva"
 msgid "Copy ticket id"
 msgstr "Kopiraj ID zahtjeva"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr "Nije moguće poslati e-poštu zbog: {0}"
 
@@ -1425,7 +1447,11 @@ msgstr "Nije moguće poslati e-poštu zbog: {0}"
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr "Nije moguće pronaći kolonu `name` u tabHD Zahtjevu."
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr "Nije moguće migrirati kontakte za {0} klijente(a): {1}. Ispravite osnovne podatke i ponovo pokrenite zakrpu."
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr "Nije moguće poslati e-poštu s potvrdom zbog: {0}"
 
@@ -1433,11 +1459,20 @@ msgstr "Nije moguće poslati e-poštu s potvrdom zbog: {0}"
 msgid "Could not send feedback email,due to: {0}"
 msgstr "Nije moguće poslati e-poštu s povratnim informacijama zbog: {0}"
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "Zemlja"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1448,9 +1483,13 @@ msgstr "Kreiraj"
 msgid "Create & invite a contact"
 msgstr "Kreiraj i pozovi kontakt"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
-msgstr "Kreiraj Novi Kontakt"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr "Stvori Kontakt"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
+msgstr "Kreiraj Klijenta"
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
 msgid "Create View"
@@ -1484,12 +1523,6 @@ msgstr "Kreirao/la"
 msgid "Creating a ticket"
 msgstr "Kreiranje zahtjeva"
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr "Kriterij"
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr "Prilagođene Radnje"
@@ -1514,12 +1547,21 @@ msgid "Custom Views"
 msgstr "Prilagođeni prikazi"
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
 msgstr "Klijent"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
+msgstr "Odgovorni za Klijente"
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1530,17 +1572,33 @@ msgstr "Ime Klijenta"
 msgid "Customer Portal"
 msgstr "Korisnički Portal"
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
-msgstr "Klijent je uspješno kreiran."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr "Tip Klijenta"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr "Stvorio Klijent"
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
+msgstr "Ime Klijeta ne može biti prazno"
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr "Klijent Portal"
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
-msgstr "Klijent je uspješno ažuriran."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
+msgstr "Klijent ažuriran"
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
+msgstr "Klijenti"
 
 #: desk/src/components/layouts/Sidebar.vue:595
 msgid "Customers & Contacts"
@@ -1567,6 +1625,8 @@ msgstr "Cijan"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "Opasnost"
@@ -1667,18 +1727,26 @@ msgstr "Standard Tip Zahtjeva"
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr "Definišite ko prima zahtjeve i kako se oni raspoređuju među agentima."
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "Izbriši"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr "Izbriši Kontakt"
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1695,6 +1763,10 @@ msgstr "Obriši kategoriju?"
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
 msgstr "Izbriši {0}"
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
+msgstr "Obriši {0} zahtjeva"
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
 #. Label of the description (Text Editor) field in DocType 'HD Holiday'
@@ -1742,7 +1814,7 @@ msgstr "Detaljno objašnjenje"
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1828,7 +1900,12 @@ msgstr "Dokumenti"
 msgid "Document Type"
 msgstr "Tip Dokumenta"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr "Mujić"
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "Domena"
@@ -1870,6 +1947,10 @@ msgstr "Dupliciraj Ugovor o Nivou Usluge princip"
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
 msgstr "Dupliciraj Definisani Odgovor"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
+msgstr "Duplikati kontakata nisu dozvoljeni"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
 #: desk/src/pages/call-logs/CallLogModal.vue:68
@@ -1919,7 +2000,8 @@ msgstr "Sistem nije instaliran na vašoj web stranici. Molimo vas da instalirate
 msgid "Easily invite new agents, managers, or admins."
 msgstr "Jednostavno pozovite nove agente, upravitelje ili administratore."
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1928,6 +2010,14 @@ msgstr "Uredi"
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
 msgstr "Uredi Zapisnik Poziva"
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr "Uredi Kontakt"
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
+msgstr "Uredi Klijenta"
 
 #: desk/src/components/Settings/EmailAdd.vue:70
 #: desk/src/components/Settings/EmailEdit.vue:63
@@ -1946,10 +2036,10 @@ msgstr "Uredi Naslov"
 msgid "Edit your email account"
 msgstr "Uredi račun e-pošte"
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "E-pošta"
 
@@ -1977,8 +2067,9 @@ msgstr "Računi e-pošte"
 msgid "Email Content"
 msgstr "Sadržaj e-pošte"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
 msgstr "E-pošta"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
@@ -2004,22 +2095,22 @@ msgstr "Naziv računa e-pošte"
 msgid "Email account updated successfully"
 msgstr "Račun e-pošte uspješno ažuriran"
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr "Adresa e-pošte primarnog kontakta"
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr "Postavke e-pošte uspješno ažurirane."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr "Adresa e-pošte ne smije biti prazna"
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "E-pošta"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr "E-pošta & Potpis"
 
@@ -2057,8 +2148,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr "Omogući povratne informacije za Korisnički Portal"
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2083,8 +2172,6 @@ msgstr "Omogući povratne informacije za Korisnički Portal"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2107,21 +2194,25 @@ msgstr "Vrijeme Završetka"
 msgid "Enter a name for this HD Service Holiday List."
 msgstr "Unesi naziv za ovu Listu Praznika."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr "Unesi važeću adresu e-pošte"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr "Unesi važeći broj telefona"
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr "Unesite naziv marke"
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr "Unesi adresu e-pošte"
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
 msgstr "Unesi novo ime tima"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr "Unesite adresu e-pošte primarnog kontakta"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
+msgstr "Unesite ime primarnog kontakta"
 
 #: helpdesk/api/knowledge_base.py:86
 msgid "Error moving article to category"
@@ -2131,22 +2222,18 @@ msgstr "Greška pri premještanju članka u kategoriju"
 msgid "Error processing email at index {0}, message: {1}"
 msgstr "Greška pri obradi e-pošte na indeksu {0}, poruka: {1}"
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr "Greška pri ažuriranju klijenta"
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "Greška prilikom povezivanja na račun e-pošte {0}"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr "Pravilo eskalacije već postoji za ovaj kriterij"
 
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
 msgstr "Excel"
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
+msgstr "Postojeći korisnici se pridružuju odmah. Ostali dobijaju pozivnicu."
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
 #: desk/src/components/Settings/Telephony/Telephony.vue:96
@@ -2174,11 +2261,6 @@ msgstr "Izvezi Sve {0} Zapis(e)"
 msgid "Export Type"
 msgstr "Tip Izvoza"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr "Vanjska veza"
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2186,6 +2268,10 @@ msgstr "Vanjska veza"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "Neuspješno"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr "Neuspjeli Ugovor o Nivou Usluge"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2220,11 +2306,11 @@ msgstr "Nije uspjelo spremanje postavki Exotela"
 msgid "Failed to save Twilio settings"
 msgstr "Nije uspjelo spremanje postavki Twilia"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr "Ažuriranje dodijeljenih osoba nije uspjelo."
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr "Nije uspjelo ažuriranje dodijeljenih."
 
@@ -2253,6 +2339,7 @@ msgstr "Favicon"
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2290,13 +2377,17 @@ msgstr "Povratne informacije već postoje"
 msgid "Feedback Rating"
 msgstr "Ocjena povratnih informacija"
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr "Trend povratnih informacija"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
 msgstr "E-pošta s povratnim informacijama je poslana klijentu"
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
+msgstr "Povratne informacije od ovog kontakta će se pojaviti ovdje kada budu dostupne."
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
 msgid "Feedback submitted successfully."
@@ -2340,13 +2431,14 @@ msgid "Field dependency updated successfully."
 msgstr "Zavisnost polja uspješno ažurirana."
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "Polja"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "Filteri"
@@ -2356,7 +2448,8 @@ msgstr "Filteri"
 msgid "Find out all of the variables that can be used in the content"
 msgstr "Saznajte sve varijable koje se mogu koristiti u sadržaju"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "Ime"
 
@@ -2364,6 +2457,10 @@ msgstr "Ime"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
 msgstr "Prvi Odgovor"
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
+msgstr "Prvi odgovor"
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -2388,10 +2485,6 @@ msgstr "Vrijeme Prvog Odgovora"
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
 msgstr "Vrijeme prvog odgovora za Slučajeve"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
-msgstr "Ime ne smije biti prazno"
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
@@ -2482,6 +2575,10 @@ msgstr "Globalno"
 msgid "Go to Ticket #{0}"
 msgstr "Otvori Zahtjev #{0}"
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr "Dodjeli Pristup Odgovornog"
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2511,8 +2608,6 @@ msgid "Group By Field"
 msgstr "Grupiraj po Polju"
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr "Gost"
@@ -2520,11 +2615,6 @@ msgstr "Gost"
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
 msgstr "Vodite korisnike do članaka prije nego što ih pošaljete na zahtjeve."
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
-msgstr "Radnja"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -2556,25 +2646,37 @@ msgstr "Povratne informacije Članka"
 msgid "HD Comment Reaction"
 msgstr "Reakcija na Komentar"
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr "Klijent"
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr "Odgovorni za Klijente"
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
-msgstr "Zahtjev za račun Radne Površine"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
+msgstr "Član Klijenta"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
 msgstr "Povratne informacije putem e-pošte"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
-msgstr "Pravilo Eskalacije"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -2584,7 +2686,7 @@ msgstr "Raspored Polja"
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 msgid "HD Form Script"
-msgstr "Formular Skripte"
+msgstr "Obrazac Skripte"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_holiday/hd_holiday.json
@@ -2595,21 +2697,6 @@ msgstr "Praznik"
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
 msgstr "Obavještenje"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr "Organizacija"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr "Kontakt Organizacije"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
-msgstr "Zahtjev za registraciju na portalu"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -2651,11 +2738,6 @@ msgstr "Postavke"
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
 msgstr "Zaustavna riječ"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
-msgstr "Izvor Pretrage Podrške"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_synonym/hd_synonym.json
@@ -2752,12 +2834,6 @@ msgstr "Podrška"
 msgid "Helpdesk"
 msgstr "Podrška"
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr "Kontakt Podrške"
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2774,11 +2850,6 @@ msgstr "Hej"
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
 msgstr "Sakrij "
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr "Sakrij Uslov"
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
@@ -2848,15 +2919,8 @@ msgstr "Razumijem, dodaj uslove"
 msgid "ID"
 msgstr "ID"
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "IP Adresa"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2943,6 +3007,11 @@ msgstr "Pristigla Pošta"
 msgid "Incoming"
 msgstr "Dolazna"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr "Privatna"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr "Pokrenut"
@@ -2956,7 +3025,7 @@ msgstr "Instaliraj"
 msgid "Instantly send e-mail"
 msgstr "Trenutno pošalji e-poštu"
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "Nedovoljne Dozvole za {0}"
 
@@ -2970,12 +3039,12 @@ msgstr "Brojčana vrijednost"
 msgid "Introduction"
 msgstr "Introdukcija"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr "Nevažeća dostupnost"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
 msgstr "Nevažeća adresa e-pošte"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
@@ -2984,23 +3053,43 @@ msgstr "Nevažeća adresa e-pošte"
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr "Nevažeća polja, provjerite jesu li sva popunjena i jesu li vrijednosti ispravne."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr "Nevažeći tip datoteke, dozvoljene su samo PNG i JPG slike"
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr "Nevažeća obavijest"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
 msgstr "Nevažeći broj telefona"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr "Nevažeća uloga {0}"
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr "Pozivnica je istekla"
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr "Pozivnica je uspješno otkazana"
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr "Pozivnica je istekla. Ponovo pošaljite da biste ponovo pozvali."
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
+msgstr "Pozovi"
 
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
 msgstr "Pozovi agente"
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
+msgstr "Pozovi Kontakt"
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
 msgid "Invite agent"
@@ -3010,13 +3099,30 @@ msgstr "Pozovi agenta"
 msgid "Invite agents"
 msgstr "Pozovi agente"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
-msgstr "Pozovi kao korisnika"
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
+msgstr "Kreiraj Korisnika"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
 msgstr "Pozovi putem e-pošte"
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr "Pozivnica je poslana. Čeka se da je korisnik prihvati."
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr "Pozovi putem e-pošte"
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr "Pozvani"
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
+msgstr "Pozvao/la"
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -3032,6 +3138,11 @@ msgstr "Je Klijentni Portal"
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "Je Standard"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr "Je Odgovorni"
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3060,6 +3171,10 @@ msgstr "Je fiksirano"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
 msgstr "Je podešavanje završeno"
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
+msgstr "Suljo"
 
 #: desk/src/components/command-palette/CP.vue:114
 msgid "Jump to"
@@ -3095,11 +3210,9 @@ msgstr "Prečice Tastature"
 msgid "Knowledge Base"
 msgstr "Baza Znanja"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3133,9 +3246,9 @@ msgstr "Posljednji"
 msgid "Last 3 Months"
 msgstr "Poslednjih 3 Meseci"
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr "Posljednja 3 mjeseca"
 
@@ -3176,7 +3289,8 @@ msgstr "Posljednji odgovor klijenta"
 msgid "Last Month"
 msgstr "Prošli Mjesec"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "Prezime"
 
@@ -3185,24 +3299,33 @@ msgstr "Prezime"
 msgid "Last Week"
 msgstr "Prošle Sedmice"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
 msgstr "Prošli mjesec"
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
+msgstr "Posljednji put viđen/a"
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr "Posljednji korisnik dodijeljen ovim pravilom"
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
 msgstr "Prošle sedmice"
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
+msgstr "Najnovije"
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -3219,26 +3342,6 @@ msgstr "Saznajte više o uslovima"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
 msgstr "Obavijesti klijente da podnose slučaj izvan radnog vremena i kada mogu očekivati odgovor."
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "Veza"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr "Opcije Veze"
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr "Link do klijenta"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
-msgstr "Link do zapisa klijenta"
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #. Label of the list_tab (Tab Break) field in DocType 'HD View'
@@ -3266,6 +3369,8 @@ msgstr "Učitaj Standard Kolone"
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "Učitaj Još"
 
@@ -3288,6 +3393,8 @@ msgstr "Prijavi se na Frappe Cloud"
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr "Logo"
@@ -3326,7 +3433,7 @@ msgstr "Upravljaj općim postavkama vaše aplikacije."
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr "Upravljajte unaprijed definiranim odgovorima koji se mogu koristiti za odgovaranje na upite klijenta."
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr "Upravljajte e-poštom računa i potpisom e-pošte za komunikaciju."
 
@@ -3340,11 +3447,15 @@ msgstr "Upravljajte potpisom e-pošte."
 
 #: desk/src/components/Settings/Preferences/Preferences.vue:2
 msgid "Manage your personal preferences."
-msgstr "Upravljaj svojim osobnim postavkama."
+msgstr "Upravljaj osobnim postavkama."
 
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
 msgstr "Upravljaj informacijama profila."
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
+msgstr "Upravitelj"
 
 #: desk/src/pages/MobileNotifications.vue:11
 #: desk/src/pages/MobileNotifications.vue:14
@@ -3366,7 +3477,7 @@ msgstr "Članovi ({0})"
 #. Option for the 'Type' (Select) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "Mention"
-msgstr "Pomeni"
+msgstr "Spominjanje"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:158
 msgid "Merge"
@@ -3397,6 +3508,20 @@ msgstr "Razno"
 #: desk/src/components/layouts/Sidebar.vue:640
 msgid "Mobile App Installation"
 msgstr "Instalacija mobilne aplikacije"
+
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr "Mobilni Broj"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr "Mobilni Broj"
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr "Broj mobilnog telefona primarnog kontakta"
 
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
@@ -3438,7 +3563,7 @@ msgid "My Tickets"
 msgstr "Moji Zahtjevi"
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3449,8 +3574,9 @@ msgstr "Moji Zahtjevi"
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3460,6 +3586,10 @@ msgstr "Naziv"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
 msgstr "Težina Naziva"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
+msgstr "Ime je obavezno"
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
 #. Ticket Status'
@@ -3471,10 +3601,18 @@ msgstr "Ime prikazano na korisničkom portalu<br> (npr. Odgovoreno → Čeka se 
 msgid "Navigation"
 msgstr "Navigacija"
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr "Negativno"
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr "Prvo negativno"
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "Nikad"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3583,11 +3721,11 @@ msgstr "Bez Odgovora"
 msgid "No Data Found"
 msgstr "Nisu Pronađeni Podaci"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr "Nije pronađen račun e-pošte za {0}"
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr "Nema zapisa Agenta za trenutnog korisnika"
 
@@ -3599,9 +3737,15 @@ msgstr "Nije pronađena lista praznika"
 msgid "No SLA found"
 msgstr "Nije pronađen Ugovor o Nivou Usluge"
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
 msgstr "Nema Tima"
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
+msgstr "Nema aktivnih zahtjeva"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
 msgid "No additional comments"
@@ -3635,19 +3779,27 @@ msgstr "Nema dostupnih kategorija"
 msgid "No changes made"
 msgstr "Nisu napravljene promjene"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr "Nema promjena za spremanje"
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr "Nijedan grafikon nije dodat"
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr "Nisu pronađeni kontakti"
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr "Nije pronađen nijedan kontakt za primijenjene filtere. Pokušajte prilagoditi ili obrisati filtere."
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr "Nema kontakata za dodavanje"
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr "Nije pronađena nijedna država"
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr "Nisu pronađeni klijenti za primijenjene filtere. Pokušajte prilagoditi ili obrisati filtere."
 
@@ -3659,7 +3811,11 @@ msgstr "Nije pronađen nijedan email račun"
 msgid "No feedback"
 msgstr "Nema povratnih informacija"
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr "Još nema povratnih informacija"
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr "Nisu pronađena polja"
 
@@ -3699,19 +3855,25 @@ msgstr "Nema razloga"
 msgid "No recently assigned tickets"
 msgstr "Nema nedavno dodijeljenih slušajeva"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr "Nema rezultata"
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
 msgstr "Nisu pronađeni rezultati"
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
+msgstr "Nisu pronađene recenzije"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:91
 msgid "No saved replies found"
 msgstr "Nisu pronađeni definisani odgovori"
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr "Nisu pronađeni zahtjevi"
@@ -3732,7 +3894,11 @@ msgstr "Nisu pronađeni zahtjevi za pregled."
 msgid "No tickets selected"
 msgstr "Nije odabran nijedan zahtjev"
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr "Nijedan korisnik nije povezan s kontaktom {0}"
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "Nije Dozvoljeno"
 
@@ -3744,7 +3910,7 @@ msgstr "Nije dodijeljeno"
 msgid "Not Saved"
 msgstr "Nespremljeno"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "Nije Postavljeno"
 
@@ -3783,11 +3949,6 @@ msgstr "Stari Uslovi"
 msgid "On Hold Since"
 msgstr "Na čekanju od"
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr "Na klik (Javascript)"
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr "Na Status Zahtjeva"
@@ -3818,6 +3979,10 @@ msgstr "Otvori paletu komandi"
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
 msgstr "Otvori okvir za komentare"
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
+msgstr "Otvori Klijenta"
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
 msgid "Open help"
@@ -3908,7 +4073,12 @@ msgstr "Nadređeno polje"
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr "Nadređeno polje, podređeno polje i mapiranje nadređeno-podređeno polja je obavezno."
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr "Partnerstvo"
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "Lozinka"
 
@@ -3946,6 +4116,7 @@ msgid "Pending"
 msgstr "Na Čekanju"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr "Pozivnice na Čekanju"
 
@@ -3955,19 +4126,19 @@ msgstr "Pozivnice na Čekanju"
 msgid "Pending Tickets"
 msgstr "Zahtjevi na čekanju"
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr "Procenat ukupnog broja zahtjeva po Kanalu"
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr "Procenat ukupnog broja zahtjeva po Prioritetu"
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr "Procenat ukupnog broja zahtjeva po Timu"
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr "Procenat ukupnog broja zahtjeva po Tipu"
 
@@ -3988,14 +4159,15 @@ msgstr "Lična"
 msgid "Personal mobile no"
 msgstr "Broj ličnog mobilnog telefona"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "Telefon"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
-msgstr "Brojevi telefona"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
+msgstr "Fotografija"
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
 msgid "Pick an option"
@@ -4051,7 +4223,7 @@ msgstr "Unesi predmet da biste nastavili"
 msgid "Please enter a valid phone number"
 msgstr "Unesi važeći broj telefona"
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr "Molimo unesite barem jednu važeću adresu e-pošte za slanje pozivnice."
 
@@ -4094,34 +4266,15 @@ msgstr "Odaberi sedmične neradne dane"
 msgid "Policy name"
 msgstr "Naziv Principa"
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr "Pozitivno"
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
 msgstr "Prvo pozitivno"
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr "Upiši Opisni Ključ"
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr "Postavi Listu Ključa Rute"
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr "Postavi Niz Rute"
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
-msgstr "Postavi Naziv Ključa"
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:10
@@ -4155,14 +4308,32 @@ msgstr "Pregled"
 msgid "Previous ticket"
 msgstr "Prethodni zahtjev"
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "Primarno"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "Primarni Kontakt"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr "Primarni kontakt mora biti jedan od navedenih kontakata"
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr "Primarni kontakt je ažuriran"
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr "Prioriteti"
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4170,9 +4341,10 @@ msgstr "Prioriteti"
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4252,17 +4424,6 @@ msgstr "Preuzimanje e-pošte, ovo može potrajati nekoliko minuta."
 msgid "Quarterly"
 msgstr "Kvartalno"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "Opcije Upita"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr "Niz Rute Upita"
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "U Redu"
@@ -4285,14 +4446,14 @@ msgstr "Ocijenite Iskustvo s Podrškom"
 msgid "Rate this ticket"
 msgstr "Ocijenite ovaj zahtjev"
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr "Ocijenjeni Zahtjevi"
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4388,8 +4549,15 @@ msgstr "Obnovi Indeks Pretrage"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "Ukloni"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr "Ukloni Kontakt"
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4399,10 +4567,19 @@ msgstr "Ukloni logotip"
 msgid "Remove Photo"
 msgstr "Ukloni Sliku"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr "Ukloni filter"
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
 msgstr "Ukloni sliku"
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
+msgstr "Ukloni primarni"
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
 #: desk/src/components/Settings/Teams/TeamsList.vue:161
@@ -4422,6 +4599,15 @@ msgstr "Preimenuj (⌘ + ⏎)"
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
 msgstr "Preimenuj tim"
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr "Zamijeni filter"
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
+msgstr "Zamijeni sliku"
 
 #. Option in a Select field in the tickets Web Form
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
@@ -4460,17 +4646,14 @@ msgstr "Odgovor kontakta"
 msgid "Reply on a ticket"
 msgstr "Odgovor na zahtjev"
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr "Ključ Zahtjeva"
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
 msgstr "Obavezno"
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
+msgstr "Ponovo pošalji pozivnicu"
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
 msgid "Reset"
@@ -4490,6 +4673,7 @@ msgid "Reset to Default"
 msgstr "Vrati na Standard"
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr "Rezolucija"
@@ -4543,18 +4727,6 @@ msgstr "Odgovor"
 msgid "Response By"
 msgstr "Odgovor od"
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr "Opcije Odgovora"
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr "Put Ključa Rezultata Odgovora"
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr "Vrijeme Odgovora za {0} prioritet u redu {1} ne može biti veće od Vremena Rezolucije."
@@ -4597,37 +4769,33 @@ msgstr "Ograniči pregled i upravljanje zahtjevima samo od strane članova tima.
 msgid "Restrict visibility to these teams"
 msgstr "Ograničite vidljivost na ove timove"
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr "Polje Pregleda Rezultata"
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr "Polje Rute Rezultata"
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr "Polje Naziva Rezultata"
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
 msgstr "Recenzije"
 
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr "Povuci poziv"
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
+msgstr "Oduzmi Pristup Odgovornog"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:215
 msgid "Ringing"
 msgstr "Zvoni"
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "Uloga"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr "Uloga je uspješno ažurirana"
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4726,9 +4894,9 @@ msgstr "Subota"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4804,17 +4972,19 @@ msgstr "Indeks Pretrage Obnovljen"
 msgid "Search Score"
 msgstr "Ocjena Pretrage"
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr "Naziv Parametra Pretrage"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr "Pretraži agente..."
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr "Pretraživanje po ID-u ili Predmetu"
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr "Pretraži državu"
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "Polja za Pretragu..."
 
@@ -4854,6 +5024,7 @@ msgstr "Traži..."
 msgid "Searched for:"
 msgstr "Tražilo se:"
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr "Pretraga..."
@@ -4873,6 +5044,10 @@ msgstr "Odaberi"
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
 msgstr "Odaberi Kategoriju"
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
+msgstr "Odaberi Klijenta"
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
 msgid "Select Range"
@@ -4894,6 +5069,10 @@ msgstr "Odaberi Standard Prioritet."
 msgid "Select a rating"
 msgstr "Odaberi ocjenu"
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr "Odaberi državu"
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4906,6 +5085,10 @@ msgstr "Odaberi timove"
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
 msgstr "Odaberi zahtjev za pregled"
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
+msgstr "Odaberi vremensku zonu"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
 msgid "Select what type all tickets get by default."
@@ -4932,6 +5115,10 @@ msgstr "Pošalji odgovor"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
 msgstr "Pošalji povratne informacije kada"
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
+msgstr "Pošalji e-poštu za poništenje lozinke"
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
 msgid "Send to {0} tickets"
@@ -4971,7 +5158,7 @@ msgstr "Naziv Servisnog Nivoa"
 msgid "Service not supported"
 msgstr "Usluga nije podržana"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "Postavi"
 
@@ -4979,6 +5166,10 @@ msgstr "Postavi"
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
 msgstr "Postavi broj telefona"
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
+msgstr "Postavi Primarni Kontakt"
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
 msgid "Set Resolution Time for Priority {0} in row {1}."
@@ -4988,12 +5179,21 @@ msgstr "Postavi vrijeme rješavanja za prioritet {0} u redu {1}."
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr "Postavi Vrijeme Odgovora za Prioritet {0} u redu {1}."
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr "Postavi kao Primarni"
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr "Postavi kao standard Ugovor o Nivou Usluge"
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr "Postavi kao Primarni"
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr "Postavi status"
 
@@ -5005,7 +5205,7 @@ msgstr "Postavi standard status koji se dodjeljuje prilikom kreiranja zahtjeva i
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr "Postavi radne dane, sate i praznike odabirom unaprijed definiranog rasporeda ili kreiranjem novog."
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr "Podesi dostupnost kako bi vaš tim znao kada ste dostupni."
 
@@ -5139,23 +5339,6 @@ msgstr "Došlo je do greške prilikom ažuriranja liste praznika"
 msgid "Sort"
 msgstr "Sortiraj"
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr "Izvorni DocType"
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "Naziv Izvora"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr "Tip Izvora"
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr "Izvorna i ciljana kategorija ne mogu biti iste"
@@ -5176,7 +5359,7 @@ msgstr "Razdjeli i Spoji"
 
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.js:9
 msgid "Standard Form Scripts can't be modified, duplicate the script instead."
-msgstr "Standardni Formulari Skripte se ne mogu mijenjati, umjesto toga dupliciraj skriptu."
+msgstr "Standardni Obrasci Skripte ne mogu se mijenjati, umjesto toga dupliciraj skriptu."
 
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.py:55
 msgid "Standard Views cannot be deleted."
@@ -5200,6 +5383,8 @@ msgstr "Vrijeme početka ne može biti kasnije ili jednako vremenu završetka u 
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5268,6 +5453,7 @@ msgstr "Status zahtjeva, kada je kreiran u sistemu."
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5379,21 +5565,16 @@ msgstr "Sistem"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5432,8 +5613,6 @@ msgstr "Ciljani zahtjev ne postoji"
 msgid "Teal"
 msgstr "Tirkizna"
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5444,7 +5623,6 @@ msgstr "Tirkizna"
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5550,6 +5728,10 @@ msgstr "Uslov dodjeljivanja '{0}' je nevažeći: {1}"
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr "JSON Uvjet Dodjeljivanja {0}' nije valjan: {1}"
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr "Kontakt {0} je povezan s više klijenata. Molimo odaberite klijenta ručno."
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr "Dijalog za povratne informacije će se prikazati kada korisnik pokuša zatvoriti zahtjev s korisničkog portala."
@@ -5561,6 +5743,10 @@ msgstr "Praznik {0} nije između Od Datuma i Do Datuma"
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
 msgstr "Broj dana mora biti 1 ili više"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
+msgstr "Odabrani klijent {0} nije povezan s kontaktom {1}. Molimo odaberite važećeg klijenta ili ažurirajte povezane klijente kontakta."
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
 msgid "The status for sending feedback must be of <u>Resolved</u> category."
@@ -5582,6 +5768,14 @@ msgstr "Trenutno nema objavljenih kategorija."
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr "Treba postojati barem jedno pravilo dodjele za zahtjev"
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr "Imat će pristup zahtjevima koje su prikupili svi u organizaciji."
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr "Ubuduće će vidjeti samo svoje zahtjeve."
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr "Ovo Pravilo Dodjele je povezano s Timom {0}.</br> Korisnik {1} je dodan u Pravilo Dodjele, ali ne i u povezani Tim. Molimo dodajte korisnika u {2} kako biste osigurali pravilnu strukturu tima."
@@ -5590,6 +5784,10 @@ msgstr "Ovo Pravilo Dodjele je povezano s Timom {0}.</br> Korisnik {1} je dodan 
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
 msgstr "Ova akcija je nepovratna."
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
+msgstr "Ovaj kontakt će postati primarna kontakt osoba i moći će vidjeti zahtjeve koje su podnijeli svi ostali kontakti u organizaciji."
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
 msgid "This date is calculated based on configured SLAs, working hours, and holidays."
@@ -5658,7 +5856,7 @@ msgstr "Četvrtak"
 msgid "Ticket"
 msgstr "Zahtjev"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr "Zahtjev #{0}: Primili smo vaš zahtjev"
 
@@ -5673,6 +5871,10 @@ msgstr "Analitika Zahtjeva"
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
 msgstr "Konfiguracija Zahtjeva"
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
+msgstr "ID Zahtjeva"
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
 msgid "Ticket Info"
@@ -5731,7 +5933,7 @@ msgstr "Predmet Zahtjeva"
 msgid "Ticket Summary"
 msgstr "Sažetak Zahtjeva"
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr "Trend Zahtjeva"
 
@@ -5764,7 +5966,7 @@ msgstr "Zahtjev ne postoji."
 msgid "Ticket merged successfully."
 msgstr "Zahtjev uspješno spojen."
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr "Zahtjev mora biti riješen povratnom informacijom"
 
@@ -5799,12 +6001,6 @@ msgstr "Status Zahtjeva"
 msgid "Ticket to merged with is required"
 msgstr "Potreban je zahtjv za spajanje sa"
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr "Tip Zahtjeva"
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr "Zahtjev uspješno ažuriran."
@@ -5816,12 +6012,15 @@ msgstr "Analiza Pretrage Zahtjeva"
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr "Zahtjevi"
 
@@ -5833,19 +6032,19 @@ msgstr "Zahtjevi koji se približavaju ili krše Ugovor o Nivou Usluge"
 msgid "Tickets assigned to you in the last 7 days"
 msgstr "Zahtjevi koji su vam dodijeljeni u posljednjih 7 dana"
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr "Zahtjevi po Kanalu"
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr "Zahtjevi po Prioritetu"
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr "Zahtjevi po Timu"
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr "Zahtjevi po Tipu"
 
@@ -5862,6 +6061,7 @@ msgid "Tickets that are awaiting your response"
 msgstr "Zahtjevi koje čekaju vaš odgovor"
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr "Vremenska Zona"
 
@@ -5951,19 +6151,19 @@ msgstr "Ukupno Praznika"
 msgid "Total Ticket"
 msgstr "Ukupano Zahtjeva"
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr "Ukupan broj kreiranih zahtjeva"
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr "Ukupan broj zahtjeva po prioritetu"
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr "Ukupan broj zahtjeva po timu"
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr "Ukupan broj zahtjeva po tipu"
 
@@ -5995,6 +6195,10 @@ msgstr "Tip"
 msgid "Type a message"
 msgstr "Upiši poruku"
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr "Upišite adresu e-pošte"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr "Tip je obavezan"
@@ -6004,7 +6208,7 @@ msgstr "Tip je obavezan"
 msgid "URL/Method"
 msgstr "URL/Metod"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr "Nije moguće poslati e-poštu. Molimo vas da postavite standard račun za odlaznu e-poštu."
 
@@ -6038,6 +6242,8 @@ msgid "Unpublish"
 msgstr "Poništi Objavu"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr "Nesačuvano"
 
@@ -6055,6 +6261,10 @@ msgstr "Nesačuvano"
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
 msgstr "Nesačuvane promjene"
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
+msgstr "Nepodržani tip dokumenta '{0}' za statistiku zahtjeva."
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
 msgid "Untitled"
@@ -6082,10 +6292,13 @@ msgstr "Učitaj"
 msgid "Upload Photo"
 msgstr "Otpremi Sliku"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
-msgstr "Otpremi sliku"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
+msgstr "Otpremite sliku u PNG ili JPG formatu"
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
+msgstr "Učitaj Sliku"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
 msgid "Uploading {0}%"
@@ -6094,17 +6307,13 @@ msgstr "Prijenos {0}%"
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6116,6 +6325,10 @@ msgstr "Korisnik"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
 msgstr "Korisnikovo Vrijeme Rješenja"
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
+msgstr "Recenzije Korisnika"
 
 #: desk/src/components/Settings/General/General.vue:42
 msgid "User Signup"
@@ -6134,7 +6347,7 @@ msgstr "Korisnici"
 msgid "Valid From"
 msgstr "Važi od"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "Vrijednost"
 
@@ -6263,19 +6476,23 @@ msgstr "Godišnje"
 msgid "Yellow"
 msgstr "Žuta"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr "Nije vam dozvoljeno da pregledate statistiku drugog agenta."
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr "Nije vam dozvoljeno da pregledate podatke ove kontrolne table."
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr "Nije vam dozvoljen pristup ovom resursu."
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr "Nije vam dozvoljeno dodavanje komentara"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr "Nije vam dozvoljeno odgovoriti kao agent"
 
@@ -6303,6 +6520,14 @@ msgstr "Ne možete postaviti više od jednog Standard Prioriteta."
 msgid "You do not have permission to access Assignment Rules"
 msgstr "Nemate dozvolu za pristup Pravilima Dodjele"
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr "Nemate dozvolu za pristup ovom resursu"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr "Nemate dozvolu za ažuriranje kontakata"
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr "Nemate pristup ovom zahtjevu ili on više ne postoji."
@@ -6326,6 +6551,14 @@ msgstr "Vaši stari uslovi će biti prepisani. Jeste li sigurni da želite saču
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
 msgstr "Vaš učinak je"
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr "aktivni zahtjev"
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
+msgstr "aktivni zahtjevi"
 
 #: desk/src/pages/MobileNotifications.vue:46
 msgid "assigned you a ticket"
@@ -6355,7 +6588,7 @@ msgstr "kreirano"
 msgid "customize {0}"
 msgstr "prilagodi {0}"
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr "dana"
 
@@ -6406,7 +6639,7 @@ msgstr "ovdje"
 msgid "here."
 msgstr "ovdje."
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr "sati"
 
@@ -6414,7 +6647,7 @@ msgstr "sati"
 msgid "in"
 msgstr "u"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "upravo sada"
 
@@ -6447,7 +6680,11 @@ msgstr "objavio/la"
 msgid "purple"
 msgstr "ljubičasta"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr "recenzije"
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr "zvijezde"
 
@@ -6464,7 +6701,7 @@ msgstr "zahtjev"
 msgid "to enable this integration."
 msgstr "da omogući ovu integraciju"
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr "pogledao/la je ovo"
 
@@ -6472,13 +6709,33 @@ msgstr "pogledao/la je ovo"
 msgid "views"
 msgstr "pogledi"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr "{0} Klijenata"
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr "{0} je već dodat"
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr "{0} je nevažeća adresa e-pošte"
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr "{0} je trenutno odsutan/na."
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
 msgstr "{0} trenutno nedostupan."
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr "{0} nije postojeći kontakt"
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
+msgstr "{0} nije postojeći korisnik"
 
 #: desk/src/components/ListViewBuilder.vue:307
 msgid "{0} item(s) deleted successfully"
@@ -6504,7 +6761,7 @@ msgstr "Prikaz {0} je trenutno javan. Promjenom u privatni prikaz, sakrit će se
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr "Prikaz {0} trenutno je vidljiv u bočnoj traci. Skrivanjem će se ukloniti s bočne trake."
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr "{0} · Posljednji aktivan {1}"
 

--- a/helpdesk/locale/cs.po
+++ b/helpdesk/locale/cs.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-15 18:50\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-29 21:57\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Czech\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr "% splněných SLA"
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr ""
@@ -108,14 +108,6 @@ msgstr "Krátký popis"
 msgid "A workday with this name already exists"
 msgstr ""
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr "API"
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr ""
@@ -132,7 +124,7 @@ msgstr ""
 msgid "Account"
 msgstr "Účet"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr "Informace o účtu & Zabezpečení"
 
@@ -152,11 +144,9 @@ msgstr "Akce"
 msgid "Action Required"
 msgstr "Vyžadována akce"
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr ""
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "Akce"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr ""
 msgid "Active"
 msgstr "Aktivní"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr ""
 
@@ -175,7 +165,7 @@ msgid "Active: The agent is available and working.<br>\n"
 "Unavailable: The agent is off and unavailable."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "Aktivita"
@@ -193,10 +183,11 @@ msgid "Add Column"
 msgstr "Přidat sloupec"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "Přidat filtr..."
 
@@ -207,6 +198,10 @@ msgstr "Přidat svátek"
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
 msgstr "Přidat nový článek"
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
+msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:148
 msgid "Add Sort"
@@ -244,7 +239,7 @@ msgstr "Přidat podmínku"
 msgid "Add condition group"
 msgstr "Přidat skupinu podmínek"
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "Přidat filtr"
 
@@ -278,6 +273,12 @@ msgstr "Přidejte časové cíle pro milníky podpory, jako je první odpověď 
 msgid "Add to Holidays"
 msgstr "Přidat do svátků"
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr ""
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr "Přidávejte a spravujte agenty a přiřazujte jim role."
@@ -295,17 +296,14 @@ msgid "Administrator"
 msgstr "Administrátor"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -316,6 +314,7 @@ msgstr "Administrátor"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -335,6 +334,7 @@ msgstr ""
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -342,6 +342,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -376,18 +377,9 @@ msgstr "Agenti už nebudou moci zobrazovat ani vytvářet uložené odpovědi s 
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "Vše"
 
@@ -508,6 +500,14 @@ msgstr ""
 msgid "Are you sure you want to delete these articles?"
 msgstr "Opravdu chcete smazat tyto články?"
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr ""
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr ""
@@ -544,6 +544,10 @@ msgstr "Opravdu chcete odejít? Neuložené změny budou ztraceny."
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
 msgstr "Opravdu chcete odstranit logo?"
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
+msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
 msgid "Are you sure you want to reset the content? Current content will be overridden."
@@ -595,16 +599,11 @@ msgstr ""
 msgid "Assign ticket"
 msgstr ""
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr "Přiřadit komu"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -618,7 +617,7 @@ msgstr "Příjemce"
 msgid "Assignee Rules"
 msgstr "Pravidla řešitelů"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr ""
 
@@ -626,7 +625,7 @@ msgstr ""
 msgid "Assignees"
 msgstr "Řešitelé"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr ""
 
@@ -692,10 +691,6 @@ msgstr ""
 msgid "Assignment rule {0} updated successfully."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -712,10 +707,6 @@ msgstr "Pro hodnocení {0} musí být povolena alespoň jedna možnost zpětné 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
 msgstr "Je vyžadován alespoň jeden tým"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
-msgstr ""
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
@@ -766,7 +757,7 @@ msgid "Automation"
 msgstr ""
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr ""
@@ -802,7 +793,7 @@ msgstr "Průměrná doba odezvy"
 msgid "Average Time Metrics"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr "Průměrné denní hodnocení zpětné vazby je kolem {0} hvězdiček"
 
@@ -810,24 +801,36 @@ msgstr "Průměrné denní hodnocení zpětné vazby je kolem {0} hvězdiček"
 msgid "Average response and resolution metrics not available"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr "Prům. hodnocení zpětné vazby"
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr "Prům. první odpověď"
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr "Prům. vyřešení"
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
 msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
@@ -840,11 +843,11 @@ msgstr ""
 msgid "Avg. resolution time"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr ""
 
@@ -867,11 +870,6 @@ msgstr ""
 msgid "Base Support Rotation"
 msgstr "Základní rota podpory"
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "Základní URL"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -885,11 +883,11 @@ msgstr "Podle vaší HR politiky vyberte datum konce období přidělení dovole
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr "Podle vaší HR politiky vyberte datum začátku období přidělení dovolené"
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr ""
 
@@ -944,11 +942,6 @@ msgstr "Firemní svátky"
 msgid "Busy"
 msgstr "Obsazeno"
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "Tlačítko"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr ""
@@ -973,19 +966,31 @@ msgstr "Délka trvání hovoru v sekundách"
 msgid "Caller"
 msgstr "Volající"
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr ""
 
@@ -1025,7 +1030,7 @@ msgstr "Pravidlo nelze zapnout bez přidání uživatelů"
 msgid "Cannot merge General category"
 msgstr "Kategorii Obecné nelze sloučit"
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr ""
 
@@ -1073,11 +1078,11 @@ msgstr "Kategorie musí obsahovat alespoň jeden článek"
 msgid "Category updated successfully."
 msgstr "Kategorie byla úspěšně aktualizována."
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr ""
 
@@ -1085,7 +1090,7 @@ msgstr ""
 msgid "Change"
 msgstr "Změnit"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "Změnit Heslo"
@@ -1098,10 +1103,9 @@ msgstr ""
 msgid "Change language of the application."
 msgstr "Změnit jazyk aplikace."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
-msgstr "Změnit fotografii"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
+msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
 msgid "Change priority"
@@ -1123,7 +1127,7 @@ msgstr ""
 msgid "Change timezone of the application."
 msgstr "Změnit časové pásmo aplikace."
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr "Z bezpečnostních důvodů změňte heslo svého účtu."
 
@@ -1136,7 +1140,7 @@ msgstr "Kanály"
 msgid "Child field"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr ""
 
@@ -1189,7 +1193,7 @@ msgstr ""
 msgid "Clear Table"
 msgstr "Vymazat tabulku"
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr ""
 
@@ -1203,6 +1207,10 @@ msgstr "Vymazat všechny filtry"
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
@@ -1223,7 +1231,7 @@ msgstr ""
 msgid "Closed"
 msgstr "Uzavřeno"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr ""
 
@@ -1250,7 +1258,7 @@ msgstr "Sloupce"
 msgid "Comma separated emails to invite."
 msgstr "E-maily k pozvání oddělené čárkou."
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr ""
 
@@ -1283,7 +1291,7 @@ msgstr "Komentoval"
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "Komentáře"
@@ -1294,6 +1302,11 @@ msgstr "Komunikace"
 
 #: desk/src/components/ticket/TicketSplitModal.vue:76
 msgid "Communication ID is required"
+msgstr ""
+
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:209
@@ -1307,7 +1320,7 @@ msgstr "Dokončeno"
 msgid "Condition"
 msgstr "Podmínka"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr ""
 
@@ -1331,6 +1344,10 @@ msgstr ""
 msgid "Configure your telephony settings."
 msgstr "Nastavte své telefonní nastavení."
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1356,10 +1373,11 @@ msgstr "Potvrdit přepsání"
 msgid "Connect your support email"
 msgstr ""
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1373,26 +1391,30 @@ msgstr "Kontakt"
 msgid "Contact HTML"
 msgstr "Kontakt HTML"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
 msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
-msgstr "Kontakt byl úspěšně pozván."
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
 msgstr ""
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
 msgstr "Kontakty"
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
+msgstr ""
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
 #. Label of the content (Text Editor) field in DocType 'HD Article'
@@ -1415,7 +1437,7 @@ msgstr ""
 msgid "Copy ticket id"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr ""
 
@@ -1423,7 +1445,11 @@ msgstr ""
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr ""
 
@@ -1431,11 +1457,20 @@ msgstr ""
 msgid "Could not send feedback email,due to: {0}"
 msgstr ""
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "Země"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1446,9 +1481,13 @@ msgstr "Vytvořit"
 msgid "Create & invite a contact"
 msgstr "Vytvořit a pozvat kontakt"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
-msgstr "Vytvořit nový kontakt"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
+msgstr "Vytvořit zákazníka"
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
 msgid "Create View"
@@ -1482,12 +1521,6 @@ msgstr ""
 msgid "Creating a ticket"
 msgstr ""
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr "Kritérium"
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr ""
@@ -1512,12 +1545,21 @@ msgid "Custom Views"
 msgstr ""
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
 msgstr "Zákazník"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
+msgstr ""
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1528,16 +1570,32 @@ msgstr "Název zákazníka"
 msgid "Customer Portal"
 msgstr ""
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
-msgstr "Zákazník úspěšně vytvořen."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr "Zákaznický portál"
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
 msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:595
@@ -1565,6 +1623,8 @@ msgstr "Azurová"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "Nebezpečí"
@@ -1665,18 +1725,26 @@ msgstr ""
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr ""
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "Smazat"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1692,6 +1760,10 @@ msgstr "Smazat kategorii?"
 
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
+msgstr ""
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
 msgstr ""
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
@@ -1740,7 +1812,7 @@ msgstr "Podrobné vysvětlení"
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1826,7 +1898,12 @@ msgstr "Dokumentace"
 msgid "Document Type"
 msgstr "Typ dokumentu"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr ""
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "Doména"
@@ -1868,6 +1945,10 @@ msgstr "Duplikovat SLA politiku"
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
 msgstr "Duplikovat uloženou odpověď"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
 #: desk/src/pages/call-logs/CallLogModal.vue:68
@@ -1917,7 +1998,8 @@ msgstr ""
 msgid "Easily invite new agents, managers, or admins."
 msgstr "Snadno zvěte nové agenty, manažery nebo administrátory."
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1926,6 +2008,14 @@ msgstr "Upravit"
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
 msgstr "Upravit záznam hovoru"
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
+msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:70
 #: desk/src/components/Settings/EmailEdit.vue:63
@@ -1944,10 +2034,10 @@ msgstr "Upravit název"
 msgid "Edit your email account"
 msgstr ""
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "E-mail"
 
@@ -1975,8 +2065,9 @@ msgstr ""
 msgid "Email Content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
 msgstr "E-mailová adresa"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
@@ -2002,22 +2093,22 @@ msgstr ""
 msgid "Email account updated successfully"
 msgstr ""
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr ""
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr ""
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "E-maily"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr ""
 
@@ -2055,8 +2146,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr "Povolit zpětnou vazbu pro zákaznický portál"
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2081,8 +2170,6 @@ msgstr "Povolit zpětnou vazbu pro zákaznický portál"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2105,21 +2192,25 @@ msgstr "Čas ukončení"
 msgid "Enter a name for this HD Service Holiday List."
 msgstr "Zadejte název tohoto seznamu svátků služby HD."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr "Zadejte platné telefonní číslo"
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr "Zadejte název značky"
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr ""
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
 msgstr "Zadejte nový název týmu"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
+msgstr ""
 
 #: helpdesk/api/knowledge_base.py:86
 msgid "Error moving article to category"
@@ -2129,21 +2220,17 @@ msgstr "Chyba při přesunu článku do kategorie"
 msgid "Error processing email at index {0}, message: {1}"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr ""
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "Chyba při připojování k e-mailovému účtu {0}"
 
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr "Pravidlo eskalace pro tato kritéria již existuje"
-
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
 msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
@@ -2172,11 +2259,6 @@ msgstr ""
 msgid "Export Type"
 msgstr "Typ exportu"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr "Externí odkaz"
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2184,6 +2266,10 @@ msgstr "Externí odkaz"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "Neúspěšné"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2218,11 +2304,11 @@ msgstr ""
 msgid "Failed to save Twilio settings"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr ""
 
@@ -2251,6 +2337,7 @@ msgstr ""
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2288,12 +2375,16 @@ msgstr "Zpětná vazba již existuje"
 msgid "Feedback Rating"
 msgstr "Hodnocení zpětné vazby"
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr "Trend zpětné vazby"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
+msgstr ""
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
 msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
@@ -2338,13 +2429,14 @@ msgid "Field dependency updated successfully."
 msgstr "Závislost pole byla úspěšně aktualizována."
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "Pole"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "Filtry"
@@ -2354,7 +2446,8 @@ msgstr "Filtry"
 msgid "Find out all of the variables that can be used in the content"
 msgstr "Zjistěte všechny proměnné, které lze v obsahu použít"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "Jméno"
 
@@ -2362,6 +2455,10 @@ msgstr "Jméno"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
 msgstr "Poprvé reagováno dne"
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
+msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -2386,10 +2483,6 @@ msgstr "Doba první reakce"
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
 msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
-msgstr "Jméno nesmí být prázdné"
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
@@ -2480,6 +2573,10 @@ msgstr "Globální"
 msgid "Go to Ticket #{0}"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr ""
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2509,8 +2606,6 @@ msgid "Group By Field"
 msgstr "Pole pro seskupení"
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr "Host"
@@ -2518,11 +2613,6 @@ msgstr "Host"
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
 msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
-msgstr "HD akce"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -2554,25 +2644,37 @@ msgstr "Zpětná vazba k HD článku"
 msgid "HD Comment Reaction"
 msgstr "Reakce na HD komentář"
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr "HD zákazník"
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr ""
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
 msgstr ""
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
 msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
-msgstr "Pravidlo eskalace HD"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -2593,21 +2695,6 @@ msgstr "HD svátek"
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
 msgstr "HD oznámení"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr "HD organizace"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr "Položka kontaktu HD organizace"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
-msgstr "Žádost o registraci do HD portálu"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -2649,11 +2736,6 @@ msgstr "Nastavení HD"
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
 msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
-msgstr "Zdroj vyhledávání podpory HD"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_synonym/hd_synonym.json
@@ -2750,12 +2832,6 @@ msgstr ""
 msgid "Helpdesk"
 msgstr ""
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr ""
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2772,11 +2848,6 @@ msgstr "Ahoj"
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
 msgstr "Skryt "
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr "Skrýt podmínku"
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
@@ -2846,15 +2917,8 @@ msgstr "Rozumím, přidat podmínky"
 msgid "ID"
 msgstr ""
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "IP adresa"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2941,6 +3005,11 @@ msgstr "Doručená pošta"
 msgid "Incoming"
 msgstr "Příchozí"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr "Zahájeno"
@@ -2954,7 +3023,7 @@ msgstr ""
 msgid "Instantly send e-mail"
 msgstr ""
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "Nedostatečné oprávnění pro {0}"
 
@@ -2968,12 +3037,12 @@ msgstr "Celočíselná hodnota"
 msgid "Introduction"
 msgstr "Úvod"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
@@ -2982,23 +3051,43 @@ msgstr ""
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr "Neplatná pole, zkontrolujte, zda jsou všechna vyplněna a hodnoty jsou správné."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr "Neplatný typ souboru, povoleny jsou pouze obrázky PNG a JPG"
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr "Neplatné oznámení"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
 msgstr "Neplatné telefonní číslo"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr ""
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
+msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
 msgstr "Pozvat agenty"
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
 msgid "Invite agent"
@@ -3008,13 +3097,30 @@ msgstr "Pozvat agenta"
 msgid "Invite agents"
 msgstr "Pozvat agenty"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
 msgstr "Pozvat jako uživatele"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
 msgstr "Pozvat e-mailem"
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
+msgstr ""
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -3030,6 +3136,11 @@ msgstr "Je zákaznický portál"
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "Je výchozí"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr ""
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3058,6 +3169,10 @@ msgstr "Je připnuto"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
 msgstr "Je nastavení dokončeno"
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
+msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:114
 msgid "Jump to"
@@ -3093,11 +3208,9 @@ msgstr "Klávesové zkratky"
 msgid "Knowledge Base"
 msgstr "Znalostní báze"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3131,9 +3244,9 @@ msgstr "Poslední"
 msgid "Last 3 Months"
 msgstr "Posledních 3 měsíců"
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr ""
 
@@ -3174,7 +3287,8 @@ msgstr "Poslední odpověď zákazníka"
 msgid "Last Month"
 msgstr "Minulý měsíc"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "Příjmení"
 
@@ -3183,23 +3297,32 @@ msgstr "Příjmení"
 msgid "Last Week"
 msgstr "Minulý týden"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr "Poslední uživatel přiřazený tímto pravidlem"
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
 msgstr ""
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
@@ -3217,26 +3340,6 @@ msgstr "Zjistit více o podmínkách"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
 msgstr ""
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "Odkaz"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr "Možnosti propojení"
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr "Odkaz na zákazníka"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
-msgstr "Odkaz na záznam zákazníka"
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #. Label of the list_tab (Tab Break) field in DocType 'HD View'
@@ -3264,6 +3367,8 @@ msgstr "Načíst výchozí sloupce"
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "Načíst více"
 
@@ -3286,6 +3391,8 @@ msgstr "Přihlásit se do Frappe Cloud"
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr "Logo"
@@ -3324,7 +3431,7 @@ msgstr "Spravujte obecná nastavení své aplikace."
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr "Spravujte předdefinované odpovědi, které lze použít pro odpovědi na dotazy zákazníků."
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr ""
 
@@ -3343,6 +3450,10 @@ msgstr ""
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
 msgstr "Spravujte informace svého profilu."
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
+msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:11
 #: desk/src/pages/MobileNotifications.vue:14
@@ -3396,6 +3507,20 @@ msgstr "Různé"
 msgid "Mobile App Installation"
 msgstr ""
 
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr ""
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr ""
+
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
 #. List'
@@ -3436,7 +3561,7 @@ msgid "My Tickets"
 msgstr ""
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3447,8 +3572,9 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3458,6 +3584,10 @@ msgstr "Název"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
 msgstr "Váha názvu"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
+msgstr ""
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
 #. Ticket Status'
@@ -3469,10 +3599,18 @@ msgstr "Název zobrazený na zákaznickém portálu<br> (např. Odpovězeno → 
 msgid "Navigation"
 msgstr "Navigace"
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "Nikdy"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3581,11 +3719,11 @@ msgstr "Žádná odpověď"
 msgid "No Data Found"
 msgstr "Nebyla nalezena žádná data"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr ""
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr ""
 
@@ -3597,9 +3735,15 @@ msgstr "Nebyl nalezen žádný seznam svátků"
 msgid "No SLA found"
 msgstr "Nebyla nalezena žádná SLA"
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
 msgstr "Bez týmu"
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
+msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
 msgid "No additional comments"
@@ -3633,19 +3777,27 @@ msgstr ""
 msgid "No changes made"
 msgstr "Nebyly provedeny žádné změny"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr "Žádné změny k uložení"
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr ""
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr ""
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr ""
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
@@ -3657,7 +3809,11 @@ msgstr "Nebyl nalezen žádný e-mailový účet"
 msgid "No feedback"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr ""
 
@@ -3697,19 +3853,25 @@ msgstr ""
 msgid "No recently assigned tickets"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr ""
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
 msgstr "Nebyly nalezeny žádné výsledky"
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
+msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:91
 msgid "No saved replies found"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr ""
@@ -3730,7 +3892,11 @@ msgstr ""
 msgid "No tickets selected"
 msgstr ""
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr ""
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "Nepovoleno"
 
@@ -3742,7 +3908,7 @@ msgstr ""
 msgid "Not Saved"
 msgstr "Neuloženo"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "Nenastaveno"
 
@@ -3781,11 +3947,6 @@ msgstr "Původní podmínky"
 msgid "On Hold Since"
 msgstr "Pozastaveno od"
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr ""
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr ""
@@ -3816,6 +3977,10 @@ msgstr "Otevřít paletu příkazů"
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
 msgstr "Otevřít pole komentáře"
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
+msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
 msgid "Open help"
@@ -3904,7 +4069,12 @@ msgstr ""
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr "Nadřazené pole, podřízené pole a mapování nadřazený-podřízený jsou povinné."
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr ""
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "Heslo"
 
@@ -3942,6 +4112,7 @@ msgid "Pending"
 msgstr "Čeká na vyřízení"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr "Čekající pozvánky"
 
@@ -3951,19 +4122,19 @@ msgstr "Čekající pozvánky"
 msgid "Pending Tickets"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr ""
 
@@ -3984,14 +4155,15 @@ msgstr "Osobní"
 msgid "Personal mobile no"
 msgstr "Soukromé mobilní číslo"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "Telefon"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
-msgstr "Telefonní čísla"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
+msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
 msgid "Pick an option"
@@ -4047,7 +4219,7 @@ msgstr "Pro pokračování zadejte předmět"
 msgid "Please enter a valid phone number"
 msgstr "Zadejte prosím platné telefonní číslo"
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr ""
 
@@ -4090,34 +4262,15 @@ msgstr "Vyberte prosím týdenní den volna"
 msgid "Policy name"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
 msgstr ""
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr "Klíč popisu účtování"
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr "Seznam klíčů tras pošty"
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr "Řetězec poštovní trasy"
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
-msgstr "Klíč názvu účtování"
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:10
@@ -4151,14 +4304,32 @@ msgstr "Náhled"
 msgid "Previous ticket"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "primární"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "Primární kontakt"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr ""
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr "Priority"
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4166,9 +4337,10 @@ msgstr "Priority"
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4248,17 +4420,6 @@ msgstr ""
 msgid "Quarterly"
 msgstr "Čtvrtletně"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "Možnosti dotazu"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr "Řetězec trasy dotazu"
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "Ve frontě"
@@ -4281,14 +4442,14 @@ msgstr "Ohodnoťte svou zkušenost s podporou"
 msgid "Rate this ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr ""
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4384,8 +4545,15 @@ msgstr "Znovu vygenerovat index vyhledávání"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "Odebrat"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4395,10 +4563,19 @@ msgstr "Odstranit logo"
 msgid "Remove Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
-msgstr "Odstranit fotografii"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr "Odebrat obrázek"
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
+msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
 #: desk/src/components/Settings/Teams/TeamsList.vue:161
@@ -4418,6 +4595,15 @@ msgstr ""
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
 msgstr "Přejmenovat tým"
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
+msgstr ""
 
 #. Option in a Select field in the tickets Web Form
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
@@ -4456,17 +4642,14 @@ msgstr "Odpověď od kontaktu"
 msgid "Reply on a ticket"
 msgstr ""
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr "Klíč požadavku"
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
 msgstr "Povinné"
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
+msgstr ""
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
 msgid "Reset"
@@ -4486,6 +4669,7 @@ msgid "Reset to Default"
 msgstr ""
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr "Vyřešení"
@@ -4539,18 +4723,6 @@ msgstr "Odpověď"
 msgid "Response By"
 msgstr "Odpovědět do"
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr "Možnosti odpovědi"
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr "Cesta klíče výsledku odpovědi"
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr "Doba odpovědi pro prioritu {0} na řádku {1} nemůže být delší než doba vyřešení."
@@ -4593,28 +4765,18 @@ msgstr ""
 msgid "Restrict visibility to these teams"
 msgstr "Omezit viditelnost na tyto týmy"
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr "Pole náhledu výsledku"
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr "Pole trasy výsledku"
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr "Pole názvu výsledku"
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
+msgstr ""
+
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:215
@@ -4622,8 +4784,14 @@ msgid "Ringing"
 msgstr "Vyzvánění"
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "Role"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr ""
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4722,9 +4890,9 @@ msgstr "Sobota"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4800,17 +4968,19 @@ msgstr "Index vyhledávání byl znovu vygenerován"
 msgid "Search Score"
 msgstr "Skóre vyhledávání"
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr "Název parametru vyhledávacího výrazu"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "Hledat pole..."
 
@@ -4850,6 +5020,7 @@ msgstr "Vyhledávání..."
 msgid "Searched for:"
 msgstr "Hledáno:"
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr "Vyhledávání..."
@@ -4869,6 +5040,10 @@ msgstr "Vyberte"
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
 msgstr "Vybrat kategorii"
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
+msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
 msgid "Select Range"
@@ -4890,6 +5065,10 @@ msgstr "Vyberte výchozí prioritu."
 msgid "Select a rating"
 msgstr "Vyberte hodnocení"
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr ""
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4901,6 +5080,10 @@ msgstr "Vybrat týmy"
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
+msgstr ""
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
@@ -4928,6 +5111,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
 msgstr "Odeslat zpětnou vazbu, když"
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
+msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
 msgid "Send to {0} tickets"
@@ -4967,7 +5154,7 @@ msgstr "Název úrovně služby"
 msgid "Service not supported"
 msgstr "Služba není podporována"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "Nastaveno"
 
@@ -4975,6 +5162,10 @@ msgstr "Nastaveno"
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
 msgstr "Nastavit telefonní číslo"
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
 msgid "Set Resolution Time for Priority {0} in row {1}."
@@ -4984,12 +5175,21 @@ msgstr "Nastavte dobu vyřešení pro prioritu {0} na řádku {1}."
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr "Nastavte dobu odpovědi pro prioritu {0} na řádku {1}."
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr "Nastavit jako výchozí SLA"
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr ""
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr ""
 
@@ -5001,7 +5201,7 @@ msgstr ""
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr "Nastavte pracovní dny, hodiny a svátky výběrem předdefinovaného rozvrhu nebo vytvořením nového."
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr ""
 
@@ -5135,23 +5335,6 @@ msgstr "Při aktualizaci seznamu svátků došlo k chybě"
 msgid "Sort"
 msgstr ""
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr "Zdrojový typ dokumentu"
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "Název zdroje"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr "Zdrojový typ"
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr "Zdrojová a cílová kategorie nemohou být stejné"
@@ -5196,6 +5379,8 @@ msgstr "Čas začátku nemůže být větší nebo roven času konce na řádku 
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5262,6 +5447,7 @@ msgstr ""
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5373,21 +5559,16 @@ msgstr "Systém"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5426,8 +5607,6 @@ msgstr ""
 msgid "Teal"
 msgstr "Modrozelená"
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5438,7 +5617,6 @@ msgstr "Modrozelená"
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5544,6 +5722,10 @@ msgstr "Podmínka přiřazení '{0}' je neplatná: {1}"
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr ""
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr ""
@@ -5555,6 +5737,10 @@ msgstr "Svátek dne {0} není mezi datem od a datem do"
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
 msgstr "Počet dní musí být 1 nebo více"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
 msgid "The status for sending feedback must be of <u>Resolved</u> category."
@@ -5576,6 +5762,14 @@ msgstr ""
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr ""
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr ""
@@ -5583,6 +5777,10 @@ msgstr ""
 #: desk/src/components/ticket/TicketMergeModal.vue:79
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
 msgstr ""
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
@@ -5652,7 +5850,7 @@ msgstr "Čtvrtek"
 msgid "Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr ""
 
@@ -5666,6 +5864,10 @@ msgstr ""
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
+msgstr ""
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
 msgstr ""
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
@@ -5725,7 +5927,7 @@ msgstr ""
 msgid "Ticket Summary"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr ""
 
@@ -5758,7 +5960,7 @@ msgstr ""
 msgid "Ticket merged successfully."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr ""
 
@@ -5793,12 +5995,6 @@ msgstr ""
 msgid "Ticket to merged with is required"
 msgstr ""
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr ""
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr ""
@@ -5810,12 +6006,15 @@ msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr ""
 
@@ -5827,19 +6026,19 @@ msgstr ""
 msgid "Tickets assigned to you in the last 7 days"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr ""
 
@@ -5856,6 +6055,7 @@ msgid "Tickets that are awaiting your response"
 msgstr ""
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr "Časové pásmo"
 
@@ -5945,19 +6145,19 @@ msgstr "Celkem svátků"
 msgid "Total Ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr ""
 
@@ -5989,6 +6189,10 @@ msgstr "Typ"
 msgid "Type a message"
 msgstr "Napište zprávu"
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr "Typ je povinný"
@@ -5998,7 +6202,7 @@ msgstr "Typ je povinný"
 msgid "URL/Method"
 msgstr "URL/metoda"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr ""
 
@@ -6032,6 +6236,8 @@ msgid "Unpublish"
 msgstr "Zrušit publikování"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr "Neuloženo"
 
@@ -6049,6 +6255,10 @@ msgstr "Neuloženo"
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
 msgstr "Neuložené změny"
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
 msgid "Untitled"
@@ -6076,10 +6286,13 @@ msgstr "Nahrát"
 msgid "Upload Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
-msgstr "Nahrát fotografii"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
+msgstr "Nahrát obrázek"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
 msgid "Uploading {0}%"
@@ -6088,17 +6301,13 @@ msgstr "Nahrávání {0}%"
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6110,6 +6319,10 @@ msgstr "Uživatel"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
 msgstr "Doba vyřešení uživatelem"
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
+msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
 msgid "User Signup"
@@ -6128,7 +6341,7 @@ msgstr "Uživatelé"
 msgid "Valid From"
 msgstr "Platné od"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "Hodnota"
 
@@ -6257,19 +6470,23 @@ msgstr "Ročně"
 msgid "Yellow"
 msgstr "Žlutá"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr ""
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr ""
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr "Nemáte oprávnění přistupovat k tomuto zdroji."
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr "Nemáte oprávnění přidat komentář"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr ""
 
@@ -6297,6 +6514,14 @@ msgstr "Nelze nastavit více než jednu výchozí prioritu."
 msgid "You do not have permission to access Assignment Rules"
 msgstr "Nemáte oprávnění přistupovat k pravidlům přiřazení"
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr ""
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr ""
@@ -6319,6 +6544,14 @@ msgstr "Vaše původní podmínky budou přepsány. Opravdu chcete uložit?"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:46
@@ -6349,7 +6582,7 @@ msgstr ""
 msgid "customize {0}"
 msgstr "přizpůsobit {0}"
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr "dní"
 
@@ -6400,7 +6633,7 @@ msgstr "zde"
 msgid "here."
 msgstr ""
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr "hod"
 
@@ -6408,7 +6641,7 @@ msgstr "hod"
 msgid "in"
 msgstr "v"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "právě nyní"
 
@@ -6441,7 +6674,11 @@ msgstr ""
 msgid "purple"
 msgstr "fialová"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr "hvězdičky"
 
@@ -6458,7 +6695,7 @@ msgstr "ticket"
 msgid "to enable this integration."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr "si toto prohlédl"
 
@@ -6466,12 +6703,32 @@ msgstr "si toto prohlédl"
 msgid "views"
 msgstr "zobrazení"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr ""
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
 msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:307
@@ -6498,7 +6755,7 @@ msgstr ""
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr ""
 

--- a/helpdesk/locale/da.po
+++ b/helpdesk/locale/da.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-15 18:50\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-29 21:57\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Danish\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr ""
@@ -108,14 +108,6 @@ msgstr ""
 msgid "A workday with this name already exists"
 msgstr ""
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr "API"
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr ""
@@ -132,7 +124,7 @@ msgstr ""
 msgid "Account"
 msgstr "Konto"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr ""
 
@@ -152,11 +144,9 @@ msgstr "Handling"
 msgid "Action Required"
 msgstr ""
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr ""
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "Handlinger"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr ""
 msgid "Active"
 msgstr "Aktiv"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr ""
 
@@ -175,7 +165,7 @@ msgid "Active: The agent is available and working.<br>\n"
 "Unavailable: The agent is off and unavailable."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "Aktivitet"
@@ -193,10 +183,11 @@ msgid "Add Column"
 msgstr "Tilføj Kolonne"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "Tilføj Filter..."
 
@@ -206,6 +197,10 @@ msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
 msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:148
@@ -244,7 +239,7 @@ msgstr ""
 msgid "Add condition group"
 msgstr "Tilføj betingelsesgruppe"
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "Tilføj filter"
 
@@ -278,6 +273,12 @@ msgstr ""
 msgid "Add to Holidays"
 msgstr ""
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr ""
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr ""
@@ -295,17 +296,14 @@ msgid "Administrator"
 msgstr "Administrator"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -316,6 +314,7 @@ msgstr "Administrator"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -335,6 +334,7 @@ msgstr ""
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -342,6 +342,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -376,18 +377,9 @@ msgstr ""
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "Alle"
 
@@ -508,6 +500,14 @@ msgstr ""
 msgid "Are you sure you want to delete these articles?"
 msgstr ""
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr ""
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr ""
@@ -543,6 +543,10 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
 msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
@@ -595,16 +599,11 @@ msgstr ""
 msgid "Assign ticket"
 msgstr ""
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr "Tildel til"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -618,7 +617,7 @@ msgstr "Tildeler"
 msgid "Assignee Rules"
 msgstr "Tildelte Regler"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr ""
 
@@ -626,7 +625,7 @@ msgstr ""
 msgid "Assignees"
 msgstr "Tildelte"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr ""
 
@@ -692,10 +691,6 @@ msgstr ""
 msgid "Assignment rule {0} updated successfully."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -711,10 +706,6 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
-msgstr ""
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
 msgstr ""
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
@@ -766,7 +757,7 @@ msgid "Automation"
 msgstr ""
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr ""
@@ -802,7 +793,7 @@ msgstr ""
 msgid "Average Time Metrics"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr ""
 
@@ -810,24 +801,36 @@ msgstr ""
 msgid "Average response and resolution metrics not available"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
 msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
@@ -840,11 +843,11 @@ msgstr ""
 msgid "Avg. resolution time"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr ""
 
@@ -867,11 +870,6 @@ msgstr ""
 msgid "Base Support Rotation"
 msgstr ""
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "Basis-URL"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -885,11 +883,11 @@ msgstr ""
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr ""
 
@@ -944,11 +942,6 @@ msgstr ""
 msgid "Busy"
 msgstr ""
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "Knap"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr ""
@@ -973,19 +966,31 @@ msgstr "Opkaldets varighed i sekunder"
 msgid "Caller"
 msgstr "Opkalder"
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr ""
 
@@ -1025,7 +1030,7 @@ msgstr ""
 msgid "Cannot merge General category"
 msgstr ""
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr ""
 
@@ -1073,11 +1078,11 @@ msgstr "Kategori skal have mindst én artikel"
 msgid "Category updated successfully."
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr ""
 
@@ -1085,7 +1090,7 @@ msgstr ""
 msgid "Change"
 msgstr "Ændre"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "Ændre Adgangskode"
@@ -1098,9 +1103,8 @@ msgstr ""
 msgid "Change language of the application."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
@@ -1123,7 +1127,7 @@ msgstr ""
 msgid "Change timezone of the application."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr ""
 
@@ -1136,7 +1140,7 @@ msgstr "Kanaler"
 msgid "Child field"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr ""
 
@@ -1189,7 +1193,7 @@ msgstr ""
 msgid "Clear Table"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr ""
 
@@ -1203,6 +1207,10 @@ msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
@@ -1223,7 +1231,7 @@ msgstr ""
 msgid "Closed"
 msgstr "Lukket"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr ""
 
@@ -1250,7 +1258,7 @@ msgstr "Kolonner"
 msgid "Comma separated emails to invite."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr ""
 
@@ -1283,7 +1291,7 @@ msgstr ""
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "Kommentarer"
@@ -1296,6 +1304,11 @@ msgstr "Kommunikation"
 msgid "Communication ID is required"
 msgstr ""
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
+msgstr "Selskab"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
 msgstr "Udført"
@@ -1307,7 +1320,7 @@ msgstr "Udført"
 msgid "Condition"
 msgstr "Betingelse"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr ""
 
@@ -1331,6 +1344,10 @@ msgstr ""
 msgid "Configure your telephony settings."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1356,10 +1373,11 @@ msgstr ""
 msgid "Connect your support email"
 msgstr ""
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1373,26 +1391,30 @@ msgstr "Kontakt"
 msgid "Contact HTML"
 msgstr "Kontakt HTML"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
 msgstr ""
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
 msgstr "Kontakter"
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
+msgstr ""
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
 #. Label of the content (Text Editor) field in DocType 'HD Article'
@@ -1415,7 +1437,7 @@ msgstr ""
 msgid "Copy ticket id"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr ""
 
@@ -1423,7 +1445,11 @@ msgstr ""
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr ""
 
@@ -1431,11 +1457,20 @@ msgstr ""
 msgid "Could not send feedback email,due to: {0}"
 msgstr ""
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "Land"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1446,8 +1481,12 @@ msgstr "Skabe"
 msgid "Create & invite a contact"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
 msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
@@ -1482,12 +1521,6 @@ msgstr ""
 msgid "Creating a ticket"
 msgstr ""
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr ""
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr ""
@@ -1512,12 +1545,21 @@ msgid "Custom Views"
 msgstr ""
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
 msgstr "Kunde"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
+msgstr ""
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1528,16 +1570,32 @@ msgstr ""
 msgid "Customer Portal"
 msgstr ""
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
 msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
 msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:595
@@ -1565,6 +1623,8 @@ msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "Fare"
@@ -1665,18 +1725,26 @@ msgstr ""
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr ""
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "Slet"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1692,6 +1760,10 @@ msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
+msgstr ""
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
 msgstr ""
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
@@ -1740,7 +1812,7 @@ msgstr ""
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1826,7 +1898,12 @@ msgstr ""
 msgid "Document Type"
 msgstr "Dokument Type"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr ""
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "Domæne"
@@ -1867,6 +1944,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
@@ -1917,7 +1998,8 @@ msgstr ""
 msgid "Easily invite new agents, managers, or admins."
 msgstr ""
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1925,6 +2007,14 @@ msgstr "Redigere"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
 msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:70
@@ -1944,10 +2034,10 @@ msgstr ""
 msgid "Edit your email account"
 msgstr ""
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "E-mail"
 
@@ -1975,9 +2065,10 @@ msgstr ""
 msgid "Email Content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
-msgstr "E-mail"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
+msgstr "E-mail-ID"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
 #. Settings'
@@ -2002,22 +2093,22 @@ msgstr ""
 msgid "Email account updated successfully"
 msgstr ""
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr ""
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr ""
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "E-mails"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr ""
 
@@ -2055,8 +2146,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr ""
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2081,8 +2170,6 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2105,20 +2192,24 @@ msgstr ""
 msgid "Enter a name for this HD Service Holiday List."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr ""
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr ""
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
 msgstr ""
 
 #: helpdesk/api/knowledge_base.py:86
@@ -2129,21 +2220,17 @@ msgstr ""
 msgid "Error processing email at index {0}, message: {1}"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr ""
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "Fejl under tilslutning til e-mailkonto {0}"
 
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr ""
-
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
 msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
@@ -2172,11 +2259,6 @@ msgstr ""
 msgid "Export Type"
 msgstr "Eksporttype"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr ""
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2184,6 +2266,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "Mislykkedes"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2218,11 +2304,11 @@ msgstr ""
 msgid "Failed to save Twilio settings"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr ""
 
@@ -2251,6 +2337,7 @@ msgstr ""
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2288,12 +2375,16 @@ msgstr ""
 msgid "Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
+msgstr ""
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
 msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
@@ -2338,13 +2429,14 @@ msgid "Field dependency updated successfully."
 msgstr ""
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "Felter"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "Filtre"
@@ -2354,13 +2446,18 @@ msgstr "Filtre"
 msgid "Find out all of the variables that can be used in the content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "Fornavn"
 
 #. Label of the first_responded_on (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
+msgstr ""
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
 msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
@@ -2385,10 +2482,6 @@ msgstr ""
 #. Name of a report
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -2480,6 +2573,10 @@ msgstr ""
 msgid "Go to Ticket #{0}"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr ""
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2509,19 +2606,12 @@ msgid "Group By Field"
 msgstr ""
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr "Gæst"
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
 msgstr ""
 
 #. Name of a DocType
@@ -2554,24 +2644,36 @@ msgstr ""
 msgid "HD Comment Reaction"
 msgstr ""
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr ""
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr ""
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
 msgstr ""
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
 msgstr ""
 
 #. Name of a DocType
@@ -2592,21 +2694,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
 msgstr ""
 
 #. Name of a DocType
@@ -2648,11 +2735,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
 msgstr ""
 
 #. Name of a DocType
@@ -2750,12 +2832,6 @@ msgstr ""
 msgid "Helpdesk"
 msgstr ""
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr ""
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2772,11 +2848,6 @@ msgstr ""
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
 msgstr "Skjul "
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr ""
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
@@ -2846,15 +2917,8 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "IP-adresse"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2941,6 +3005,11 @@ msgstr "Indbakke"
 msgid "Incoming"
 msgstr "Indgående"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr ""
@@ -2954,7 +3023,7 @@ msgstr ""
 msgid "Instantly send e-mail"
 msgstr ""
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "Utilstrækkelige rettigheder for {0}"
 
@@ -2968,12 +3037,12 @@ msgstr ""
 msgid "Introduction"
 msgstr "Introduktion"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
@@ -2982,22 +3051,42 @@ msgstr ""
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr ""
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr ""
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
+msgstr "Invitere"
+
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
@@ -3008,12 +3097,29 @@ msgstr ""
 msgid "Invite agents"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
-msgstr ""
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
+msgstr "Inviter som bruger"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
 msgstr ""
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
@@ -3030,6 +3136,11 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "Er standard"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr ""
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3057,6 +3168,10 @@ msgstr ""
 #. Label of the setup_complete (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
 msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:114
@@ -3093,11 +3208,9 @@ msgstr "Tastaturgenveje"
 msgid "Knowledge Base"
 msgstr "Vidensbase"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3131,9 +3244,9 @@ msgstr ""
 msgid "Last 3 Months"
 msgstr ""
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr ""
 
@@ -3174,7 +3287,8 @@ msgstr ""
 msgid "Last Month"
 msgstr "Sidste måned"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "Efternavn"
 
@@ -3183,23 +3297,32 @@ msgstr "Efternavn"
 msgid "Last Week"
 msgstr "Sidste uge"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr ""
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
 msgstr ""
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
@@ -3216,26 +3339,6 @@ msgstr ""
 #. 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
-msgstr ""
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr ""
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -3264,6 +3367,8 @@ msgstr ""
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "Indlæs mere"
 
@@ -3286,6 +3391,8 @@ msgstr ""
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr ""
@@ -3324,7 +3431,7 @@ msgstr ""
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr ""
 
@@ -3342,6 +3449,10 @@ msgstr ""
 
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:11
@@ -3396,6 +3507,20 @@ msgstr ""
 msgid "Mobile App Installation"
 msgstr ""
 
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr ""
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr ""
+
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
 #. List'
@@ -3436,7 +3561,7 @@ msgid "My Tickets"
 msgstr ""
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3447,8 +3572,9 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3457,6 +3583,10 @@ msgstr "Navn"
 #. Label of the name_weight (Int) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
 msgstr ""
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
@@ -3469,10 +3599,18 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "Aldrig"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3581,11 +3719,11 @@ msgstr ""
 msgid "No Data Found"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr ""
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr ""
 
@@ -3597,8 +3735,14 @@ msgstr ""
 msgid "No SLA found"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
 msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
@@ -3633,19 +3777,27 @@ msgstr ""
 msgid "No changes made"
 msgstr "Ingen ændringer foretaget"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr ""
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr ""
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr ""
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
@@ -3657,7 +3809,11 @@ msgstr ""
 msgid "No feedback"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr ""
 
@@ -3697,12 +3853,17 @@ msgstr ""
 msgid "No recently assigned tickets"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr ""
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
 msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
@@ -3710,6 +3871,7 @@ msgstr ""
 msgid "No saved replies found"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr ""
@@ -3730,7 +3892,11 @@ msgstr ""
 msgid "No tickets selected"
 msgstr ""
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr ""
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "Ikke Tilladt"
 
@@ -3742,7 +3908,7 @@ msgstr ""
 msgid "Not Saved"
 msgstr "Ikke gemt"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "Ikke angivet"
 
@@ -3781,11 +3947,6 @@ msgstr ""
 msgid "On Hold Since"
 msgstr ""
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr ""
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr ""
@@ -3815,6 +3976,10 @@ msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
@@ -3904,7 +4069,12 @@ msgstr ""
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr ""
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "Adgangskode"
 
@@ -3942,6 +4112,7 @@ msgid "Pending"
 msgstr "Afventer"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr ""
 
@@ -3951,19 +4122,19 @@ msgstr ""
 msgid "Pending Tickets"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr ""
 
@@ -3984,13 +4155,14 @@ msgstr "Personlig"
 msgid "Personal mobile no"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "Telefon"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
 msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
@@ -4047,7 +4219,7 @@ msgstr ""
 msgid "Please enter a valid phone number"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr ""
 
@@ -4090,33 +4262,14 @@ msgstr ""
 msgid "Policy name"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
-msgstr ""
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr ""
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr ""
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr ""
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
 msgstr ""
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
@@ -4151,14 +4304,32 @@ msgstr "Forhåndsvisning"
 msgid "Previous ticket"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "Primær"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "Primær kontaktperson"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr ""
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr ""
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4166,9 +4337,10 @@ msgstr ""
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4248,17 +4420,6 @@ msgstr ""
 msgid "Quarterly"
 msgstr "Kvartalsvis"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "Forespørgselsmuligheder"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr ""
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "I kø"
@@ -4281,14 +4442,14 @@ msgstr ""
 msgid "Rate this ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr ""
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4384,8 +4545,15 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "Fjern"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4395,9 +4563,18 @@ msgstr ""
 msgid "Remove Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr ""
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
 msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
@@ -4417,6 +4594,15 @@ msgstr ""
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
 msgstr ""
 
 #. Option in a Select field in the tickets Web Form
@@ -4456,16 +4642,13 @@ msgstr ""
 msgid "Reply on a ticket"
 msgstr ""
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr "Anmodning Nøgle"
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
 msgstr ""
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
@@ -4486,6 +4669,7 @@ msgid "Reset to Default"
 msgstr ""
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr ""
@@ -4539,18 +4723,6 @@ msgstr "Svar"
 msgid "Response By"
 msgstr ""
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr ""
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr ""
@@ -4593,28 +4765,18 @@ msgstr ""
 msgid "Restrict visibility to these teams"
 msgstr ""
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr ""
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr ""
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
+msgstr ""
+
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:215
@@ -4622,8 +4784,14 @@ msgid "Ringing"
 msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "Rolle"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr ""
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4722,9 +4890,9 @@ msgstr "Lørdag"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4800,17 +4968,19 @@ msgstr ""
 msgid "Search Score"
 msgstr ""
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr ""
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "Søg i felter..."
 
@@ -4850,6 +5020,7 @@ msgstr "Søg..."
 msgid "Searched for:"
 msgstr ""
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr "Søger..."
@@ -4868,6 +5039,10 @@ msgstr "Vælg"
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
 msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
@@ -4890,6 +5065,10 @@ msgstr ""
 msgid "Select a rating"
 msgstr ""
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr ""
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4901,6 +5080,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
+msgstr ""
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
@@ -4927,6 +5110,10 @@ msgstr ""
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
 msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
@@ -4967,13 +5154,17 @@ msgstr ""
 msgid "Service not supported"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "Angivet"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:4
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
@@ -4984,12 +5175,21 @@ msgstr ""
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr ""
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr ""
 
@@ -5001,7 +5201,7 @@ msgstr ""
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr ""
 
@@ -5135,23 +5335,6 @@ msgstr ""
 msgid "Sort"
 msgstr ""
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr ""
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "Kildenavn"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr ""
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr ""
@@ -5196,6 +5379,8 @@ msgstr ""
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5262,6 +5447,7 @@ msgstr ""
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5373,21 +5559,16 @@ msgstr ""
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5426,8 +5607,6 @@ msgstr ""
 msgid "Teal"
 msgstr ""
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5438,7 +5617,6 @@ msgstr ""
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5544,6 +5722,10 @@ msgstr ""
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr ""
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr ""
@@ -5554,6 +5736,10 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
@@ -5576,6 +5762,14 @@ msgstr ""
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr ""
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr ""
@@ -5583,6 +5777,10 @@ msgstr ""
 #: desk/src/components/ticket/TicketMergeModal.vue:79
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
 msgstr ""
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
@@ -5652,7 +5850,7 @@ msgstr "Torsdag"
 msgid "Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr ""
 
@@ -5666,6 +5864,10 @@ msgstr ""
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
+msgstr ""
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
 msgstr ""
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
@@ -5725,7 +5927,7 @@ msgstr ""
 msgid "Ticket Summary"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr ""
 
@@ -5758,7 +5960,7 @@ msgstr ""
 msgid "Ticket merged successfully."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr ""
 
@@ -5793,12 +5995,6 @@ msgstr ""
 msgid "Ticket to merged with is required"
 msgstr ""
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr ""
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr ""
@@ -5810,12 +6006,15 @@ msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr ""
 
@@ -5827,19 +6026,19 @@ msgstr ""
 msgid "Tickets assigned to you in the last 7 days"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr ""
 
@@ -5856,6 +6055,7 @@ msgid "Tickets that are awaiting your response"
 msgstr ""
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr ""
 
@@ -5945,19 +6145,19 @@ msgstr ""
 msgid "Total Ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr ""
 
@@ -5989,6 +6189,10 @@ msgstr ""
 msgid "Type a message"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr ""
@@ -5998,7 +6202,7 @@ msgstr ""
 msgid "URL/Method"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr ""
 
@@ -6032,6 +6236,8 @@ msgid "Unpublish"
 msgstr "Afpublicer"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr ""
 
@@ -6048,6 +6254,10 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:214
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
+msgstr ""
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
@@ -6076,9 +6286,12 @@ msgstr "Overfør"
 msgid "Upload Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
@@ -6088,17 +6301,13 @@ msgstr ""
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6109,6 +6318,10 @@ msgstr "Bruger"
 #. Label of the user_resolution_time (Duration) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
 msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
@@ -6128,7 +6341,7 @@ msgstr "Brugere"
 msgid "Valid From"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "Værdi"
 
@@ -6257,19 +6470,23 @@ msgstr "Årligt"
 msgid "Yellow"
 msgstr "Gul"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr ""
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr ""
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr ""
 
@@ -6297,6 +6514,14 @@ msgstr ""
 msgid "You do not have permission to access Assignment Rules"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr ""
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr ""
@@ -6319,6 +6544,14 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:46
@@ -6349,7 +6582,7 @@ msgstr ""
 msgid "customize {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr ""
 
@@ -6400,7 +6633,7 @@ msgstr ""
 msgid "here."
 msgstr ""
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr ""
 
@@ -6408,7 +6641,7 @@ msgstr ""
 msgid "in"
 msgstr "i"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "lige nu"
 
@@ -6441,7 +6674,11 @@ msgstr ""
 msgid "purple"
 msgstr "lilla"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr ""
 
@@ -6458,7 +6695,7 @@ msgstr ""
 msgid "to enable this integration."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr ""
 
@@ -6466,12 +6703,32 @@ msgstr ""
 msgid "views"
 msgstr "visninger"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr ""
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
 msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:307
@@ -6498,7 +6755,7 @@ msgstr ""
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr ""
 

--- a/helpdesk/locale/de.po
+++ b/helpdesk/locale/de.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-15 18:50\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-29 21:57\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: German\n"
 "MIME-Version: 1.0\n"
@@ -20,128 +20,120 @@ msgstr ""
 
 #: desk/src/components/CommentBox.vue:14
 msgid " commented"
-msgstr ""
+msgstr " kommentierte"
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
-msgstr ""
+msgstr "% SLA erfüllt"
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
-msgstr ""
+msgstr "% der erstellten Tickets, die innerhalb der SLA gelöst wurden"
 
 #: desk/src/pages/SearchAgent.vue:120
 msgid "({0}s)"
-msgstr ""
+msgstr "({0}s)"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:114
 msgid "- Default Ticket Status<br>"
-msgstr ""
+msgstr "- Standard-Ticketstatus<br>"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:116
 msgid "- Ticket Reopen Status<br>"
-msgstr ""
+msgstr "- Status für Ticket-Wiedereröffnung<br>"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:92
 msgid "- {0} as Default Status<br>"
-msgstr ""
+msgstr "- {0} als Standardstatus<br>"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:94
 msgid "- {0} as Reopen Status<br>"
-msgstr ""
+msgstr "- {0} als Wiedereröffnungsstatus<br>"
 
 #. Description of the 'Feedback' (Select) field in DocType 'HD Article
 #. Feedback'
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 msgid "0 is no feedback, 1 is Like, 2 is Dislike"
-msgstr ""
+msgstr "0 bedeutet keine Rückmeldung, 1 bedeutet Gefällt mir, 2 bedeutet Gefällt mir nicht"
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:178
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:196
 msgid "1 Year"
-msgstr ""
+msgstr "1 Jahr"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.py:154
 msgid "1 person reacted to your comment"
-msgstr ""
+msgstr "1 Person hat auf Ihren Kommentar reagiert"
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:176
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:188
 msgid "3 Months"
-msgstr ""
+msgstr "3 Monate"
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:177
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:183
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:192
 msgid "6 Months"
-msgstr ""
+msgstr "6 Monate"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:117
 msgid "<br>Please update HD Settings to use a different status before disabling this status."
-msgstr ""
+msgstr "<br>Bitte aktualisieren Sie die HD-Einstellungen, um einen anderen Status zu verwenden, bevor Sie diesen Status deaktivieren."
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:95
 msgid "<br>Please update the SLA(s) to use a different status before disabling this status."
-msgstr ""
+msgstr "<br>Bitte aktualisieren Sie die SLA(s), um einen anderen Status zu verwenden, bevor Sie diesen Status deaktivieren."
 
 #. Introduction text of the email-feedback Web Form
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
 msgid "<div class=\"ql-editor read-mode\"><p>Let us know if we solved your issue well. It’ll help us serve you better next time.</p></div>"
-msgstr ""
+msgstr "<div class=\"ql-editor read-mode\"><p>Teilen Sie uns mit, ob wir Ihr Anliegen zu Ihrer Zufriedenheit gelöst haben. Das hilft uns, Ihnen beim nächsten Mal noch besser zu helfen.</p></div>"
 
 #. Header text in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "<span class=\"h3\" style=\"\"><a href=\"/helpdesk\">Visit Helpdesk</a></span>"
-msgstr ""
+msgstr "<span class=\"h3\" style=\"\"><a href=\"/helpdesk\">Helpdesk besuchen</a></span>"
 
 #. Paragraph text in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "<span class=\"h4\">Helpdesk Configuration<br></span>"
-msgstr ""
+msgstr "<span class=\"h4\">Helpdesk-Konfiguration<br></span>"
 
 #: desk/src/pages/ticket/TicketNew.vue:69
 msgid "A short description"
-msgstr ""
+msgstr "Eine kurze Beschreibung"
 
 #: desk/src/components/Settings/Sla/Modals/WorkDayModal.vue:268
 msgid "A workday with this name already exists"
-msgstr ""
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr "API"
+msgstr "Ein Arbeitstag mit diesem Namen existiert bereits"
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
-msgstr ""
+msgstr "Zugriff auf alle Team-Tickets"
 
 #: helpdesk/api/knowledge_base.py:15
 msgid "Access denied"
-msgstr ""
+msgstr "Zugriff verweigert"
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:262
 msgid "Access only this team's tickets"
-msgstr ""
+msgstr "Nur Zugriff auf die Tickets dieses Teams"
 
 #: desk/src/components/Settings/SettingsModal.vue:19
 msgid "Account"
 msgstr "Konto"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
-msgstr ""
+msgstr "Kontoinformationen & Sicherheit"
 
 #. Label of the acknowledgement_section (Section Break) field in DocType 'HD
 #. Settings'
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:72
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Acknowledgement"
-msgstr ""
+msgstr "Bestätigung"
 
 #. Label of the action (Small Text) field in DocType 'HD Ticket Activity'
 #: helpdesk/helpdesk/doctype/hd_ticket_activity/hd_ticket_activity.json
@@ -150,13 +142,11 @@ msgstr "Aktion"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.py:24
 msgid "Action Required"
-msgstr ""
+msgstr "Aktion erforderlich"
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr ""
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "Aktionen"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,49 +154,56 @@ msgstr ""
 msgid "Active"
 msgstr "Aktiv"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
-msgstr ""
+msgstr "Jetzt aktiv"
 
 #. Description of the 'Category' (Select) field in DocType 'HD Agent Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 msgid "Active: The agent is available and working.<br>\n"
 "Away: The agent is temporarily unreachable.<br>\n"
 "Unavailable: The agent is off and unavailable."
-msgstr ""
+msgstr "Aktiv: Der Agent ist verfügbar und arbeitet.<br>\n"
+"Abwesend: Der Agent ist vorübergehend nicht erreichbar.<br>\n"
+"Nicht verfügbar: Der Agent ist offline und nicht verfügbar."
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "Aktivität"
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:9
 msgid "Add Assignee"
-msgstr ""
+msgstr "Beauftragten hinzufügen"
 
 #: desk/src/pages/knowledge-base/Article.vue:643
 msgid "Add Category"
-msgstr ""
+msgstr "Kategorie hinzufügen"
 
 #: desk/src/components/view-controls/ColumnSettings.vue:69
 msgid "Add Column"
 msgstr "Spalte hinzufügen"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
-msgstr ""
+msgstr "E-Mail hinzufügen"
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "Filter hinzufügen..."
 
 #: desk/src/components/Settings/Holiday/HolidayView.vue:163
 msgid "Add Holiday"
-msgstr ""
+msgstr "Feiertag hinzufügen"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
-msgstr ""
+msgstr "Neuen Artikel hinzufügen"
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
+msgstr "Telefonnummer hinzufügen"
 
 #: desk/src/components/view-controls/SortBy.vue:148
 msgid "Add Sort"
@@ -220,41 +217,41 @@ msgstr "Wöchentlich freie Tage hinzufügen"
 
 #: desk/src/components/layouts/Sidebar.vue:507
 msgid "Add a comment on a ticket"
-msgstr ""
+msgstr "Einen Kommentar zu einem Ticket hinzufügen"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesSection.vue:17
 msgid "Add a condition"
-msgstr ""
+msgstr "Eine Bedingung hinzufügen"
 
 #: desk/src/components/Settings/Sla/SlaAssignmentConditions.vue:14
 msgid "Add a custom condition"
-msgstr ""
+msgstr "Eine benutzerdefinierte Bedingung hinzufügen"
 
 #: desk/src/pages/home/Home.vue:91
 msgid "Add charts to get started"
-msgstr ""
+msgstr "Fügen Sie Diagramme hinzu, um loszulegen"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesSection.vue:29
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesSection.vue:66
 #: desk/src/components/Settings/Sla/SlaAssignmentConditions.vue:25
 msgid "Add condition"
-msgstr ""
+msgstr "Bedingung hinzufügen"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesSection.vue:72
 msgid "Add condition group"
-msgstr ""
+msgstr "Bedingungsgruppe hinzufügen"
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "Filter hinzufügen"
 
 #: desk/src/components/Settings/Holiday/HolidayView.vue:136
 msgid "Add holidays here to make sure they’re excluded from SLA calculations."
-msgstr ""
+msgstr "Fügen Sie hier arbeitsfreie Tage hinzu, damit sie von der SLA-Berechnung ausgeschlossen werden."
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:97
 msgid "Add members to this team to get started."
-msgstr ""
+msgstr "Fügen Sie diesem Team Mitglieder hinzu, um loszulegen."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:23
 #: desk/src/components/Settings/EmailAccountList.vue:47
@@ -262,15 +259,15 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:92
 #: desk/src/components/Settings/Sla/SlaPolicyList.vue:23
 msgid "Add one to get started."
-msgstr ""
+msgstr "Fügen Sie eines hinzu, um loszulegen."
 
 #: desk/src/components/Settings/Holiday/HolidayView.vue:117
 msgid "Add recurring holidays such as weekends."
-msgstr ""
+msgstr "Fügen Sie wiederkehrende arbeitsfreie Tage wie Wochenenden hinzu."
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:183
 msgid "Add time targets around support milestones like first reply and resolution times."
-msgstr ""
+msgstr "Fügen Sie Zeitvorgaben für Support-Meilensteine wie erste Antwort- und Lösungszeiten hinzu."
 
 #. Label of the get_weekly_off_dates (Button) field in DocType 'HD Service
 #. Holiday List'
@@ -278,9 +275,15 @@ msgstr ""
 msgid "Add to Holidays"
 msgstr "Zu arbeitsfreien Tagen hinzufügen"
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr "Zu Empfängern hinzufügen"
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
-msgstr ""
+msgstr "Agenten hinzufügen, verwalten und ihnen Rollen zuweisen."
 
 #. Label of the about (Code) field in DocType 'HD Ticket Template'
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
@@ -295,17 +298,14 @@ msgid "Administrator"
 msgstr "Administrator"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -316,6 +316,7 @@ msgstr "Administrator"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -326,15 +327,16 @@ msgstr "Agent"
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Agent Configuration"
-msgstr ""
+msgstr "Agentenkonfiguration"
 
 #: desk/src/pages/dashboard/Dashboard.vue:248
 msgid "Agent Dashboard"
-msgstr ""
+msgstr "Agenten-Dashboard"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -342,24 +344,25 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
-msgstr ""
+msgstr "Agenten-Manager"
 
 #. Label of the agent_name (Data) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Agent Name"
-msgstr ""
+msgstr "Agentenname"
 
 #. Label of the agent_status (Data) field in DocType 'HD Agent Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 msgid "Agent Status"
-msgstr ""
+msgstr "Agentenstatus"
 
 #: desk/src/components/Settings/Agents.vue:109
 msgid "Agent name"
-msgstr ""
+msgstr "Agentenname"
 
 #: desk/src/components/Settings/Agents.vue:3
 msgid "Agents"
@@ -367,72 +370,63 @@ msgstr "Agenten"
 
 #: desk/src/components/layouts/Sidebar.vue:591
 msgid "Agents & Teams"
-msgstr ""
+msgstr "Agenten & Teams"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:70
 msgid "Agents will no longer be able to view and create saved replies with global scope."
-msgstr ""
+msgstr "Agenten können gespeicherte Antworten mit globalem Geltungsbereich nicht mehr anzeigen oder erstellen."
 
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "Alle"
 
 #: desk/src/pages/home/components/PendingTickets.vue:253
 msgid "All SLAs on track"
-msgstr ""
+msgstr "Alle SLAs im Zeitplan"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:360
 #: desk/src/pages/home/components/RecentFeedback.vue:398
 #: desk/src/pages/home/components/RecentFeedback.vue:406
 msgid "All Time"
-msgstr ""
+msgstr "Gesamter Zeitraum"
 
 #: desk/src/components/layouts/Sidebar.vue:293
 msgid "All Views"
-msgstr ""
+msgstr "Alle Ansichten"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:322
 msgid "All articles from this category will move to General category."
-msgstr ""
+msgstr "Alle Artikel dieser Kategorie werden in die Kategorie Allgemein verschoben."
 
 #: desk/src/components/ticket/TicketMergeModal.vue:7
 msgid "All comments and emails from both tickets will be merged into the selected ticket"
-msgstr ""
+msgstr "Alle Kommentare und E-Mails beider Tickets werden in das ausgewählte Ticket zusammengeführt"
 
 #: desk/src/pages/home/components/PendingTickets.vue:262
 msgid "All your assigned tickets have been responded to"
-msgstr ""
+msgstr "Auf alle Ihnen zugewiesenen Tickets wurde bereits geantwortet"
 
 #. Label of the allow_anyone_to_create_tickets (Check) field in DocType 'HD
 #. Settings'
 #: desk/src/components/Settings/General/components/TicketSettings.vue:109
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Allow anyone to create tickets"
-msgstr ""
+msgstr "Jedem erlauben, Tickets zu erstellen"
 
 #. Description of the 'Enable comment reactions' (Check) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Allow users to react to comments with emojis"
-msgstr ""
+msgstr "Benutzern erlauben, mit Emojis auf Kommentare zu reagieren"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:26
 msgid "Allow users to react to comments with emojis."
-msgstr ""
+msgstr "Benutzern erlauben, mit Emojis auf Kommentare zu reagieren."
 
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
@@ -443,24 +437,24 @@ msgstr "Bernstein"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:113
 msgid "Anyone will be able to create tickets without any permission. e.g. from webform."
-msgstr ""
+msgstr "Jeder kann ohne Berechtigung Tickets erstellen, z. B. über ein Webformular."
 
 #: desk/src/components/Settings/Preferences/Preferences.vue:26
 msgid "Appearance"
-msgstr ""
+msgstr "Erscheinungsbild"
 
 #: desk/src/components/Settings/General/components/Branding.vue:17
 msgid "Appears in the left sidebar. Recommended size is minimum 32x32 px in PNG or SVG."
-msgstr ""
+msgstr "Erscheint in der linken Seitenleiste. Empfohlene Mindestgröße: 32x32 px im PNG- oder SVG-Format."
 
 #. Description of the 'Favicon' (Attach Image) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Appears next to the title in your browser tab. Recommended size is minimum 32x32 px in PNG or ICO"
-msgstr ""
+msgstr "Erscheint neben dem Titel in Ihrem Browser-Tab. Empfohlene Mindestgröße: 32x32 px im PNG- oder ICO-Format"
 
 #: desk/src/components/Settings/General/components/Branding.vue:29
 msgid "Appears next to the title in your browser tab. Recommended size is minimum 32x32 px in PNG or ICO."
-msgstr ""
+msgstr "Erscheint neben dem Titel in Ihrem Browser-Tab. Empfohlene Mindestgröße: 32x32 px im PNG- oder ICO-Format."
 
 #. Label of the apply_sla_for_resolution (Check) field in DocType 'HD Service
 #. Level Agreement'
@@ -476,19 +470,19 @@ msgstr "Anwenden auf"
 #. Label of the apply_on_new_page (Check) field in DocType 'HD Form Script'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 msgid "Apply on new page"
-msgstr ""
+msgstr "Auf neuer Seite anwenden"
 
 #. Label of the enable_outside_hours_banner (Check) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Apply outside working hours"
-msgstr ""
+msgstr "Außerhalb der Arbeitszeiten anwenden"
 
 #. Label of the apply_to_customer_portal (Check) field in DocType 'HD Form
 #. Script'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 msgid "Apply to customer portal"
-msgstr ""
+msgstr "Auf Kundenportal anwenden"
 
 #. Option for the 'Status' (Select) field in DocType 'HD Article'
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:451
@@ -498,31 +492,39 @@ msgstr "Archiviert"
 
 #: desk/src/components/Settings/SettingsModal.vue:74
 msgid "Are you sure you want to change tabs? Unsaved changes will be lost."
-msgstr ""
+msgstr "Möchten Sie den Tab wirklich wechseln? Ungespeicherte Änderungen gehen verloren."
 
 #: desk/src/pages/ticket/TicketCustomer.vue:314
 msgid "Are you sure you want to close this ticket?"
-msgstr ""
+msgstr "Möchten Sie dieses Ticket wirklich schließen?"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:205
 msgid "Are you sure you want to delete these articles?"
-msgstr ""
+msgstr "Möchten Sie diese Artikel wirklich löschen?"
+
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr "Möchten Sie diesen Kontakt wirklich löschen? Der Kontakt wird dauerhaft gelöscht und von allen zugehörigen Kunden und Tickets getrennt."
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr "Möchten Sie diesen Kunden wirklich löschen? Der Verweis auf diesen Kunden wird aus allen zugehörigen Tickets entfernt."
 
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
-msgstr ""
+msgstr "Möchten Sie dieses Ticket wirklich löschen? Diese Aktion ist unwiderruflich und kann nicht rückgängig gemacht werden."
 
 #: desk/src/pages/ticket/Tickets.vue:541
 msgid "Are you sure you want to delete this view?"
-msgstr ""
+msgstr "Möchten Sie diese Ansicht wirklich löschen?"
 
 #: desk/src/pages/knowledge-base/Article.vue:147
 msgid "Are you sure you want to discard changes?"
-msgstr ""
+msgstr "Möchten Sie die Änderungen wirklich verwerfen?"
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:144
 msgid "Are you sure you want to discard this article?"
-msgstr ""
+msgstr "Möchten Sie diesen Artikel wirklich verwerfen?"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:450
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:103
@@ -535,76 +537,75 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:215
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:184
 msgid "Are you sure you want to go back? Unsaved changes will be lost."
-msgstr ""
+msgstr "Möchten Sie wirklich zurückgehen? Ungespeicherte Änderungen gehen verloren."
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:165
 msgid "Are you sure you want to leave? Unsaved changes will be lost."
-msgstr ""
+msgstr "Möchten Sie die Seite wirklich verlassen? Ungespeicherte Änderungen gehen verloren."
 
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
-msgstr ""
+msgstr "Möchten Sie das Logo wirklich entfernen?"
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
+msgstr "Möchten Sie diesen Kontakt wirklich vom Kunden entfernen?"
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
 msgid "Are you sure you want to reset the content? Current content will be overridden."
-msgstr ""
+msgstr "Möchten Sie den Inhalt wirklich zurücksetzen? Der aktuelle Inhalt wird überschrieben."
 
 #. Label of the article (Link) field in DocType 'HD Article Feedback'
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:114
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 msgid "Article"
-msgstr ""
+msgstr "Artikel"
 
 #: desk/src/pages/knowledge-base/Article.vue:519
 msgid "Article body cannot be set as empty."
-msgstr ""
+msgstr "Der Artikelinhalt darf nicht leer sein."
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:117
 msgid "Article created successfully."
-msgstr ""
+msgstr "Artikel erfolgreich erstellt."
 
 #: desk/src/pages/knowledge-base/Article.vue:558
 msgid "Article deleted successfully."
-msgstr ""
+msgstr "Artikel erfolgreich gelöscht."
 
 #: desk/src/pages/knowledge-base/Article.vue:654
 msgid "Article link copied to clipboard"
-msgstr ""
+msgstr "Artikellink in die Zwischenablage kopiert"
 
 #: desk/src/pages/knowledge-base/Article.vue:514
 msgid "Article title cannot be set as empty"
-msgstr ""
+msgstr "Der Artikeltitel darf nicht leer sein"
 
 #: desk/src/pages/knowledge-base/Article.vue:545
 msgid "Article updated successfully."
-msgstr ""
+msgstr "Artikel erfolgreich aktualisiert."
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:359
 msgid "Articles deleted successfully."
-msgstr ""
+msgstr "Artikel erfolgreich gelöscht."
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:235
 msgid "Articles moved successfully."
-msgstr ""
+msgstr "Artikel erfolgreich verschoben."
 
 #: desk/src/components/layouts/Sidebar.vue:482
 msgid "Assign a ticket to an agent"
-msgstr ""
+msgstr "Ein Ticket einem Agenten zuweisen"
 
 #: desk/src/components/modals/ShortcutsModal.vue:90
 msgid "Assign ticket"
-msgstr ""
-
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr "Zuweisen an"
+msgstr "Ticket zuweisen"
 
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
-msgstr ""
+msgstr "Sich selbst zuweisen"
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -612,23 +613,23 @@ msgstr "Zugewiesen zu"
 
 #: desk/src/components/ticket-agent/AssignTo.vue:11
 msgid "Assignee"
-msgstr "Beauftragte"
+msgstr "Beauftragter"
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:5
 msgid "Assignee Rules"
-msgstr ""
+msgstr "Regeln für Beauftragte"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
-msgstr ""
+msgstr "Beauftragter erfolgreich aktualisiert."
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:75
 msgid "Assignees"
-msgstr ""
+msgstr "Beauftragte"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
-msgstr ""
+msgstr "Beauftragte erfolgreich aktualisiert."
 
 #. Option for the 'Type' (Select) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
@@ -637,7 +638,7 @@ msgstr "Zuweisung"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:122
 msgid "Assignment Condition"
-msgstr ""
+msgstr "Zuweisungsbedingung"
 
 #. Label of the filters_section (Section Break) field in DocType 'HD Service
 #. Level Agreement'
@@ -662,60 +663,52 @@ msgstr "Zuweisungsregeln"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:11
 msgid "Assignment Rules automatically route tickets to the right team members based on predefined conditions."
-msgstr ""
+msgstr "Zuweisungsregeln leiten Tickets automatisch anhand vordefinierter Bedingungen an die richtigen Teammitglieder weiter."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:276
 msgid "Assignment Schedule"
-msgstr ""
+msgstr "Zuweisungsplan"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:29
 msgid "Assignment rule"
-msgstr ""
+msgstr "Zuweisungsregel"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:545
 msgid "Assignment rule created successfully."
-msgstr ""
+msgstr "Zuweisungsregel erfolgreich erstellt."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:130
 msgid "Assignment rule deleted successfully."
-msgstr ""
+msgstr "Zuweisungsregel erfolgreich gelöscht."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:173
 msgid "Assignment rule duplicated successfully."
-msgstr ""
+msgstr "Zuweisungsregel erfolgreich dupliziert."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:632
 msgid "Assignment rule updated successfully."
-msgstr ""
+msgstr "Zuweisungsregel erfolgreich aktualisiert."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:226
 msgid "Assignment rule {0} updated successfully."
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr ""
+msgstr "Zuweisungsregel {0} erfolgreich aktualisiert."
 
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
-msgstr ""
+msgstr "Mindestens ein aktivierter Status der Kategorie „Aktiv“ ist erforderlich."
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:73
 msgid "At least one enabled status for <u>{0}</u> category must be enabled."
-msgstr ""
+msgstr "Mindestens ein aktivierter Status der Kategorie <u>{0}</u> muss aktiviert sein."
 
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.py:38
 msgid "At least one feedback option must be enabled for rating {0}"
-msgstr ""
+msgstr "Für die Bewertung {0} muss mindestens eine Rückmeldungsoption aktiviert sein"
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
-msgstr ""
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
-msgstr ""
+msgstr "Mindestens ein Team ist erforderlich"
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
@@ -733,32 +726,32 @@ msgstr "Autor"
 #: desk/src/components/Settings/General/components/TicketSettings.vue:80
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Auto update status"
-msgstr ""
+msgstr "Status automatisch aktualisieren"
 
 #. Label of the auto_close_after_days (Int) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/TicketSettings.vue:176
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Auto-close after (Days)"
-msgstr ""
+msgstr "Automatisch schließen nach (Tage)"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:148
 msgid "Auto-close tickets that remain in a status for the specified number of days."
-msgstr ""
+msgstr "Tickets automatisch schließen, die für die angegebene Anzahl von Tagen in einem Status verbleiben."
 
 #. Description of the 'Condition' (Code) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Auto-generated from the portal view — do not edit directly unless you know what you're doing! "
-msgstr ""
+msgstr "Automatisch aus der Portalansicht generiert — bitte nicht direkt bearbeiten, es sei denn, Sie wissen genau, was Sie tun! "
 
 #. Label of the auto_close_tickets (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Automatically Close Tickets when"
-msgstr ""
+msgstr "Tickets automatisch schließen, wenn"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:145
 msgid "Automatically close stale tickets"
-msgstr ""
+msgstr "Veraltete Tickets automatisch schließen"
 
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
@@ -766,31 +759,31 @@ msgid "Automation"
 msgstr "Automatisierung"
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
-msgstr ""
+msgstr "Verfügbarkeit"
 
 #. Label of the availability_changed_on (Datetime) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability Changed On"
-msgstr ""
+msgstr "Verfügbarkeit geändert am"
 
 #: desk/src/pages/home/components/ChartItem.vue:6
 msgid "Average First Response"
-msgstr ""
+msgstr "Durchschnittliche erste Antwort"
 
 #: desk/src/pages/home/Home.vue:317
 msgid "Average First Response Time"
-msgstr ""
+msgstr "Durchschnittliche erste Antwortzeit"
 
 #: desk/src/pages/home/components/ChartItem.vue:16
 msgid "Average Resolution"
-msgstr ""
+msgstr "Durchschnittliche Lösung"
 
 #: desk/src/pages/home/Home.vue:329
 msgid "Average Resolution Time"
-msgstr ""
+msgstr "Durchschnittliche Lösungszeit"
 
 #. Label of the avg_response_time (Duration) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -800,58 +793,70 @@ msgstr "Durchschnittliche Reaktionszeit"
 #: desk/src/pages/home/Home.vue:305
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:5
 msgid "Average Time Metrics"
-msgstr ""
+msgstr "Durchschnittliche Zeitmetriken"
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
-msgstr ""
+msgstr "Die durchschnittliche Rückmeldungsbewertung pro Tag liegt bei etwa {0} Sternen"
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:107
 msgid "Average response and resolution metrics not available"
-msgstr ""
+msgstr "Durchschnittliche Antwort- und Lösungsmetriken nicht verfügbar"
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
-msgstr ""
+msgstr "Die durchschnittliche Anzahl an Tickets pro Tag liegt bei etwa {0}"
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
-msgstr ""
+msgstr "Durchschn. Rückmeldungsbewertung"
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr "Durchschn. erhaltene Rückmeldungen"
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
-msgstr ""
+msgstr "Durchschn. erste Antwort"
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr "Durchschn. erste Antwortzeit"
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
-msgstr ""
+msgstr "Durchschn. Lösung"
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
-msgstr ""
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr "Durchschn. Lösungszeit"
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
+msgstr "Durchschnittliche Rückmeldungsbewertung für in diesem Zeitraum gelöste Tickets"
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:290
 msgid "Avg. first response time"
-msgstr ""
+msgstr "Durchschn. erste Antwortzeit"
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:130
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:298
 msgid "Avg. resolution time"
-msgstr ""
+msgstr "Durchschn. Lösungszeit"
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
-msgstr ""
+msgstr "Durchschnittliche Zeit bis zur ersten Antwort auf ein Ticket"
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
-msgstr ""
+msgstr "Durchschnittliche Zeit bis zur Lösung eines Tickets"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 msgid "Away"
-msgstr ""
+msgstr "Abwesend"
 
 #: desk/src/components/Settings/EmailAdd.vue:145
 #: desk/src/components/Settings/EmailEdit.vue:134
@@ -860,17 +865,12 @@ msgstr "Zurück"
 
 #: desk/src/pages/InvalidPage.vue:25 desk/src/pages/ticket/TicketAgent.vue:44
 msgid "Back to Tickets"
-msgstr ""
+msgstr "Zurück zu Tickets"
 
 #. Label of the base_support_rotation (Link) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Base Support Rotation"
-msgstr ""
-
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "Basis-URL"
+msgstr "Basis-Support-Rotation"
 
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
@@ -885,13 +885,13 @@ msgstr "Wählen Sie auf der Grundlage Ihrer HR-Richtlinien das Enddatum Ihres Ab
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr "Wählen Sie auf der Grundlage Ihrer HR-Richtlinie das Startdatum Ihres Abwesenheitskontingents aus"
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
-msgstr ""
+msgstr "Bcc"
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
-msgstr ""
+msgstr "Bcc:"
 
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
@@ -926,28 +926,23 @@ msgstr "Stapelverarbeitung erfolgreich"
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:2
 #: desk/src/pages/ticket/Tickets.vue:122
 msgid "Bulk Reply"
-msgstr ""
+msgstr "Sammelantwort"
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:105
 msgid "Bulk reply sent successfully to 1 ticket."
-msgstr ""
+msgstr "Sammelantwort erfolgreich an 1 Ticket gesendet."
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:106
 msgid "Bulk reply sent successfully to {0} tickets."
-msgstr ""
+msgstr "Sammelantwort erfolgreich an {0} Tickets gesendet."
 
 #: desk/src/components/Settings/Holiday/Holidays.vue:3
 msgid "Business Holidays"
-msgstr ""
+msgstr "Betriebsferien"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:210
 msgid "Busy"
 msgstr "Beschäftigt"
-
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "Button"
 
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
@@ -959,7 +954,7 @@ msgstr "Anrufdetails"
 
 #: desk/src/components/layouts/Sidebar.vue:288
 msgid "Call Logs"
-msgstr ""
+msgstr "Anrufprotokolle"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:81
 msgid "Call Received By"
@@ -967,27 +962,39 @@ msgstr "Anruf empfangen von"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:69
 msgid "Call duration in seconds"
-msgstr ""
+msgstr "Anrufdauer in Sekunden"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:93
 msgid "Caller"
 msgstr "Anrufer"
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr "Anrufe"
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
-msgstr ""
+msgstr "Kann neue Agenten einladen, Tickets verwalten, benutzerdefinierte Ansichten erstellen und öffentliche Ansichten verwalten."
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
-msgstr ""
+msgstr "Kann alle Aspekte von Helpdesk verwalten."
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr "Kann Tickets im Namen der Organisation erstellen und die von ihm erstellten Tickets verwalten."
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr "Kann alle von der Organisation erstellten Tickets einsehen und andere Mitglieder als Manager zuweisen."
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr "Kann Tickets aller Kontakte des Kunden einsehen."
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
-msgstr ""
+msgstr "Kann an Tickets arbeiten, benutzerdefinierte Ansichten erstellen und private Ansichten verwalten."
 
 #: desk/src/components/ListViewBuilder.vue:714 desk/src/pages/home/Home.vue:44
 msgid "Cancel"
@@ -995,7 +1002,7 @@ msgstr "Abbrechen"
 
 #: desk/src/components/Settings/InviteAgents.vue:63
 msgid "Cancel Invitation"
-msgstr ""
+msgstr "Einladung stornieren"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:214
 msgid "Canceled"
@@ -1003,35 +1010,35 @@ msgstr "Abgebrochen"
 
 #: helpdesk/integrations/erpnext/api.py:47
 msgid "Cannot Sync Customers"
-msgstr ""
+msgstr "Kunden können nicht synchronisiert werden"
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:526
 msgid "Cannot delete the default SLA. At least one SLA must be marked as default."
-msgstr ""
+msgstr "Die Standard-SLA kann nicht gelöscht werden. Mindestens eine SLA muss als Standard gekennzeichnet sein."
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:110
 msgid "Cannot disable this status as it is linked in HD Settings:<br><br>"
-msgstr ""
+msgstr "Dieser Status kann nicht deaktiviert werden, da er in den HD-Einstellungen verknüpft ist:<br><br>"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:88
 msgid "Cannot disable this status as it is linked in the following SLAs:<br><br>"
-msgstr ""
+msgstr "Dieser Status kann nicht deaktiviert werden, da er in den folgenden SLAs verknüpft ist:<br><br>"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:198
 msgid "Cannot enable rule without adding users in it"
-msgstr ""
+msgstr "Die Regel kann nicht aktiviert werden, ohne dass Benutzer hinzugefügt wurden"
 
 #: helpdesk/api/knowledge_base.py:128
 msgid "Cannot merge General category"
-msgstr ""
+msgstr "Die Kategorie Allgemein kann nicht zusammengeführt werden"
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
-msgstr ""
+msgstr "Umbenennen nicht möglich: Ein nicht verwandtes {0} „{1}“ existiert bereits auf der anderen Seite. Bitte lösen Sie den Konflikt zunächst manuell auf."
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseCustomer.vue:24
 msgid "Categories"
-msgstr ""
+msgstr "Kategorien"
 
 #. Label of the category (Select) field in DocType 'HD Agent Status'
 #. Label of the category (Link) field in DocType 'HD Article'
@@ -1045,7 +1052,7 @@ msgstr "Kategorie"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:175
 msgid "Category '{0}' link copied to clipboard"
-msgstr ""
+msgstr "Link der Kategorie „{0}“ in die Zwischenablage kopiert"
 
 #: desk/src/pages/knowledge-base/Article.vue:335
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:266
@@ -1058,127 +1065,126 @@ msgstr "Kategorie erfolgreich gelöscht."
 
 #: desk/src/components/ticket/TicketMergeModal.vue:188
 msgid "Category is required"
-msgstr ""
+msgstr "Kategorie ist erforderlich"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:374
 msgid "Category merged successfully."
-msgstr ""
+msgstr "Kategorie erfolgreich zusammengeführt."
 
 #: helpdesk/api/knowledge_base.py:78
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.py:65
 msgid "Category must have atleast one article"
-msgstr ""
+msgstr "Die Kategorie muss mindestens einen Artikel enthalten"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:305
 msgid "Category updated successfully."
 msgstr "Kategorie erfolgreich aktualisiert."
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
-msgstr ""
+msgstr "Cc"
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
-msgstr ""
+msgstr "Cc:"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:40
 msgid "Change"
 msgstr "Ändern"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "Kennwort ändern"
 
 #: desk/src/components/Settings/Profile/Profile.vue:198
 msgid "Change Photo"
-msgstr ""
+msgstr "Foto ändern"
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:9
 msgid "Change language of the application."
-msgstr ""
+msgstr "Sprache der Anwendung ändern."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
-msgstr ""
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
+msgstr "Operator ändern ({0})"
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
 msgid "Change priority"
-msgstr ""
+msgstr "Priorität ändern"
 
 #: desk/src/components/modals/ShortcutsModal.vue:91
 msgid "Change status"
-msgstr ""
+msgstr "Status ändern"
 
 #: desk/src/components/modals/ShortcutsModal.vue:89
 msgid "Change team"
-msgstr ""
+msgstr "Team ändern"
 
 #: desk/src/components/modals/ShortcutsModal.vue:87
 msgid "Change ticket type"
-msgstr ""
+msgstr "Ticket-Typ ändern"
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:25
 msgid "Change timezone of the application."
-msgstr ""
+msgstr "Zeitzone der Anwendung ändern."
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
-msgstr ""
+msgstr "Ändern Sie Ihr Kontokennwort aus Sicherheitsgründen."
 
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Channels"
-msgstr ""
+msgstr "Kanäle"
 
 #: desk/src/components/Settings/FieldDependency/FieldDependencyFieldsSelection.vue:18
 msgid "Child field"
-msgstr ""
+msgstr "Unterfeld"
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
-msgstr ""
+msgstr "Feld auswählen"
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:135
 msgid "Choose how long this SLA policy will be active."
-msgstr ""
+msgstr "Legen Sie fest, wie lange diese SLA-Richtlinie aktiv sein soll."
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:22
 msgid "Choose how tickets are distributed among selected assignees."
-msgstr ""
+msgstr "Legen Sie fest, wie Tickets unter den ausgewählten Beauftragten verteilt werden."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:280
 msgid "Choose the days of the week when this rule should be active."
-msgstr ""
+msgstr "Wählen Sie die Wochentage aus, an denen diese Regel aktiv sein soll."
 
 #: desk/src/components/Settings/Holiday/HolidayView.vue:66
 msgid "Choose the duration of this holiday list."
-msgstr ""
+msgstr "Legen Sie die Dauer dieser Feiertagsliste fest."
 
 #: desk/src/components/Settings/EmailAdd.vue:5
 msgid "Choose the email service provider you want to configure."
-msgstr ""
+msgstr "Wählen Sie den E-Mail-Dienstanbieter aus, den Sie konfigurieren möchten."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:127
 msgid "Choose which tickets are affected by this assignment rule."
-msgstr ""
+msgstr "Wählen Sie aus, welche Tickets von dieser Zuweisungsregel betroffen sind."
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:69
 msgid "Choose which tickets are affected by this policy."
-msgstr ""
+msgstr "Wählen Sie aus, welche Tickets von dieser Richtlinie betroffen sind."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:204
 msgid "Choose which tickets are affected by this un-assignment rule."
-msgstr ""
+msgstr "Wählen Sie aus, welche Tickets von dieser Rückweisungsregel betroffen sind."
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:69
 msgid "Choose who can view and use this response."
-msgstr ""
+msgstr "Wählen Sie aus, wer diese Antwort ansehen und verwenden kann."
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:78
 msgid "Choose who receives the tickets."
-msgstr ""
+msgstr "Wählen Sie aus, wer die Tickets erhält."
 
 #: desk/src/components/view-controls/SortBy.vue:160
 msgid "Clear Sort"
@@ -1189,9 +1195,9 @@ msgstr "Sortierung aufheben"
 msgid "Clear Table"
 msgstr "Tabelle leeren"
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
-msgstr ""
+msgstr "Alle löschen"
 
 #: desk/src/components/view-controls/filter/FilterTrigger.vue:17
 msgid "Clear all Filter"
@@ -1199,11 +1205,15 @@ msgstr "Alle Filter leeren"
 
 #: desk/src/pages/SearchAgent.vue:86
 msgid "Clear all filters"
-msgstr ""
+msgstr "Alle Filter löschen"
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
 msgstr "Klicken Sie auf „Zu arbeitsfreien Tagen hinzufügen“. Dadurch wird die Tabelle der arbeitsfreien Tage mit allen Terminen gefüllt, die auf den ausgewählten Wochentag fallen. Wiederholen Sie den Vorgang, um die Daten für alle arbeitsfreien Wochentage einzugeben"
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
+msgstr "Zum Kopieren klicken"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:47
@@ -1216,16 +1226,16 @@ msgstr "Schließen"
 
 #: desk/src/pages/ticket/TicketCustomer.vue:313
 msgid "Close Ticket"
-msgstr ""
+msgstr "Ticket schließen"
 
 #. Option in a Select field in the tickets Web Form
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
 msgid "Closed"
 msgstr "Geschlossen"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
-msgstr ""
+msgstr "Geschlossene oder bewertete Tickets können nicht von Nicht-Agenten aktualisiert werden"
 
 #: desk/src/components/layouts/Sidebar.vue:143
 msgid "Collapse"
@@ -1248,11 +1258,11 @@ msgstr "Spalten"
 
 #: desk/src/components/Settings/InviteAgents.vue:15
 msgid "Comma separated emails to invite."
-msgstr ""
+msgstr "Durch Komma getrennte E-Mail-Adressen zum Einladen."
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
-msgstr ""
+msgstr "Durch Komma getrennte Werte"
 
 #. Label of the reference_comment (Link) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
@@ -1261,29 +1271,29 @@ msgstr "Kommentar"
 
 #: desk/src/components/CommentBox.vue:318
 msgid "Comment cannot be empty."
-msgstr ""
+msgstr "Der Kommentar darf nicht leer sein."
 
 #: desk/src/components/CommentBox.vue:308
 msgid "Comment deleted successfully."
-msgstr ""
+msgstr "Kommentar erfolgreich gelöscht."
 
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.py:67
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.py:112
 msgid "Comment not found"
-msgstr ""
+msgstr "Kommentar nicht gefunden"
 
 #: desk/src/components/CommentBox.vue:334
 msgid "Comment updated successfully."
-msgstr ""
+msgstr "Kommentar erfolgreich aktualisiert."
 
 #. Label of the commented_by (Link) field in DocType 'HD Ticket Comment'
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 msgid "Commented By"
-msgstr ""
+msgstr "Kommentiert von"
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "Kommentare"
@@ -1294,7 +1304,12 @@ msgstr "Kommunikation"
 
 #: desk/src/components/ticket/TicketSplitModal.vue:76
 msgid "Communication ID is required"
-msgstr ""
+msgstr "Kommunikations-ID ist erforderlich"
+
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
+msgstr "Unternehmen"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
@@ -1307,30 +1322,34 @@ msgstr "Abgeschlossen"
 msgid "Condition"
 msgstr "Bedingung"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
-msgstr ""
+msgstr "Konfigurieren"
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:3
 msgid "Configure your Exotel settings for Helpdesk."
-msgstr ""
+msgstr "Konfigurieren Sie Ihre Exotel-Einstellungen für Helpdesk."
 
 #: desk/src/components/Settings/Telephony/Telephony.vue:100
 msgid "Configure your Exotel telephony integration settings here"
-msgstr ""
+msgstr "Konfigurieren Sie hier Ihre Exotel-Telefonieintegration"
 
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:3
 msgid "Configure your Twilio settings for Helpdesk."
-msgstr ""
+msgstr "Konfigurieren Sie Ihre Twilio-Einstellungen für Helpdesk."
 
 #: desk/src/components/Settings/Telephony/Telephony.vue:76
 msgid "Configure your Twilio telephony integration settings here"
-msgstr ""
+msgstr "Konfigurieren Sie hier Ihre Twilio-Telefonieintegration"
 
 #: desk/src/components/Settings/Telephony/Telephony.vue:2
 msgid "Configure your telephony settings."
-msgstr ""
+msgstr "Konfigurieren Sie Ihre Telefonie-Einstellungen."
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1342,7 +1361,7 @@ msgstr "Bestätigen"
 
 #: desk/src/components/ListViewBuilder.vue:698
 msgid "Confirm Changes"
-msgstr ""
+msgstr "Änderungen bestätigen"
 
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:19
 msgid "Confirm Password"
@@ -1350,16 +1369,17 @@ msgstr "Kennwort bestätigen"
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:393
 msgid "Confirm overwrite"
-msgstr ""
+msgstr "Überschreiben bestätigen"
 
 #: desk/src/components/layouts/Sidebar.vue:439
 msgid "Connect your support email"
-msgstr ""
+msgstr "Verbinden Sie Ihre Support-E-Mail-Adresse"
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1373,26 +1393,30 @@ msgstr "Kontakt"
 msgid "Contact HTML"
 msgstr "Kontakt-HTML"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
-msgstr ""
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
+msgstr "Kontakt erfolgreich entfernt"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
-msgstr ""
+msgstr "Kontakt erfolgreich aktualisiert."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
-msgstr ""
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
+msgstr "Kontakt {0} hat keine E-Mail-Adresse"
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
 msgstr "Kontakte"
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
+msgstr "Kontakte erfolgreich hinzugefügt"
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
 #. Label of the content (Text Editor) field in DocType 'HD Article'
@@ -1409,33 +1433,46 @@ msgstr "Inhaltstyp"
 
 #: desk/src/components/modals/ShortcutsModal.vue:93
 msgid "Copy ticket URL"
-msgstr ""
+msgstr "Ticket-URL kopieren"
 
 #: desk/src/components/modals/ShortcutsModal.vue:92
 msgid "Copy ticket id"
-msgstr ""
+msgstr "Ticket-ID kopieren"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
-msgstr ""
+msgstr "E-Mail konnte nicht gesendet werden, Grund: {0}"
 
 #: helpdesk/patches/set_hd_ticket_naming_series.py:37
 msgid "Could not find the `name` column in tabHD Ticket"
-msgstr ""
+msgstr "Die Spalte `name` konnte in tabHD Ticket nicht gefunden werden"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr "Kontakte für {0} Kunde(n) konnten nicht migriert werden: {1}. Beheben Sie die zugrunde liegenden Daten und führen Sie den Patch erneut aus."
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
-msgstr ""
+msgstr "Bestätigungs-E-Mail konnte nicht gesendet werden, Grund: {0}"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:169
 msgid "Could not send feedback email,due to: {0}"
-msgstr ""
+msgstr "Rückmeldungs-E-Mail konnte nicht gesendet werden, Grund: {0}"
+
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "Land"
 
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1444,11 +1481,15 @@ msgstr "Erstellen"
 #: desk/src/components/layouts/Sidebar.vue:537
 #: desk/src/components/layouts/Sidebar.vue:543
 msgid "Create & invite a contact"
-msgstr ""
+msgstr "Kontakt erstellen & einladen"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
-msgstr "Neuen Kontakt erstellen"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr "Kontakt erstellen"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
+msgstr "Kunden erstellen"
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
 msgid "Create View"
@@ -1456,47 +1497,41 @@ msgstr "Ansicht erstellen"
 
 #: desk/src/components/layouts/Sidebar.vue:472
 msgid "Create a ticket"
-msgstr ""
+msgstr "Ein Ticket erstellen"
 
 #: desk/src/components/layouts/Sidebar.vue:520
 msgid "Create an article"
-msgstr ""
+msgstr "Einen Artikel erstellen"
 
 #: desk/src/components/Settings/Teams/TeamsList.vue:5
 msgid "Create and manage teams and assign agents to specific teams."
-msgstr ""
+msgstr "Teams erstellen und verwalten und Agenten bestimmten Teams zuweisen."
 
 #: desk/src/components/Settings/FieldDependency/FieldDependencyList.vue:13
 msgid "Create field dependencies to dynamically update options based on user selections. Learn more about field dependencies"
-msgstr ""
+msgstr "Erstellen Sie Feldabhängigkeiten, um Optionen dynamisch basierend auf Benutzerauswahlen zu aktualisieren. Erfahren Sie mehr über Feldabhängigkeiten"
 
 #: desk/src/components/Settings/Sla/SlaHolidays.vue:57
 msgid "Create new business holiday"
-msgstr ""
+msgstr "Neue Betriebsferien erstellen"
 
 #: desk/src/components/Settings/FieldDependency/FieldDependencyList.vue:69
 msgid "Created by"
-msgstr ""
+msgstr "Erstellt von"
 
 #: desk/src/components/layouts/Sidebar.vue:583
 msgid "Creating a ticket"
-msgstr ""
-
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr ""
+msgstr "Ein Ticket erstellen"
 
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
-msgstr ""
+msgstr "Benutzerdefinierte Aktionen"
 
 #. Label of the outside_working_hours_message (Small Text) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Custom Outside Working Hours Message"
-msgstr ""
+msgstr "Benutzerdefinierte Nachricht außerhalb der Arbeitszeiten"
 
 #: desk/src/pages/dashboard/Dashboard.vue:509
 #: desk/src/pages/dashboard/Dashboard.vue:515
@@ -1509,15 +1544,24 @@ msgstr "Benutzerdefinierter Bereich"
 
 #: desk/src/components/layouts/Sidebar.vue:629
 msgid "Custom Views"
-msgstr ""
+msgstr "Benutzerdefinierte Ansichten"
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
 msgstr "Kunde"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
+msgstr "Kunden-Manager"
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1526,35 +1570,51 @@ msgstr "Kundenname"
 
 #: desk/src/components/layouts/Sidebar.vue:603
 msgid "Customer Portal"
-msgstr ""
+msgstr "Kundenportal"
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
-msgstr "Der Kunde wurde erfolgreich erstellt."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr "Kundentyp"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr "Kunde erstellt"
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
+msgstr "Kundenname darf nicht leer sein"
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
-msgstr ""
+msgstr "Kundenportal"
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
-msgstr ""
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
+msgstr "Kunde aktualisiert"
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
+msgstr "Kunden"
 
 #: desk/src/components/layouts/Sidebar.vue:595
 msgid "Customers & Contacts"
-msgstr ""
+msgstr "Kunden & Kontakte"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:82
 msgid "Customers are in sync"
-msgstr ""
+msgstr "Kunden sind synchronisiert"
 
 #: desk/src/components/layouts/Sidebar.vue:624
 msgid "Customizations"
-msgstr ""
+msgstr "Anpassungen"
 
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:5
 msgid "Customize your email notification preferences to stay informed about important updates and activities."
-msgstr ""
+msgstr "Passen Sie Ihre E-Mail-Benachrichtigungseinstellungen an, um über wichtige Updates und Aktivitäten informiert zu bleiben."
 
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
@@ -1565,6 +1625,8 @@ msgstr "Türkis"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "Gefahr"
@@ -1575,7 +1637,7 @@ msgstr "Dashboard"
 
 #: desk/src/pages/home/Home.vue:264 desk/src/pages/home/Home.vue:286
 msgid "Dashboard saved"
-msgstr ""
+msgstr "Dashboard gespeichert"
 
 #. Label of the holiday_date (Date) field in DocType 'HD Holiday'
 #: helpdesk/helpdesk/doctype/hd_holiday/hd_holiday.json
@@ -1585,7 +1647,7 @@ msgstr "Datum"
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:29
 msgid "Day count for auto closing tickets cannot be negative or zero"
-msgstr ""
+msgstr "Die Tagesanzahl für das automatische Schließen von Tickets darf nicht negativ oder null sein"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:38
 msgid "Days"
@@ -1608,7 +1670,7 @@ msgstr "Standardpriorität"
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Default SLA"
-msgstr ""
+msgstr "Standard-SLA"
 
 #: desk/src/components/Settings/EmailAccountCard.vue:56
 msgid "Default Sending"
@@ -1622,16 +1684,16 @@ msgstr "Standard-Versand und Posteingang"
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Default Ticket Status"
-msgstr ""
+msgstr "Standard-Ticketstatus"
 
 #: desk/src/pages/ticket/Tickets.vue:354 desk/src/pages/ticket/Tickets.vue:447
 msgid "Default Views"
-msgstr ""
+msgstr "Standardansichten"
 
 #: desk/src/components/ticket-agent/TicketHeader.vue:264
 #: desk/src/components/ticket-agent/TicketHeader.vue:275
 msgid "Default actions"
-msgstr ""
+msgstr "Standardaktionen"
 
 #: desk/src/components/Settings/Telephony/Telephony.vue:45
 msgid "Default calling medium for logged in user"
@@ -1644,33 +1706,37 @@ msgstr "Standard-Medium"
 #. Label of the default_priority (Link) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Default priority"
-msgstr ""
+msgstr "Standardpriorität"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.py:63
 msgid "Default template can not be deleted"
-msgstr ""
+msgstr "Die Standardvorlage kann nicht gelöscht werden"
 
 #. Label of the default_ticket_status (Link) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Default ticket status"
-msgstr ""
+msgstr "Standard-Ticketstatus"
 
 #. Label of the default_ticket_type (Link) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/TicketSettings.vue:129
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Default ticket type"
-msgstr ""
+msgstr "Standard-Ticket-Typ"
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:9
 msgid "Define who receives the tickets and how they’re distributed among agents."
-msgstr ""
+msgstr "Legen Sie fest, wer die Tickets erhält und wie sie unter den Agenten verteilt werden."
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
@@ -1678,21 +1744,29 @@ msgstr ""
 msgid "Delete"
 msgstr "Löschen"
 
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr "Kontakt löschen"
+
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
 msgstr "Ansicht löschen"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:204
 msgid "Delete articles"
-msgstr ""
+msgstr "Artikel löschen"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:321
 msgid "Delete category?"
-msgstr ""
+msgstr "Kategorie löschen?"
 
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
-msgstr ""
+msgstr "{0} löschen"
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
+msgstr "{0} Ticket(s) löschen"
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
 #. Label of the description (Text Editor) field in DocType 'HD Holiday'
@@ -1724,23 +1798,23 @@ msgstr "Beschreibung"
 #. Template'
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Description Template"
-msgstr ""
+msgstr "Beschreibungsvorlage"
 
 #. Label of the description_weight (Int) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Description Weight"
-msgstr ""
+msgstr "Gewichtung der Beschreibung"
 
 #: desk/src/pages/ticket/TicketNew.vue:90
 #: desk/src/pages/ticket/TicketNew.vue:115
 msgid "Detailed explanation"
-msgstr ""
+msgstr "Ausführliche Erklärung"
 
 #. Label of the details_section (Section Break) field in DocType 'HD
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1749,17 +1823,17 @@ msgstr "Details"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:67
 msgid "Disable global saved replies"
-msgstr ""
+msgstr "Globale gespeicherte Antworten deaktivieren"
 
 #. Label of the disable_saved_replies_global_scope (Check) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Disable saved replies with scope 'Global'"
-msgstr ""
+msgstr "Gespeicherte Antworten mit Geltungsbereich „Global“ deaktivieren"
 
 #: desk/src/components/Settings/General/General.vue:47
 msgid "Disable signup"
-msgstr ""
+msgstr "Registrierung deaktivieren"
 
 #. Label of the disabled (Check) field in DocType 'HD Team'
 #. Label of the disabled (Check) field in DocType 'HD Ticket Feedback Option'
@@ -1775,7 +1849,7 @@ msgstr "Deaktiviert"
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:29
 msgid "Disables all email notifications for the ticket - including creation, updates, and alerts."
-msgstr ""
+msgstr "Deaktiviert alle E-Mail-Benachrichtigungen für das Ticket – einschließlich Erstellung, Aktualisierungen und Warnungen."
 
 #: desk/src/components/TextEditor.vue:41
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:24
@@ -1785,30 +1859,30 @@ msgstr "Verwerfen"
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:143
 msgid "Discard Article"
-msgstr ""
+msgstr "Artikel verwerfen"
 
 #: desk/src/pages/knowledge-base/Article.vue:146
 msgid "Discard changes?"
-msgstr ""
+msgstr "Änderungen verwerfen?"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:203
 msgid "Display a customizable banner message when customers raise tickets outside your working hours."
-msgstr ""
+msgstr "Zeigen Sie eine anpassbare Bannernachricht an, wenn Kunden außerhalb Ihrer Arbeitszeiten Tickets erstellen."
 
 #. Description of the 'Ignore Restrictions' (Check) field in DocType 'HD Team'
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Do not apply filters and restrictions to agents of this team"
-msgstr ""
+msgstr "Filter und Einschränkungen nicht auf Agenten dieses Teams anwenden"
 
 #. Label of the do_not_restrict_tickets_without_an_agent_group (Check) field in
 #. DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Do not restrict tickets without a Team"
-msgstr ""
+msgstr "Tickets ohne Team nicht einschränken"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:52
 msgid "Do not restrict tickets without a team"
-msgstr ""
+msgstr "Tickets ohne Team nicht einschränken"
 
 #. Label of the dt (Link) field in DocType 'HD Form Script'
 #. Label of the dt (Link) field in DocType 'HD View'
@@ -1819,14 +1893,19 @@ msgstr "DocType"
 
 #: desk/src/components/layouts/Sidebar.vue:371
 msgid "Docs"
-msgstr ""
+msgstr "Dokumentation"
 
 #. Label of the document_type (Link) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 msgid "Document Type"
 msgstr "Dokumententyp"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr "Mustermann"
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "Domain"
@@ -1855,19 +1934,23 @@ msgstr "Duplizieren"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:53
 msgid "Duplicate Assignment Rule"
-msgstr ""
+msgstr "Zuweisungsregel duplizieren"
 
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:30
 msgid "Duplicate Holiday List"
-msgstr ""
+msgstr "Feiertagsliste duplizieren"
 
 #: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:42
 msgid "Duplicate SLA Policy"
-msgstr ""
+msgstr "SLA-Richtlinie duplizieren"
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
-msgstr ""
+msgstr "Gespeicherte Antwort duplizieren"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
+msgstr "Doppelte Kontakte sind nicht zulässig"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
 #: desk/src/pages/call-logs/CallLogModal.vue:68
@@ -1876,7 +1959,7 @@ msgstr "Dauer"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:388
 msgid "Duration is required"
-msgstr ""
+msgstr "Dauer ist erforderlich"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:8
 msgid "ERPNext"
@@ -1885,39 +1968,40 @@ msgstr "ERPNext"
 #. Label of the erpnext_customer (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "ERPNext Customer"
-msgstr ""
+msgstr "ERPNext-Kunde"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 msgid "ERPNext HD Settings"
-msgstr ""
+msgstr "ERPNext HD-Einstellungen"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:182
 msgid "ERPNext Integration is disabled"
-msgstr ""
+msgstr "ERPNext-Integration ist deaktiviert"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:181
 msgid "ERPNext Integration is enabled"
-msgstr ""
+msgstr "ERPNext-Integration ist aktiviert"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:66
 msgid "ERPNext app"
-msgstr ""
+msgstr "ERPNext-App"
 
 #: helpdesk/integrations/erpnext/api.py:47
 msgid "ERPNext integration is not enabled"
-msgstr ""
+msgstr "ERPNext-Integration ist nicht aktiviert"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:203
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.py:19
 msgid "ERPNext is not installed on your site. Please install ERPNext to enable this setting"
-msgstr ""
+msgstr "ERPNext ist auf Ihrer Website nicht installiert. Bitte installieren Sie ERPNext, um diese Einstellung zu aktivieren"
 
 #: desk/src/components/Settings/InviteAgents.vue:4
 msgid "Easily invite new agents, managers, or admins."
-msgstr ""
+msgstr "Laden Sie ganz einfach neue Agenten, Manager oder Admins ein."
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1927,10 +2011,18 @@ msgstr "Bearbeiten"
 msgid "Edit Call Log"
 msgstr "Anrufprotokoll bearbeiten"
 
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr "Kontakt bearbeiten"
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
+msgstr "Kunde bearbeiten"
+
 #: desk/src/components/Settings/EmailAdd.vue:70
 #: desk/src/components/Settings/EmailEdit.vue:63
 msgid "Edit Domain"
-msgstr ""
+msgstr "Domain bearbeiten"
 
 #: desk/src/components/Settings/EmailEdit.vue:3
 msgid "Edit Email"
@@ -1938,16 +2030,16 @@ msgstr "E-Mail bearbeiten"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:147
 msgid "Edit Title"
-msgstr ""
+msgstr "Titel bearbeiten"
 
 #: desk/src/components/Settings/EmailEdit.vue:4
 msgid "Edit your email account"
-msgstr ""
+msgstr "Bearbeiten Sie Ihr E-Mail-Konto"
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "E-Mail"
 
@@ -1973,10 +2065,11 @@ msgstr "E-Mail Konten"
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:61
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Email Content"
-msgstr ""
+msgstr "E-Mail-Inhalt"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
 msgstr "E-Mail-Adresse"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
@@ -1984,7 +2077,7 @@ msgstr "E-Mail-Adresse"
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:3
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Email Notifications"
-msgstr ""
+msgstr "E-Mail-Benachrichtigungen"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:3
 msgid "Email Settings"
@@ -1992,47 +2085,47 @@ msgstr "E-Mail-Einstellungen"
 
 #: desk/src/components/Settings/EmailAdd.vue:309
 msgid "Email account created"
-msgstr ""
+msgstr "E-Mail-Konto erstellt"
 
 #: desk/src/components/Settings/EmailAccountList.vue:27
 msgid "Email account name"
-msgstr ""
+msgstr "Name des E-Mail-Kontos"
 
 #: desk/src/components/Settings/EmailEdit.vue:471
 msgid "Email account updated successfully"
 msgstr "E-Mail-Konto erfolgreich aktualisiert"
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr "Geben Sie die E-Mail-Adresse des Hauptkontakts ein"
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr ""
+msgstr "E-Mail-Einstellungen erfolgreich aktualisiert"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "E-Mails"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
-msgstr ""
+msgstr "E-Mails & Signatur"
 
 #: desk/src/components/Settings/EmailEdit.vue:417
 msgid "Emails pulled successfully"
-msgstr ""
+msgstr "E-Mails erfolgreich abgerufen"
 
 #. Label of the emoji (Data) field in DocType 'HD Comment Reaction'
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
 msgid "Emoji"
-msgstr ""
+msgstr "Emoji"
 
 #: desk/src/components/view-controls/SortBy.vue:134
 msgid "Empty - Choose a field to sort by"
-msgstr ""
+msgstr "Leer – Wählen Sie ein Feld zum Sortieren aus"
 
 #. Label of the enable (Check) field in DocType 'HD Agent Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2041,22 +2134,20 @@ msgstr "Aktivieren"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:36
 msgid "Enable ERPNext Integration"
-msgstr ""
+msgstr "ERPNext-Integration aktivieren"
 
 #. Label of the enable_comment_reactions (Check) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/TicketSettings.vue:23
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Enable comment reactions"
-msgstr ""
+msgstr "Kommentarreaktionen aktivieren"
 
 #. Label of the is_feedback_mandatory (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Enable feedback for Customer Portal"
-msgstr ""
+msgstr "Rückmeldung für Kundenportal aktivieren"
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2081,8 +2172,6 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2103,48 +2192,48 @@ msgstr "Endzeit"
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:22
 msgid "Enter a name for this HD Service Holiday List."
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr ""
+msgstr "Geben Sie einen Namen für diese HD-Feiertagsliste ein."
 
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
-msgstr ""
+msgstr "Markennamen eingeben"
+
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr "E-Mail-Adresse eingeben"
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
-msgstr ""
+msgstr "Geben Sie den neuen Namen für das Team ein"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr "Geben Sie die E-Mail-Adresse des Hauptkontakts ein"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
+msgstr "Geben Sie den Vornamen des Hauptkontakts ein"
 
 #: helpdesk/api/knowledge_base.py:86
 msgid "Error moving article to category"
-msgstr ""
+msgstr "Fehler beim Verschieben des Artikels in die Kategorie"
 
 #: helpdesk/overrides/email_account.py:93
 msgid "Error processing email at index {0}, message: {1}"
-msgstr ""
-
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr ""
+msgstr "Fehler bei der Verarbeitung der E-Mail an Index {0}, Meldung: {1}"
 
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "Fehler beim Verbinden mit dem E-Mail-Konto {0}"
 
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr ""
-
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
 msgstr "Excel"
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
+msgstr "Bestehende Benutzer treten sofort bei. Andere erhalten eine Einladung."
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
 #: desk/src/components/Settings/Telephony/Telephony.vue:96
@@ -2157,7 +2246,7 @@ msgstr "Erweitern"
 
 #: desk/src/components/layouts/Sidebar.vue:557
 msgid "Explore customer portal"
-msgstr ""
+msgstr "Kundenportal erkunden"
 
 #: desk/src/components/ticket/ExportModal.vue:2
 #: desk/src/pages/ticket/Tickets.vue:130
@@ -2172,11 +2261,6 @@ msgstr "Alle {0} Datensätze exportieren"
 msgid "Export Type"
 msgstr "Exporttyp"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr ""
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2185,62 +2269,66 @@ msgstr ""
 msgid "Failed"
 msgstr "Fehlgeschlagen"
 
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr "Nicht erfüllte SLAs"
+
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
-msgstr ""
+msgstr "Kategorie konnte nicht erstellt werden"
 
 #: desk/src/components/Settings/EmailAdd.vue:315
 msgid "Failed to create email account, Invalid credentials"
-msgstr ""
+msgstr "E-Mail-Konto konnte nicht erstellt werden, ungültige Anmeldedaten"
 
 #: desk/src/components/ticket-agent/TicketHeader.vue:222
 msgid "Failed to delete ticket."
-msgstr ""
+msgstr "Ticket konnte nicht gelöscht werden."
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:194
 #: desk/src/components/Settings/Telephony/Telephony.vue:195
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:172
 msgid "Failed to load telephony agent"
-msgstr ""
+msgstr "Telefonie-Agent konnte nicht geladen werden"
 
 #: desk/src/components/Settings/EmailEdit.vue:422
 msgid "Failed to pull emails"
-msgstr ""
+msgstr "E-Mails konnten nicht abgerufen werden"
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:259
 #: desk/src/components/Settings/Telephony/Telephony.vue:238
 msgid "Failed to save Exotel settings"
-msgstr ""
+msgstr "Exotel-Einstellungen konnten nicht gespeichert werden"
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:251
 #: desk/src/components/Settings/Telephony/Telephony.vue:230
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:215
 msgid "Failed to save Twilio settings"
-msgstr ""
+msgstr "Twilio-Einstellungen konnten nicht gespeichert werden"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
-msgstr ""
+msgstr "Beauftragte konnten nicht aktualisiert werden."
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
-msgstr ""
+msgstr "Beauftragte konnten nicht aktualisiert werden."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:232
 msgid "Failed to update assignment rule {0}."
-msgstr ""
+msgstr "Zuweisungsregel {0} konnte nicht aktualisiert werden."
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:312
 msgid "Failed to update category."
-msgstr ""
+msgstr "Kategorie konnte nicht aktualisiert werden."
 
 #: desk/src/components/Settings/EmailEdit.vue:476
 msgid "Failed to update email account, Invalid credentials"
-msgstr ""
+msgstr "E-Mail-Konto konnte nicht aktualisiert werden, ungültige Anmeldedaten"
 
 #: desk/src/components/Settings/FieldDependency/FieldDependencyList.vue:184
 msgid "Failed to update field dependency."
-msgstr ""
+msgstr "Feldabhängigkeit konnte nicht aktualisiert werden."
 
 #. Label of the favicon (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:27
@@ -2251,6 +2339,7 @@ msgstr "Favicon"
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2270,81 +2359,86 @@ msgstr "Rückmeldung "
 #. Label of the feedback_extra (Long Text) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Feedback (Extra)"
-msgstr ""
+msgstr "Rückmeldung (Zusatz)"
 
 #. Label of the feedback (Link) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Feedback (Option)"
-msgstr ""
+msgstr "Rückmeldung (Option)"
 
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:30
 msgid "Feedback Already Exists"
-msgstr ""
+msgstr "Rückmeldung existiert bereits"
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Email Feedback'
 #. Label of a field in the email-feedback Web Form
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
 msgid "Feedback Rating"
-msgstr ""
+msgstr "Rückmeldungsbewertung"
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
-msgstr ""
+msgstr "Rückmeldungstrend"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
-msgstr ""
+msgstr "Rückmeldungs-E-Mail wurde an den Kunden gesendet"
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
+msgstr "Rückmeldungen dieses Kontakts werden hier angezeigt, sobald verfügbar."
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
 msgid "Feedback submitted successfully."
-msgstr ""
+msgstr "Rückmeldung erfolgreich übermittelt."
 
 #. Label of the fieldname (Data) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Field (fieldname)"
-msgstr ""
+msgstr "Feld (Feldname)"
 
 #: desk/src/components/Settings/FieldDependency/FieldDependencyList.vue:6
 msgid "Field Dependencies"
-msgstr ""
+msgstr "Feldabhängigkeiten"
 
 #: desk/src/components/layouts/Sidebar.vue:628
 msgid "Field Dependency"
-msgstr ""
+msgstr "Feldabhängigkeit"
 
 #: desk/src/components/Settings/FieldDependency/FieldDependency.vue:303
 msgid "Field Dependency created successfully"
-msgstr ""
+msgstr "Feldabhängigkeit erfolgreich erstellt"
 
 #: desk/src/components/Settings/FieldDependency/FieldDependency.vue:304
 msgid "Field Dependency updated successfully"
-msgstr ""
+msgstr "Feldabhängigkeit erfolgreich aktualisiert"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.py:25
 msgid "Field `{0}` does not exist in Ticket"
-msgstr ""
+msgstr "Feld `{0}` existiert im Ticket nicht"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.py:41
 msgid "Field `{0}` is not allowed in Ticket Template"
-msgstr ""
+msgstr "Feld `{0}` ist in der Ticketvorlage nicht zulässig"
 
 #: desk/src/components/Settings/FieldDependency/FieldDependencyList.vue:160
 msgid "Field dependency deleted successfully."
-msgstr ""
+msgstr "Feldabhängigkeit erfolgreich gelöscht."
 
 #: desk/src/components/Settings/FieldDependency/FieldDependencyList.vue:180
 msgid "Field dependency updated successfully."
-msgstr ""
+msgstr "Feldabhängigkeit erfolgreich aktualisiert."
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "Felder"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "Filter"
@@ -2352,9 +2446,10 @@ msgstr "Filter"
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:70
 #: desk/src/components/Settings/General/components/TicketSettings.vue:229
 msgid "Find out all of the variables that can be used in the content"
-msgstr ""
+msgstr "Erfahren Sie mehr über alle Variablen, die im Inhalt verwendet werden können"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "Vorname"
 
@@ -2362,6 +2457,10 @@ msgstr "Vorname"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
 msgstr "Zuerst geantwortet auf"
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
+msgstr "Erste Antwort"
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -2372,7 +2471,7 @@ msgstr "Erste Antwort fällig"
 #. Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Response Failed By"
-msgstr ""
+msgstr "Erste Antwort verfehlt um"
 
 #. Label of the response_time (Duration) field in DocType 'HD Service Level
 #. Priority'
@@ -2385,11 +2484,7 @@ msgstr "Erste Antwortzeit"
 #. Name of a report
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
-msgstr ""
+msgstr "Erste Antwortzeit für Tickets"
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
@@ -2398,7 +2493,7 @@ msgstr "Formular"
 
 #: desk/src/components/layouts/Sidebar.vue:637
 msgid "Frappe Helpdesk Mobile"
-msgstr ""
+msgstr "Frappe Helpdesk Mobil"
 
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
@@ -2427,11 +2522,11 @@ msgstr "Von-Datum"
 #: desk/src/components/Settings/Holiday/HolidayView.vue:71
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:140
 msgid "From date"
-msgstr ""
+msgstr "Von-Datum"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:374
 msgid "From is required"
-msgstr ""
+msgstr "„Von“ ist erforderlich"
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/Tickets.vue:224 desk/src/pages/ticket/Tickets.vue:263
@@ -2452,16 +2547,16 @@ msgstr "Grundeinstellungen"
 
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.py:40
 msgid "General category can't be deleted"
-msgstr ""
+msgstr "Die Kategorie Allgemein kann nicht gelöscht werden"
 
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.py:36
 msgid "General category name can't be changed"
-msgstr ""
+msgstr "Der Name der Kategorie Allgemein kann nicht geändert werden"
 
 #: helpdesk/api/knowledge_base.py:56
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.py:23
 msgid "General is a reserved category name. Please use a different name to proceed."
-msgstr ""
+msgstr "Allgemein ist ein reservierter Kategoriename. Bitte verwenden Sie einen anderen Namen, um fortzufahren."
 
 #: desk/src/components/layouts/Sidebar.vue:578
 msgid "Getting Started"
@@ -2474,11 +2569,15 @@ msgstr "Erste Schritte"
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:200
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 msgid "Global"
-msgstr ""
+msgstr "Global"
 
 #: desk/src/components/command-palette/CP.vue:89
 msgid "Go to Ticket #{0}"
-msgstr ""
+msgstr "Zu Ticket #{0} wechseln"
+
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr "Manager-Zugriff gewähren"
 
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
@@ -2489,7 +2588,7 @@ msgstr "Grau"
 
 #: desk/src/pages/home/components/PendingTickets.vue:254
 msgid "Great! All your tickets are within SLA"
-msgstr ""
+msgstr "Großartig! Alle Ihre Tickets liegen innerhalb der SLA"
 
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
@@ -2509,171 +2608,156 @@ msgid "Group By Field"
 msgstr "Nach Feld gruppieren"
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr "Gast"
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
-msgstr ""
+msgstr "Verweisen Sie Benutzer vor der Ticketerstellung auf Artikel."
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "HD Agent"
-msgstr ""
+msgstr "HD Agent"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 msgid "HD Agent Status"
-msgstr ""
+msgstr "HD Agentenstatus"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 msgid "HD Article"
-msgstr ""
+msgstr "HD Artikel"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 msgid "HD Article Category"
-msgstr ""
+msgstr "HD Artikelkategorie"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 msgid "HD Article Feedback"
-msgstr ""
+msgstr "HD Artikelrückmeldung"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
 msgid "HD Comment Reaction"
-msgstr ""
+msgstr "HD Kommentarreaktion"
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
-msgstr ""
+msgstr "HD Kunde"
+
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr "HD Kunden-Manager"
 
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
-msgstr ""
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
+msgstr "HD Kundenmitglied"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
-msgstr ""
+msgstr "HD E-Mail-Rückmeldung"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 msgid "HD Field Layout"
-msgstr ""
+msgstr "HD Feldlayout"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 msgid "HD Form Script"
-msgstr ""
+msgstr "HD Formularskript"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_holiday/hd_holiday.json
 msgid "HD Holiday"
-msgstr ""
+msgstr "HD Feiertag"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
-msgstr ""
+msgstr "HD Benachrichtigung"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 msgid "HD Saved Reply"
-msgstr ""
+msgstr "HD Gespeicherte Antwort"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 msgid "HD Saved Reply Team"
-msgstr ""
+msgstr "HD Gespeicherte Antwort-Team"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
 msgid "HD Service Day"
-msgstr ""
+msgstr "HD Arbeitstag"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list_calendar.js:20
 msgid "HD Service Holiday List"
-msgstr ""
+msgstr "HD Feiertagsliste"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "HD Service Level Agreement"
-msgstr ""
+msgstr "HD Service Level Agreement"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 msgid "HD Service Level Priority"
-msgstr ""
+msgstr "HD Service-Level-Priorität"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "HD Settings"
-msgstr ""
+msgstr "HD Einstellungen"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
-msgstr ""
+msgstr "HD Stoppwort"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_synonym/hd_synonym.json
 msgid "HD Synonym"
-msgstr ""
+msgstr "HD Synonym"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_synonyms/hd_synonyms.json
 msgid "HD Synonyms"
-msgstr ""
+msgstr "HD Synonyme"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "HD Team"
-msgstr ""
+msgstr "HD Team"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 msgid "HD Team Member"
-msgstr ""
+msgstr "HD Teammitglied"
 
 #. Name of a DocType
 #. Label of the ticket (Link) field in DocType 'HD Ticket Activity'
@@ -2681,61 +2765,61 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_activity/hd_ticket_activity.json
 msgid "HD Ticket"
-msgstr ""
+msgstr "HD Ticket"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_ticket_activity/hd_ticket_activity.json
 msgid "HD Ticket Activity"
-msgstr ""
+msgstr "HD Ticket-Aktivität"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 msgid "HD Ticket Comment"
-msgstr ""
+msgstr "HD Ticket-Kommentar"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "HD Ticket Feedback Option"
-msgstr ""
+msgstr "HD Ticket-Rückmeldungsoption"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 msgid "HD Ticket Priority"
-msgstr ""
+msgstr "HD Ticket-Priorität"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "HD Ticket Status"
-msgstr ""
+msgstr "HD Ticket-Status"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "HD Ticket Template"
-msgstr ""
+msgstr "HD Ticketvorlage"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "HD Ticket Template Field"
-msgstr ""
+msgstr "HD Ticketvorlage-Feld"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Ticket Type"
-msgstr ""
+msgstr "HD Ticket-Typ"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "HD View"
-msgstr ""
+msgstr "HD Ansicht"
 
 #. Label of the headings_weight (Int) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Headings Weight"
-msgstr ""
+msgstr "Gewichtung der Überschriften"
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:100
 msgid "Hello {{ contact }}, \\n\\nWe are sorry for the inconvenience, we will get back to you soon. \\n\\nRegards, \\n{{ full_name }}"
-msgstr ""
+msgstr "Hallo {{ contact }}, \\n\\nWir entschuldigen uns für die Unannehmlichkeiten und melden uns in Kürze bei Ihnen. \\n\\nMit freundlichen Grüßen, \\n{{ full_name }}"
 
 #: desk/src/components/layouts/Sidebar.vue:125
 msgid "Help"
@@ -2743,23 +2827,17 @@ msgstr "Hilfe"
 
 #: helpdesk/config/desktop.py:11
 msgid "HelpDesk"
-msgstr ""
+msgstr "HelpDesk"
 
 #. Name of a Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk"
-msgstr ""
-
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr ""
+msgstr "Helpdesk"
 
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
-msgstr ""
+msgstr "Helpdesk-Berichte"
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:53
 msgid "Here, your weekly offs are pre-populated based on the previous selections. You can add more rows to also add public and national holidays individually."
@@ -2773,24 +2851,19 @@ msgstr "Hallo"
 msgid "Hide "
 msgstr "Ausblenden "
 
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr ""
-
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Hide from customer"
-msgstr ""
+msgstr "Vor Kunde verbergen"
 
 #: desk/src/pages/ticket/Tickets.vue:481
 msgid "Hide from sidebar"
-msgstr ""
+msgstr "Aus Seitenleiste ausblenden"
 
 #: desk/src/pages/ticket/Tickets.vue:489
 msgid "Hide view from sidebar"
-msgstr ""
+msgstr "Ansicht aus Seitenleiste ausblenden"
 
 #. Option in a Select field in the tickets Web Form
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
@@ -2811,19 +2884,19 @@ msgstr "Name der Feiertagsliste"
 
 #: desk/src/components/Settings/Holiday/HolidayView.vue:355
 msgid "Holiday list created successfully."
-msgstr ""
+msgstr "Feiertagsliste erfolgreich erstellt."
 
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:153
 msgid "Holiday list deleted successfully."
-msgstr ""
+msgstr "Feiertagsliste erfolgreich gelöscht."
 
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:126
 msgid "Holiday list duplicated successfully."
-msgstr ""
+msgstr "Feiertagsliste erfolgreich dupliziert."
 
 #: desk/src/components/Settings/Holiday/HolidayView.vue:417
 msgid "Holiday list updated successfully."
-msgstr ""
+msgstr "Feiertagsliste erfolgreich aktualisiert."
 
 #. Label of the holidays_section (Section Break) field in DocType 'HD Service
 #. Holiday List'
@@ -2840,21 +2913,14 @@ msgstr "Start"
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:115
 msgid "I understand, add conditions"
-msgstr ""
+msgstr "Verstanden, Bedingungen hinzufügen"
 
 #: desk/src/pages/home/components/PendingTickets.vue:26
 msgid "ID"
 msgstr "ID"
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "IP-Adresse"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2863,43 +2929,43 @@ msgstr "Symbol"
 #. Description of the 'Enabled' (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "If enabled, a ticket creation acknowledgement email will be sent to the user right after creating an email ticket"
-msgstr ""
+msgstr "Wenn aktiviert, wird dem Benutzer direkt nach der Erstellung eines E-Mail-Tickets eine Bestätigungs-E-Mail gesendet"
 
 #. Description of the 'Enabled' (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "If enabled, an email is sent to all of the recipients associated with an agent's reply"
-msgstr ""
+msgstr "Wenn aktiviert, wird eine E-Mail an alle Empfänger gesendet, die mit der Antwort eines Agenten verknüpft sind"
 
 #. Description of the 'Enabled' (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "If enabled, an email will be sent to all of the assigned agents after a reply from one of the contacts"
-msgstr ""
+msgstr "Wenn aktiviert, wird nach einer Antwort eines der Kontakte eine E-Mail an alle zugewiesenen Agenten gesendet"
 
 #. Description of the 'Allow anyone to create tickets' (Check) field in DocType
 #. 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "If enabled, anyone will be able to create tickets (without any permission). "
-msgstr ""
+msgstr "Wenn aktiviert, kann jeder Tickets erstellen (ohne Berechtigung). "
 
 #. Description of the 'Enabled' (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "If enabled, feedback email will be sent to the customer when you mark a ticket as the status selected below.\n"
-msgstr ""
+msgstr "Wenn aktiviert, wird dem Kunden eine Rückmeldungs-E-Mail gesendet, sobald Sie ein Ticket auf den unten ausgewählten Status setzen.\n"
 
 #. Description of the 'Enable feedback for Customer Portal' (Check) field in
 #. DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "If enabled, the feedback dialog will be shown, when a user tries to close a ticket. \n"
-msgstr ""
+msgstr "Wenn aktiviert, wird der Rückmeldungsdialog angezeigt, sobald ein Benutzer versucht, ein Ticket zu schließen. \n"
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:15
 msgid "If your issue isn't resolved, raise a support ticket"
-msgstr ""
+msgstr "Falls Ihr Anliegen nicht gelöst wurde, erstellen Sie ein Support-Ticket"
 
 #. Label of the ignore_restrictions (Check) field in DocType 'HD Team'
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Ignore Restrictions"
-msgstr ""
+msgstr "Einschränkungen ignorieren"
 
 #. Label of the user_image (Attach Image) field in DocType 'HD Agent'
 #. Label of the image (Attach Image) field in DocType 'HD Customer'
@@ -2910,16 +2976,16 @@ msgstr "Bild"
 
 #: desk/src/components/Settings/General/components/Branding.vue:80
 msgid "Image removed successfully."
-msgstr ""
+msgstr "Bild erfolgreich entfernt."
 
 #. Description of the 'Logo' (Attach Image) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Image to be used in various places, including Login and Signup pages. An image with transparent background and 160 x 32 is preferred"
-msgstr ""
+msgstr "Bild, das an verschiedenen Stellen verwendet wird, einschließlich Login- und Registrierungsseiten. Ein Bild mit transparentem Hintergrund und 160 x 32 wird bevorzugt"
 
 #: desk/src/components/Settings/General/components/Branding.vue:83
 msgid "Image updated successfully."
-msgstr ""
+msgstr "Bild erfolgreich aktualisiert."
 
 #: desk/src/pages/call-logs/CallLogModal.vue:217
 msgid "In Progress"
@@ -2941,80 +3007,122 @@ msgstr "Posteingang"
 msgid "Incoming"
 msgstr "Eingehend"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr "Einzelperson"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr "Initiiert"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:59
 msgid "Install the"
-msgstr ""
+msgstr "Installieren Sie die"
 
 #. Label of the instantly_send_email (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Instantly send e-mail"
-msgstr ""
+msgstr "E-Mail sofort senden"
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "Unzureichende Berechtigung für {0}"
 
 #. Label of the integer_value (Int) field in DocType 'HD Ticket Priority'
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 msgid "Integer value"
-msgstr ""
+msgstr "Ganzzahliger Wert"
 
 #: desk/src/components/layouts/Sidebar.vue:570
 #: desk/src/components/layouts/Sidebar.vue:573
 msgid "Introduction"
 msgstr "Einleitung"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
-msgstr ""
+msgstr "Ungültige Verfügbarkeit"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
-msgstr ""
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
+msgstr "Ungültige E-Mail-Adresse"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
 #: desk/src/components/Settings/Holiday/HolidayView.vue:325
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:384
 msgid "Invalid fields, check if all are filled in and values are correct."
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr ""
+msgstr "Ungültige Felder, prüfen Sie, ob alle ausgefüllt und die Werte korrekt sind."
 
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
-msgstr ""
+msgstr "Ungültige Benachrichtigung"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
-msgstr ""
+msgstr "Ungültige Telefonnummer"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr "Ungültige Rolle {0}"
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr "Einladung abgelaufen"
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr "Einladung erfolgreich storniert"
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr "Einladung abgelaufen. Erneut senden, um wieder einzuladen."
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
+msgstr "Einladen"
 
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
-msgstr ""
+msgstr "Agenten einladen"
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
+msgstr "Kontakt einladen"
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
 msgid "Invite agent"
-msgstr ""
+msgstr "Agent einladen"
 
 #: desk/src/components/layouts/Sidebar.vue:450
 msgid "Invite agents"
-msgstr ""
+msgstr "Agenten einladen"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
-msgstr ""
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
+msgstr "Als Benutzer einladen"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
 msgstr "Per E-Mail einladen"
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr "Einladung gesendet. Warten auf Annahme durch den Benutzer."
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr "Per E-Mail einladen"
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr "Eingeladen"
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
+msgstr "Eingeladen von"
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -3024,12 +3132,17 @@ msgstr "Ist aktiv"
 #. Label of the is_customer_portal (Check) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Customer Portal"
-msgstr ""
+msgstr "Ist Kundenportal"
 
 #. Label of the is_default (Check) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "Ist Standard"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr "Ist Manager"
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3041,23 +3154,27 @@ msgstr "Ist Standard"
 #. Label of the apply_to_system (Check) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 msgid "Is applied to system"
-msgstr ""
+msgstr "Wird auf das System angewendet"
 
 #. Label of the initial_helpdesk_name_setup_skipped (Check) field in DocType
 #. 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is name setup skipped"
-msgstr ""
+msgstr "Namenseinrichtung übersprungen"
 
 #. Label of the is_pinned (Check) field in DocType 'HD Ticket Comment'
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 msgid "Is pinned"
-msgstr ""
+msgstr "Ist angepinnt"
 
 #. Label of the setup_complete (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
-msgstr ""
+msgstr "Einrichtung abgeschlossen"
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
+msgstr "Max"
 
 #: desk/src/components/command-palette/CP.vue:114
 msgid "Jump to"
@@ -3065,7 +3182,7 @@ msgstr "Springen zu"
 
 #: desk/src/pages/knowledge-base/Article.vue:672
 msgid "KB"
-msgstr ""
+msgstr "Wissensbasis"
 
 #. Label of the key (Data) field in DocType 'HD Email Feedback'
 #. Label of the key (Data) field in DocType 'HD Ticket'
@@ -3093,11 +3210,9 @@ msgstr "Tastaturkürzel"
 msgid "Knowledge Base"
 msgstr "Wissensbasis"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3107,7 +3222,7 @@ msgstr "Bezeichnung"
 #. Label of the label_customer (Data) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Label (customer view)"
-msgstr ""
+msgstr "Bezeichnung (Kundenansicht)"
 
 #. Option for the 'Type' (Select) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -3120,22 +3235,22 @@ msgstr "Sprache"
 
 #: desk/src/components/Settings/Preferences/Preferences.vue:36
 msgid "Language & Time"
-msgstr ""
+msgstr "Sprache & Zeit"
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:102
 msgid "Last"
-msgstr ""
+msgstr "Zuletzt"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:372
 #: desk/src/pages/home/components/RecentFeedback.vue:401
 msgid "Last 3 Months"
 msgstr "Letzte 3 Monate"
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
-msgstr ""
+msgstr "Letzte 3 Monate"
 
 #: desk/src/pages/dashboard/Dashboard.vue:453
 #: desk/src/pages/dashboard/Dashboard.vue:486
@@ -3162,19 +3277,20 @@ msgstr "Letzte 90 Tage"
 #. Label of the last_agent_response (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Last Agent Response"
-msgstr ""
+msgstr "Letzte Agentenantwort"
 
 #. Label of the last_customer_response (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Last Customer Response"
-msgstr ""
+msgstr "Letzte Kundenantwort"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:368
 #: desk/src/pages/home/components/RecentFeedback.vue:400
 msgid "Last Month"
 msgstr "Letzter Monat"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "Nachname"
 
@@ -3183,24 +3299,33 @@ msgstr "Nachname"
 msgid "Last Week"
 msgstr "Letzte Woche"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
-msgstr ""
+msgstr "Letzter Monat"
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
+msgstr "Zuletzt gesehen"
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
-msgstr ""
+msgstr "Zuletzt von dieser Regel zugewiesener Benutzer"
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
-msgstr ""
+msgstr "Letzte Woche"
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
+msgstr "Neueste"
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -3210,33 +3335,13 @@ msgstr "Layout"
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:135
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:212
 msgid "Learn about conditions"
-msgstr ""
+msgstr "Mehr über Bedingungen erfahren"
 
 #. Description of the 'Apply outside working hours' (Check) field in DocType
 #. 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
-msgstr ""
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "Verknüpfung"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr "Verknüpfungsoptionen"
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
-msgstr ""
+msgstr "Informieren Sie Kunden darüber, dass sie ein Ticket außerhalb der Arbeitszeiten erstellen, und wann sie mit einer Antwort rechnen können."
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #. Label of the list_tab (Tab Break) field in DocType 'HD View'
@@ -3264,6 +3369,8 @@ msgstr "Standardspalten laden"
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "Mehr laden"
 
@@ -3273,7 +3380,7 @@ msgstr "Laden ..."
 
 #: desk/src/components/ticket/ActivityHeader.vue:65
 msgid "Log a Call"
-msgstr ""
+msgstr "Anruf protokollieren"
 
 #: desk/src/components/layouts/Sidebar.vue:344
 #: desk/src/components/layouts/Sidebar.vue:395
@@ -3286,6 +3393,8 @@ msgstr "Melden Sie sich bei Frappe Cloud an"
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr "Logo"
@@ -3294,7 +3403,7 @@ msgstr "Logo"
 #. Priority'
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 msgid "Lower the Integer value, higher is the priority of the issue"
-msgstr ""
+msgstr "Je niedriger der Ganzzahlwert, desto höher die Priorität des Anliegens"
 
 #: desk/src/pages/ticket/Tickets.vue:501
 msgid "Make Private"
@@ -3310,39 +3419,43 @@ msgstr "Einen Anruf tätigen"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:10
 msgid "Make feedback mandatory"
-msgstr ""
+msgstr "Rückmeldung verpflichtend machen"
 
 #: desk/src/pages/ticket/Tickets.vue:509
 msgid "Make view private"
-msgstr ""
+msgstr "Ansicht privat machen"
 
 #: desk/src/components/Settings/General/General.vue:2
 msgid "Manage general settings of your app."
-msgstr ""
+msgstr "Verwalten Sie die allgemeinen Einstellungen Ihrer App."
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:5
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
-msgstr ""
+msgstr "Verwalten Sie vordefinierte Antworten, mit denen Sie auf Kundenanfragen reagieren können."
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
-msgstr ""
+msgstr "Verwalten Sie Ihre Konto-E-Mails und E-Mail-Signatur für die Kommunikation."
 
 #: desk/src/components/Settings/EmailAccountList.vue:5
 msgid "Manage your email accounts and configure incoming and outgoing settings."
-msgstr ""
+msgstr "Verwalten Sie Ihre E-Mail-Konten und konfigurieren Sie Eingangs- und Ausgangseinstellungen."
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:25
 msgid "Manage your email signature."
-msgstr ""
+msgstr "Verwalten Sie Ihre E-Mail-Signatur."
 
 #: desk/src/components/Settings/Preferences/Preferences.vue:2
 msgid "Manage your personal preferences."
-msgstr ""
+msgstr "Verwalten Sie Ihre persönlichen Einstellungen."
 
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
-msgstr ""
+msgstr "Verwalten Sie Ihre Profilinformationen."
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
+msgstr "Manager:in"
 
 #: desk/src/pages/MobileNotifications.vue:11
 #: desk/src/pages/MobileNotifications.vue:14
@@ -3359,12 +3472,12 @@ msgstr "Mitglieder"
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:56
 msgid "Members ({0})"
-msgstr ""
+msgstr "Mitglieder ({0})"
 
 #. Option for the 'Type' (Select) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "Mention"
-msgstr "Erwähnung"
+msgstr "Erwähnen"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:158
 msgid "Merge"
@@ -3373,12 +3486,12 @@ msgstr "Zusammenführen"
 #: desk/src/components/ticket-agent/TicketHeader.vue:255
 #: desk/src/components/ticket/TicketAgentSidebar.vue:18
 msgid "Merge Ticket"
-msgstr ""
+msgstr "Ticket zusammenführen"
 
 #. Label of the merged_with (Link) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Merged With"
-msgstr ""
+msgstr "Zusammengeführt mit"
 
 #. Label of the message (Text) field in DocType 'HD Notification'
 #. Label of the message (Text Editor) field in DocType 'HD Saved Reply'
@@ -3390,11 +3503,25 @@ msgstr "Nachricht"
 #. Label of the misc_tab (Tab Break) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Misc"
-msgstr ""
+msgstr "Sonstiges"
 
 #: desk/src/components/layouts/Sidebar.vue:640
 msgid "Mobile App Installation"
-msgstr ""
+msgstr "Installation der mobilen App"
+
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr "Mobilfunknummer"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr "Mobilfunknummer"
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr "Mobilnummer des Hauptansprechpartners"
 
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
@@ -3415,28 +3542,28 @@ msgstr "Bewegen nach"
 
 #: desk/src/pages/dashboard/Dashboard.vue:249
 msgid "My Dashboard"
-msgstr ""
+msgstr "Mein Dashboard"
 
 #: desk/src/pages/dashboard/Dashboard.vue:302
 msgid "My Organization"
-msgstr ""
+msgstr "Meine Organisation"
 
 #: desk/src/pages/dashboard/Dashboard.vue:307
 msgid "My Stats"
-msgstr ""
+msgstr "Meine Statistiken"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:175
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:337
 msgid "My Team"
-msgstr ""
+msgstr "Mein Team"
 
 #: desk/src/pages/home/Home.vue:293
 #: desk/src/pages/home/components/AgentTicketsCard.vue:4
 msgid "My Tickets"
-msgstr ""
+msgstr "Meine Tickets"
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3447,8 +3574,9 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3457,22 +3585,34 @@ msgstr "Name"
 #. Label of the name_weight (Int) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
-msgstr ""
+msgstr "Gewichtung des Namens"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
+msgstr "Name is erforderlich"
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
 #. Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Name shown on the customer portal<br> (e.g., Replied → Awaiting Response)."
-msgstr ""
+msgstr "Im Kundenportal angezeigter Name<br> (z. B. Beantwortet → Antwort ausstehend)."
 
 #: desk/src/components/modals/ShortcutsModal.vue:105
 msgid "Navigation"
-msgstr ""
+msgstr "Navigation"
+
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr "Negativ"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
-msgstr ""
+msgstr "Negative zuerst"
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "Nie"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3490,19 +3630,19 @@ msgstr "Neu"
 #: desk/src/pages/knowledge-base/NewArticle.vue:174
 #: desk/src/pages/knowledge-base/NewArticle.vue:181
 msgid "New Article"
-msgstr ""
+msgstr "Neuer Artikel"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:4
 msgid "New Assignment Rule"
-msgstr ""
+msgstr "Neue Zuweisungsregel"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:59
 msgid "New Assignment Rule Name"
-msgstr ""
+msgstr "Name der neuen Zuweisungsregel"
 
 #: desk/src/components/Settings/Holiday/HolidayView.vue:3
 msgid "New Business Holiday"
-msgstr ""
+msgstr "Neue Betriebsferien"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "New Call Log"
@@ -3510,11 +3650,11 @@ msgstr "Neues Anrufprotokoll"
 
 #: desk/src/components/Settings/FieldDependency/FieldDependency.vue:104
 msgid "New Field Dependency"
-msgstr ""
+msgstr "Neue Feldabhängigkeit"
 
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:36
 msgid "New Holiday List Name"
-msgstr ""
+msgstr "Name der neuen Feiertagsliste"
 
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:8
 msgid "New Password"
@@ -3522,48 +3662,48 @@ msgstr "Neues Passwort"
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:3
 msgid "New SLA Policy"
-msgstr ""
+msgstr "Neue SLA-Richtlinie"
 
 #: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:48
 msgid "New SLA Policy Name"
-msgstr ""
+msgstr "Name der neuen SLA-Richtlinie"
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:3
 msgid "New Saved Reply"
-msgstr ""
+msgstr "Neue gespeicherte Antwort"
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:184
 msgid "New Saved reply Name"
-msgstr ""
+msgstr "Name der neuen gespeicherten Antwort"
 
 #: desk/src/pages/ticket/MobileTicketAgent.vue:141
 msgid "New Subject"
-msgstr ""
+msgstr "Neuer Betreff"
 
 #: desk/src/components/Settings/Teams/NewTeam.vue:3
 msgid "New Team"
-msgstr ""
+msgstr "Neues Team"
 
 #: desk/src/pages/ticket/TicketNew.vue:302
 #: desk/src/pages/ticket/TicketNew.vue:312
 msgid "New Ticket"
-msgstr ""
+msgstr "Neues Ticket"
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:53
 msgid "New and old title cannot be same"
-msgstr ""
+msgstr "Neuer und alter Titel dürfen nicht gleich sein"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:86
 msgid "New and updated customers sync automatically between Helpdesk and ERPNext."
-msgstr ""
+msgstr "Neue und aktualisierte Kunden werden automatisch zwischen Helpdesk und ERPNext synchronisiert."
 
 #: desk/src/components/Settings/NewTeamModal.vue:4
 msgid "New team"
-msgstr ""
+msgstr "Neues Team"
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:51
 msgid "New title is required"
-msgstr ""
+msgstr "Neuer Titel ist erforderlich"
 
 #: desk/src/components/Settings/General/General.vue:50
 msgid "New users will have to be manually registered by system managers."
@@ -3571,7 +3711,7 @@ msgstr "Neue Benutzer müssen von den Systemmanagern manuell angelegt werden."
 
 #: desk/src/components/modals/ShortcutsModal.vue:107
 msgid "Next ticket"
-msgstr ""
+msgstr "Nächstes Ticket"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:216
 msgid "No Answer"
@@ -3579,87 +3719,105 @@ msgstr "Keine Antwort"
 
 #: desk/src/components/ListViewBuilder.vue:345
 msgid "No Data Found"
-msgstr ""
+msgstr "Keine Daten gefunden"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
-msgstr ""
+msgstr "Kein E-Mail-Konto für {0} gefunden"
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
-msgstr ""
+msgstr "Kein HD-Agent-Datensatz für den aktuellen Benutzer"
 
 #: desk/src/components/Settings/Holiday/HolidayList.vue:20
 msgid "No Holiday list found"
-msgstr ""
+msgstr "Keine Feiertagsliste gefunden"
 
 #: desk/src/components/Settings/Sla/SlaPolicyList.vue:20
 msgid "No SLA found"
-msgstr ""
+msgstr "Keine SLA gefunden"
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
-msgstr ""
+msgstr "Kein Team"
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
+msgstr "Keine aktiven Tickets"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
 msgid "No additional comments"
-msgstr ""
+msgstr "Keine weiteren Kommentare"
 
 #: desk/src/components/ticket-agent/AssignTo.vue:144
 msgid "No agents found"
-msgstr ""
+msgstr "Keine Agenten gefunden"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:425
 msgid "No articles found for the applied filters. Try adjusting or clearing your filters."
-msgstr ""
+msgstr "Keine Artikel für die angewendeten Filter gefunden. Passen Sie Ihre Filter an oder löschen Sie sie."
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:428
 msgid "No articles found in the following category."
-msgstr ""
+msgstr "Keine Artikel in der folgenden Kategorie gefunden."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:20
 msgid "No assignment rule found"
-msgstr ""
+msgstr "Keine Zuweisungsregel gefunden"
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:105
 msgid "No average metrics"
-msgstr ""
+msgstr "Keine Durchschnittsmetriken"
 
 #: desk/src/components/knowledge-base/CategoryFolderContainer.vue:17
 msgid "No categories available"
-msgstr ""
+msgstr "Keine Kategorien verfügbar"
 
 #: desk/src/components/Settings/EmailEdit.vue:344
 msgid "No changes made"
 msgstr "Keine Änderungen vorgenommen"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
-msgstr ""
+msgstr "Keine Diagramme hinzugefügt"
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr "Keine Kontakte gefunden"
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
-msgstr ""
+msgstr "Keine Kontakte für die angewendeten Filter gefunden. Passen Sie Ihre Filter an oder löschen Sie sie."
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr "Keine Kontakte zum Hinzufügen"
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr "Kein Land gefunden"
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
-msgstr ""
+msgstr "Keine Kunden für die angewendeten Filter gefunden. Passen Sie Ihre Filter an oder löschen Sie sie."
 
 #: desk/src/components/Settings/EmailAccountList.vue:46
 msgid "No email account found"
-msgstr ""
+msgstr "Kein E-Mail-Konto gefunden"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:283
 msgid "No feedback"
-msgstr ""
+msgstr "Keine Rückmeldung"
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr "Noch kein Feedback"
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
-msgstr ""
+msgstr "Keine Felder gefunden"
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:94
 msgid "No members found"
@@ -3671,78 +3829,88 @@ msgstr "Keine neuen Benachrichtigungen"
 
 #: desk/src/pages/home/components/PendingTickets.vue:258
 msgid "No new tickets assigned to you in the last 7 days"
-msgstr ""
+msgstr "Ihnen wurden in den letzten 7 Tagen keine neuen Tickets zugewiesen"
 
 #: desk/src/components/ticket-agent/TicketNavigation.vue:25
 msgid "No next ticket"
-msgstr ""
+msgstr "Kein nächstes Ticket"
 
 #: desk/src/components/ticket-agent/AssignTo.vue:33
 msgid "No one"
-msgstr ""
+msgstr "Niemand"
 
 #: desk/src/pages/home/components/PendingTickets.vue:261
 msgid "No pending tickets"
-msgstr ""
+msgstr "Keine ausstehenden Tickets"
 
 #: desk/src/components/ticket-agent/TicketNavigation.vue:10
 msgid "No previous ticket"
-msgstr ""
+msgstr "Kein vorheriges Ticket"
 
 #: desk/src/pages/home/components/PendingTickets.vue:94
 msgid "No reason"
-msgstr ""
+msgstr "Kein Grund"
 
 #: desk/src/pages/home/components/PendingTickets.vue:257
 msgid "No recently assigned tickets"
-msgstr ""
+msgstr "Keine kürzlich zugewiesenen Tickets"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
-msgstr ""
+msgstr "Keine Ergebnisse"
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
 msgstr "Keine Ergebnisse gefunden"
 
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
+msgstr "Keine Bewertungen gefunden"
+
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:91
 msgid "No saved replies found"
-msgstr ""
+msgstr "Keine gespeicherten Antworten gefunden"
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
-msgstr ""
+msgstr "Keine Tickets gefunden"
 
 #: desk/src/pages/ticket/Tickets.vue:202
 msgid "No tickets found for the applied filters. Try adjusting or clearing your filters."
-msgstr ""
+msgstr "Keine Tickets für die angewendeten Filter gefunden. Passen Sie Ihre Filter an oder löschen Sie sie."
 
 #: desk/src/pages/ticket/Tickets.vue:198
 msgid "No tickets found for this view. Try adjusting your filters or creating a new view."
-msgstr ""
+msgstr "Keine Tickets für diese Ansicht gefunden. Passen Sie Ihre Filter an oder erstellen Sie eine neue Ansicht."
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:99
 msgid "No tickets found to preview."
-msgstr ""
+msgstr "Keine Tickets zur Vorschau gefunden."
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:84
 msgid "No tickets selected"
-msgstr ""
+msgstr "Keine Tickets ausgewählt"
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr "Kein Benutzer mit Kontakt {0} verknüpft"
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "Nicht Erlaubt"
 
 #: desk/src/pages/home/components/PendingTickets.vue:69
 msgid "Not Assigned"
-msgstr ""
+msgstr "Nicht zugewiesen"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:10
 msgid "Not Saved"
 msgstr "Nicht gespeichert"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "Nicht eingetragen"
 
@@ -3754,7 +3922,7 @@ msgstr "Keine Angabe"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:14
 msgid "Not installed"
-msgstr ""
+msgstr "Nicht installiert"
 
 #. Label of a Link in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
@@ -3770,37 +3938,32 @@ msgstr "Benachrichtigungen"
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:146
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:227
 msgid "Old Condition"
-msgstr ""
+msgstr "Alte Bedingung"
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:88
 msgid "Old Conditions"
-msgstr ""
+msgstr "Alte Bedingungen"
 
 #. Label of the on_hold_since (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "On Hold Since"
 msgstr "Auf Eis gelegt seit"
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr ""
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
-msgstr ""
+msgstr "Bei Ticketstatus"
 
 #: helpdesk/api/ticket.py:75
 msgid "Only administrators can delete tickets."
-msgstr ""
+msgstr "Nur Administratoren können Tickets löschen."
 
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.py:29
 msgid "Only one default view is allowed per user for {0}"
-msgstr ""
+msgstr "Pro Benutzer ist nur eine Standardansicht für {0} zulässig"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:29
 msgid "Only the 'color' and 'order' fields of the 'Closed' status can be modified."
-msgstr ""
+msgstr "Nur die Felder „Farbe“ und „Reihenfolge“ des Status „Geschlossen“ können geändert werden."
 
 #. Option for the 'Category' (Select) field in DocType 'HD Ticket Status'
 #. Option in a Select field in the tickets Web Form
@@ -3811,34 +3974,40 @@ msgstr "Offen"
 
 #: desk/src/components/modals/ShortcutsModal.vue:78
 msgid "Open command palette"
-msgstr ""
+msgstr "Befehlspalette öffnen"
 
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
-msgstr ""
+msgstr "Kommentarfeld öffnen"
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
+msgstr "Kunde öffnen"
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
 msgid "Open help"
-msgstr ""
+msgstr "Hilfe öffnen"
 
 #: desk/src/components/Settings/EmailEdit.vue:37
 msgid "Open in Desk"
-msgstr ""
+msgstr "In Desk öffnen"
 
 #: desk/src/components/modals/ShortcutsModal.vue:99
 msgid "Open reply box"
-msgstr ""
+msgstr "Antwortfeld öffnen"
 
 #: desk/src/components/modals/ShortcutsModal.vue:79
 msgid "Open settings"
-msgstr ""
+msgstr "Einstellungen öffnen"
 
 #. Description of the 'Category' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Open: SLA continues. <br>\n"
 "Paused: SLA is paused. <br>\n"
 "Resolved: SLA timer stops."
-msgstr ""
+msgstr "Offen: SLA läuft weiter. <br>\n"
+"Pausiert: SLA ist pausiert. <br>\n"
+"Geklärt: SLA-Zähler stoppt."
 
 #. Label of the opening_date (Date) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -3870,7 +4039,7 @@ msgstr "Sortieren nach"
 
 #: desk/src/pages/dashboard/Dashboard.vue:249
 msgid "Organization Dashboard"
-msgstr ""
+msgstr "Organisations-Dashboard"
 
 #: desk/src/pages/ticket/TicketFeedback.vue:50
 msgid "Other"
@@ -3886,7 +4055,7 @@ msgstr "Ausgang"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:199
 msgid "Outside working hours notice"
-msgstr ""
+msgstr "Hinweis außerhalb der Arbeitszeiten"
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:105
 msgid "Owner"
@@ -3898,23 +4067,28 @@ msgstr "Seite nicht gefunden"
 
 #: desk/src/components/Settings/FieldDependency/FieldDependencyFieldsSelection.vue:5
 msgid "Parent field"
-msgstr ""
+msgstr "Übergeordnetes Feld"
 
 #: helpdesk/api/settings/field_dependency.py:47
 msgid "Parent field, child field, and parent-child mapping are required."
-msgstr ""
+msgstr "Übergeordnetes Feld, Unterfeld und Zuordnung zwischen ihnen sind erforderlich."
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr "GbR"
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "Passwort"
 
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:104
 msgid "Password must be at least 8 characters"
-msgstr ""
+msgstr "Das Passwort muss mindestens 8 Zeichen lang sein"
 
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:107
 msgid "Password must contain lowercase, uppercase, number, and symbol"
-msgstr ""
+msgstr "Das Passwort muss Klein- und Großbuchstaben, eine Zahl und ein Symbol enthalten"
 
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:87
 msgid "Password updated successfully."
@@ -3927,7 +4101,7 @@ msgstr "Passwörter stimmen nicht überein"
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:36
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:123
 msgid "Passwords match"
-msgstr ""
+msgstr "Passwörter stimmen überein"
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #. Option for the 'Category' (Select) field in DocType 'HD Ticket Status'
@@ -3942,6 +4116,7 @@ msgid "Pending"
 msgstr "Ausstehend"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr "Ausstehende Einladungen"
 
@@ -3949,23 +4124,23 @@ msgstr "Ausstehende Einladungen"
 #: desk/src/pages/home/components/PendingTickets.vue:234
 #: desk/src/pages/home/components/PendingTickets.vue:238
 msgid "Pending Tickets"
-msgstr ""
+msgstr "Ausstehende Tickets"
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
-msgstr ""
+msgstr "Prozentualer Anteil aller Tickets nach Kanal"
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
-msgstr ""
+msgstr "Prozentualer Anteil aller Tickets nach Priorität"
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
-msgstr ""
+msgstr "Prozentualer Anteil aller Tickets nach Team"
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
-msgstr ""
+msgstr "Prozentualer Anteil aller Tickets nach Typ"
 
 #: desk/src/pages/dashboard/Dashboard.vue:46
 msgid "Period"
@@ -3982,20 +4157,21 @@ msgstr "Persönlich"
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:54
 msgid "Personal mobile no"
-msgstr ""
+msgstr "Persönliche Mobilnummer"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "Telefon"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
-msgstr ""
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
+msgstr "Foto"
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
 msgid "Pick an option"
-msgstr ""
+msgstr "Wählen Sie eine Option"
 
 #: desk/src/pages/ticket/Tickets.vue:468
 msgid "Pin View"
@@ -4020,67 +4196,67 @@ msgstr "Platzhalter"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.py:21
 msgid "Please add this priority in the <a href='/app/hd-service-level-agreement'>required SLA documents</a>"
-msgstr ""
+msgstr "Bitte fügen Sie diese Priorität in den <a href='/app/hd-service-level-agreement'>erforderlichen SLA-Dokumenten</a> hinzu"
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:341
 msgid "Please add {0} priority in {1} SLA"
-msgstr ""
+msgstr "Bitte fügen Sie die Priorität {0} in der SLA {1} hinzu"
 
 #: desk/src/components/Settings/Telephony/Telephony.vue:219
 msgid "Please configure your Exotel settings correctly"
-msgstr ""
+msgstr "Bitte konfigurieren Sie Ihre Exotel-Einstellungen korrekt"
 
 #: desk/src/components/Settings/Telephony/Telephony.vue:215
 msgid "Please configure your Twilio settings correctly"
-msgstr ""
+msgstr "Bitte konfigurieren Sie Ihre Twilio-Einstellungen korrekt"
 
 #: desk/src/components/layouts/Sidebar.vue:658
 msgid "Please create a new ticket to proceed with the next step."
-msgstr ""
+msgstr "Bitte erstellen Sie ein neues Ticket, um mit dem nächsten Schritt fortzufahren."
 
 #: desk/src/pages/ticket/TicketNew.vue:83
 msgid "Please enter a subject to continue"
-msgstr ""
+msgstr "Bitte geben Sie einen Betreff ein, um fortzufahren"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:368
 #: desk/src/pages/call-logs/CallLogModal.vue:376
 msgid "Please enter a valid phone number"
-msgstr ""
+msgstr "Bitte geben Sie eine gültige Telefonnummer ein"
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
-msgstr ""
+msgstr "Bitte geben Sie mindestens eine gültige E-Mail-Adresse ein, um eine Einladung zu senden."
 
 #: desk/src/components/Settings/Teams/NewTeam.vue:129
 #: desk/src/pages/call-logs/CallLogModal.vue:264
 #: desk/src/pages/call-logs/CallLogModal.vue:310
 msgid "Please fill all required fields"
-msgstr ""
+msgstr "Bitte füllen Sie alle erforderlichen Felder aus"
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:240
 msgid "Please fill all required fields for Exotel"
-msgstr ""
+msgstr "Bitte füllen Sie alle erforderlichen Felder für Exotel aus"
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:236
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:204
 msgid "Please fill all required fields for Twilio"
-msgstr ""
+msgstr "Bitte füllen Sie alle erforderlichen Felder für Twilio aus"
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:303
 msgid "Please fill all the required fields"
-msgstr ""
+msgstr "Bitte füllen Sie alle erforderlichen Felder aus"
 
 #: desk/src/components/Settings/Sla/Modals/WorkDayModal.vue:244
 msgid "Please fix the errors in the form"
-msgstr ""
+msgstr "Bitte beheben Sie die Fehler im Formular"
 
 #: helpdesk/api/saved_replies.py:11
 msgid "Please provide saved_reply_id"
-msgstr ""
+msgstr "Bitte geben Sie saved_reply_id an"
 
 #: desk/src/components/Settings/General/General.vue:239
 msgid "Please select at least one restriction option for teams in the settings."
-msgstr ""
+msgstr "Bitte wählen Sie in den Einstellungen mindestens eine Einschränkungsoption für Teams aus."
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.py:41
 msgid "Please select weekly off day"
@@ -4088,54 +4264,35 @@ msgstr "Bitte die wöchentlichen Auszeittage auswählen"
 
 #: desk/src/components/Settings/Sla/SlaPolicyList.vue:32
 msgid "Policy name"
-msgstr ""
+msgstr "Richtlinienname"
+
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr "Positiv"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
-msgstr ""
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr "Post Beschreibung Schlüssel"
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr "Nach der Route Schlüsselliste"
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr "Post-Route-Zeichenfolge"
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
-msgstr "Beitragstitel eingeben"
+msgstr "Positive zuerst"
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:10
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Prefer knowledge base"
-msgstr ""
+msgstr "Wissensbasis bevorzugen"
 
 #: desk/src/components/Settings/Preferences/Preferences.vue:6
 msgid "Preferences"
-msgstr ""
+msgstr "Einstellungen"
 
 #: desk/src/components/Settings/Preferences/Preferences.vue:75
 msgid "Preferences updated successfully."
-msgstr ""
+msgstr "Einstellungen erfolgreich aktualisiert."
 
 #: desk/src/pages/dashboard/Dashboard.vue:468
 msgid "Presets"
-msgstr ""
+msgstr "Voreinstellungen"
 
 #: desk/src/pages/SearchAgent.vue:108
 msgid "Press enter to search"
@@ -4149,7 +4306,27 @@ msgstr "Vorschau"
 
 #: desk/src/components/modals/ShortcutsModal.vue:108
 msgid "Previous ticket"
-msgstr ""
+msgstr "Vorheriges Ticket"
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "Primär"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "Hauptkontakt"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr "Der Hauptkontakt muss einer der aufgeführten Kontakte sein"
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr "Hauptkontakt aktualisiert"
 
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
@@ -4157,8 +4334,6 @@ msgstr ""
 msgid "Priorities"
 msgstr "Prioritäten"
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4166,9 +4341,10 @@ msgstr "Prioritäten"
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4179,7 +4355,7 @@ msgstr "Priorität"
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:86
 msgid "Priority <u>{0}</u> must be included in the SLA {1}."
-msgstr ""
+msgstr "Die Priorität <u>{0}</u> muss in der SLA {1} enthalten sein."
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:75
 msgid "Priority {0} has been repeated."
@@ -4188,16 +4364,16 @@ msgstr "Die Priorität {0} wurde wiederholt."
 #: desk/src/components/layouts/Sidebar.vue:309
 #: desk/src/pages/ticket/Tickets.vue:377
 msgid "Private Views"
-msgstr ""
+msgstr "Private Ansichten"
 
 #: desk/src/components/Settings/Teams/NewTeam.vue:30
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:11
 msgid "Product Experts"
-msgstr ""
+msgstr "Produktexperten"
 
 #: desk/src/components/Settings/NewTeamModal.vue:20
 msgid "Product experts"
-msgstr ""
+msgstr "Produktexperten"
 
 #: desk/src/components/Settings/Profile/Profile.vue:3
 msgid "Profile"
@@ -4234,7 +4410,7 @@ msgstr "Veröffentlicht am"
 
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.py:24
 msgid "Published articles must have content."
-msgstr ""
+msgstr "Veröffentlichte Artikel müssen Inhalt haben."
 
 #: desk/src/components/Settings/EmailEdit.vue:149
 msgid "Pull Emails"
@@ -4242,22 +4418,11 @@ msgstr "E-Mails abrufen"
 
 #: desk/src/components/Settings/EmailEdit.vue:407
 msgid "Pulling emails, this may take a few minutes."
-msgstr ""
+msgstr "E-Mails werden abgerufen, dies kann einige Minuten dauern."
 
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:36
 msgid "Quarterly"
 msgstr "Quartalsweise"
-
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "Abfrageoptionen"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr "Abfrage Route String"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
@@ -4275,20 +4440,20 @@ msgstr "Zeitraum"
 #. Title of the email-feedback Web Form
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
 msgid "Rate Your Support Experience"
-msgstr ""
+msgstr "Bewerten Sie Ihre Support-Erfahrung"
 
 #: desk/src/pages/ticket/TicketFeedback.vue:4
 msgid "Rate this ticket"
-msgstr ""
+msgstr "Bewerten Sie dieses Ticket"
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
-msgstr ""
+msgstr "Bewertete Tickets"
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4296,21 +4461,21 @@ msgstr "Bewertung"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.py:23
 msgid "Rating must be between 0.2 and 1.0"
-msgstr ""
+msgstr "Die Bewertung muss zwischen 0,2 und 1,0 liegen"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.py:19
 msgid "Rating {0} is not allowed"
-msgstr ""
+msgstr "Die Bewertung {0} ist nicht zulässig"
 
 #. Option for the 'Type' (Select) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "Reaction"
-msgstr ""
+msgstr "Reaktion"
 
 #. Label of the reactions (Table) field in DocType 'HD Ticket Comment'
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 msgid "Reactions"
-msgstr ""
+msgstr "Reaktionen"
 
 #. Label of the read (Check) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
@@ -4323,11 +4488,11 @@ msgstr "Grund"
 
 #: desk/src/pages/home/components/PendingTickets.vue:226
 msgid "Recent"
-msgstr ""
+msgstr "Kürzlich"
 
 #: desk/src/pages/home/components/PendingTickets.vue:233
 msgid "Recent Tickets"
-msgstr ""
+msgstr "Kürzliche Tickets"
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:30
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:29
@@ -4336,14 +4501,14 @@ msgstr "Anrufe aufzeichnen"
 
 #: desk/src/components/Settings/Holiday/HolidayView.vue:114
 msgid "Recurring Holidays"
-msgstr ""
+msgstr "Wiederkehrende Feiertage"
 
 #. Label of the recurring_holidays (JSON) field in DocType 'HD Service Holiday
 #. List'
 #: desk/src/components/Settings/Holiday/HolidayView.vue:178
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Recurring holidays"
-msgstr ""
+msgstr "Wiederkehrende Feiertage"
 
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
@@ -4360,7 +4525,7 @@ msgstr "Referenz"
 #. Label of the reference_ticket (Link) field in DocType 'HD Ticket Comment'
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 msgid "Reference Ticket"
-msgstr ""
+msgstr "Referenz-Ticket"
 
 #. Label of the references_tab (Tab Break) field in DocType 'HD Customer'
 #. Label of the references_section (Section Break) field in DocType 'HD
@@ -4376,29 +4541,45 @@ msgstr "Aktualisieren"
 
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:75
 msgid "Refresh Apps"
-msgstr ""
+msgstr "Apps aktualisieren"
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.js:6
 msgid "Regenerate Search Index"
-msgstr ""
+msgstr "Suchindex neu erstellen"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "Entfernen"
 
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr "Kontakt entfernen"
+
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
-msgstr ""
+msgstr "Logo entfernen"
 
 #: desk/src/components/Settings/Profile/Profile.vue:197
 msgid "Remove Photo"
-msgstr ""
+msgstr "Foto entfernen"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
-msgstr ""
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr "Filter entfernen"
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr "Bild entfernen"
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
+msgstr "Primär entfernen"
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
 #: desk/src/components/Settings/Teams/TeamsList.vue:161
@@ -4409,15 +4590,24 @@ msgstr "Umbenennen"
 
 #: desk/src/components/ticket-agent/TicketSubjectModal.vue:24
 msgid "Rename (Ctrl + ⏎)"
-msgstr ""
+msgstr "Umbenennen (Strg + ⏎)"
 
 #: desk/src/components/ticket-agent/TicketSubjectModal.vue:23
 msgid "Rename (⌘ + ⏎)"
-msgstr ""
+msgstr "Umbenennen (⌘ + ⏎)"
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
-msgstr ""
+msgstr "Team umbenennen"
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr "Filter ersetzen"
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
+msgstr "Bild ersetzen"
 
 #. Option in a Select field in the tickets Web Form
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
@@ -4436,37 +4626,34 @@ msgstr "Allen antworten"
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Reply From Agent"
-msgstr ""
+msgstr "Antwort vom Agenten"
 
 #. Label of the reply_from_contact_section (Section Break) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Reply From Contact"
-msgstr ""
+msgstr "Antwort vom Kontakt"
 
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:84
 msgid "Reply from agent"
-msgstr ""
+msgstr "Antwort vom Agenten"
 
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:77
 msgid "Reply from contact"
-msgstr ""
+msgstr "Antwort vom Kontakt"
 
 #: desk/src/components/layouts/Sidebar.vue:494
 msgid "Reply on a ticket"
-msgstr ""
-
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr "Schlüssel anfordern"
+msgstr "Auf ein Ticket antworten"
 
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
-msgstr ""
+msgstr "Erforderlich"
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
+msgstr "Einladung erneut senden"
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
 msgid "Reset"
@@ -4475,17 +4662,18 @@ msgstr "Zurücksetzen"
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:89
 #: desk/src/components/Settings/General/components/TicketSettings.vue:252
 msgid "Reset Content"
-msgstr ""
+msgstr "Inhalt zurücksetzen"
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:114
 msgid "Reset content"
-msgstr ""
+msgstr "Inhalt zurücksetzen"
 
 #: desk/src/components/view-controls/ColumnSettings.vue:93
 msgid "Reset to Default"
-msgstr ""
+msgstr "Auf Standard zurücksetzen"
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr "Lösung"
@@ -4513,7 +4701,7 @@ msgstr "Lösung fällig"
 #. Label of the resolution_failed_by (Duration) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution Failed By"
-msgstr ""
+msgstr "Lösung verfehlt um"
 
 #. Label of the resolution_time (Duration) field in DocType 'HD Service Level
 #. Priority'
@@ -4539,18 +4727,6 @@ msgstr "Antwort"
 msgid "Response By"
 msgstr "Antwort von"
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr "Antwortoptionen"
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr "Antwort Ergebnis Schlüsselpfad"
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr "Die Antwortzeit für die Priorität {0} in Zeile {1} darf nicht größer als die Lösungszeit sein."
@@ -4564,52 +4740,34 @@ msgstr "Antwort und Lösung"
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:407
 msgid "Response is required"
-msgstr ""
+msgstr "Antwort ist erforderlich"
 
 #. Label of the assign_within_team (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Restrict agent assignment to selected Team"
-msgstr ""
+msgstr "Zuweisung von Bearbeitern auf ausgewähltes Team beschränken"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:57
 msgid "Restrict agent assignment to selected team"
-msgstr ""
+msgstr "Zuweisung von Bearbeitern auf ausgewähltes Team beschränken"
 
 #. Label of the restrict_tickets_by_agent_group (Check) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Restrict tickets by Team"
-msgstr ""
+msgstr "Tickets nach Team einschränken"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:35
 msgid "Restrict tickets by team"
-msgstr ""
+msgstr "Tickets nach Team einschränken"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:38
 msgid "Restrict tickets to be viewed and managed by team members only."
-msgstr ""
+msgstr "Tickets dürfen nur von Teammitgliedern angesehen und verwaltet werden."
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:83
 msgid "Restrict visibility to these teams"
-msgstr ""
-
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr "Ergebnis Vorschaufeld"
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr "Ergebnis Routenfeld"
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr "Ergebnis Titelfeld"
+msgstr "Sichtbarkeit auf diese Teams beschränken"
 
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
@@ -4617,18 +4775,32 @@ msgstr "Ergebnis Titelfeld"
 msgid "Reviews"
 msgstr "Bewertungen"
 
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr "Einladung widerrufen"
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
+msgstr "Manager-Zugriff widerrufen"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:215
 msgid "Ringing"
 msgstr "Es klingelt"
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "Rolle"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr "Rolle erfolgreich aktualisiert"
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Route Name"
-msgstr ""
+msgstr "Routenname"
 
 #. Label of the rows (Code) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4637,7 +4809,7 @@ msgstr "Zeilen"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:108
 msgid "Run an initial sync to reconcile existing records. New ones update automatically."
-msgstr ""
+msgstr "Führen Sie eine erste Synchronisierung durch, um bestehende Datensätze abzugleichen. Neue werden automatisch aktualisiert."
 
 #. Label of the sla (Link) field in DocType 'HD Ticket'
 #. Label of the sla_tab (Tab Break) field in DocType 'HD Ticket'
@@ -4645,60 +4817,60 @@ msgstr ""
 #: desk/src/pages/ticket/MobileTicketAgent.vue:76
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "SLA"
-msgstr ""
+msgstr "SLA"
 
 #: desk/src/pages/home/components/PendingTickets.vue:232
 msgid "SLA Alerts"
-msgstr ""
+msgstr "SLA-Warnungen"
 
 #. Label of the service_level_agreement_creation (Datetime) field in DocType
 #. 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "SLA Creation"
-msgstr ""
+msgstr "SLA-Erstellung"
 
 #. Label of the sla_mapping_section (Section Break) field in DocType 'HD Ticket
 #. Status'
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "SLA Mapping"
-msgstr ""
+msgstr "SLA-Zuordnung"
 
 #. Label of the agreement_status (Select) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "SLA Status"
-msgstr ""
+msgstr "SLA-Status"
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:430
 msgid "SLA policy created successfully."
-msgstr ""
+msgstr "SLA-Richtlinie erfolgreich erstellt."
 
 #: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:167
 msgid "SLA policy deleted successfully."
-msgstr ""
+msgstr "SLA-Richtlinie erfolgreich gelöscht."
 
 #: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:139
 msgid "SLA policy duplicated successfully."
-msgstr ""
+msgstr "SLA-Richtlinie erfolgreich dupliziert."
 
 #: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:184
 msgid "SLA policy status updated successfully."
-msgstr ""
+msgstr "Status der SLA-Richtlinie erfolgreich aktualisiert."
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:469
 msgid "SLA policy updated successfully."
-msgstr ""
+msgstr "SLA-Richtlinie erfolgreich aktualisiert."
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:478
 msgid "SLA set as default cannot be disabled"
-msgstr ""
+msgstr "Eine als Standard festgelegte SLA kann nicht deaktiviert werden"
 
 #: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:174
 msgid "SLA set as default cannot be disabled."
-msgstr ""
+msgstr "Eine als Standard festgelegte SLA kann nicht deaktiviert werden."
 
 #: desk/src/components/Settings/Sla/SlaPolicies.vue:11
 msgid "SLAs align your team and customers with defined timelines for a reliable experience. Learn more about SLA "
-msgstr ""
+msgstr "SLAs sorgen mit festgelegten Zeitrahmen für ein verlässliches Erlebnis für Ihr Team und Ihre Kunden. Erfahren Sie mehr über SLA "
 
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
@@ -4722,9 +4894,9 @@ msgstr "Samstag"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4739,7 +4911,7 @@ msgstr "Änderungen speichern"
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:3
 #: desk/src/components/layouts/Sidebar.vue:617
 msgid "Saved Replies"
-msgstr ""
+msgstr "Gespeicherte Antworten"
 
 #: desk/src/pages/ticket/Tickets.vue:371
 msgid "Saved Views"
@@ -4747,23 +4919,23 @@ msgstr "Gespeicherte Ansichten"
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:286
 msgid "Saved reply deleted successfully."
-msgstr ""
+msgstr "Gespeicherte Antwort erfolgreich gelöscht."
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:303
 msgid "Saved reply duplicated successfully."
-msgstr ""
+msgstr "Gespeicherte Antwort erfolgreich dupliziert."
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:326
 msgid "Saved reply saved successfully."
-msgstr ""
+msgstr "Gespeicherte Antwort erfolgreich gespeichert."
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:389
 msgid "Saved reply updated successfully."
-msgstr ""
+msgstr "Gespeicherte Antwort erfolgreich aktualisiert."
 
 #: desk/src/components/Settings/Holiday/HolidayList.vue:29
 msgid "Schedule name"
-msgstr ""
+msgstr "Name des Zeitplans"
 
 #. Label of the scope (Select) field in DocType 'HD Saved Reply'
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:106
@@ -4794,53 +4966,55 @@ msgstr "Suchen"
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.js:10
 msgid "Search Index Regenerated"
-msgstr ""
+msgstr "Suchindex neu erstellt"
 
 #: helpdesk/helpdesk/report/ticket_search_analysis/ticket_search_analysis.py:40
 msgid "Search Score"
-msgstr ""
-
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr "Suchbegriff Param Name"
+msgstr "Suchbewertung"
 
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
-msgstr ""
+msgstr "Agenten suchen..."
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr "Nach ID oder Betreff suchen"
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr "Land suchen"
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "Felder durchsuchen..."
 
 #: desk/src/components/command-palette/CP.vue:126
 msgid "Search for \"{0}\""
-msgstr ""
+msgstr "Suchen nach „{0}“"
 
 #: desk/src/pages/SearchAgent.vue:100
 msgid "Search index does not exist. Please build the index first."
-msgstr ""
+msgstr "Suchindex existiert nicht. Bitte erstellen Sie zunächst den Index."
 
 #: helpdesk/api/search.py:41
 msgid "Search index not available. Please contact administrator."
-msgstr ""
+msgstr "Suchindex nicht verfügbar. Bitte kontaktieren Sie den Administrator."
 
 #: helpdesk/api/search.py:17
 msgid "Search query must be at least 2 characters"
-msgstr ""
+msgstr "Die Suchanfrage muss mindestens 2 Zeichen lang sein"
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:20
 msgid "Search ticket"
-msgstr ""
+msgstr "Ticket suchen"
 
 #: desk/src/pages/SearchAgent.vue:16
 msgid "Search tickets, comments, and communications..."
-msgstr ""
+msgstr "Tickets, Kommentare und Kommunikation durchsuchen..."
 
 #: desk/src/components/command-palette/CP.vue:12
 msgid "Search tickets, emails, comments, or #234 to navigate to ticket"
-msgstr ""
+msgstr "Tickets, E-Mails, Kommentare durchsuchen oder #234 eingeben, um zum Ticket zu wechseln"
 
 #: desk/src/components/view-controls/filter/FilterValueEditor.vue:33
 msgid "Search..."
@@ -4848,15 +5022,16 @@ msgstr "Suche..."
 
 #: desk/src/pages/SearchAgent.vue:137
 msgid "Searched for:"
-msgstr ""
+msgstr "Gesucht nach:"
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr "Suchen..."
 
 #: desk/src/pages/home/components/PendingTickets.vue:147
 msgid "See all {0} tickets"
-msgstr ""
+msgstr "Alle {0} Tickets ansehen"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:28
 #: desk/src/pages/call-logs/CallLogModal.vue:57
@@ -4868,44 +5043,56 @@ msgstr "Auswählen"
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
-msgstr ""
+msgstr "Kategorie auswählen"
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
+msgstr "Kunde auswählen"
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
 msgid "Select Range"
-msgstr ""
+msgstr "Zeitraum auswählen"
 
 #: desk/src/components/ticket/TicketMergeModal.vue:55
 msgid "Select Ticket"
-msgstr ""
+msgstr "Ticket auswählen"
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:31
 msgid "Select Timezone"
-msgstr ""
+msgstr "Zeitzone auswählen"
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:167
 msgid "Select a Default Priority."
-msgstr "Wählen Sie eine Standardpriorität."
+msgstr "Wählen Sie eine Standardpriorität aus."
 
 #: desk/src/pages/ticket/TicketFeedback.vue:26
 msgid "Select a rating"
-msgstr ""
+msgstr "Bewertung auswählen"
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr "Land auswählen"
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
-msgstr ""
+msgstr "Zeitraum auswählen"
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:78
 msgid "Select teams"
-msgstr ""
+msgstr "Teams auswählen"
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
-msgstr ""
+msgstr "Ticket für Vorschau auswählen"
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
+msgstr "Zeitzone auswählen"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
 msgid "Select what type all tickets get by default."
-msgstr ""
+msgstr "Wählen Sie aus, welchen Typ alle Tickets standardmäßig erhalten."
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:41
 msgid "Select your weekly off day"
@@ -4921,33 +5108,37 @@ msgstr "Einladungen versenden"
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:32
 msgid "Send Reply"
-msgstr ""
+msgstr "Antwort senden"
 
 #. Label of the send_email_feedback_on_status (Link) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
-msgstr ""
+msgstr "Rückmeldung senden, wenn"
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
+msgstr "Kennwort-Zurücksetzen-E-Mail senden"
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
 msgid "Send to {0} tickets"
-msgstr ""
+msgstr "An {0} Tickets senden"
 
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:78
 msgid "Sent to all of the agents assigned to the ticket whenever a contact has replied."
-msgstr ""
+msgstr "Wird an alle dem Ticket zugewiesenen Agenten gesendet, sobald ein Kontakt geantwortet hat."
 
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:85
 msgid "Sent to all of the recipients associated with the ticket whenever an agent has replied."
-msgstr ""
+msgstr "Wird an alle mit dem Ticket verknüpften Empfänger gesendet, sobald ein Agent geantwortet hat."
 
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:73
 msgid "Sent to the user right after creating an email ticket."
-msgstr ""
+msgstr "Wird direkt nach der Erstellung eines E-Mail-Tickets an den Benutzer gesendet."
 
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:66
 msgid "Sent to the user who has raised the ticket after the ticket is closed or resolved."
-msgstr ""
+msgstr "Wird an den Benutzer gesendet, der das Ticket erstellt hat, nachdem das Ticket geschlossen oder gelöst wurde."
 
 #: desk/src/components/layouts/Sidebar.vue:618
 msgid "Service Level Agreement"
@@ -4955,63 +5146,76 @@ msgstr "Service Level Agreement"
 
 #: desk/src/components/Settings/Sla/SlaPolicies.vue:5
 msgid "Service Level Agreements (SLAs)"
-msgstr ""
+msgstr "Service Level Agreements (SLAs)"
 
 #. Label of the service_level (Data) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Service Level Name"
-msgstr "Name des Service Levels"
+msgstr "SLA-Name"
 
 #: helpdesk/api/settings/email.py:14
 msgid "Service not supported"
-msgstr ""
+msgstr "Dienst wird nicht unterstützt"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "Eingetragen"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:4
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
-msgstr ""
+msgstr "Telefonnummer festlegen"
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
+msgstr "Primärkontakt festlegen"
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
 msgid "Set Resolution Time for Priority {0} in row {1}."
-msgstr ""
+msgstr "Legen Sie die Lösungszeit für die Priorität {0} in Zeile {1} fest."
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:48
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr "Legen Sie die Reaktionszeit für die Priorität {0} in der Zeile {1} fest."
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr "Als primär festlegen"
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
-msgstr ""
+msgstr "Als Standard-SLA festlegen"
+
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr "Als primär festlegen"
 
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
-msgstr ""
+msgstr "Status festlegen"
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:231
 msgid "Set the default status assigned when a ticket is created, and the status to apply when a ticket is reopened. If not specified, the default status from HD Settings will be used."
-msgstr ""
+msgstr "Legen Sie den Standardstatus fest, der bei der Erstellung eines Tickets zugewiesen wird, sowie den Status, der bei der Wiedereröffnung eines Tickets angewendet wird. Falls nicht festgelegt, wird der Standardstatus aus den HD-Einstellungen verwendet."
 
 #: desk/src/components/Settings/Sla/SlaHolidays.vue:9
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
-msgstr ""
+msgstr "Legen Sie Arbeitstage, Arbeitszeiten und Feiertage fest, indem Sie einen vordefinierten Zeitplan auswählen oder einen neuen erstellen."
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
-msgstr ""
+msgstr "Legen Sie Ihre Verfügbarkeit fest, damit Ihr Team weiß, wann Sie erreichbar sind."
 
 #: desk/src/components/Settings/Holiday/Holidays.vue:5
 msgid "Set your team’s working days, hours, and holidays using a template or custom schedule."
-msgstr ""
+msgstr "Legen Sie die Arbeitstage, Arbeitszeiten und Feiertage Ihres Teams mithilfe einer Vorlage oder eines benutzerdefinierten Zeitplans fest."
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:125
 msgid "Setting <strong>{0}</strong> as the default SLA removes <strong>{1}</strong> as the default SLA. You’ll need to add a condition in <strong>{1}</strong> for the SLA to work."
-msgstr ""
+msgstr "Wenn Sie <strong>{0}</strong> als Standard-SLA festlegen, wird <strong>{1}</strong> als Standard-SLA entfernt. Sie müssen eine Bedingung in <strong>{1}</strong> hinzufügen, damit die SLA funktioniert."
 
 #: desk/src/components/layouts/Sidebar.vue:574
 msgid "Setting up"
@@ -5028,14 +5232,14 @@ msgstr "Einstellungen"
 #: desk/src/components/Settings/General/General.vue:291
 #: desk/src/components/Settings/General/General.vue:300
 msgid "Settings updated"
-msgstr ""
+msgstr "Einstellungen aktualisiert"
 
 #: desk/src/components/Settings/EmailNotifications/Acknowledgement.vue:47
 #: desk/src/components/Settings/EmailNotifications/ReplyToAgents.vue:47
 #: desk/src/components/Settings/EmailNotifications/ReplyViaAgent.vue:47
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:77
 msgid "Settings updated successfully."
-msgstr ""
+msgstr "Einstellungen erfolgreich aktualisiert."
 
 #. Label of the setup_section (Section Break) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -5044,11 +5248,11 @@ msgstr "Einrichtung"
 
 #: desk/src/components/Settings/EmailAdd.vue:3
 msgid "Setup Email"
-msgstr ""
+msgstr "E-Mail einrichten"
 
 #: desk/src/components/layouts/Sidebar.vue:461
 msgid "Setup SLA"
-msgstr ""
+msgstr "SLA einrichten"
 
 #: desk/src/pages/knowledge-base/Article.vue:649
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:167
@@ -5059,11 +5263,11 @@ msgstr "Freigeben"
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Share Feedback"
-msgstr ""
+msgstr "Rückmeldung teilen"
 
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:65
 msgid "Share feedback"
-msgstr ""
+msgstr "Rückmeldung teilen"
 
 #: desk/src/components/layouts/Sidebar.vue:381
 msgid "Shortcuts"
@@ -5076,19 +5280,19 @@ msgstr "Anzeigen "
 #. Label of the different_view (Check) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Show end users a different view"
-msgstr ""
+msgstr "Endbenutzern eine andere Ansicht anzeigen"
 
 #: desk/src/pages/ticket/Tickets.vue:481
 msgid "Show in sidebar"
-msgstr ""
+msgstr "In Seitenleiste anzeigen"
 
 #: desk/src/components/modals/ShortcutsModal.vue:80
 msgid "Show keyboard shortcuts"
-msgstr ""
+msgstr "Tastaturkürzel anzeigen"
 
 #: desk/src/pages/home/components/PendingTickets.vue:154
 msgid "Showing {0} of {1} {2}"
-msgstr ""
+msgstr "{0} von {1} {2} werden angezeigt"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:22
 msgid "Signature"
@@ -5103,31 +5307,31 @@ msgstr "Einfacher Python-Ausdruck, zum Beispiel: doc.status == 'Open' and doc.ti
 #. Label of the skip_email_workflow (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Skip e-mail workflow"
-msgstr ""
+msgstr "E-Mail-Workflow überspringen"
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:26
 msgid "Skip email workflow"
-msgstr ""
+msgstr "E-Mail-Workflow überspringen"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:617
 msgid "Some error occurred while renaming assignment rule"
-msgstr ""
+msgstr "Beim Umbenennen der Zuweisungsregel ist ein Fehler aufgetreten"
 
 #: desk/src/components/Settings/Holiday/HolidayView.vue:399
 msgid "Some error occurred while renaming holiday list"
-msgstr ""
+msgstr "Beim Umbenennen der Feiertagsliste ist ein Fehler aufgetreten"
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:368
 msgid "Some error occurred while renaming saved reply"
-msgstr ""
+msgstr "Beim Umbenennen der gespeicherten Antwort ist ein Fehler aufgetreten"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:601
 msgid "Some error occurred while updating assignment rule"
-msgstr ""
+msgstr "Beim Aktualisieren der Zuweisungsregel ist ein Fehler aufgetreten"
 
 #: desk/src/components/Settings/Holiday/HolidayView.vue:389
 msgid "Some error occurred while updating holiday list"
-msgstr ""
+msgstr "Beim Aktualisieren der Feiertagsliste ist ein Fehler aufgetreten"
 
 #: desk/src/components/view-controls/SortBy.vue:10
 #: desk/src/components/view-controls/SortBy.vue:22
@@ -5135,48 +5339,31 @@ msgstr ""
 msgid "Sort"
 msgstr "Sortieren"
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr "Quelle DocType"
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "Quellenname"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr "Quelle Typ"
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
-msgstr ""
+msgstr "Quell- und Zielkategorie dürfen nicht identisch sein"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/api.py:339
 msgid "Source and target ticket cannot be same"
-msgstr ""
+msgstr "Quell- und Zielticket dürfen nicht identisch sein"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/api.py:335
 msgid "Source ticket does not exist"
-msgstr ""
+msgstr "Quellticket existiert nicht"
 
 #. Label of the split_and_merge_section (Section Break) field in DocType 'HD
 #. Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Split and Merge"
-msgstr ""
+msgstr "Aufteilen und Zusammenführen"
 
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.js:9
 msgid "Standard Form Scripts can't be modified, duplicate the script instead."
-msgstr ""
+msgstr "Standard-Formularskripte können nicht geändert werden, duplizieren Sie stattdessen das Skript."
 
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.py:55
 msgid "Standard Views cannot be deleted."
-msgstr ""
+msgstr "Standardansichten können nicht gelöscht werden."
 
 #. Label of the start_date (Date) field in DocType 'HD Service Level Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5190,12 +5377,14 @@ msgstr "Startzeit"
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:100
 msgid "Start Time can't be greater than or equal to End Time in row <u>{0}</u>."
-msgstr ""
+msgstr "Die Startzeit darf in Zeile <u>{0}</u> nicht größer oder gleich der Endzeit sein."
 
 #. Label of the status (Select) field in DocType 'HD Article'
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5216,7 +5405,7 @@ msgstr "Status "
 #. Label of the status_category (Data) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Status Category"
-msgstr ""
+msgstr "Statuskategorie"
 
 #. Label of the status_details (Section Break) field in DocType 'HD Service
 #. Level Agreement'
@@ -5228,40 +5417,43 @@ msgstr "Statusdetails"
 #. Label of the status_order (Int) field in DocType 'HD Agent Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 msgid "Status Order"
-msgstr ""
+msgstr "Statusreihenfolge"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:382
 msgid "Status is required"
-msgstr ""
+msgstr "Status ist erforderlich"
 
 #. Description of the 'Ticket Reopen status' (Link) field in DocType 'HD
 #. Service Level Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Status of the ticket, when a customer replies on the ticket with this SLA.\n\n"
 "If not selected, the value will be takes from HD Settings DocType."
-msgstr ""
+msgstr "Status des Tickets, wenn ein Kunde mit dieser SLA auf das Ticket antwortet.\n\n"
+"Falls nicht ausgewählt, wird der Wert aus dem DocType HD-Einstellungen übernommen."
 
 #. Description of the 'Ticket Reopen status' (Link) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Status of the ticket, when a customer replies on the ticket."
-msgstr ""
+msgstr "Status des Tickets, wenn ein Kunde auf das Ticket antwortet."
 
 #. Description of the 'Default Ticket Status' (Link) field in DocType 'HD
 #. Service Level Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Status of the ticket, when it is created in the system with this SLA.\n"
 "If not selected, the value will be taken from HD Settings DocType"
-msgstr ""
+msgstr "Status des Tickets, wenn es mit dieser SLA im System erstellt wird.\n"
+"Falls nicht ausgewählt, wird der Wert aus dem DocType HD-Einstellungen übernommen"
 
 #. Description of the 'Default ticket status' (Link) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Status of the ticket, when it is created in the system."
-msgstr ""
+msgstr "Status des Tickets, wenn es im System erstellt wird."
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5273,7 +5465,7 @@ msgstr "Betreff"
 #. Label of the subject_weight (Int) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Subject Weight"
-msgstr ""
+msgstr "Gewichtung des Betreffs"
 
 #: desk/src/components/ticket/TicketSplitModal.vue:74
 msgid "Subject is required"
@@ -5310,7 +5502,7 @@ msgstr "Stützzeitverteilung"
 #. Label of a Link in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Support Policy"
-msgstr ""
+msgstr "Support-Richtlinie"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
@@ -5320,51 +5512,51 @@ msgstr "Support-Team"
 
 #: desk/src/components/Settings/Preferences/components/ThemeSwitcher.vue:11
 msgid "Switch between light, dark, or system theme"
-msgstr ""
+msgstr "Zwischen hellem, dunklem oder Systemdesign wechseln"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:44
 msgid "Switch between outgoing email accounts when sending emails from your configured accounts."
-msgstr ""
+msgstr "Wechseln Sie beim Senden von E-Mails zwischen Ihren konfigurierten Ausgangs-E-Mail-Konten."
 
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.js:16
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.js:18
 msgid "Sync Customers"
-msgstr ""
+msgstr "Kunden synchronisieren"
 
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.js:22
 msgid "Sync all customers between ERPNext and Helpdesk? The sync runs in the background and can take a few minutes depending on the number of customers."
-msgstr ""
+msgstr "Alle Kunden zwischen ERPNext und Helpdesk synchronisieren? Die Synchronisierung läuft im Hintergrund und kann je nach Kundenanzahl einige Minuten dauern."
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:216
 msgid "Sync completed successfully"
-msgstr ""
+msgstr "Synchronisierung erfolgreich abgeschlossen"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:3
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:39
 msgid "Sync customers between Helpdesk and ERPNext."
-msgstr ""
+msgstr "Kunden zwischen Helpdesk und ERPNext synchronisieren."
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:120
 msgid "Sync now"
-msgstr ""
+msgstr "Jetzt synchronisieren"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:197
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.js:35
 msgid "Sync started"
-msgstr ""
+msgstr "Synchronisierung gestartet"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:104
 msgid "Sync your existing customers"
-msgstr ""
+msgstr "Synchronisieren Sie Ihre bestehenden Kunden"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:120
 msgid "Syncing…"
-msgstr ""
+msgstr "Wird synchronisiert…"
 
 #. Label of the synonyms (Table) field in DocType 'HD Synonyms'
 #: helpdesk/helpdesk/doctype/hd_synonyms/hd_synonyms.json
 msgid "Synonyms"
-msgstr ""
+msgstr "Synonyme"
 
 #. Label of the is_system (Check) field in DocType 'HD Ticket Type'
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
@@ -5373,21 +5565,16 @@ msgstr "System"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5409,15 +5596,15 @@ msgstr "System-Manager"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.py:12
 msgid "System types can not be deleted"
-msgstr ""
+msgstr "Systemtypen können nicht gelöscht werden"
 
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:22
 msgid "Tampered Access"
-msgstr ""
+msgstr "Manipulierter Zugriff"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/api.py:337
 msgid "Target ticket does not exist"
-msgstr ""
+msgstr "Zielticket existiert nicht"
 
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
@@ -5426,8 +5613,6 @@ msgstr ""
 msgid "Teal"
 msgstr "Blaugrün"
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5438,7 +5623,6 @@ msgstr "Blaugrün"
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5448,71 +5632,71 @@ msgstr "Team"
 
 #: desk/src/components/Settings/Teams/NewTeam.vue:29
 msgid "Team Name"
-msgstr ""
+msgstr "Teamname"
 
 #. Label of the agent_groups_section (Section Break) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Team Restrictions"
-msgstr ""
+msgstr "Team-Einschränkungen"
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:269
 msgid "Team can now access all tickets."
-msgstr ""
+msgstr "Das Team hat jetzt Zugriff auf alle Tickets."
 
 #: desk/src/components/Settings/NewTeamModal.vue:52
 msgid "Team created"
-msgstr ""
+msgstr "Team erstellt"
 
 #: desk/src/components/Settings/Teams/NewTeam.vue:140
 msgid "Team created successfully."
-msgstr ""
+msgstr "Team erfolgreich erstellt."
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:162
 #: desk/src/components/Settings/Teams/TeamsList.vue:185
 msgid "Team deleted successfully."
-msgstr ""
+msgstr "Team erfolgreich gelöscht."
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:184
 msgid "Team disabled successfully."
-msgstr ""
+msgstr "Team erfolgreich deaktiviert."
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:183
 msgid "Team enabled successfully."
-msgstr ""
+msgstr "Team erfolgreich aktiviert."
 
 #: desk/src/components/Settings/Teams/TeamsList.vue:51
 msgid "Team name"
-msgstr ""
+msgstr "Teamname"
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:56
 msgid "Team renamed successfully."
-msgstr ""
+msgstr "Team erfolgreich umbenannt."
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:270
 msgid "Team will only see their own tickets."
-msgstr ""
+msgstr "Das Team sieht nur seine eigenen Tickets."
 
 #. Label of the teams (Table MultiSelect) field in DocType 'HD Saved Reply'
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:74
 #: desk/src/components/Settings/Teams/TeamsList.vue:3
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 msgid "Teams"
-msgstr ""
+msgstr "Teams"
 
 #: desk/src/components/Settings/Telephony/Telephony.vue:6
 msgid "Telephony"
-msgstr ""
+msgstr "Telefonie"
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:281
 #: desk/src/components/Settings/Telephony/Telephony.vue:260
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:233
 msgid "Telephony settings updated successfully."
-msgstr ""
+msgstr "Telefonie-Einstellungen erfolgreich aktualisiert."
 
 #: desk/src/pages/ticket/TicketFeedback.vue:54
 msgid "Tell us more"
-msgstr ""
+msgstr "Erzählen Sie uns mehr"
 
 #. Label of the template (Link) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5526,27 +5710,31 @@ msgstr "Vorlagenname"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:12
 msgid "The 'Closed' status cannot be renamed."
-msgstr ""
+msgstr "Der Status „Geschlossen“ kann nicht umbenannt werden."
 
 #: helpdesk/extends/assignment_rule.py:20
 msgid "The Assign Condition JSON '{0}' is invalid: </br> {1}"
-msgstr ""
+msgstr "Das Zuweisungsbedingung-JSON „{0}“ ist ungültig: </br> {1}"
 
 #: helpdesk/extends/assignment_rule.py:28
 msgid "The Unassign Condition JSON '{0}' is invalid: </br> {1}"
-msgstr ""
+msgstr "Das Rückweisungsbedingung-JSON „{0}“ ist ungültig: </br> {1}"
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:147
 msgid "The assignment condition '{0}' is invalid: {1}"
-msgstr ""
+msgstr "Die Zuweisungsbedingung „{0}“ ist ungültig: {1}"
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:154
 msgid "The assignment condition json '{0}' is invalid: {1}"
-msgstr ""
+msgstr "Das Zuweisungsbedingung-JSON „{0}“ ist ungültig: {1}"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr "Der Kontakt {0} ist mit mehreren Kunden verknüpft. Bitte wählen Sie den Kunden manuell aus."
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
-msgstr ""
+msgstr "Der Rückmeldungsdialog wird angezeigt, sobald ein Benutzer versucht, ein Ticket über das Kundenportal zu schließen."
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.py:54
 msgid "The holiday on {0} is not between From Date and To Date"
@@ -5554,15 +5742,19 @@ msgstr "Der Urlaub am {0} ist nicht zwischen dem Von-Datum und dem Bis-Datum"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
-msgstr ""
+msgstr "Die Anzahl der Tage muss 1 oder mehr betragen"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
+msgstr "Der ausgewählte Kunde {0} ist nicht mit dem Kontakt {1} verknüpft. Bitte wählen Sie einen gültigen Kunden aus oder aktualisieren Sie die verknüpften Kunden des Kontakts."
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
 msgid "The status for sending feedback must be of <u>Resolved</u> category."
-msgstr ""
+msgstr "Der Status zum Senden von Rückmeldungen muss der Kategorie <u>Geklärt</u> angehören."
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:83
 msgid "The ticket status will automatically change whenever the agent respond to a ticket."
-msgstr ""
+msgstr "Der Ticketstatus ändert sich automatisch, sobald der Agent auf ein Ticket antwortet."
 
 #: desk/src/components/Settings/Preferences/components/ThemeSwitcher.vue:6
 msgid "Theme"
@@ -5570,41 +5762,53 @@ msgstr "Thema"
 
 #: desk/src/components/knowledge-base/CategoryFolderContainer.vue:18
 msgid "There are no categories published at the moment."
-msgstr ""
+msgstr "Derzeit sind keine Kategorien veröffentlicht."
 
 #: helpdesk/extends/assignment_rule.py:14
 msgid "There should be at least 1 assignment rule for ticket"
-msgstr ""
+msgstr "Es sollte mindestens eine Zuweisungsregel für das Ticket geben"
+
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr "Sie erhalten Zugriff auf Tickets, die von allen in der Organisation erstellt wurden."
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr "Sie sehen künftig nur noch ihre eigenen Tickets."
 
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
-msgstr ""
+msgstr "Diese Zuweisungsregel ist mit dem Team {0} verknüpft.</br> Benutzer {1} wurde der Zuweisungsregel hinzugefügt, ist aber nicht im verknüpften Team enthalten. Bitte fügen Sie den Benutzer in {2} hinzu, um eine korrekte Teamstruktur sicherzustellen."
 
 #: desk/src/components/ticket/TicketMergeModal.vue:79
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
-msgstr ""
+msgstr "Diese Aktion ist unwiderruflich."
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
+msgstr "Dieser Kontakt wird zum Hauptansprechpartner und kann Tickets aller anderen Kontakte der Organisation einsehen."
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
 msgid "This date is calculated based on configured SLAs, working hours, and holidays."
-msgstr ""
+msgstr "Dieses Datum wird auf Grundlage der konfigurierten SLAs, Arbeitszeiten und Feiertage berechnet."
 
 #. Description of a DocType
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "This doctype will be deprecated in the future"
-msgstr ""
+msgstr "Dieser DocType wird in Zukunft veraltet sein"
 
 #. Description of the 'Instantly send e-mail' (Check) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "This field is used to send an email instantly without adding it into the queue. If this field is checked, the email will be sent immediately after clicking the \"Send\" button, instead of being added to the email queue for later processing."
-msgstr ""
+msgstr "Dieses Feld wird verwendet, um eine E-Mail sofort zu senden, ohne sie in die Warteschlange aufzunehmen. Wenn dieses Feld aktiviert ist, wird die E-Mail sofort nach Klick auf die Schaltfläche „Senden“ gesendet, anstatt zur späteren Verarbeitung in die E-Mail-Warteschlange aufgenommen zu werden."
 
 #. Description of the 'Skip e-mail workflow' (Check) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "This field is used to skip email-related workflows for tickets. If this field is checked, no emails will be sent related to tickets, such as new ticket creation, status updates, or notifications."
-msgstr ""
+msgstr "Dieses Feld wird verwendet, um E-Mail-bezogene Workflows für Tickets zu überspringen. Wenn dieses Feld aktiviert ist, werden keine ticketbezogenen E-Mails gesendet, wie z. B. bei neuer Ticketerstellung, Statusaktualisierungen oder Benachrichtigungen."
 
 #: helpdesk/www/helpdesk/index.py:26
 msgid "This method is only meant for developer mode"
@@ -5612,23 +5816,23 @@ msgstr "Diese Methode ist nur für den Entwicklermodus gedacht"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/api.py:373
 msgid "This ticket (#{0}) has been merged with ticket <a href = '/helpdesk/tickets/{1}'>#{1}</a>."
-msgstr ""
+msgstr "Dieses Ticket (#{0}) wurde mit Ticket <a href = '/helpdesk/tickets/{1}'>#{1}</a> zusammengeführt."
 
 #: helpdesk/helpdesk/doctype/hd_ticket/api.py:514
 msgid "This ticket has been split to a new ticket. Please follow up on ticket <a href={0}>#{1}</a>."
-msgstr ""
+msgstr "Dieses Ticket wurde in ein neues Ticket aufgeteilt. Bitte verfolgen Sie Ticket <a href={0}>#{1}</a> weiter."
 
 #: desk/src/pages/ticket/Tickets.vue:544
 msgid "This view is public, and will be removed for all users."
-msgstr ""
+msgstr "Diese Ansicht ist öffentlich und wird für alle Benutzer entfernt."
 
 #: desk/src/components/ListViewBuilder.vue:699
 msgid "This view is public. Changes made will be visible to everyone."
-msgstr ""
+msgstr "Diese Ansicht ist öffentlich. Vorgenommene Änderungen sind für alle sichtbar."
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:249
 msgid "This will reset the content to the default message."
-msgstr ""
+msgstr "Dadurch wird der Inhalt auf die Standardnachricht zurückgesetzt."
 
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
@@ -5650,40 +5854,44 @@ msgstr "Donnerstag"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
 msgid "Ticket"
-msgstr ""
+msgstr "Ticket"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
-msgstr ""
+msgstr "Ticket #{0}: Wir haben Ihre Anfrage erhalten"
 
 #. Name of a report
 #. Label of a Link in the Helpdesk Workspace
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.json
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Analytics"
-msgstr ""
+msgstr "Ticket-Analyse"
 
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
-msgstr ""
+msgstr "Ticket-Konfiguration"
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
+msgstr "Ticket-ID"
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
 msgid "Ticket Info"
-msgstr ""
+msgstr "Ticket-Info"
 
 #: desk/src/components/modals/ShortcutsModal.vue:85
 msgid "Ticket Management"
-msgstr ""
+msgstr "Ticketverwaltung"
 
 #. Label of the is_merged (Check) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Ticket Merged"
-msgstr ""
+msgstr "Ticket zusammengeführt"
 
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:40
 msgid "Ticket Not Found"
-msgstr ""
+msgstr "Ticket nicht gefunden"
 
 #: desk/src/components/layouts/Sidebar.vue:620
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:50
@@ -5691,7 +5899,7 @@ msgstr ""
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:37
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.py:105
 msgid "Ticket Priority"
-msgstr ""
+msgstr "Ticket-Priorität"
 
 #. Label of the ticket_reopen_status (Link) field in DocType 'HD Service Level
 #. Agreement'
@@ -5699,35 +5907,35 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Ticket Reopen status"
-msgstr ""
+msgstr "Status bei Ticket-Wiedereröffnung"
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:18
 msgid "Ticket Routing"
-msgstr ""
+msgstr "Ticket-Weiterleitung"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:4
 msgid "Ticket Settings"
-msgstr ""
+msgstr "Ticket-Einstellungen"
 
 #. Label of the ticket_split_from (Link) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Ticket Split From"
-msgstr ""
+msgstr "Ticket aufgeteilt von"
 
 #: desk/src/components/ticket/TicketMergeModal.vue:65
 msgid "Ticket Subject"
-msgstr ""
+msgstr "Ticket-Betreff"
 
 #. Name of a report
 #. Label of a Link in the Helpdesk Workspace
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.json
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Summary"
-msgstr ""
+msgstr "Ticket-Zusammenfassung"
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
-msgstr ""
+msgstr "Ticket-Trend"
 
 #. Label of the ticket_type_section (Section Break) field in DocType 'HD
 #. Settings'
@@ -5740,36 +5948,36 @@ msgstr ""
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.py:94
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Type"
-msgstr ""
+msgstr "Ticket-Typ"
 
 #: desk/src/pages/ticket/TicketCustomer.vue:325
 msgid "Ticket closed successfully."
-msgstr ""
+msgstr "Ticket erfolgreich geschlossen."
 
 #: desk/src/components/ticket-agent/TicketHeader.vue:218
 msgid "Ticket deleted successfully."
-msgstr ""
+msgstr "Ticket erfolgreich gelöscht."
 
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:21
 msgid "Ticket does not exist."
-msgstr ""
+msgstr "Ticket existiert nicht."
 
 #: desk/src/components/ticket/TicketMergeModal.vue:192
 msgid "Ticket merged successfully."
-msgstr ""
+msgstr "Ticket erfolgreich zusammengeführt."
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
-msgstr ""
+msgstr "Das Ticket muss mit einer Rückmeldung gelöst werden"
 
 #: desk/src/pages/ticket/TicketAgent.vue:33
 #: helpdesk/helpdesk/doctype/hd_ticket/api.py:63
 msgid "Ticket not found"
-msgstr ""
+msgstr "Ticket nicht gefunden"
 
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:40
 msgid "Ticket not found for the provided key."
-msgstr ""
+msgstr "Für den angegebenen Schlüssel wurde kein Ticket gefunden."
 
 #: desk/src/pages/ticket/TicketCustomer.vue:164
 msgid "Ticket not found."
@@ -5779,83 +5987,81 @@ msgstr "Ticket nicht gefunden."
 #. Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Ticket raised outside working hours"
-msgstr ""
+msgstr "Ticket außerhalb der Arbeitszeiten erstellt"
 
 #: desk/src/components/ticket/TicketSplitModal.vue:79
 msgid "Ticket split successfully."
-msgstr ""
+msgstr "Ticket erfolgreich aufgeteilt."
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:155
 msgid "Ticket status"
-msgstr ""
+msgstr "Ticketstatus"
 
 #: desk/src/components/ticket/TicketMergeModal.vue:189
 msgid "Ticket to merged with is required"
-msgstr ""
-
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr ""
+msgstr "Das Ticket, mit dem zusammengeführt werden soll, ist erforderlich"
 
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
-msgstr ""
+msgstr "Ticket erfolgreich aktualisiert."
 
 #. Name of a report
 #: helpdesk/helpdesk/report/ticket_search_analysis/ticket_search_analysis.json
 msgid "Ticket-Search Analysis"
-msgstr ""
+msgstr "Ticket-Suchanalyse"
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
-msgstr ""
+msgstr "Tickets"
 
 #: desk/src/pages/home/components/PendingTickets.vue:242
 msgid "Tickets approaching or breached SLA"
-msgstr ""
+msgstr "Tickets, deren SLA sich dem Ende nähert oder verletzt wurde"
 
 #: desk/src/pages/home/components/PendingTickets.vue:243
 msgid "Tickets assigned to you in the last 7 days"
-msgstr ""
+msgstr "Ihnen in den letzten 7 Tagen zugewiesene Tickets"
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
-msgstr ""
+msgstr "Tickets nach Kanal"
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
-msgstr ""
+msgstr "Tickets nach Priorität"
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
-msgstr ""
+msgstr "Tickets nach Team"
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
-msgstr ""
+msgstr "Tickets nach Typ"
 
 #: helpdesk/api/ticket.py:65
 msgid "Tickets can only be assigned to agents"
-msgstr ""
+msgstr "Tickets können nur Agenten zugewiesen werden"
 
 #: desk/src/components/ticket/TicketMergeModal.vue:29
 msgid "Tickets must meet the following conditions:"
-msgstr ""
+msgstr "Tickets müssen die folgenden Bedingungen erfüllen:"
 
 #: desk/src/pages/home/components/PendingTickets.vue:244
 msgid "Tickets that are awaiting your response"
-msgstr ""
+msgstr "Tickets, die auf Ihre Antwort warten"
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr "Zeitzone"
 
@@ -5874,7 +6080,7 @@ msgstr "Titel"
 #. Label of the title_slug (Data) field in DocType 'HD Article'
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 msgid "Title Slug"
-msgstr ""
+msgstr "Titel-Slug"
 
 #: desk/src/components/Settings/NewTeamModal.vue:48
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:397
@@ -5904,15 +6110,15 @@ msgstr "Bis-Datum kann nicht vor Von-Datum liegen"
 #: desk/src/components/Settings/Holiday/HolidayView.vue:92
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:157
 msgid "To date"
-msgstr ""
+msgstr "Bis-Datum"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:366
 msgid "To is required"
-msgstr ""
+msgstr "„An“ ist erforderlich"
 
 #: desk/src/components/Settings/EmailEdit.vue:268
 msgid "To know more about setting up email accounts, click"
-msgstr ""
+msgstr "Um mehr über die Einrichtung von E-Mail-Konten zu erfahren, klicken Sie"
 
 #: desk/src/pages/dashboard/Dashboard.vue:472
 #: desk/src/pages/dashboard/Dashboard.vue:474
@@ -5921,11 +6127,11 @@ msgstr "Heute"
 
 #: desk/src/components/layouts/Sidebar.vue:262
 msgid "Toggle theme"
-msgstr ""
+msgstr "Design umschalten"
 
 #: helpdesk/helpdesk/report/ticket_search_analysis/ticket_search_analysis.py:35
 msgid "Top Result"
-msgstr ""
+msgstr "Bestes Ergebnis"
 
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:98
 msgid "Total"
@@ -5943,23 +6149,23 @@ msgstr "Anzahl arbeitsfreier Tage"
 
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.py:126
 msgid "Total Ticket"
-msgstr ""
+msgstr "Tickets gesamt"
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
-msgstr ""
+msgstr "Gesamtzahl der erstellten Tickets"
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
-msgstr ""
+msgstr "Tickets gesamt nach Priorität"
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
-msgstr ""
+msgstr "Tickets gesamt nach Team"
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
-msgstr ""
+msgstr "Tickets gesamt nach Typ"
 
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
@@ -5972,7 +6178,7 @@ msgstr "Dienstag"
 #: desk/src/components/Settings/Telephony/Telephony.vue:72
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:4
 msgid "Twilio"
-msgstr ""
+msgstr "Twilio"
 
 #. Label of the type (Select) field in DocType 'HD Field Layout'
 #. Label of the notification_type (Select) field in DocType 'HD Notification'
@@ -5987,53 +6193,59 @@ msgstr "Typ"
 
 #: desk/src/pages/ticket/TicketCustomer.vue:69
 msgid "Type a message"
-msgstr ""
+msgstr "Nachricht eingeben"
+
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr "E-Mail-Adresse eingeben"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
-msgstr ""
+msgstr "Typ ist erforderlich"
 
 #. Label of the url_method (Data) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "URL/Method"
-msgstr ""
+msgstr "URL/Methode"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
-msgstr ""
+msgstr "E-Mail konnte nicht gesendet werden. Bitte richten Sie ein Standard-Ausgangs-E-Mail-Konto ein."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:199
 msgid "Unassignment Condition"
-msgstr ""
+msgstr "Rückweisungsbedingung"
 
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:16
 msgid "Unauthorized Access"
-msgstr ""
+msgstr "Unbefugter Zugriff"
 
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:16
 msgid "Unauthorized access."
-msgstr ""
+msgstr "Unbefugter Zugriff."
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 msgid "Unavailable"
-msgstr ""
+msgstr "Nicht verfügbar"
 
 #: desk/src/components/layouts/Sidebar.vue:587
 msgid "Understanding ticket view"
-msgstr ""
+msgstr "Ticketansicht verstehen"
 
 #: desk/src/pages/ticket/Tickets.vue:468
 msgid "Unpin View"
-msgstr ""
+msgstr "Ansicht loslösen"
 
 #: desk/src/pages/knowledge-base/Article.vue:21
 msgid "Unpublish"
 msgstr "Zurückziehen"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
-msgstr ""
+msgstr "Nicht gespeichert"
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:164
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:449
@@ -6048,11 +6260,15 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:214
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
-msgstr ""
+msgstr "Nicht gespeicherte Änderungen"
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
+msgstr "Nicht unterstützter DocType „{0}“ für Ticket-Statistiken."
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
 msgid "Untitled"
-msgstr ""
+msgstr "Unbenannt"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:12
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:47
@@ -6061,12 +6277,12 @@ msgstr "Aktualisieren"
 
 #: desk/src/components/Settings/EmailEdit.vue:142
 msgid "Update Account"
-msgstr ""
+msgstr "Konto aktualisieren"
 
 #. Label of the update_status_to (Link) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Update status to"
-msgstr ""
+msgstr "Status aktualisieren auf"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:41
 msgid "Upload"
@@ -6074,12 +6290,15 @@ msgstr "Hochladen"
 
 #: desk/src/components/Settings/Profile/Profile.vue:198
 msgid "Upload Photo"
-msgstr ""
+msgstr "Foto hochladen"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
-msgstr ""
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
+msgstr "Bild im PNG- oder JPG-Format hochladen"
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
+msgstr "Bild hochladen"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
 msgid "Uploading {0}%"
@@ -6088,17 +6307,13 @@ msgstr "Hochladen {0}%"
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6111,9 +6326,13 @@ msgstr "Benutzer"
 msgid "User Resolution Time"
 msgstr "Lösungszeit des Benutzers"
 
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
+msgstr "Benutzerbewertungen"
+
 #: desk/src/components/Settings/General/General.vue:42
 msgid "User Signup"
-msgstr ""
+msgstr "Benutzerregistrierung"
 
 #. Label of the users (Table MultiSelect) field in DocType 'HD Team'
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
@@ -6128,7 +6347,7 @@ msgstr "Benutzer"
 msgid "Valid From"
 msgstr "Gültig ab"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "Wert"
 
@@ -6141,7 +6360,7 @@ msgstr "Über das Kundenportal"
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:241
 msgid "View Assignment rule"
-msgstr ""
+msgstr "Zuweisungsregel anzeigen"
 
 #: desk/src/pages/ticket/Tickets.vue:652
 msgid "View {0}"
@@ -6161,7 +6380,7 @@ msgstr "Violett"
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:10
 msgid "Was this article Helpful?"
-msgstr ""
+msgstr "War dieser Artikel hilfreich?"
 
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
@@ -6186,18 +6405,18 @@ msgstr "Wöchentlich frei"
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "When enabled, the ticket status will automatically change to the status selected below whenever the agent responds to a ticket.\n"
-msgstr ""
+msgstr "Wenn aktiviert, ändert sich der Ticketstatus automatisch auf den unten ausgewählten Status, sobald der Agent auf ein Ticket antwortet.\n"
 
 #. Label of the word (Data) field in DocType 'HD Stopword'
 #. Label of the word (Data) field in DocType 'HD Synonyms'
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 #: helpdesk/helpdesk/doctype/hd_synonyms/hd_synonyms.json
 msgid "Word"
-msgstr ""
+msgstr "Wort"
 
 #: desk/src/components/Settings/Sla/SlaHolidays.vue:5
 msgid "Work Schedule and Holidays"
-msgstr ""
+msgstr "Arbeitszeitplan und Feiertage"
 
 #. Label of the workday (Select) field in DocType 'HD Service Day'
 #: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
@@ -6206,11 +6425,11 @@ msgstr "Werktag"
 
 #: desk/src/components/Settings/Sla/Modals/WorkDayModal.vue:274
 msgid "Workday added successfully."
-msgstr ""
+msgstr "Arbeitstag erfolgreich hinzugefügt."
 
 #: desk/src/components/Settings/Sla/Modals/WorkDayModal.vue:259
 msgid "Workday updated successfully."
-msgstr ""
+msgstr "Arbeitstag erfolgreich aktualisiert."
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:111
 msgid "Workday {0} has been repeated."
@@ -6223,7 +6442,7 @@ msgstr "Workflow"
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:4
 msgid "Workflow & Knowledge Base Settings"
-msgstr ""
+msgstr "Workflow- & Wissensbasis-Einstellungen"
 
 #. Label of the support_and_resolution_section_break (Section Break) field in
 #. DocType 'HD Service Level Agreement'
@@ -6236,15 +6455,15 @@ msgstr "Arbeitszeit"
 #: desk/src/pages/knowledge-base/Article.vue:172
 #: desk/src/pages/knowledge-base/NewArticle.vue:55
 msgid "Write your article here..."
-msgstr ""
+msgstr "Schreiben Sie hier Ihren Artikel..."
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:31
 msgid "Write your email signature here."
-msgstr ""
+msgstr "Schreiben Sie hier Ihre E-Mail-Signatur."
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:13
 msgid "Write your reply..."
-msgstr ""
+msgstr "Schreiben Sie Ihre Antwort..."
 
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:37
 msgid "Yearly"
@@ -6257,73 +6476,93 @@ msgstr "Jährlich"
 msgid "Yellow"
 msgstr "Gelb"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr "Sie dürfen die Statistiken eines anderen Agenten nicht einsehen."
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
-msgstr ""
+msgstr "Sie sind nicht berechtigt, diese Dashboard-Daten anzuzeigen."
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr "Sie sind nicht berechtigt, auf diese Ressource zuzugreifen."
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
-msgstr ""
+msgstr "Sie sind nicht berechtigt, einen Kommentar hinzuzufügen"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
-msgstr ""
+msgstr "Sie sind nicht berechtigt, als Agent zu antworten"
 
 #: desk/src/App.vue:41
 msgid "You are now offline."
-msgstr ""
+msgstr "Sie sind jetzt offline."
 
 #: desk/src/App.vue:34
 msgid "You are now online."
-msgstr ""
+msgstr "Sie sind jetzt online."
 
 #: desk/src/components/telephony/CallUI.vue:33
 msgid "You can change the default calling medium from the settings"
-msgstr ""
+msgstr "Sie können das Standard-Telefoniemedium in den Einstellungen ändern"
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:138
 msgid "You cannot disable the default SLA."
-msgstr ""
+msgstr "Sie können die Standard-SLA nicht deaktivieren."
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:41
 msgid "You cannot set more than one Default Priority."
-msgstr ""
+msgstr "Sie können nicht mehr als eine Standardpriorität festlegen."
 
 #: helpdesk/api/assignment_rule.py:8
 msgid "You do not have permission to access Assignment Rules"
-msgstr ""
+msgstr "Sie haben keine Berechtigung, auf Zuweisungsregeln zuzugreifen"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr "Sie haben keine Berechtigung, auf diese Ressource zuzugreifen"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr "Sie sind nicht berechtigt, Kontakte zu aktualisieren"
 
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
-msgstr ""
+msgstr "Sie haben keinen Zugriff auf dieses Ticket, oder es existiert nicht mehr."
 
 #: desk/src/pages/InvalidPage.vue:15
 msgid "You don't have permission to view this page, or it no longer exists."
-msgstr ""
+msgstr "Sie haben keine Berechtigung, diese Seite anzuzeigen, oder sie existiert nicht mehr."
 
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:29
 msgid "You have already provided feedback for this ticket."
-msgstr ""
+msgstr "Sie haben für dieses Ticket bereits eine Rückmeldung abgegeben."
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:132
 msgid "You must set one SLA as Default. Please check the Default SLA option."
-msgstr ""
+msgstr "Sie müssen eine SLA als Standard festlegen. Bitte prüfen Sie die Option „Standard-SLA“."
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:394
 msgid "Your old conditions will be overwritten. Are you sure you want to save?"
-msgstr ""
+msgstr "Ihre alten Bedingungen werden überschrieben. Möchten Sie wirklich speichern?"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
-msgstr ""
+msgstr "Ihre Leistung ist"
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr "aktives Ticket"
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
+msgstr "aktive Tickets"
 
 #: desk/src/pages/MobileNotifications.vue:46
 msgid "assigned you a ticket"
-msgstr ""
+msgstr "hat Ihnen ein Ticket zugewiesen"
 
 #: desk/src/components/ticket-agent/AssignTo.vue:29
 msgid "assignees"
@@ -6335,11 +6574,11 @@ msgstr "durchschnittlich"
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:13
 msgid "back to email event list"
-msgstr ""
+msgstr "zurück zur E-Mail-Ereignisliste"
 
 #: desk/src/components/HistoryBox.vue:12
 msgid "changes from"
-msgstr ""
+msgstr "Änderungen von"
 
 #: desk/src/pages/ticket/Tickets.vue:651
 msgid "created"
@@ -6347,9 +6586,9 @@ msgstr "erstellt"
 
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:42
 msgid "customize {0}"
-msgstr ""
+msgstr "{0} anpassen"
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr "tage"
 
@@ -6359,7 +6598,7 @@ msgstr "gelöscht"
 
 #: desk/src/components/ticket/TicketSplitModal.vue:7
 msgid "emails/ comments"
-msgstr ""
+msgstr "E-Mails/Kommentare"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:473
 msgid "excellent"
@@ -6367,40 +6606,40 @@ msgstr "ausgezeichnet"
 
 #: desk/src/components/ticket/TicketSplitModal.vue:8
 msgid "from this email onwards will be moved to new ticket."
-msgstr ""
+msgstr "wird ab dieser E-Mail in ein neues Ticket verschoben."
 
 #: desk/src/pages/home/components/RecentFeedback.vue:475
 msgid "good"
-msgstr ""
+msgstr "gut"
 
 #. Option for the 'Type' (Select) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "group_by"
-msgstr ""
+msgstr "gruppieren_nach"
 
 #: desk/src/components/CallArea.vue:16
 msgid "has made a call"
-msgstr ""
+msgstr "hat angerufen"
 
 #: desk/src/components/CallArea.vue:15
 msgid "has reached out"
-msgstr ""
+msgstr "hat sich gemeldet"
 
 #: desk/src/pages/MobileNotifications.vue:49
 msgid "has reopened the ticket"
-msgstr ""
+msgstr "hat das Ticket wieder geöffnet"
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:78
 #: desk/src/components/Settings/General/components/TicketSettings.vue:237
 msgid "here"
-msgstr ""
+msgstr "hier"
 
 #: desk/src/components/Settings/FieldDependency/FieldDependencyList.vue:21
 #: desk/src/components/Settings/Sla/SlaPolicies.vue:19
 msgid "here."
-msgstr ""
+msgstr "hier."
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr "std"
 
@@ -6408,7 +6647,7 @@ msgstr "std"
 msgid "in"
 msgstr "in"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "gerade eben"
 
@@ -6424,15 +6663,15 @@ msgstr "Liste"
 
 #: desk/src/pages/MobileNotifications.vue:43
 msgid "mentioned you in ticket"
-msgstr ""
+msgstr "hat Sie im Ticket erwähnt"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:479
 msgid "poor"
-msgstr ""
+msgstr "schlecht"
 
 #: desk/src/pages/knowledge-base/Article.vue:197
 msgid "published by"
-msgstr ""
+msgstr "veröffentlicht von"
 
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
@@ -6441,14 +6680,18 @@ msgstr ""
 msgid "purple"
 msgstr "lila"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr "bewertungen"
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
-msgstr ""
+msgstr "sterne"
 
 #. Label of the synonym (Data) field in DocType 'HD Synonym'
 #: helpdesk/helpdesk/doctype/hd_synonym/hd_synonym.json
 msgid "synonym"
-msgstr ""
+msgstr "synonym"
 
 #: desk/src/pages/home/components/PendingTickets.vue:158
 msgid "ticket"
@@ -6456,53 +6699,72 @@ msgstr "ticket"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:68
 msgid "to enable this integration."
-msgstr ""
+msgstr "um diese Integration zu aktivieren."
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
-msgstr ""
+msgstr "hat dies angesehen"
 
 #: desk/src/pages/knowledge-base/Article.vue:85
 msgid "views"
 msgstr "ansichten"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
-msgid "{0} is currently away."
-msgstr ""
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr "{0} Kunden"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr "{0} wurde bereits hinzugefügt"
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr "{0} ist keine gültige E-Mail-Adresse"
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
+msgid "{0} is currently away."
+msgstr "{0} ist derzeit abwesend."
+
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
-msgstr ""
+msgstr "{0} ist derzeit nicht verfügbar."
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr "{0} ist kein bestehender Kontakt"
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
+msgstr "{0} ist kein bestehender Benutzer"
 
 #: desk/src/components/ListViewBuilder.vue:307
 msgid "{0} item(s) deleted successfully"
-msgstr ""
+msgstr "{0} Element(e) erfolgreich gelöscht"
 
 #: desk/src/components/ListViewBuilder.vue:321
 msgid "{0} item(s) queued for deletion"
-msgstr ""
+msgstr "{0} Element(e) zum Löschen vorgemerkt"
 
 #: desk/src/pages/SearchAgent.vue:117
 msgid "{0} matches"
-msgstr ""
+msgstr "{0} Treffer"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:46
 msgid "{0} reviews"
-msgstr ""
+msgstr "{0} Bewertungen"
 
 #: desk/src/pages/ticket/Tickets.vue:510
 msgid "{0} view is currently public. Changing it to private will hide it for all the users."
-msgstr ""
+msgstr "Die Ansicht {0} ist derzeit öffentlich. Wenn Sie sie auf privat setzen, wird sie für alle Benutzer ausgeblendet."
 
 #: desk/src/pages/ticket/Tickets.vue:490
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
-msgstr ""
+msgstr "Die Ansicht {0} ist derzeit in der Seitenleiste sichtbar. Wenn Sie sie ausblenden, wird sie aus der Seitenleiste entfernt."
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
-msgstr ""
+msgstr "{0} · Zuletzt aktiv {1}"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.py:156
 msgid "{} people reacted to your comment"
-msgstr ""
-
+msgstr "{} Personen haben auf Ihren Kommentar reagiert"

--- a/helpdesk/locale/eo.po
+++ b/helpdesk/locale/eo.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-15 18:51\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-29 21:58\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Esperanto\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr "crwdns200630:0crwdne200630:0"
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr "crwdns160518:0crwdne160518:0"
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr "crwdns160520:0crwdne160520:0"
@@ -108,14 +108,6 @@ msgstr "crwdns195210:0crwdne195210:0"
 msgid "A workday with this name already exists"
 msgstr "crwdns199660:0crwdne199660:0"
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr "crwdns157510:0crwdne157510:0"
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr "crwdns161534:0crwdne161534:0"
@@ -132,7 +124,7 @@ msgstr "crwdns161536:0crwdne161536:0"
 msgid "Account"
 msgstr "crwdns200654:0crwdne200654:0"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr "crwdns200656:0crwdne200656:0"
 
@@ -152,11 +144,9 @@ msgstr "crwdns157514:0crwdne157514:0"
 msgid "Action Required"
 msgstr "crwdns157516:0crwdne157516:0"
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr "crwdns157518:0crwdne157518:0"
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "crwdns205123:0crwdne205123:0"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr "crwdns157518:0crwdne157518:0"
 msgid "Active"
 msgstr "crwdns161540:0crwdne161540:0"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr "crwdns203757:0crwdne203757:0"
 
@@ -175,7 +165,7 @@ msgid "Active: The agent is available and working.<br>\n"
 "Unavailable: The agent is off and unavailable."
 msgstr "crwdns203759:0crwdne203759:0"
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "crwdns195212:0crwdne195212:0"
@@ -193,10 +183,11 @@ msgid "Add Column"
 msgstr "crwdns203761:0crwdne203761:0"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr "crwdns200658:0crwdne200658:0"
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "crwdns203763:0crwdne203763:0"
 
@@ -207,6 +198,10 @@ msgstr "crwdns161542:0crwdne161542:0"
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
 msgstr "crwdns195214:0crwdne195214:0"
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
+msgstr "crwdns205125:0crwdne205125:0"
 
 #: desk/src/components/view-controls/SortBy.vue:148
 msgid "Add Sort"
@@ -244,7 +239,7 @@ msgstr "crwdns158422:0crwdne158422:0"
 msgid "Add condition group"
 msgstr "crwdns161544:0crwdne161544:0"
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "crwdns203767:0crwdne203767:0"
 
@@ -278,6 +273,12 @@ msgstr "crwdns199666:0crwdne199666:0"
 msgid "Add to Holidays"
 msgstr "crwdns157522:0crwdne157522:0"
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr "crwdns205127:0crwdne205127:0"
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr "crwdns157524:0crwdne157524:0"
@@ -295,17 +296,14 @@ msgid "Administrator"
 msgstr "crwdns157528:0crwdne157528:0"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -316,6 +314,7 @@ msgstr "crwdns157528:0crwdne157528:0"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -335,6 +334,7 @@ msgstr "crwdns199668:0crwdne199668:0"
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -342,6 +342,7 @@ msgstr "crwdns199668:0crwdne199668:0"
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -376,18 +377,9 @@ msgstr "crwdns195222:0crwdne195222:0"
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "crwdns157540:0crwdne157540:0"
 
@@ -508,6 +500,14 @@ msgstr "crwdns195232:0crwdne195232:0"
 msgid "Are you sure you want to delete these articles?"
 msgstr "crwdns195234:0crwdne195234:0"
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr "crwdns205129:0crwdne205129:0"
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr "crwdns205131:0crwdne205131:0"
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr "crwdns199680:0crwdne199680:0"
@@ -544,6 +544,10 @@ msgstr "crwdns161566:0crwdne161566:0"
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
 msgstr "crwdns161568:0crwdne161568:0"
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
+msgstr "crwdns205133:0crwdne205133:0"
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
 msgid "Are you sure you want to reset the content? Current content will be overridden."
@@ -595,16 +599,11 @@ msgstr "crwdns195260:0crwdne195260:0"
 msgid "Assign ticket"
 msgstr "crwdns195262:0crwdne195262:0"
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr "crwdns157556:0crwdne157556:0"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr "crwdns200632:0crwdne200632:0"
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -618,7 +617,7 @@ msgstr "crwdns200634:0crwdne200634:0"
 msgid "Assignee Rules"
 msgstr "crwdns158424:0crwdne158424:0"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr "crwdns199696:0crwdne199696:0"
 
@@ -626,7 +625,7 @@ msgstr "crwdns199696:0crwdne199696:0"
 msgid "Assignees"
 msgstr "crwdns158426:0crwdne158426:0"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr "crwdns200636:0crwdne200636:0"
 
@@ -692,10 +691,6 @@ msgstr "crwdns199706:0crwdne199706:0"
 msgid "Assignment rule {0} updated successfully."
 msgstr "crwdns199708:0{0}crwdne199708:0"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr "crwdns195264:0crwdne195264:0"
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -712,10 +707,6 @@ msgstr "crwdns160042:0{0}crwdne160042:0"
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
 msgstr "crwdns195266:0crwdne195266:0"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
-msgstr "crwdns157568:0crwdne157568:0"
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
@@ -766,7 +757,7 @@ msgid "Automation"
 msgstr "crwdns157582:0crwdne157582:0"
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr "crwdns203779:0crwdne203779:0"
@@ -802,7 +793,7 @@ msgstr "crwdns157584:0crwdne157584:0"
 msgid "Average Time Metrics"
 msgstr "crwdns199390:0crwdne199390:0"
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr "crwdns160522:0{0}crwdne160522:0"
 
@@ -810,25 +801,37 @@ msgstr "crwdns160522:0{0}crwdne160522:0"
 msgid "Average response and resolution metrics not available"
 msgstr "crwdns201731:0crwdne201731:0"
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr "crwdns160524:0{0}crwdne160524:0"
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr "crwdns160526:0crwdne160526:0"
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr "crwdns205135:0crwdne205135:0"
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr "crwdns160528:0crwdne160528:0"
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr "crwdns205137:0crwdne205137:0"
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr "crwdns160530:0crwdne160530:0"
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
-msgstr "crwdns160532:0crwdne160532:0"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr "crwdns205139:0crwdne205139:0"
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
+msgstr "crwdns205141:0crwdne205141:0"
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:290
@@ -840,11 +843,11 @@ msgstr "crwdns199394:0crwdne199394:0"
 msgid "Avg. resolution time"
 msgstr "crwdns199396:0crwdne199396:0"
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr "crwdns160534:0crwdne160534:0"
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr "crwdns160536:0crwdne160536:0"
 
@@ -867,11 +870,6 @@ msgstr "crwdns199710:0crwdne199710:0"
 msgid "Base Support Rotation"
 msgstr "crwdns157586:0crwdne157586:0"
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "crwdns157588:0crwdne157588:0"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -885,11 +883,11 @@ msgstr "crwdns157592:0crwdne157592:0"
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr "crwdns157594:0crwdne157594:0"
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr "crwdns200660:0crwdne200660:0"
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr "crwdns200662:0crwdne200662:0"
 
@@ -944,11 +942,6 @@ msgstr "crwdns161592:0crwdne161592:0"
 msgid "Busy"
 msgstr "crwdns195268:0crwdne195268:0"
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "crwdns157598:0crwdne157598:0"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr "crwdns195270:0crwdne195270:0"
@@ -973,19 +966,31 @@ msgstr "crwdns195276:0crwdne195276:0"
 msgid "Caller"
 msgstr "crwdns195278:0crwdne195278:0"
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr "crwdns195280:0crwdne195280:0"
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr "crwdns161594:0crwdne161594:0"
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr "crwdns161596:0crwdne161596:0"
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr "crwdns205143:0crwdne205143:0"
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr "crwdns205145:0crwdne205145:0"
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr "crwdns205147:0crwdne205147:0"
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr "crwdns161598:0crwdne161598:0"
 
@@ -1025,7 +1030,7 @@ msgstr "crwdns161602:0crwdne161602:0"
 msgid "Cannot merge General category"
 msgstr "crwdns157604:0crwdne157604:0"
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr "crwdns203199:0{0}crwdnd203199:0{1}crwdne203199:0"
 
@@ -1073,11 +1078,11 @@ msgstr "crwdns157608:0crwdne157608:0"
 msgid "Category updated successfully."
 msgstr "crwdns199718:0crwdne199718:0"
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr "crwdns200664:0crwdne200664:0"
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr "crwdns200666:0crwdne200666:0"
 
@@ -1085,7 +1090,7 @@ msgstr "crwdns200666:0crwdne200666:0"
 msgid "Change"
 msgstr "crwdns161604:0crwdne161604:0"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "crwdns161606:0crwdne161606:0"
@@ -1098,10 +1103,9 @@ msgstr "crwdns200668:0crwdne200668:0"
 msgid "Change language of the application."
 msgstr "crwdns161610:0crwdne161610:0"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
-msgstr "crwdns195294:0crwdne195294:0"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
+msgstr "crwdns204727:0{0}crwdne204727:0"
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
 msgid "Change priority"
@@ -1123,7 +1127,7 @@ msgstr "crwdns195302:0crwdne195302:0"
 msgid "Change timezone of the application."
 msgstr "crwdns197088:0crwdne197088:0"
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr "crwdns161612:0crwdne161612:0"
 
@@ -1136,7 +1140,7 @@ msgstr "crwdns157610:0crwdne157610:0"
 msgid "Child field"
 msgstr "crwdns199720:0crwdne199720:0"
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr "crwdns203789:0crwdne203789:0"
 
@@ -1189,7 +1193,7 @@ msgstr "crwdns203791:0crwdne203791:0"
 msgid "Clear Table"
 msgstr "crwdns157612:0crwdne157612:0"
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr "crwdns203793:0crwdne203793:0"
 
@@ -1204,6 +1208,10 @@ msgstr "crwdns195306:0crwdne195306:0"
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
 msgstr "crwdns157614:0crwdne157614:0"
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
+msgstr "crwdns205149:0crwdne205149:0"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:47
@@ -1223,7 +1231,7 @@ msgstr "crwdns195308:0crwdne195308:0"
 msgid "Closed"
 msgstr "crwdns160186:0crwdne160186:0"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr "crwdns157618:0crwdne157618:0"
 
@@ -1250,7 +1258,7 @@ msgstr "crwdns157622:0crwdne157622:0"
 msgid "Comma separated emails to invite."
 msgstr "crwdns199724:0crwdne199724:0"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr "crwdns203797:0crwdne203797:0"
 
@@ -1283,7 +1291,7 @@ msgstr "crwdns157626:0crwdne157626:0"
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "crwdns195314:0crwdne195314:0"
@@ -1296,6 +1304,11 @@ msgstr "crwdns195316:0crwdne195316:0"
 msgid "Communication ID is required"
 msgstr "crwdns199732:0crwdne199732:0"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
+msgstr "crwdns205151:0crwdne205151:0"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
 msgstr "crwdns195318:0crwdne195318:0"
@@ -1307,7 +1320,7 @@ msgstr "crwdns195318:0crwdne195318:0"
 msgid "Condition"
 msgstr "crwdns157628:0crwdne157628:0"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr "crwdns200670:0crwdne200670:0"
 
@@ -1331,6 +1344,10 @@ msgstr "crwdns199740:0crwdne199740:0"
 msgid "Configure your telephony settings."
 msgstr "crwdns161628:0crwdne161628:0"
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1356,10 +1373,11 @@ msgstr "crwdns161634:0crwdne161634:0"
 msgid "Connect your support email"
 msgstr "crwdns195320:0crwdne195320:0"
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1373,26 +1391,30 @@ msgstr "crwdns157630:0crwdne157630:0"
 msgid "Contact HTML"
 msgstr "crwdns157632:0crwdne157632:0"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
-msgstr "crwdns199744:0crwdne199744:0"
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
-msgstr "crwdns199746:0crwdne199746:0"
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
+msgstr "crwdns205153:0crwdne205153:0"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr "crwdns199748:0crwdne199748:0"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
-msgstr "crwdns195328:0crwdne195328:0"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
+msgstr "crwdns205155:0{0}crwdne205155:0"
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
 msgstr "crwdns157636:0crwdne157636:0"
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
+msgstr "crwdns205157:0crwdne205157:0"
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
 #. Label of the content (Text Editor) field in DocType 'HD Article'
@@ -1415,7 +1437,7 @@ msgstr "crwdns195330:0crwdne195330:0"
 msgid "Copy ticket id"
 msgstr "crwdns195332:0crwdne195332:0"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr "crwdns159052:0{0}crwdne159052:0"
 
@@ -1423,7 +1445,11 @@ msgstr "crwdns159052:0{0}crwdne159052:0"
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr "crwdns201813:0crwdne201813:0"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr "crwdns205159:0{0}crwdnd205159:0{1}crwdne205159:0"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr "crwdns159054:0{0}crwdne159054:0"
 
@@ -1431,11 +1457,20 @@ msgstr "crwdns159054:0{0}crwdne159054:0"
 msgid "Could not send feedback email,due to: {0}"
 msgstr "crwdns157642:0{0}crwdne157642:0"
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "crwdns205161:0crwdne205161:0"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1446,9 +1481,13 @@ msgstr "crwdns161636:0crwdne161636:0"
 msgid "Create & invite a contact"
 msgstr "crwdns195334:0crwdne195334:0"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
-msgstr "crwdns195336:0crwdne195336:0"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr "crwdns205163:0crwdne205163:0"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
+msgstr "crwdns205165:0crwdne205165:0"
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
 msgid "Create View"
@@ -1482,12 +1521,6 @@ msgstr "crwdns199752:0crwdne199752:0"
 msgid "Creating a ticket"
 msgstr "crwdns203799:0crwdne203799:0"
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr "crwdns157644:0crwdne157644:0"
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr "crwdns203801:0crwdne203801:0"
@@ -1512,12 +1545,21 @@ msgid "Custom Views"
 msgstr "crwdns203803:0crwdne203803:0"
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
 msgstr "crwdns157646:0crwdne157646:0"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
+msgstr "crwdns205167:0crwdne205167:0"
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1528,17 +1570,33 @@ msgstr "crwdns157648:0crwdne157648:0"
 msgid "Customer Portal"
 msgstr "crwdns203805:0crwdne203805:0"
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
-msgstr "crwdns199754:0crwdne199754:0"
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr "crwdns205169:0crwdne205169:0"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr "crwdns205171:0crwdne205171:0"
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
+msgstr "crwdns205173:0crwdne205173:0"
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr "crwdns195348:0crwdne195348:0"
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
-msgstr "crwdns199756:0crwdne199756:0"
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
+msgstr "crwdns205175:0crwdne205175:0"
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
+msgstr "crwdns205177:0crwdne205177:0"
 
 #: desk/src/components/layouts/Sidebar.vue:595
 msgid "Customers & Contacts"
@@ -1565,6 +1623,8 @@ msgstr "crwdns159058:0crwdne159058:0"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "crwdns195350:0crwdne195350:0"
@@ -1665,18 +1725,26 @@ msgstr "crwdns157662:0crwdne157662:0"
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr "crwdns158452:0crwdne158452:0"
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "crwdns161654:0crwdne161654:0"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr "crwdns205179:0crwdne205179:0"
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1693,6 +1761,10 @@ msgstr "crwdns195364:0crwdne195364:0"
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
 msgstr "crwdns199764:0{0}crwdne199764:0"
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
+msgstr "crwdns205181:0{0}crwdne205181:0"
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
 #. Label of the description (Text Editor) field in DocType 'HD Holiday'
@@ -1740,7 +1812,7 @@ msgstr "crwdns195368:0crwdne195368:0"
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1826,7 +1898,12 @@ msgstr "crwdns195382:0crwdne195382:0"
 msgid "Document Type"
 msgstr "crwdns199402:0crwdne199402:0"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr "crwdns205183:0crwdne205183:0"
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "crwdns157678:0crwdne157678:0"
@@ -1868,6 +1945,10 @@ msgstr "crwdns161666:0crwdne161666:0"
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
 msgstr "crwdns195386:0crwdne195386:0"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
+msgstr "crwdns205185:0crwdne205185:0"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
 #: desk/src/pages/call-logs/CallLogModal.vue:68
@@ -1917,7 +1998,8 @@ msgstr "crwdns203817:0crwdne203817:0"
 msgid "Easily invite new agents, managers, or admins."
 msgstr "crwdns161668:0crwdne161668:0"
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1926,6 +2008,14 @@ msgstr "crwdns195392:0crwdne195392:0"
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
 msgstr "crwdns195394:0crwdne195394:0"
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr "crwdns205187:0crwdne205187:0"
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
+msgstr "crwdns205189:0crwdne205189:0"
 
 #: desk/src/components/Settings/EmailAdd.vue:70
 #: desk/src/components/Settings/EmailEdit.vue:63
@@ -1944,10 +2034,10 @@ msgstr "crwdns195396:0crwdne195396:0"
 msgid "Edit your email account"
 msgstr "crwdns161672:0crwdne161672:0"
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "crwdns157682:0crwdne157682:0"
 
@@ -1975,9 +2065,10 @@ msgstr "crwdns161676:0crwdne161676:0"
 msgid "Email Content"
 msgstr "crwdns159064:0crwdne159064:0"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
-msgstr "crwdns195398:0crwdne195398:0"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
+msgstr "crwdns205191:0crwdne205191:0"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
 #. Settings'
@@ -2002,22 +2093,22 @@ msgstr "crwdns199766:0crwdne199766:0"
 msgid "Email account updated successfully"
 msgstr "crwdns161680:0crwdne161680:0"
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr "crwdns205193:0crwdne205193:0"
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr "crwdns200674:0crwdne200674:0"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr "crwdns195400:0crwdne195400:0"
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "crwdns195402:0crwdne195402:0"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr "crwdns200676:0crwdne200676:0"
 
@@ -2055,8 +2146,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr "crwdns157686:0crwdne157686:0"
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2081,8 +2170,6 @@ msgstr "crwdns157686:0crwdne157686:0"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2105,21 +2192,25 @@ msgstr "crwdns157694:0crwdne157694:0"
 msgid "Enter a name for this HD Service Holiday List."
 msgstr "crwdns157696:0crwdne157696:0"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr "crwdns195408:0crwdne195408:0"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr "crwdns195410:0crwdne195410:0"
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr "crwdns161686:0crwdne161686:0"
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr "crwdns205195:0crwdne205195:0"
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
 msgstr "crwdns161688:0crwdne161688:0"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr "crwdns205197:0crwdne205197:0"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
+msgstr "crwdns205199:0crwdne205199:0"
 
 #: helpdesk/api/knowledge_base.py:86
 msgid "Error moving article to category"
@@ -2129,22 +2220,18 @@ msgstr "crwdns157698:0crwdne157698:0"
 msgid "Error processing email at index {0}, message: {1}"
 msgstr "crwdns160636:0{0}crwdnd160636:0{1}crwdne160636:0"
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr "crwdns199768:0crwdne199768:0"
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "crwdns157700:0{0}crwdne157700:0"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr "crwdns157702:0crwdne157702:0"
 
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
 msgstr "crwdns195412:0crwdne195412:0"
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
+msgstr "crwdns205201:0crwdne205201:0"
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
 #: desk/src/components/Settings/Telephony/Telephony.vue:96
@@ -2172,11 +2259,6 @@ msgstr "crwdns195420:0{0}crwdne195420:0"
 msgid "Export Type"
 msgstr "crwdns195422:0crwdne195422:0"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr "crwdns157704:0crwdne157704:0"
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2184,6 +2266,10 @@ msgstr "crwdns157704:0crwdne157704:0"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "crwdns157706:0crwdne157706:0"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr "crwdns205203:0crwdne205203:0"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2218,11 +2304,11 @@ msgstr "crwdns161696:0crwdne161696:0"
 msgid "Failed to save Twilio settings"
 msgstr "crwdns161698:0crwdne161698:0"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr "crwdns199776:0crwdne199776:0"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr "crwdns200638:0crwdne200638:0"
 
@@ -2251,6 +2337,7 @@ msgstr "crwdns161702:0crwdne161702:0"
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2288,13 +2375,17 @@ msgstr "crwdns157716:0crwdne157716:0"
 msgid "Feedback Rating"
 msgstr "crwdns157718:0crwdne157718:0"
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr "crwdns160538:0crwdne160538:0"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
 msgstr "crwdns157720:0crwdne157720:0"
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
+msgstr "crwdns205205:0crwdne205205:0"
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
 msgid "Feedback submitted successfully."
@@ -2338,13 +2429,14 @@ msgid "Field dependency updated successfully."
 msgstr "crwdns161712:0crwdne161712:0"
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "crwdns157728:0crwdne157728:0"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "crwdns157730:0crwdne157730:0"
@@ -2354,7 +2446,8 @@ msgstr "crwdns157730:0crwdne157730:0"
 msgid "Find out all of the variables that can be used in the content"
 msgstr "crwdns159068:0crwdne159068:0"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "crwdns161714:0crwdne161714:0"
 
@@ -2362,6 +2455,10 @@ msgstr "crwdns161714:0crwdne161714:0"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
 msgstr "crwdns157732:0crwdne157732:0"
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
+msgstr "crwdns205207:0crwdne205207:0"
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -2386,10 +2483,6 @@ msgstr "crwdns157736:0crwdne157736:0"
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
 msgstr "crwdns157738:0crwdne157738:0"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
-msgstr "crwdns195424:0crwdne195424:0"
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
@@ -2480,6 +2573,10 @@ msgstr "crwdns195428:0crwdne195428:0"
 msgid "Go to Ticket #{0}"
 msgstr "crwdns195430:0#{0}crwdne195430:0"
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr "crwdns205209:0crwdne205209:0"
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2509,8 +2606,6 @@ msgid "Group By Field"
 msgstr "crwdns157758:0crwdne157758:0"
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr "crwdns157760:0crwdne157760:0"
@@ -2518,11 +2613,6 @@ msgstr "crwdns157760:0crwdne157760:0"
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
 msgstr "crwdns161720:0crwdne161720:0"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
-msgstr "crwdns157762:0crwdne157762:0"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -2554,25 +2644,37 @@ msgstr "crwdns157770:0crwdne157770:0"
 msgid "HD Comment Reaction"
 msgstr "crwdns195432:0crwdne195432:0"
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr "crwdns157774:0crwdne157774:0"
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr "crwdns205211:0crwdne205211:0"
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
-msgstr "crwdns157776:0crwdne157776:0"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
+msgstr "crwdns205213:0crwdne205213:0"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
 msgstr "crwdns157778:0crwdne157778:0"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
-msgstr "crwdns157780:0crwdne157780:0"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -2593,21 +2695,6 @@ msgstr "crwdns157784:0crwdne157784:0"
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
 msgstr "crwdns157786:0crwdne157786:0"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr "crwdns157788:0crwdne157788:0"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr "crwdns157790:0crwdne157790:0"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
-msgstr "crwdns157794:0crwdne157794:0"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -2649,11 +2736,6 @@ msgstr "crwdns157806:0crwdne157806:0"
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
 msgstr "crwdns157808:0crwdne157808:0"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
-msgstr "crwdns157810:0crwdne157810:0"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_synonym/hd_synonym.json
@@ -2750,12 +2832,6 @@ msgstr "crwdns157840:0crwdne157840:0"
 msgid "Helpdesk"
 msgstr "crwdns157842:0crwdne157842:0"
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr "crwdns157844:0crwdne157844:0"
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2772,11 +2848,6 @@ msgstr "crwdns199408:0crwdne199408:0"
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
 msgstr "crwdns203835:0crwdne203835:0"
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr "crwdns157850:0crwdne157850:0"
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
@@ -2846,15 +2917,8 @@ msgstr "crwdns161730:0crwdne161730:0"
 msgid "ID"
 msgstr "crwdns199416:0crwdne199416:0"
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "crwdns157860:0crwdne157860:0"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2941,6 +3005,11 @@ msgstr "crwdns161734:0crwdne161734:0"
 msgid "Incoming"
 msgstr "crwdns195444:0crwdne195444:0"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr "crwdns205215:0crwdne205215:0"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr "crwdns195446:0crwdne195446:0"
@@ -2954,7 +3023,7 @@ msgstr "crwdns203837:0crwdne203837:0"
 msgid "Instantly send e-mail"
 msgstr "crwdns157878:0crwdne157878:0"
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "crwdns157880:0{0}crwdne157880:0"
 
@@ -2968,13 +3037,13 @@ msgstr "crwdns157882:0crwdne157882:0"
 msgid "Introduction"
 msgstr "crwdns203839:0crwdne203839:0"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr "crwdns203841:0crwdne203841:0"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
-msgstr "crwdns195448:0crwdne195448:0"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
+msgstr "crwdns205217:0crwdne205217:0"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
 #: desk/src/components/Settings/Holiday/HolidayView.vue:325
@@ -2982,23 +3051,43 @@ msgstr "crwdns195448:0crwdne195448:0"
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr "crwdns161736:0crwdne161736:0"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr "crwdns195450:0crwdne195450:0"
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr "crwdns159084:0crwdne159084:0"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
 msgstr "crwdns195452:0crwdne195452:0"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr "crwdns205219:0{0}crwdne205219:0"
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr "crwdns205221:0crwdne205221:0"
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr "crwdns205223:0crwdne205223:0"
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr "crwdns205225:0crwdne205225:0"
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
+msgstr "crwdns205227:0crwdne205227:0"
 
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
 msgstr "crwdns161738:0crwdne161738:0"
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
+msgstr "crwdns205229:0crwdne205229:0"
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
 msgid "Invite agent"
@@ -3008,13 +3097,30 @@ msgstr "crwdns158458:0crwdne158458:0"
 msgid "Invite agents"
 msgstr "crwdns195454:0crwdne195454:0"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
-msgstr "crwdns195456:0crwdne195456:0"
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
+msgstr "crwdns205231:0crwdne205231:0"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
 msgstr "crwdns161740:0crwdne161740:0"
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr "crwdns205233:0crwdne205233:0"
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr "crwdns205235:0crwdne205235:0"
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr "crwdns205237:0crwdne205237:0"
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
+msgstr "crwdns205239:0crwdne205239:0"
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -3030,6 +3136,11 @@ msgstr "crwdns157886:0crwdne157886:0"
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "crwdns157888:0crwdne157888:0"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr "crwdns205241:0crwdne205241:0"
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3058,6 +3169,10 @@ msgstr "crwdns157894:0crwdne157894:0"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
 msgstr "crwdns157896:0crwdne157896:0"
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
+msgstr "crwdns205243:0crwdne205243:0"
 
 #: desk/src/components/command-palette/CP.vue:114
 msgid "Jump to"
@@ -3093,11 +3208,9 @@ msgstr "crwdns195462:0crwdne195462:0"
 msgid "Knowledge Base"
 msgstr "crwdns157900:0crwdne157900:0"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3131,9 +3244,9 @@ msgstr "crwdns158460:0crwdne158460:0"
 msgid "Last 3 Months"
 msgstr "crwdns199422:0crwdne199422:0"
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr "crwdns199424:0crwdne199424:0"
 
@@ -3174,7 +3287,8 @@ msgstr "crwdns195474:0crwdne195474:0"
 msgid "Last Month"
 msgstr "crwdns199426:0crwdne199426:0"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "crwdns161746:0crwdne161746:0"
 
@@ -3183,24 +3297,33 @@ msgstr "crwdns161746:0crwdne161746:0"
 msgid "Last Week"
 msgstr "crwdns199428:0crwdne199428:0"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
 msgstr "crwdns199430:0crwdne199430:0"
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
+msgstr "crwdns205245:0crwdne205245:0"
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr "crwdns158462:0crwdne158462:0"
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
 msgstr "crwdns199432:0crwdne199432:0"
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
+msgstr "crwdns205247:0crwdne205247:0"
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -3217,26 +3340,6 @@ msgstr "crwdns158464:0crwdne158464:0"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
 msgstr "crwdns195476:0crwdne195476:0"
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "crwdns157904:0crwdne157904:0"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr "crwdns157906:0crwdne157906:0"
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr "crwdns195478:0crwdne195478:0"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
-msgstr "crwdns195480:0crwdne195480:0"
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #. Label of the list_tab (Tab Break) field in DocType 'HD View'
@@ -3264,6 +3367,8 @@ msgstr "crwdns157910:0crwdne157910:0"
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "crwdns161750:0crwdne161750:0"
 
@@ -3286,6 +3391,8 @@ msgstr "crwdns195488:0crwdne195488:0"
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr "crwdns157912:0crwdne157912:0"
@@ -3324,7 +3431,7 @@ msgstr "crwdns161754:0crwdne161754:0"
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr "crwdns195498:0crwdne195498:0"
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr "crwdns200678:0crwdne200678:0"
 
@@ -3343,6 +3450,10 @@ msgstr "crwdns203847:0crwdne203847:0"
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
 msgstr "crwdns161758:0crwdne161758:0"
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
+msgstr "crwdns205249:0crwdne205249:0"
 
 #: desk/src/pages/MobileNotifications.vue:11
 #: desk/src/pages/MobileNotifications.vue:14
@@ -3396,6 +3507,20 @@ msgstr "crwdns157924:0crwdne157924:0"
 msgid "Mobile App Installation"
 msgstr "crwdns203851:0crwdne203851:0"
 
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr "crwdns205251:0crwdne205251:0"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr "crwdns205253:0crwdne205253:0"
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr "crwdns205255:0crwdne205255:0"
+
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
 #. List'
@@ -3436,7 +3561,7 @@ msgid "My Tickets"
 msgstr "crwdns199438:0crwdne199438:0"
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3447,8 +3572,9 @@ msgstr "crwdns199438:0crwdne199438:0"
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3458,6 +3584,10 @@ msgstr "crwdns157930:0crwdne157930:0"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
 msgstr "crwdns157932:0crwdne157932:0"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
+msgstr "crwdns205257:0crwdne205257:0"
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
 #. Ticket Status'
@@ -3469,10 +3599,18 @@ msgstr "crwdns159088:0crwdne159088:0"
 msgid "Navigation"
 msgstr "crwdns195510:0crwdne195510:0"
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr "crwdns205259:0crwdne205259:0"
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr "crwdns199440:0crwdne199440:0"
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "crwdns205261:0crwdne205261:0"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3581,11 +3719,11 @@ msgstr "crwdns195532:0crwdne195532:0"
 msgid "No Data Found"
 msgstr "crwdns195534:0crwdne195534:0"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr "crwdns200682:0{0}crwdne200682:0"
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr "crwdns203859:0crwdne203859:0"
 
@@ -3597,9 +3735,15 @@ msgstr "crwdns161792:0crwdne161792:0"
 msgid "No SLA found"
 msgstr "crwdns161794:0crwdne161794:0"
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
 msgstr "crwdns160540:0crwdne160540:0"
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
+msgstr "crwdns205263:0crwdne205263:0"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
 msgid "No additional comments"
@@ -3633,19 +3777,27 @@ msgstr "crwdns199818:0crwdne199818:0"
 msgid "No changes made"
 msgstr "crwdns161800:0crwdne161800:0"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr "crwdns195542:0crwdne195542:0"
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr "crwdns199446:0crwdne199446:0"
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr "crwdns205265:0crwdne205265:0"
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr "crwdns199820:0crwdne199820:0"
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr "crwdns205267:0crwdne205267:0"
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr "crwdns205269:0crwdne205269:0"
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr "crwdns199822:0crwdne199822:0"
 
@@ -3657,7 +3809,11 @@ msgstr "crwdns203861:0crwdne203861:0"
 msgid "No feedback"
 msgstr "crwdns199448:0crwdne199448:0"
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr "crwdns205271:0crwdne205271:0"
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr "crwdns203863:0crwdne203863:0"
 
@@ -3697,19 +3853,25 @@ msgstr "crwdns199454:0crwdne199454:0"
 msgid "No recently assigned tickets"
 msgstr "crwdns199456:0crwdne199456:0"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr "crwdns203865:0crwdne203865:0"
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
 msgstr "crwdns158470:0crwdne158470:0"
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
+msgstr "crwdns205273:0crwdne205273:0"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:91
 msgid "No saved replies found"
 msgstr "crwdns199828:0crwdne199828:0"
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr "crwdns199830:0crwdne199830:0"
@@ -3730,7 +3892,11 @@ msgstr "crwdns195546:0crwdne195546:0"
 msgid "No tickets selected"
 msgstr "crwdns203217:0crwdne203217:0"
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr "crwdns205275:0{0}crwdne205275:0"
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "crwdns157934:0crwdne157934:0"
 
@@ -3742,7 +3908,7 @@ msgstr "crwdns199458:0crwdne199458:0"
 msgid "Not Saved"
 msgstr "crwdns195548:0crwdne195548:0"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "crwdns203867:0crwdne203867:0"
 
@@ -3781,11 +3947,6 @@ msgstr "crwdns161810:0crwdne161810:0"
 msgid "On Hold Since"
 msgstr "crwdns157940:0crwdne157940:0"
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr "crwdns157942:0crwdne157942:0"
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr "crwdns199836:0crwdne199836:0"
@@ -3816,6 +3977,10 @@ msgstr "crwdns195552:0crwdne195552:0"
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
 msgstr "crwdns195554:0crwdne195554:0"
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
+msgstr "crwdns205277:0crwdne205277:0"
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
 msgid "Open help"
@@ -3904,7 +4069,12 @@ msgstr "crwdns199842:0crwdne199842:0"
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr "crwdns157954:0crwdne157954:0"
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr "crwdns205279:0crwdne205279:0"
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "crwdns161812:0crwdne161812:0"
 
@@ -3942,6 +4112,7 @@ msgid "Pending"
 msgstr "crwdns199460:0crwdne199460:0"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr "crwdns161824:0crwdne161824:0"
 
@@ -3951,19 +4122,19 @@ msgstr "crwdns161824:0crwdne161824:0"
 msgid "Pending Tickets"
 msgstr "crwdns199462:0crwdne199462:0"
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr "crwdns199846:0crwdne199846:0"
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr "crwdns199848:0crwdne199848:0"
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr "crwdns199850:0crwdne199850:0"
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr "crwdns199852:0crwdne199852:0"
 
@@ -3984,14 +4155,15 @@ msgstr "crwdns195572:0crwdne195572:0"
 msgid "Personal mobile no"
 msgstr "crwdns161826:0crwdne161826:0"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "crwdns195574:0crwdne195574:0"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
-msgstr "crwdns195576:0crwdne195576:0"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
+msgstr "crwdns205281:0crwdne205281:0"
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
 msgid "Pick an option"
@@ -4047,7 +4219,7 @@ msgstr "crwdns195582:0crwdne195582:0"
 msgid "Please enter a valid phone number"
 msgstr "crwdns195584:0crwdne195584:0"
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr "crwdns201817:0crwdne201817:0"
 
@@ -4090,34 +4262,15 @@ msgstr "crwdns157966:0crwdne157966:0"
 msgid "Policy name"
 msgstr "crwdns199860:0crwdne199860:0"
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr "crwdns205283:0crwdne205283:0"
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
 msgstr "crwdns199464:0crwdne199464:0"
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr "crwdns157968:0crwdne157968:0"
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr "crwdns157970:0crwdne157970:0"
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr "crwdns157972:0crwdne157972:0"
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
-msgstr "crwdns157974:0crwdne157974:0"
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:10
@@ -4151,14 +4304,32 @@ msgstr "crwdns195594:0crwdne195594:0"
 msgid "Previous ticket"
 msgstr "crwdns195596:0crwdne195596:0"
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "crwdns205285:0crwdne205285:0"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "crwdns205287:0crwdne205287:0"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr "crwdns205289:0crwdne205289:0"
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr "crwdns205291:0crwdne205291:0"
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr "crwdns157978:0crwdne157978:0"
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4166,9 +4337,10 @@ msgstr "crwdns157978:0crwdne157978:0"
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4248,17 +4420,6 @@ msgstr "crwdns161848:0crwdne161848:0"
 msgid "Quarterly"
 msgstr "crwdns157992:0crwdne157992:0"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "crwdns157994:0crwdne157994:0"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr "crwdns157996:0crwdne157996:0"
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "crwdns195606:0crwdne195606:0"
@@ -4281,14 +4442,14 @@ msgstr "crwdns160190:0crwdne160190:0"
 msgid "Rate this ticket"
 msgstr "crwdns195608:0crwdne195608:0"
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr "crwdns160550:0crwdne160550:0"
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4384,8 +4545,15 @@ msgstr "crwdns158020:0crwdne158020:0"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "crwdns161854:0crwdne161854:0"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr "crwdns205293:0crwdne205293:0"
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4395,10 +4563,19 @@ msgstr "crwdns161856:0crwdne161856:0"
 msgid "Remove Photo"
 msgstr "crwdns200686:0crwdne200686:0"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
-msgstr "crwdns195612:0crwdne195612:0"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr "crwdns204729:0crwdne204729:0"
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr "crwdns205295:0crwdne205295:0"
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
+msgstr "crwdns205297:0crwdne205297:0"
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
 #: desk/src/components/Settings/Teams/TeamsList.vue:161
@@ -4418,6 +4595,15 @@ msgstr "crwdns199868:0crwdne199868:0"
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
 msgstr "crwdns161862:0crwdne161862:0"
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr "crwdns204731:0crwdne204731:0"
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
+msgstr "crwdns205299:0crwdne205299:0"
 
 #. Option in a Select field in the tickets Web Form
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
@@ -4456,17 +4642,14 @@ msgstr "crwdns161866:0crwdne161866:0"
 msgid "Reply on a ticket"
 msgstr "crwdns195614:0crwdne195614:0"
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr "crwdns158024:0crwdne158024:0"
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
 msgstr "crwdns158026:0crwdne158026:0"
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
+msgstr "crwdns205301:0crwdne205301:0"
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
 msgid "Reset"
@@ -4486,6 +4669,7 @@ msgid "Reset to Default"
 msgstr "crwdns203879:0crwdne203879:0"
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr "crwdns158028:0crwdne158028:0"
@@ -4539,18 +4723,6 @@ msgstr "crwdns158042:0crwdne158042:0"
 msgid "Response By"
 msgstr "crwdns158044:0crwdne158044:0"
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr "crwdns158046:0crwdne158046:0"
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr "crwdns158048:0crwdne158048:0"
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr "crwdns158050:0{0}crwdnd158050:0{1}crwdne158050:0"
@@ -4593,37 +4765,33 @@ msgstr "crwdns161876:0crwdne161876:0"
 msgid "Restrict visibility to these teams"
 msgstr "crwdns195618:0crwdne195618:0"
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr "crwdns158058:0crwdne158058:0"
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr "crwdns158060:0crwdne158060:0"
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr "crwdns158062:0crwdne158062:0"
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
 msgstr "crwdns199474:0crwdne199474:0"
 
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr "crwdns205303:0crwdne205303:0"
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
+msgstr "crwdns205305:0crwdne205305:0"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:215
 msgid "Ringing"
 msgstr "crwdns195620:0crwdne195620:0"
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "crwdns161878:0crwdne161878:0"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr "crwdns205307:0crwdne205307:0"
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4722,9 +4890,9 @@ msgstr "crwdns158078:0crwdne158078:0"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4800,17 +4968,19 @@ msgstr "crwdns158084:0crwdne158084:0"
 msgid "Search Score"
 msgstr "crwdns158086:0crwdne158086:0"
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr "crwdns158088:0crwdne158088:0"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr "crwdns200646:0crwdne200646:0"
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr "crwdns205309:0crwdne205309:0"
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr "crwdns205311:0crwdne205311:0"
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "crwdns203883:0crwdne203883:0"
 
@@ -4850,6 +5020,7 @@ msgstr "crwdns203885:0crwdne203885:0"
 msgid "Searched for:"
 msgstr "crwdns195648:0crwdne195648:0"
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr "crwdns195650:0crwdne195650:0"
@@ -4869,6 +5040,10 @@ msgstr "crwdns195652:0crwdne195652:0"
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
 msgstr "crwdns195654:0crwdne195654:0"
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
+msgstr "crwdns205313:0crwdne205313:0"
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
 msgid "Select Range"
@@ -4890,6 +5065,10 @@ msgstr "crwdns158090:0crwdne158090:0"
 msgid "Select a rating"
 msgstr "crwdns195658:0crwdne195658:0"
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr "crwdns205315:0crwdne205315:0"
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4902,6 +5081,10 @@ msgstr "crwdns195660:0crwdne195660:0"
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
 msgstr "crwdns195662:0crwdne195662:0"
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
+msgstr "crwdns205317:0crwdne205317:0"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
 msgid "Select what type all tickets get by default."
@@ -4928,6 +5111,10 @@ msgstr "crwdns203219:0crwdne203219:0"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
 msgstr "crwdns158096:0crwdne158096:0"
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
+msgstr "crwdns205319:0crwdne205319:0"
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
 msgid "Send to {0} tickets"
@@ -4967,7 +5154,7 @@ msgstr "crwdns158098:0crwdne158098:0"
 msgid "Service not supported"
 msgstr "crwdns195812:0crwdne195812:0"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "crwdns203893:0crwdne203893:0"
 
@@ -4975,6 +5162,10 @@ msgstr "crwdns203893:0crwdne203893:0"
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
 msgstr "crwdns195666:0crwdne195666:0"
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
+msgstr "crwdns205321:0crwdne205321:0"
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
 msgid "Set Resolution Time for Priority {0} in row {1}."
@@ -4984,12 +5175,21 @@ msgstr "crwdns158100:0{0}crwdnd158100:0{1}crwdne158100:0"
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr "crwdns158102:0{0}crwdnd158102:0{1}crwdne158102:0"
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr "crwdns205323:0crwdne205323:0"
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr "crwdns161902:0crwdne161902:0"
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr "crwdns205325:0crwdne205325:0"
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr "crwdns203895:0crwdne203895:0"
 
@@ -5001,7 +5201,7 @@ msgstr "crwdns161904:0crwdne161904:0"
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr "crwdns199900:0crwdne199900:0"
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr "crwdns203897:0crwdne203897:0"
 
@@ -5135,23 +5335,6 @@ msgstr "crwdns195680:0crwdne195680:0"
 msgid "Sort"
 msgstr "crwdns203903:0crwdne203903:0"
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr "crwdns158114:0crwdne158114:0"
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "crwdns158116:0crwdne158116:0"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr "crwdns158118:0crwdne158118:0"
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr "crwdns158120:0crwdne158120:0"
@@ -5196,6 +5379,8 @@ msgstr "crwdns158134:0{0}crwdne158134:0"
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5262,6 +5447,7 @@ msgstr "crwdns159136:0crwdne159136:0"
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5373,21 +5559,16 @@ msgstr "crwdns158158:0crwdne158158:0"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5426,8 +5607,6 @@ msgstr "crwdns158166:0crwdne158166:0"
 msgid "Teal"
 msgstr "crwdns159138:0crwdne159138:0"
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5438,7 +5617,6 @@ msgstr "crwdns159138:0crwdne159138:0"
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5544,6 +5722,10 @@ msgstr "crwdns160642:0{0}crwdnd160642:0{1}crwdne160642:0"
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr "crwdns160644:0{0}crwdnd160644:0{1}crwdne160644:0"
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr "crwdns205327:0{0}crwdne205327:0"
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr "crwdns161940:0crwdne161940:0"
@@ -5555,6 +5737,10 @@ msgstr "crwdns158178:0{0}crwdne158178:0"
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
 msgstr "crwdns161942:0crwdne161942:0"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
+msgstr "crwdns205329:0{0}crwdnd205329:0{1}crwdne205329:0"
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
 msgid "The status for sending feedback must be of <u>Resolved</u> category."
@@ -5576,6 +5762,14 @@ msgstr "crwdns199916:0crwdne199916:0"
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr "crwdns201831:0crwdne201831:0"
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr "crwdns205331:0crwdne205331:0"
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr "crwdns205333:0crwdne205333:0"
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr "crwdns201833:0{0}crwdnd201833:0{1}crwdnd201833:0{2}crwdne201833:0"
@@ -5584,6 +5778,10 @@ msgstr "crwdns201833:0{0}crwdnd201833:0{1}crwdnd201833:0{2}crwdne201833:0"
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
 msgstr "crwdns199918:0crwdne199918:0"
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
+msgstr "crwdns205335:0crwdne205335:0"
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
 msgid "This date is calculated based on configured SLAs, working hours, and holidays."
@@ -5652,7 +5850,7 @@ msgstr "crwdns158192:0crwdne158192:0"
 msgid "Ticket"
 msgstr "crwdns158194:0crwdne158194:0"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr "crwdns195698:0#{0}crwdne195698:0"
 
@@ -5667,6 +5865,10 @@ msgstr "crwdns158196:0crwdne158196:0"
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
 msgstr "crwdns158198:0crwdne158198:0"
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
+msgstr "crwdns205337:0crwdne205337:0"
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
 msgid "Ticket Info"
@@ -5725,7 +5927,7 @@ msgstr "crwdns203921:0crwdne203921:0"
 msgid "Ticket Summary"
 msgstr "crwdns158208:0crwdne158208:0"
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr "crwdns160554:0crwdne160554:0"
 
@@ -5758,7 +5960,7 @@ msgstr "crwdns158212:0crwdne158212:0"
 msgid "Ticket merged successfully."
 msgstr "crwdns203923:0crwdne203923:0"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr "crwdns158214:0crwdne158214:0"
 
@@ -5793,12 +5995,6 @@ msgstr "crwdns161948:0crwdne161948:0"
 msgid "Ticket to merged with is required"
 msgstr "crwdns203925:0crwdne203925:0"
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr "crwdns158220:0crwdne158220:0"
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr "crwdns200648:0crwdne200648:0"
@@ -5810,12 +6006,15 @@ msgstr "crwdns158224:0crwdne158224:0"
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr "crwdns160556:0crwdne160556:0"
 
@@ -5827,19 +6026,19 @@ msgstr "crwdns199484:0crwdne199484:0"
 msgid "Tickets assigned to you in the last 7 days"
 msgstr "crwdns201739:0crwdne201739:0"
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr "crwdns160558:0crwdne160558:0"
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr "crwdns160560:0crwdne160560:0"
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr "crwdns160562:0crwdne160562:0"
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr "crwdns160564:0crwdne160564:0"
 
@@ -5856,6 +6055,7 @@ msgid "Tickets that are awaiting your response"
 msgstr "crwdns199488:0crwdne199488:0"
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr "crwdns197090:0crwdne197090:0"
 
@@ -5945,19 +6145,19 @@ msgstr "crwdns158244:0crwdne158244:0"
 msgid "Total Ticket"
 msgstr "crwdns158246:0crwdne158246:0"
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr "crwdns160572:0crwdne160572:0"
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr "crwdns199942:0crwdne199942:0"
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr "crwdns199944:0crwdne199944:0"
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr "crwdns199946:0crwdne199946:0"
 
@@ -5989,6 +6189,10 @@ msgstr "crwdns158250:0crwdne158250:0"
 msgid "Type a message"
 msgstr "crwdns195714:0crwdne195714:0"
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr "crwdns205339:0crwdne205339:0"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr "crwdns195716:0crwdne195716:0"
@@ -5998,7 +6202,7 @@ msgstr "crwdns195716:0crwdne195716:0"
 msgid "URL/Method"
 msgstr "crwdns158252:0crwdne158252:0"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr "crwdns195718:0crwdne195718:0"
 
@@ -6032,6 +6236,8 @@ msgid "Unpublish"
 msgstr "crwdns195722:0crwdne195722:0"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr "crwdns158480:0crwdne158480:0"
 
@@ -6049,6 +6255,10 @@ msgstr "crwdns158480:0crwdne158480:0"
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
 msgstr "crwdns159146:0crwdne159146:0"
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
+msgstr "crwdns205341:0{0}crwdne205341:0"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
 msgid "Untitled"
@@ -6076,10 +6286,13 @@ msgstr "crwdns161960:0crwdne161960:0"
 msgid "Upload Photo"
 msgstr "crwdns200698:0crwdne200698:0"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
-msgstr "crwdns195724:0crwdne195724:0"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
+msgstr "crwdns205343:0crwdne205343:0"
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
+msgstr "crwdns205345:0crwdne205345:0"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
 msgid "Uploading {0}%"
@@ -6088,17 +6301,13 @@ msgstr "crwdns161964:0{0}crwdne161964:0"
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6110,6 +6319,10 @@ msgstr "crwdns158258:0crwdne158258:0"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
 msgstr "crwdns158262:0crwdne158262:0"
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
+msgstr "crwdns205347:0crwdne205347:0"
 
 #: desk/src/components/Settings/General/General.vue:42
 msgid "User Signup"
@@ -6128,7 +6341,7 @@ msgstr "crwdns158264:0crwdne158264:0"
 msgid "Valid From"
 msgstr "crwdns158266:0crwdne158266:0"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "crwdns203931:0crwdne203931:0"
 
@@ -6257,19 +6470,23 @@ msgstr "crwdns158290:0crwdne158290:0"
 msgid "Yellow"
 msgstr "crwdns159154:0crwdne159154:0"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr "crwdns205349:0crwdne205349:0"
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr "crwdns158292:0crwdne158292:0"
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr "crwdns158294:0crwdne158294:0"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr "crwdns158296:0crwdne158296:0"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr "crwdns200650:0crwdne200650:0"
 
@@ -6297,6 +6514,14 @@ msgstr "crwdns158300:0crwdne158300:0"
 msgid "You do not have permission to access Assignment Rules"
 msgstr "crwdns195730:0crwdne195730:0"
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr "crwdns205351:0crwdne205351:0"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr "crwdns205353:0crwdne205353:0"
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr "crwdns199968:0crwdne199968:0"
@@ -6320,6 +6545,14 @@ msgstr "crwdns161980:0crwdne161980:0"
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
 msgstr "crwdns199492:0crwdne199492:0"
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr "crwdns205355:0crwdne205355:0"
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
+msgstr "crwdns205357:0crwdne205357:0"
 
 #: desk/src/pages/MobileNotifications.vue:46
 msgid "assigned you a ticket"
@@ -6349,7 +6582,7 @@ msgstr "crwdns195734:0crwdne195734:0"
 msgid "customize {0}"
 msgstr "crwdns159158:0{0}crwdne159158:0"
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr "crwdns160576:0crwdne160576:0"
 
@@ -6400,7 +6633,7 @@ msgstr "crwdns159160:0crwdne159160:0"
 msgid "here."
 msgstr "crwdns199976:0crwdne199976:0"
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr "crwdns160578:0crwdne160578:0"
 
@@ -6408,7 +6641,7 @@ msgstr "crwdns160578:0crwdne160578:0"
 msgid "in"
 msgstr "crwdns195740:0crwdne195740:0"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "crwdns203935:0crwdne203935:0"
 
@@ -6441,7 +6674,11 @@ msgstr "crwdns203937:0crwdne203937:0"
 msgid "purple"
 msgstr "crwdns159162:0crwdne159162:0"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr "crwdns205359:0crwdne205359:0"
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr "crwdns160586:0crwdne160586:0"
 
@@ -6458,7 +6695,7 @@ msgstr "crwdns201741:0crwdne201741:0"
 msgid "to enable this integration."
 msgstr "crwdns203939:0crwdne203939:0"
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr "crwdns195744:0crwdne195744:0"
 
@@ -6466,13 +6703,33 @@ msgstr "crwdns195744:0crwdne195744:0"
 msgid "views"
 msgstr "crwdns203941:0crwdne203941:0"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr "crwdns205361:0{0}crwdne205361:0"
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr "crwdns205363:0{0}crwdne205363:0"
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr "crwdns205365:0{0}crwdne205365:0"
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr "crwdns203943:0{0}crwdne203943:0"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
 msgstr "crwdns203945:0{0}crwdne203945:0"
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr "crwdns205367:0{0}crwdne205367:0"
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
+msgstr "crwdns205369:0{0}crwdne205369:0"
 
 #: desk/src/components/ListViewBuilder.vue:307
 msgid "{0} item(s) deleted successfully"
@@ -6498,7 +6755,7 @@ msgstr "crwdns199504:0{0}crwdne199504:0"
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr "crwdns199506:0{0}crwdne199506:0"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr "crwdns203947:0{0}crwdnd203947:0{1}crwdne203947:0"
 

--- a/helpdesk/locale/es.po
+++ b/helpdesk/locale/es.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-15 18:50\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-29 21:57\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Spanish\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr "% de ANS cumplido"
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr "% de tickets creados que se resolvieron dentro del SLA"
@@ -108,14 +108,6 @@ msgstr "Una breve descripción"
 msgid "A workday with this name already exists"
 msgstr ""
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr "API"
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr "Acceder a todos los tickets del equipo"
@@ -132,7 +124,7 @@ msgstr "Acceder solo a los tickets de este equipo"
 msgid "Account"
 msgstr "Cuenta"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr ""
 
@@ -152,11 +144,9 @@ msgstr "Acción"
 msgid "Action Required"
 msgstr "Acción requerida"
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr "Acción a realizar al hacer clic en el botón. El documento estará disponible como `this`"
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "Acciones"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr "Acción a realizar al hacer clic en el botón. El documento estará disp
 msgid "Active"
 msgstr "Activo"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr ""
 
@@ -175,7 +165,7 @@ msgid "Active: The agent is available and working.<br>\n"
 "Unavailable: The agent is off and unavailable."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "Actividad"
@@ -193,10 +183,11 @@ msgid "Add Column"
 msgstr "Añadir Columna"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "Añadir filtro..."
 
@@ -207,6 +198,10 @@ msgstr "Agregar día festivo"
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
 msgstr "Agregar nuevo artículo"
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
+msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:148
 msgid "Add Sort"
@@ -244,7 +239,7 @@ msgstr "Añadir condición"
 msgid "Add condition group"
 msgstr "Añadir grupo de condiciones"
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "Añadir filtro"
 
@@ -278,6 +273,12 @@ msgstr "Agrega objetivos de tiempo para hitos de soporte, como la primera respue
 msgid "Add to Holidays"
 msgstr "Agregar a Vacaciones"
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr ""
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr "Agregue, administre agentes y asígneles roles."
@@ -295,17 +296,14 @@ msgid "Administrator"
 msgstr "Administrador"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -316,6 +314,7 @@ msgstr "Administrador"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -335,6 +334,7 @@ msgstr ""
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -342,6 +342,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -376,18 +377,9 @@ msgstr "Los agentes ya no podrán ver ni crear respuestas guardadas con alcance 
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "Todos"
 
@@ -508,6 +500,14 @@ msgstr "¿Seguro que deseas cerrar este ticket?"
 msgid "Are you sure you want to delete these articles?"
 msgstr "¿Seguro que deseas eliminar estos artículos?"
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr ""
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr ""
@@ -544,6 +544,10 @@ msgstr "¿Seguro que deseas salir? Se perderán los cambios no guardados."
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
 msgstr "¿Seguro que deseas eliminar el logo?"
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
+msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
 msgid "Are you sure you want to reset the content? Current content will be overridden."
@@ -595,16 +599,11 @@ msgstr "Asignar un ticket a un agente"
 msgid "Assign ticket"
 msgstr "Asignar ticket"
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr "Asignar a"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -618,7 +617,7 @@ msgstr "Asignado"
 msgid "Assignee Rules"
 msgstr "Reglas de asignación"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr ""
 
@@ -626,14 +625,14 @@ msgstr ""
 msgid "Assignees"
 msgstr "Gestores asignados"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "Assignment"
-msgstr "Asignación"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:122
 msgid "Assignment Condition"
@@ -692,10 +691,6 @@ msgstr ""
 msgid "Assignment rule {0} updated successfully."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr "Se requiere al menos un correo electrónico"
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -712,10 +707,6 @@ msgstr "Al menos una opción de retroalimentación debe estar habilitada para la
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
 msgstr "Se requiere al menos un equipo"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
-msgstr "Se requiere al menos uno de prioridad, equipo y tipo de ticket"
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
@@ -766,7 +757,7 @@ msgid "Automation"
 msgstr "Automatización"
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr ""
@@ -802,7 +793,7 @@ msgstr "Tiempo promedio de respuesta"
 msgid "Average Time Metrics"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr "La calificación promedio de retroalimentación por día es aproximadamente {0} estrellas"
 
@@ -810,25 +801,37 @@ msgstr "La calificación promedio de retroalimentación por día es aproximadame
 msgid "Average response and resolution metrics not available"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr "El promedio de tickets por día es aproximadamente {0}"
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr "Calificación promedio de retroalimentación"
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr "Prom. primera respuesta"
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr "Tiempo promedio de resolución"
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
-msgstr "Calificación promedio de retroalimentación para los tickets resueltos"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
+msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:290
@@ -840,11 +843,11 @@ msgstr ""
 msgid "Avg. resolution time"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr "Tiempo promedio hasta la primera respuesta a un ticket"
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr "Tiempo promedio para resolver un ticket"
 
@@ -867,11 +870,6 @@ msgstr ""
 msgid "Base Support Rotation"
 msgstr "Rotación del soporte de base"
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "URL Base"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -885,11 +883,11 @@ msgstr "Basándose en su política de RRHH, seleccione la fecha de finalización
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr "Basándose en su política de RRHH, seleccione la fecha de inicio de su período de asignación de vacaciones"
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr ""
 
@@ -944,11 +942,6 @@ msgstr "Días festivos de la empresa"
 msgid "Busy"
 msgstr "Ocupado"
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "Botón"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr "CSV"
@@ -973,19 +966,31 @@ msgstr ""
 msgid "Caller"
 msgstr "Emisor de la llamada"
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr "Llamadas"
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr "Puede invitar nuevos agentes, gestionar tickets, crear vistas personalizadas y gestionar vistas públicas."
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr "Puede gestionar todos los aspectos del Helpdesk."
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr "Puede trabajar en tickets, crear vistas personalizadas y gestionar vistas privadas."
 
@@ -1025,7 +1030,7 @@ msgstr "No se puede habilitar la regla sin añadir usuarios en ella"
 msgid "Cannot merge General category"
 msgstr "No se puede fusionar la categoría General"
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr ""
 
@@ -1073,11 +1078,11 @@ msgstr "La categoría debe tener al menos un artículo"
 msgid "Category updated successfully."
 msgstr "Categoría actualizada con éxito."
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr ""
 
@@ -1085,7 +1090,7 @@ msgstr ""
 msgid "Change"
 msgstr "Cambio"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "Cambiar contraseña"
@@ -1098,10 +1103,9 @@ msgstr ""
 msgid "Change language of the application."
 msgstr "Cambiar el idioma de la aplicación."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
-msgstr "Cambiar foto"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
+msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
 msgid "Change priority"
@@ -1123,7 +1127,7 @@ msgstr "Cambiar tipo de ticket"
 msgid "Change timezone of the application."
 msgstr "Cambiar la zona horaria de la aplicación."
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr "Cambia la contraseña de tu cuenta por seguridad."
 
@@ -1136,7 +1140,7 @@ msgstr "Canales"
 msgid "Child field"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr ""
 
@@ -1189,7 +1193,7 @@ msgstr ""
 msgid "Clear Table"
 msgstr "Borrar tabla"
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr ""
 
@@ -1204,6 +1208,10 @@ msgstr "Borrar todos los filtros"
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
 msgstr "Haga clic en Añadir a vacaciones. Esto rellenará la tabla de días festivos con todas las fechas que caen en el día festivo semanal seleccionado. Repita el proceso para rellenar las fechas de todas sus vacaciones semanales"
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:47
@@ -1223,7 +1231,7 @@ msgstr "Cerrar ticket"
 msgid "Closed"
 msgstr "Cerrado"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr "Los tickets cerrados o calificados no pueden ser actualizados por personas que no sean agentes"
 
@@ -1250,7 +1258,7 @@ msgstr "Columnas"
 msgid "Comma separated emails to invite."
 msgstr "Correos electrónicos separados por comas para invitar."
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr ""
 
@@ -1283,7 +1291,7 @@ msgstr "Comentado por"
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "Comentarios"
@@ -1296,6 +1304,11 @@ msgstr "Comunicaciones"
 msgid "Communication ID is required"
 msgstr ""
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
+msgstr "Compañía"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
 msgstr "Completado"
@@ -1307,7 +1320,7 @@ msgstr "Completado"
 msgid "Condition"
 msgstr "Condición"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr ""
 
@@ -1331,6 +1344,10 @@ msgstr ""
 msgid "Configure your telephony settings."
 msgstr "Configura los ajustes de telefonía."
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1356,10 +1373,11 @@ msgstr "Confirmar sobrescritura"
 msgid "Connect your support email"
 msgstr "Conectar el correo de soporte"
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1373,26 +1391,30 @@ msgstr "Contacto"
 msgid "Contact HTML"
 msgstr "HTML de Contacto"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
 msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
-msgstr "Contacto invitado correctamente."
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
-msgstr "Ya existe un contacto con ese correo electrónico"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
+msgstr ""
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
 msgstr "Contactos"
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
+msgstr ""
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
 #. Label of the content (Text Editor) field in DocType 'HD Article'
@@ -1415,7 +1437,7 @@ msgstr "Copiar URL del ticket"
 msgid "Copy ticket id"
 msgstr "Copiar ID del ticket"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr "No se pudo enviar un correo electrónico a: {0}"
 
@@ -1423,7 +1445,11 @@ msgstr "No se pudo enviar un correo electrónico a: {0}"
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr "No se ha podido enviar un correo electrónico de acuse de recibo debido a: {0}"
 
@@ -1431,11 +1457,20 @@ msgstr "No se ha podido enviar un correo electrónico de acuse de recibo debido 
 msgid "Could not send feedback email,due to: {0}"
 msgstr "No se pudo enviar un correo electrónico de comentarios debido a: {0}"
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "País"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1446,9 +1481,13 @@ msgstr "Crear"
 msgid "Create & invite a contact"
 msgstr "Crear e invitar a un contacto"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
-msgstr "Crear Nuevo Contacto"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
+msgstr "Crear cliente"
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
 msgid "Create View"
@@ -1482,12 +1521,6 @@ msgstr ""
 msgid "Creating a ticket"
 msgstr ""
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr "Criterio"
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr ""
@@ -1512,12 +1545,21 @@ msgid "Custom Views"
 msgstr ""
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
 msgstr "Cliente"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
+msgstr ""
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1528,17 +1570,33 @@ msgstr "Nombre del cliente"
 msgid "Customer Portal"
 msgstr ""
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
-msgstr "Cliente creado con éxito."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr "Tipo de Cliente"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr "Portal del cliente"
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
 msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
+msgstr "Clientes"
 
 #: desk/src/components/layouts/Sidebar.vue:595
 msgid "Customers & Contacts"
@@ -1565,6 +1623,8 @@ msgstr "Cian"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "Peligro"
@@ -1665,18 +1725,26 @@ msgstr "Tipo de ticket predeterminado"
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr "Define quién recibe los tickets y cómo se distribuyen entre los agentes."
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "Eliminar"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1692,6 +1760,10 @@ msgstr "¿Eliminar categoría?"
 
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
+msgstr ""
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
 msgstr ""
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
@@ -1740,7 +1812,7 @@ msgstr "Explicación detallada"
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1826,7 +1898,12 @@ msgstr "Documentación"
 msgid "Document Type"
 msgstr "Tipo de Documento"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr ""
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "Dominio"
@@ -1868,6 +1945,10 @@ msgstr "Duplicar política de ANS"
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
 msgstr "Duplicar respuesta guardada"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
 #: desk/src/pages/call-logs/CallLogModal.vue:68
@@ -1917,7 +1998,8 @@ msgstr ""
 msgid "Easily invite new agents, managers, or admins."
 msgstr "Invita fácilmente a nuevos agentes, gerentes o administradores."
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1925,6 +2007,14 @@ msgstr "Editar"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
 msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:70
@@ -1944,10 +2034,10 @@ msgstr "Editar título"
 msgid "Edit your email account"
 msgstr "Editar tu cuenta de correo electrónico"
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "Correo electrónico"
 
@@ -1975,9 +2065,10 @@ msgstr ""
 msgid "Email Content"
 msgstr "Contenido del correo electrónico"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
-msgstr "Id de Correo Electrónico"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
+msgstr "ID de correo electrónico"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
 #. Settings'
@@ -2002,22 +2093,22 @@ msgstr ""
 msgid "Email account updated successfully"
 msgstr "Cuenta de correo electrónico actualizada correctamente"
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr ""
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr "La configuración del correo electrónico se ha actualizado correctamente."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr "El correo electrónico no debe estar vacío"
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "Correos"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr ""
 
@@ -2055,8 +2146,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr "Habilitar la retroalimentación para el Portal del Cliente"
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2081,8 +2170,6 @@ msgstr "Habilitar la retroalimentación para el Portal del Cliente"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2105,21 +2192,25 @@ msgstr "Hora de finalización"
 msgid "Enter a name for this HD Service Holiday List."
 msgstr "Ingrese un nombre para esta lista de días festivos del servicio de Mesa de ayuda."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr "Introduce un correo electrónico válido"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr "Introduce un número de teléfono válido"
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr "Introduce el nombre de la marca"
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr ""
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
 msgstr "Introduce el nuevo nombre para el equipo"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
+msgstr ""
 
 #: helpdesk/api/knowledge_base.py:86
 msgid "Error moving article to category"
@@ -2129,22 +2220,18 @@ msgstr "Error al mover el artículo a categoría"
 msgid "Error processing email at index {0}, message: {1}"
 msgstr "Error al procesar el correo en el índice {0}, mensaje: {1}"
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr ""
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "Error al conectarte a la cuenta de correo electrónico {0}"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr "La regla de escalación ya existe para este criterio"
 
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
 msgstr "Excel"
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
+msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
 #: desk/src/components/Settings/Telephony/Telephony.vue:96
@@ -2172,11 +2259,6 @@ msgstr "Exportar todos los {0} registro(s)"
 msgid "Export Type"
 msgstr "Tipo de Exportación"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr "Enlace externo"
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2184,6 +2266,10 @@ msgstr "Enlace externo"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "Fallido"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2218,11 +2304,11 @@ msgstr "Fallo al guardar la configuración de Exotel"
 msgid "Failed to save Twilio settings"
 msgstr "Fallo al guardar la configuración de Twilio"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr ""
 
@@ -2251,6 +2337,7 @@ msgstr ""
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2288,13 +2375,17 @@ msgstr "La retroalimentación ya existe"
 msgid "Feedback Rating"
 msgstr "Calificación de las opiniones"
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr "Tendencia de retroalimentación"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
 msgstr "Se ha enviado un correo electrónico de respuesta al cliente"
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
+msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
 msgid "Feedback submitted successfully."
@@ -2338,13 +2429,14 @@ msgid "Field dependency updated successfully."
 msgstr "Dependencia de campo actualizada con éxito."
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "Campos"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "Filtros"
@@ -2354,7 +2446,8 @@ msgstr "Filtros"
 msgid "Find out all of the variables that can be used in the content"
 msgstr "Descubre todas las variables que pueden ser usadas en el contenido"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "Primer Nombre"
 
@@ -2362,6 +2455,10 @@ msgstr "Primer Nombre"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
 msgstr "Primera respuesta el"
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
+msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -2386,10 +2483,6 @@ msgstr "Tiempo de primera respuesta"
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
 msgstr "Tiempo de primera respuesta para tickets"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
-msgstr "El nombre no debe estar vacío"
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
@@ -2480,6 +2573,10 @@ msgstr ""
 msgid "Go to Ticket #{0}"
 msgstr "Ir al ticket #{0}"
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr ""
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2509,8 +2606,6 @@ msgid "Group By Field"
 msgstr ""
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr "Invitado"
@@ -2518,11 +2613,6 @@ msgstr "Invitado"
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
 msgstr "Guía a los usuarios hacia artículos antes de crear tickets."
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
-msgstr "Acción"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -2554,25 +2644,37 @@ msgstr "Comentarios sobre el artículo HD"
 msgid "HD Comment Reaction"
 msgstr "Reacción de comentario HD"
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr "Cliente HD"
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr ""
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
-msgstr "Solicitud de cuenta de HD Desk"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
+msgstr ""
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
 msgstr "Comentarios sobre el correo electrónico HD"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
-msgstr "Regla de Escalación HD"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -2593,21 +2695,6 @@ msgstr "Festivo HD"
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
 msgstr "Notificación HD"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr "Organización HD"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr "Contacto de la organización HD"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
-msgstr "Solicitud de registro del portal HD"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -2649,11 +2736,6 @@ msgstr "Configuración HD"
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
 msgstr "Stopword HD"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
-msgstr "Origen de búsqueda de soporte HD"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_synonym/hd_synonym.json
@@ -2750,12 +2832,6 @@ msgstr "Mesa de ayuda"
 msgid "Helpdesk"
 msgstr "Mesa de ayuda"
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr "Contacto de Mesa de ayuda"
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2772,11 +2848,6 @@ msgstr "Hola"
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
 msgstr "Esconder "
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr "Ocultar condición"
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
@@ -2846,15 +2917,8 @@ msgstr "Entiendo, añadir condiciones"
 msgid "ID"
 msgstr "Identificador"
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "Dirección IP"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2941,6 +3005,11 @@ msgstr "Bandeja de entrada"
 msgid "Incoming"
 msgstr "Entrante"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr "Persona física"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr "Iniciado"
@@ -2954,7 +3023,7 @@ msgstr ""
 msgid "Instantly send e-mail"
 msgstr "Enviar correo electrónico instantáneamente"
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "Permiso insuficiente para {0}"
 
@@ -2968,13 +3037,13 @@ msgstr "Valor entero"
 msgid "Introduction"
 msgstr "Introducción"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
-msgstr "Correo electrónico inválido"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
 #: desk/src/components/Settings/Holiday/HolidayView.vue:325
@@ -2982,23 +3051,43 @@ msgstr "Correo electrónico inválido"
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr "Tipo de archivo inválido, solo se permiten imágenes PNG y JPG"
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr "Notificación inválida"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
 msgstr "Número de teléfono inválido"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr ""
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
+msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
 msgstr "Invitar agentes"
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
 msgid "Invite agent"
@@ -3008,13 +3097,30 @@ msgstr "Invitar agente"
 msgid "Invite agents"
 msgstr "Invitar agentes"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
 msgstr "Invitar como usuario"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
 msgstr "Invitar por correo electrónico"
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr "Invitado"
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
+msgstr ""
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -3030,6 +3136,11 @@ msgstr "Es Portal del Cliente"
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "Es por defecto"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr ""
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3058,6 +3169,10 @@ msgstr "Está fijado"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
 msgstr "Está completada la configuración"
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
+msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:114
 msgid "Jump to"
@@ -3093,11 +3208,9 @@ msgstr "Atajos de teclado"
 msgid "Knowledge Base"
 msgstr "Base de conocimiento"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3131,9 +3244,9 @@ msgstr "Último"
 msgid "Last 3 Months"
 msgstr "Últimos 3 meses"
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr ""
 
@@ -3174,7 +3287,8 @@ msgstr "Última respuesta del cliente"
 msgid "Last Month"
 msgstr "Último Mes"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "Apellido"
 
@@ -3183,24 +3297,33 @@ msgstr "Apellido"
 msgid "Last Week"
 msgstr "Última semana"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr "Último usuario asignado por esta regla"
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
 msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
+msgstr "Más reciente"
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -3217,26 +3340,6 @@ msgstr "Aprende acerca de las condiciones"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
 msgstr "Informa a los clientes que están creando un ticket fuera del horario laboral y cuándo pueden esperar una respuesta."
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "Enlace"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr "Opciones de Enlace"
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr "Vincular a un cliente"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
-msgstr "Vincular con un registro de cliente"
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #. Label of the list_tab (Tab Break) field in DocType 'HD View'
@@ -3264,6 +3367,8 @@ msgstr ""
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "Carga más"
 
@@ -3286,6 +3391,8 @@ msgstr "Iniciar sesión en Frappe Cloud"
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr "Logo"
@@ -3324,7 +3431,7 @@ msgstr "Gestionar la configuración general de tu aplicación."
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr "Gestionar respuestas predefinidas que se pueden usar para responder consultas de clientes."
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr ""
 
@@ -3343,6 +3450,10 @@ msgstr ""
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
 msgstr "Gestiona la información de tu perfil."
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
+msgstr "Administrador"
 
 #: desk/src/pages/MobileNotifications.vue:11
 #: desk/src/pages/MobileNotifications.vue:14
@@ -3364,7 +3475,7 @@ msgstr "Miembros ({0})"
 #. Option for the 'Type' (Select) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "Mention"
-msgstr "Mención"
+msgstr "Mencionar"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:158
 msgid "Merge"
@@ -3394,6 +3505,20 @@ msgstr "Misceláneo"
 
 #: desk/src/components/layouts/Sidebar.vue:640
 msgid "Mobile App Installation"
+msgstr ""
+
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr "Nº Móvil"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr "Número de teléfono móvil"
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
 msgstr ""
 
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
@@ -3436,7 +3561,7 @@ msgid "My Tickets"
 msgstr ""
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3447,8 +3572,9 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3458,6 +3584,10 @@ msgstr "Nombre"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
 msgstr "Peso del nombre"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
+msgstr ""
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
 #. Ticket Status'
@@ -3469,10 +3599,18 @@ msgstr "Nombre que se muestra en el portal del cliente<br> (por ejemplo, Respond
 msgid "Navigation"
 msgstr "Navegación"
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "Nunca"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3581,11 +3719,11 @@ msgstr "Sin respuesta"
 msgid "No Data Found"
 msgstr "No se encontraron datos"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr ""
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr ""
 
@@ -3597,9 +3735,15 @@ msgstr "No se encontró lista de festividades"
 msgid "No SLA found"
 msgstr "No se encontraron ANS"
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
 msgstr "Sin equipo"
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
+msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
 msgid "No additional comments"
@@ -3633,19 +3777,27 @@ msgstr ""
 msgid "No changes made"
 msgstr "No se ha realizado ningún cambio"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr "Sin cambios para guardar"
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr ""
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr ""
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr ""
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
@@ -3657,7 +3809,11 @@ msgstr "No se encontró ninguna cuenta de correo electrónico"
 msgid "No feedback"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr ""
 
@@ -3697,12 +3853,17 @@ msgstr ""
 msgid "No recently assigned tickets"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr ""
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
 msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
@@ -3710,6 +3871,7 @@ msgstr ""
 msgid "No saved replies found"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr ""
@@ -3730,7 +3892,11 @@ msgstr "No se encontraron tickets para previsualizar."
 msgid "No tickets selected"
 msgstr ""
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr ""
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "No permitido"
 
@@ -3742,7 +3908,7 @@ msgstr ""
 msgid "Not Saved"
 msgstr "No guardado"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "No especificado"
 
@@ -3781,11 +3947,6 @@ msgstr "Condiciones antiguas"
 msgid "On Hold Since"
 msgstr "En espera desde"
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr "Al hacer clic (Javascript)"
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr ""
@@ -3816,6 +3977,10 @@ msgstr "Abrir paleta de comandos"
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
 msgstr "Abrir cuadro de comentarios"
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
+msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
 msgid "Open help"
@@ -3906,7 +4071,12 @@ msgstr ""
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr "Se requieren campos padre, campos hijo y mapeo padre-hijo."
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr "Asociación"
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "Contraseña"
 
@@ -3944,6 +4114,7 @@ msgid "Pending"
 msgstr "Pendiente"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr ""
 
@@ -3953,19 +4124,19 @@ msgstr ""
 msgid "Pending Tickets"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr ""
 
@@ -3986,14 +4157,15 @@ msgstr "Personal"
 msgid "Personal mobile no"
 msgstr "Número de móvil personal"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "Teléfono"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
-msgstr "Números de teléfono"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
+msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
 msgid "Pick an option"
@@ -4049,7 +4221,7 @@ msgstr "Por favor, introduzca un asunto para continuar"
 msgid "Please enter a valid phone number"
 msgstr "Por favor, introduzca un número de teléfono válido"
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr ""
 
@@ -4092,34 +4264,15 @@ msgstr "Por favor seleccione el día libre de la semana"
 msgid "Policy name"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
 msgstr ""
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr "Clave de Descripción de Publicación"
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr "Publicar lista de claves de ruta"
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr "Publicar cadena de ruta"
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
-msgstr "Clave de título de publicación"
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:10
@@ -4153,14 +4306,32 @@ msgstr "Vista Previa"
 msgid "Previous ticket"
 msgstr "Ticket anterior"
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "Primario"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "Contacto Principal"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr ""
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr "Prioridades"
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4168,9 +4339,10 @@ msgstr "Prioridades"
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4250,17 +4422,6 @@ msgstr "Extrayendo correos electrónicos, esto puede tardar unos minutos."
 msgid "Quarterly"
 msgstr "Trimestral"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "Opciones de Consulta"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr "Cadena de Ruta de Consulta"
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "En cola"
@@ -4283,14 +4444,14 @@ msgstr "Califica tu experiencia de soporte"
 msgid "Rate this ticket"
 msgstr "Califica este ticket"
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr "Tickets calificados"
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4386,8 +4547,15 @@ msgstr "Regenerar índice de búsqueda"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "Eliminar"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4397,10 +4565,19 @@ msgstr "Eliminar logotipo"
 msgid "Remove Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
-msgstr "Eliminar foto"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr "Eliminar imagen"
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
+msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
 #: desk/src/components/Settings/Teams/TeamsList.vue:161
@@ -4420,6 +4597,15 @@ msgstr ""
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
 msgstr "Cambiar nombre del equipo"
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
+msgstr ""
 
 #. Option in a Select field in the tickets Web Form
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
@@ -4458,17 +4644,14 @@ msgstr "Respuesta del contacto"
 msgid "Reply on a ticket"
 msgstr "Responder a un ticket"
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr "ID de la Solicitud"
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
 msgstr "Requerido"
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
+msgstr ""
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
 msgid "Reset"
@@ -4488,6 +4671,7 @@ msgid "Reset to Default"
 msgstr ""
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr "Resolución"
@@ -4541,18 +4725,6 @@ msgstr "Respuesta"
 msgid "Response By"
 msgstr "Respuesta por"
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr "Opciones de Respuesta"
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr "Ruta clave del resultado de la respuesta"
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr "El tiempo de respuesta para la {0} prioridad en la fila {1} no puede ser mayor que el tiempo de resolución."
@@ -4595,37 +4767,33 @@ msgstr "Restringir los tickets para que solo los miembros del equipo puedan verl
 msgid "Restrict visibility to these teams"
 msgstr ""
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr "Campo de Vista Previa del Resultado"
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr "Campo de ruta de resultado"
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr "Campo de título del resultado"
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
 msgstr "Comentarios"
 
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:215
 msgid "Ringing"
 msgstr "Zumbido"
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "Rol"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr ""
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4724,9 +4892,9 @@ msgstr "Sábado"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4802,17 +4970,19 @@ msgstr "Índice de búsqueda regenerado"
 msgid "Search Score"
 msgstr "Puntuación de búsqueda"
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr "Nombre del Parámetro de Búsqueda"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "Busca campos..."
 
@@ -4852,6 +5022,7 @@ msgstr "Buscar..."
 msgid "Searched for:"
 msgstr ""
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr "Buscando..."
@@ -4870,6 +5041,10 @@ msgstr "Seleccionar"
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
 msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
@@ -4892,6 +5067,10 @@ msgstr "Seleccione una prioridad predeterminada."
 msgid "Select a rating"
 msgstr "Seleccione una calificación"
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr ""
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4904,6 +5083,10 @@ msgstr "Seleccionar equipos"
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
 msgstr "Seleccionar ticket para vista previa"
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
 msgid "Select what type all tickets get by default."
@@ -4930,6 +5113,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
 msgstr "Enviar retroalimentación cuando"
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
+msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
 msgid "Send to {0} tickets"
@@ -4969,7 +5156,7 @@ msgstr "Nombre del nivel de servicio"
 msgid "Service not supported"
 msgstr "Servicio no soportado"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "Establecer"
 
@@ -4977,6 +5164,10 @@ msgstr "Establecer"
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
 msgstr "Establecer número de teléfono"
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
 msgid "Set Resolution Time for Priority {0} in row {1}."
@@ -4986,12 +5177,21 @@ msgstr "Establecer el tiempo de resolución para la prioridad {0} en la fila {1}
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr "Establecer el tiempo de respuesta para la prioridad {0} en la fila {1}."
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr "Establecer como ANS predeterminado"
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr ""
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr ""
 
@@ -5003,7 +5203,7 @@ msgstr "Establezca el estado predeterminado asignado cuando se crea un ticket y 
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr "Establezca los días laborables, las horas y los días festivos seleccionando un horario predefinido o creando uno nuevo."
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr ""
 
@@ -5137,23 +5337,6 @@ msgstr ""
 msgid "Sort"
 msgstr ""
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr "DocType Fuente"
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "Nombre de la Fuente"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr "Tipo de Fuente"
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr "La categoría de origen y la de destino no pueden ser la misma"
@@ -5198,6 +5381,8 @@ msgstr "La hora de inicio no puede ser mayor o igual que la hora de finalizació
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5266,6 +5451,7 @@ msgstr "Estado del ticket, cuando se crea en el sistema."
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5377,21 +5563,16 @@ msgstr "Sistema"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5430,8 +5611,6 @@ msgstr "El ticket de destino no existe"
 msgid "Teal"
 msgstr "Turquesa"
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5442,7 +5621,6 @@ msgstr "Turquesa"
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5548,6 +5726,10 @@ msgstr ""
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr ""
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr ""
@@ -5558,6 +5740,10 @@ msgstr "El día de fiesta en {0} no es entre De la fecha y Hasta la fecha"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
@@ -5580,6 +5766,14 @@ msgstr ""
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr ""
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr ""
@@ -5587,6 +5781,10 @@ msgstr ""
 #: desk/src/components/ticket/TicketMergeModal.vue:79
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
 msgstr ""
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
@@ -5656,7 +5854,7 @@ msgstr "Jueves"
 msgid "Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr ""
 
@@ -5671,6 +5869,10 @@ msgstr "Análisis de tickets"
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
 msgstr "Configuración de Tickets"
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
+msgstr ""
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
 msgid "Ticket Info"
@@ -5729,7 +5931,7 @@ msgstr ""
 msgid "Ticket Summary"
 msgstr "Resumen del ticket"
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr ""
 
@@ -5762,7 +5964,7 @@ msgstr "El ticket no existe."
 msgid "Ticket merged successfully."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr "El ticket debe resolverse con un comentario"
 
@@ -5797,12 +5999,6 @@ msgstr ""
 msgid "Ticket to merged with is required"
 msgstr ""
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr "Tipo de ticket"
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr ""
@@ -5814,12 +6010,15 @@ msgstr "Análisis de búsqueda de tickets"
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr ""
 
@@ -5831,19 +6030,19 @@ msgstr ""
 msgid "Tickets assigned to you in the last 7 days"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr ""
 
@@ -5860,6 +6059,7 @@ msgid "Tickets that are awaiting your response"
 msgstr ""
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr "Zona Horaria"
 
@@ -5949,19 +6149,19 @@ msgstr ""
 msgid "Total Ticket"
 msgstr "Tickets totales"
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr ""
 
@@ -5993,6 +6193,10 @@ msgstr "Tipo"
 msgid "Type a message"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr ""
@@ -6002,7 +6206,7 @@ msgstr ""
 msgid "URL/Method"
 msgstr "URL/Método"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr ""
 
@@ -6036,6 +6240,8 @@ msgid "Unpublish"
 msgstr "Despublicar"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr "Sin guardar"
 
@@ -6053,6 +6259,10 @@ msgstr "Sin guardar"
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
 msgstr "Cambios sin guardar"
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
 msgid "Untitled"
@@ -6080,10 +6290,13 @@ msgstr "Subir"
 msgid "Upload Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
 msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
+msgstr "Cargar imagen"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
 msgid "Uploading {0}%"
@@ -6092,17 +6305,13 @@ msgstr "Subiendo {0}%"
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6114,6 +6323,10 @@ msgstr "Usuario"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
 msgstr "Tiempo de resolución de usuario"
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
+msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
 msgid "User Signup"
@@ -6132,7 +6345,7 @@ msgstr "Usuarios"
 msgid "Valid From"
 msgstr "Válida desde"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "Valor"
 
@@ -6261,19 +6474,23 @@ msgstr "Anual"
 msgid "Yellow"
 msgstr "Amarillo"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr ""
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr "No tienes permiso para ver estos datos del panel."
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr "No está autorizado a acceder a este recurso."
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr "No tienes permitido agregar un comentario"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr ""
 
@@ -6301,6 +6518,14 @@ msgstr "No puede establecer más de una Prioridad por defecto."
 msgid "You do not have permission to access Assignment Rules"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr ""
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr ""
@@ -6323,6 +6548,14 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:46
@@ -6353,7 +6586,7 @@ msgstr "creado"
 msgid "customize {0}"
 msgstr "personalizar {0}"
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr "dias"
 
@@ -6404,7 +6637,7 @@ msgstr ""
 msgid "here."
 msgstr ""
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr "hrs"
 
@@ -6412,7 +6645,7 @@ msgstr "hrs"
 msgid "in"
 msgstr "en"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "justo ahora"
 
@@ -6445,7 +6678,11 @@ msgstr ""
 msgid "purple"
 msgstr "púrpura"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr "comentarios"
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr "estrellas"
 
@@ -6462,7 +6699,7 @@ msgstr "ticket"
 msgid "to enable this integration."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr ""
 
@@ -6470,12 +6707,32 @@ msgstr ""
 msgid "views"
 msgstr "vistas"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr ""
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
 msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:307
@@ -6502,7 +6759,7 @@ msgstr ""
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr ""
 

--- a/helpdesk/locale/fa.po
+++ b/helpdesk/locale/fa.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-21 20:28\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-07-06 08:52\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Persian\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr ""
@@ -108,14 +108,6 @@ msgstr ""
 msgid "A workday with this name already exists"
 msgstr ""
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr "API"
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr ""
@@ -132,7 +124,7 @@ msgstr ""
 msgid "Account"
 msgstr "حساب"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr ""
 
@@ -152,11 +144,9 @@ msgstr "اقدام"
 msgid "Action Required"
 msgstr ""
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr ""
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "اقدامات"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr ""
 msgid "Active"
 msgstr "فعال"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr ""
 
@@ -175,7 +165,7 @@ msgid "Active: The agent is available and working.<br>\n"
 "Unavailable: The agent is off and unavailable."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "فعالیت"
@@ -193,10 +183,11 @@ msgid "Add Column"
 msgstr "افزودن ستون"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "افزودن فیلتر..."
 
@@ -206,6 +197,10 @@ msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
 msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:148
@@ -244,7 +239,7 @@ msgstr "افزودن شرط"
 msgid "Add condition group"
 msgstr "افزودن گروه شرایط"
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "افزودن فیلتر"
 
@@ -278,6 +273,12 @@ msgstr ""
 msgid "Add to Holidays"
 msgstr "افزودن به تعطیلات"
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr ""
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr ""
@@ -295,17 +296,14 @@ msgid "Administrator"
 msgstr "ادمین"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -316,6 +314,7 @@ msgstr "ادمین"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -335,6 +334,7 @@ msgstr ""
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -342,6 +342,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -376,18 +377,9 @@ msgstr ""
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "همه"
 
@@ -508,6 +500,14 @@ msgstr ""
 msgid "Are you sure you want to delete these articles?"
 msgstr ""
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr ""
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr ""
@@ -543,6 +543,10 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
 msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
@@ -595,16 +599,11 @@ msgstr ""
 msgid "Assign ticket"
 msgstr "اختصاص تیکت"
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr "تخصیص به"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -618,7 +617,7 @@ msgstr "گیرنده تخصیص"
 msgid "Assignee Rules"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr ""
 
@@ -626,14 +625,14 @@ msgstr ""
 msgid "Assignees"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "Assignment"
-msgstr "تخصیص"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:122
 msgid "Assignment Condition"
@@ -692,10 +691,6 @@ msgstr ""
 msgid "Assignment rule {0} updated successfully."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr "حداقل یک ایمیل الزامی است"
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -712,10 +707,6 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
 msgstr "حداقل یک تیم الزامی است"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
-msgstr ""
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
@@ -766,7 +757,7 @@ msgid "Automation"
 msgstr "اتوماسیون"
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr ""
@@ -802,7 +793,7 @@ msgstr "میانگین زمان پاسخگویی"
 msgid "Average Time Metrics"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr ""
 
@@ -810,24 +801,36 @@ msgstr ""
 msgid "Average response and resolution metrics not available"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr "میانگین اولین پاسخ"
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
 msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
@@ -840,11 +843,11 @@ msgstr ""
 msgid "Avg. resolution time"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr ""
 
@@ -867,11 +870,6 @@ msgstr ""
 msgid "Base Support Rotation"
 msgstr ""
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "URL پایه"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -885,11 +883,11 @@ msgstr "بر اساس سیاست منابع انسانی خود، تاریخ پ�
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr "بر اساس سیاست منابع انسانی خود، تاریخ شروع دوره تخصیص مرخصی خود را انتخاب کنید"
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr "رونوشت پنهان"
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr "رونوشت پنهان:"
 
@@ -944,11 +942,6 @@ msgstr ""
 msgid "Busy"
 msgstr "مشغول"
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "دکمه"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr "CSV"
@@ -973,19 +966,31 @@ msgstr "مدت زمان تماس بر حسب ثانیه"
 msgid "Caller"
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr "تماس می گیرد"
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr ""
 
@@ -1025,7 +1030,7 @@ msgstr ""
 msgid "Cannot merge General category"
 msgstr ""
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr ""
 
@@ -1073,11 +1078,11 @@ msgstr ""
 msgid "Category updated successfully."
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr "رونوشت"
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr "رونوشت:"
 
@@ -1085,7 +1090,7 @@ msgstr "رونوشت:"
 msgid "Change"
 msgstr "تغییر دادن"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "تغییر گذرواژه"
@@ -1098,10 +1103,9 @@ msgstr ""
 msgid "Change language of the application."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
-msgstr "تغییر عکس"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
+msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
 msgid "Change priority"
@@ -1123,7 +1127,7 @@ msgstr "تغییر نوع تیکت"
 msgid "Change timezone of the application."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr ""
 
@@ -1136,7 +1140,7 @@ msgstr ""
 msgid "Child field"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr ""
 
@@ -1189,7 +1193,7 @@ msgstr ""
 msgid "Clear Table"
 msgstr "پاک کردن جدول"
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr ""
 
@@ -1204,6 +1208,10 @@ msgstr "پاک کردن همه فیلترها"
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
 msgstr "روی افزودن به تعطیلات کلیک کنید. با این کار جدول تعطیلات با تمام تاریخ‌هایی که در تعطیلات هفتگی انتخاب شده قرار می گیرند پر می‌کند. فرآیند پر کردن تاریخ‌ها را برای تمام تعطیلات هفتگی خود تکرار کنید"
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:47
@@ -1223,7 +1231,7 @@ msgstr "بستن تیکت"
 msgid "Closed"
 msgstr "بسته شده"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr ""
 
@@ -1250,7 +1258,7 @@ msgstr "ستون‌ها"
 msgid "Comma separated emails to invite."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr ""
 
@@ -1283,7 +1291,7 @@ msgstr ""
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "دیدگاه‌ها"
@@ -1296,6 +1304,11 @@ msgstr "ارتباط"
 msgid "Communication ID is required"
 msgstr ""
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
+msgstr "شرکت"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
 msgstr "تکمیل شده"
@@ -1307,7 +1320,7 @@ msgstr "تکمیل شده"
 msgid "Condition"
 msgstr "شرط"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr ""
 
@@ -1331,6 +1344,10 @@ msgstr ""
 msgid "Configure your telephony settings."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1356,10 +1373,11 @@ msgstr ""
 msgid "Connect your support email"
 msgstr ""
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1373,26 +1391,30 @@ msgstr "مخاطب"
 msgid "Contact HTML"
 msgstr "با HTML تماس بگیرید"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
 msgstr ""
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
 msgstr "مخاطب"
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
+msgstr ""
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
 #. Label of the content (Text Editor) field in DocType 'HD Article'
@@ -1415,7 +1437,7 @@ msgstr ""
 msgid "Copy ticket id"
 msgstr "کپی شناسه تیکت"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr ""
 
@@ -1423,7 +1445,11 @@ msgstr ""
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr ""
 
@@ -1431,11 +1457,20 @@ msgstr ""
 msgid "Could not send feedback email,due to: {0}"
 msgstr ""
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "کشور"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1446,9 +1481,13 @@ msgstr "ایجاد کردن"
 msgid "Create & invite a contact"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
-msgstr "ایجاد مخاطب جدید"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
+msgstr "ایجاد مشتری"
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
 msgid "Create View"
@@ -1482,12 +1521,6 @@ msgstr ""
 msgid "Creating a ticket"
 msgstr ""
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr ""
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr ""
@@ -1512,12 +1545,21 @@ msgid "Custom Views"
 msgstr ""
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
 msgstr "مشتری"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
+msgstr ""
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1528,17 +1570,33 @@ msgstr "نام مشتری"
 msgid "Customer Portal"
 msgstr ""
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
-msgstr "مشتری با موفقیت ایجاد شد."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr "نوع مشتری"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr "پورتال مشتری"
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
 msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
+msgstr "مشتریان"
 
 #: desk/src/components/layouts/Sidebar.vue:595
 msgid "Customers & Contacts"
@@ -1565,6 +1623,8 @@ msgstr "فیروزه‌ای"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "خطر"
@@ -1665,18 +1725,26 @@ msgstr ""
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr ""
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "حذف"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1693,6 +1761,10 @@ msgstr ""
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
 msgstr "حذف {0}"
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
+msgstr ""
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
 #. Label of the description (Text Editor) field in DocType 'HD Holiday'
@@ -1740,7 +1812,7 @@ msgstr ""
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1826,7 +1898,12 @@ msgstr ""
 msgid "Document Type"
 msgstr "نوع سند"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr ""
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "دامنه"
@@ -1867,6 +1944,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
@@ -1917,7 +1998,8 @@ msgstr ""
 msgid "Easily invite new agents, managers, or admins."
 msgstr ""
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1926,6 +2008,14 @@ msgstr "ویرایش"
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
 msgstr "ویرایش لاگ تماس"
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
+msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:70
 #: desk/src/components/Settings/EmailEdit.vue:63
@@ -1944,10 +2034,10 @@ msgstr ""
 msgid "Edit your email account"
 msgstr ""
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "ایمیل"
 
@@ -1975,8 +2065,9 @@ msgstr ""
 msgid "Email Content"
 msgstr "محتوای ایمیل"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
 msgstr "شناسه ایمیل"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
@@ -2002,22 +2093,22 @@ msgstr ""
 msgid "Email account updated successfully"
 msgstr ""
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr ""
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr "تنظیمات ایمیل با موفقیت به‌روزرسانی شد."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr ""
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "ایمیل ها"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr ""
 
@@ -2055,8 +2146,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr ""
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2081,8 +2170,6 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2105,20 +2192,24 @@ msgstr "زمان پایان"
 msgid "Enter a name for this HD Service Holiday List."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr ""
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr "نام برند را وارد کنید"
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr ""
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
 msgstr ""
 
 #: helpdesk/api/knowledge_base.py:86
@@ -2129,22 +2220,18 @@ msgstr ""
 msgid "Error processing email at index {0}, message: {1}"
 msgstr "خطا در پردازش ایمیل در شاخص {0}، پیام: {1}"
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr ""
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "خطا هنگام اتصال به حساب ایمیل {0}"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr ""
 
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
 msgstr "اکسل"
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
+msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
 #: desk/src/components/Settings/Telephony/Telephony.vue:96
@@ -2172,11 +2259,6 @@ msgstr ""
 msgid "Export Type"
 msgstr "نوع برون‌بُرد"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr ""
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2184,6 +2266,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "ناموفق"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2218,11 +2304,11 @@ msgstr ""
 msgid "Failed to save Twilio settings"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr ""
 
@@ -2251,6 +2337,7 @@ msgstr ""
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2288,12 +2375,16 @@ msgstr ""
 msgid "Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr "روند بازخورد"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
+msgstr ""
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
 msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
@@ -2338,13 +2429,14 @@ msgid "Field dependency updated successfully."
 msgstr ""
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "فیلدها"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "فیلترها"
@@ -2354,7 +2446,8 @@ msgstr "فیلترها"
 msgid "Find out all of the variables that can be used in the content"
 msgstr "پیدا کردن تمام متغیرهایی که می‌توانند در محتوا استفاده شوند"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "نام کوچک"
 
@@ -2362,6 +2455,10 @@ msgstr "نام کوچک"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
 msgstr "اولین پاسخ در"
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
+msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -2385,10 +2482,6 @@ msgstr "اولین زمان پاسخگویی"
 #. Name of a report
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -2480,6 +2573,10 @@ msgstr "سراسری"
 msgid "Go to Ticket #{0}"
 msgstr "به تیکت #{0} بروید"
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr ""
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2509,19 +2606,12 @@ msgid "Group By Field"
 msgstr ""
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr "مهمان"
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
 msgstr ""
 
 #. Name of a DocType
@@ -2554,24 +2644,36 @@ msgstr ""
 msgid "HD Comment Reaction"
 msgstr ""
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr ""
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr ""
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
 msgstr ""
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
 msgstr ""
 
 #. Name of a DocType
@@ -2592,21 +2694,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
 msgstr ""
 
 #. Name of a DocType
@@ -2648,11 +2735,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
 msgstr ""
 
 #. Name of a DocType
@@ -2750,12 +2832,6 @@ msgstr ""
 msgid "Helpdesk"
 msgstr ""
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr ""
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2772,11 +2848,6 @@ msgstr "سلام"
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
 msgstr "پنهان شدن "
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr "پنهان کردن شرط"
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
@@ -2846,15 +2917,8 @@ msgstr ""
 msgid "ID"
 msgstr "شناسه"
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "آدرس IP"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2941,6 +3005,11 @@ msgstr "صندوق ورودی"
 msgid "Incoming"
 msgstr "ورودی"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr "شخصی"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr "آغاز شده"
@@ -2954,7 +3023,7 @@ msgstr ""
 msgid "Instantly send e-mail"
 msgstr ""
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "مجوز ناکافی برای {0}"
 
@@ -2968,12 +3037,12 @@ msgstr ""
 msgid "Introduction"
 msgstr "معرفی"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
@@ -2982,22 +3051,42 @@ msgstr ""
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr ""
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr ""
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
+msgstr "دعوت"
+
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
@@ -3008,13 +3097,30 @@ msgstr ""
 msgid "Invite agents"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
-msgstr ""
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
+msgstr "دعوت به عنوان کاربر"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
 msgstr "دعوت از طریق ایمیل"
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr "دعوت کرد"
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
+msgstr ""
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -3030,6 +3136,11 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "پیش‌فرض است"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr ""
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3057,6 +3168,10 @@ msgstr ""
 #. Label of the setup_complete (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
 msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:114
@@ -3093,11 +3208,9 @@ msgstr "میانبرهای صفحه کلید"
 msgid "Knowledge Base"
 msgstr "دانش محور"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3131,9 +3244,9 @@ msgstr "آخرین"
 msgid "Last 3 Months"
 msgstr ""
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr ""
 
@@ -3174,7 +3287,8 @@ msgstr ""
 msgid "Last Month"
 msgstr "ماه گذشته"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "نام خانوادگی"
 
@@ -3183,24 +3297,33 @@ msgstr "نام خانوادگی"
 msgid "Last Week"
 msgstr "هفته گذشته"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr ""
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
 msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
+msgstr "آخرین"
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -3216,26 +3339,6 @@ msgstr ""
 #. 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
-msgstr ""
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "پیوند"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr "گزینه‌های پیوند"
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -3264,6 +3367,8 @@ msgstr ""
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "بارگذاری بیشتر"
 
@@ -3286,6 +3391,8 @@ msgstr "ورود به Frappe Cloud"
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr "لوگو"
@@ -3324,7 +3431,7 @@ msgstr "تنظیمات عمومی برنامه خود را مدیریت کنید
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr ""
 
@@ -3343,6 +3450,10 @@ msgstr ""
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
 msgstr "اطلاعات پروفایل خود را مدیریت کنید."
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
+msgstr "مدیر"
 
 #: desk/src/pages/MobileNotifications.vue:11
 #: desk/src/pages/MobileNotifications.vue:14
@@ -3396,6 +3507,20 @@ msgstr ""
 msgid "Mobile App Installation"
 msgstr ""
 
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr "شماره موبایل"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr "شماره موبایل"
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr ""
+
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
 #. List'
@@ -3436,7 +3561,7 @@ msgid "My Tickets"
 msgstr ""
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3447,8 +3572,9 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3457,6 +3583,10 @@ msgstr "نام"
 #. Label of the name_weight (Int) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
 msgstr ""
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
@@ -3469,10 +3599,18 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "هرگز"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3581,11 +3719,11 @@ msgstr "بدون پاسخ"
 msgid "No Data Found"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr ""
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr ""
 
@@ -3597,8 +3735,14 @@ msgstr ""
 msgid "No SLA found"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
 msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
@@ -3633,19 +3777,27 @@ msgstr ""
 msgid "No changes made"
 msgstr "هیچ تغییری ایجاد نشد"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr "هیچ تغییری برای ذخیره وجود ندارد"
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr ""
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr ""
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr ""
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
@@ -3657,7 +3809,11 @@ msgstr ""
 msgid "No feedback"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr ""
 
@@ -3697,19 +3853,25 @@ msgstr ""
 msgid "No recently assigned tickets"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr ""
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
 msgstr "نتیجه‌ای یافت نشد"
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
+msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:91
 msgid "No saved replies found"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr ""
@@ -3730,7 +3892,11 @@ msgstr "تیکتی برای پیش‌نمایش یافت نشد."
 msgid "No tickets selected"
 msgstr ""
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr ""
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "مجاز نیست"
 
@@ -3742,7 +3908,7 @@ msgstr ""
 msgid "Not Saved"
 msgstr "ذخیره نشد"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "تنظیم نشده"
 
@@ -3781,11 +3947,6 @@ msgstr ""
 msgid "On Hold Since"
 msgstr "در انتظار از آنجایی که"
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr ""
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr ""
@@ -3816,6 +3977,10 @@ msgstr ""
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
 msgstr "باز کردن کادر دیدگاه"
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
+msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
 msgid "Open help"
@@ -3904,7 +4069,12 @@ msgstr ""
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr "شراکت"
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "گذرواژه"
 
@@ -3942,6 +4112,7 @@ msgid "Pending"
 msgstr "انتظار"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr ""
 
@@ -3951,19 +4122,19 @@ msgstr ""
 msgid "Pending Tickets"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr ""
 
@@ -3984,13 +4155,14 @@ msgstr "شخصی"
 msgid "Personal mobile no"
 msgstr "شماره موبایل شخصی"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "تلفن"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
 msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
@@ -4047,7 +4219,7 @@ msgstr ""
 msgid "Please enter a valid phone number"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr ""
 
@@ -4090,34 +4262,15 @@ msgstr "لطفاً روز تعطیل هفتگی را انتخاب کنید"
 msgid "Policy name"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
 msgstr ""
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr "کلید توضیحات پست"
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr "فهرست کلید مسیر ارسال"
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr "رشته مسیر ارسال"
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
-msgstr "کلید عنوان پست"
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:10
@@ -4151,14 +4304,32 @@ msgstr "پیش‌نمایش"
 msgid "Previous ticket"
 msgstr "تیکت قبلی"
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "اصلی"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "مخاطب اصلی"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr ""
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr "اولویت های"
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4166,9 +4337,10 @@ msgstr "اولویت های"
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4248,17 +4420,6 @@ msgstr ""
 msgid "Quarterly"
 msgstr "فصلی"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "گزینه‌های پرسمان"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr "رشته مسیر پرسمان"
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "در صف"
@@ -4281,14 +4442,14 @@ msgstr ""
 msgid "Rate this ticket"
 msgstr "به این تیکت امتیاز دهید"
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr ""
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4368,7 +4529,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "References"
-msgstr "منابع"
+msgstr ""
 
 #: desk/src/pages/home/Home.vue:11
 msgid "Refresh"
@@ -4384,8 +4545,15 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "حدف"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4395,10 +4563,19 @@ msgstr ""
 msgid "Remove Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
-msgstr "حذف عکس"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr "حذف تصویر"
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
+msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
 #: desk/src/components/Settings/Teams/TeamsList.vue:161
@@ -4417,6 +4594,15 @@ msgstr ""
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
 msgstr ""
 
 #. Option in a Select field in the tickets Web Form
@@ -4456,16 +4642,13 @@ msgstr ""
 msgid "Reply on a ticket"
 msgstr ""
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr "درخواست کلید"
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
 msgstr ""
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
@@ -4486,6 +4669,7 @@ msgid "Reset to Default"
 msgstr "بازنشانی به حالت پیش‌فرض"
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr "حل و فصل"
@@ -4539,18 +4723,6 @@ msgstr "پاسخ"
 msgid "Response By"
 msgstr "پاسخ توسط"
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr "گزینه‌های پاسخ"
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr "مسیر کلیدی نتیجه پاسخ"
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr "زمان پاسخ برای اولویت {0} در ردیف {1} نمی‌تواند بیشتر از زمان حل و فصل باشد."
@@ -4593,28 +4765,18 @@ msgstr ""
 msgid "Restrict visibility to these teams"
 msgstr ""
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr "فیلد پیش‌نمایش نتایج"
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr "فیلد مسیر نتیجه"
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr "فیلد عنوان نتیجه"
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
+msgstr ""
+
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:215
@@ -4622,8 +4784,14 @@ msgid "Ringing"
 msgstr "زنگ زدن"
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "نقش"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr "نقش با موفقیت به‌روزرسانی شد"
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4722,9 +4890,9 @@ msgstr "شنبه"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4800,17 +4968,19 @@ msgstr ""
 msgid "Search Score"
 msgstr ""
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr "عبارت جستجو نام Param"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "فیلدهای جستجو..."
 
@@ -4850,6 +5020,7 @@ msgstr "جستجو..."
 msgid "Searched for:"
 msgstr "جستجو شده برای:"
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr "در حال جستجو..."
@@ -4869,6 +5040,10 @@ msgstr "انتخاب کردن"
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
 msgstr "انتخاب دسته‌بندی"
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
+msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
 msgid "Select Range"
@@ -4890,6 +5065,10 @@ msgstr "یک اولویت پیش‌فرض را انتخاب کنید."
 msgid "Select a rating"
 msgstr ""
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr ""
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4901,6 +5080,10 @@ msgstr "انتخاب تیم‌ها"
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
+msgstr ""
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
@@ -4927,6 +5110,10 @@ msgstr ""
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
 msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
@@ -4967,7 +5154,7 @@ msgstr "نام سطح خدمات"
 msgid "Service not supported"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "تنظیم"
 
@@ -4975,6 +5162,10 @@ msgstr "تنظیم"
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
 msgstr "تنظیم شماره تلفن"
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
 msgid "Set Resolution Time for Priority {0} in row {1}."
@@ -4984,12 +5175,21 @@ msgstr ""
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr "زمان پاسخ را برای اولویت {0} در ردیف {1} تنظیم کنید."
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr ""
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr ""
 
@@ -5001,7 +5201,7 @@ msgstr ""
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr ""
 
@@ -5135,23 +5335,6 @@ msgstr "هنگام به‌روزرسانی فهرست تعطیلات، خطای�
 msgid "Sort"
 msgstr "مرتب‌سازی"
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr "منبع DocType"
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "نام منبع"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr "نوع منبع"
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr "دسته بندی مبدا و مقصد نمی توانند یکسان باشند"
@@ -5196,6 +5379,8 @@ msgstr ""
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5262,6 +5447,7 @@ msgstr ""
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5373,21 +5559,16 @@ msgstr "سیستم"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5426,8 +5607,6 @@ msgstr ""
 msgid "Teal"
 msgstr "فیروزه‌ای"
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5438,7 +5617,6 @@ msgstr "فیروزه‌ای"
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5544,6 +5722,10 @@ msgstr ""
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr ""
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr ""
@@ -5554,6 +5736,10 @@ msgstr "تعطیلات در {0} بین از تاریخ و تا تاریخ نیس
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
@@ -5576,6 +5762,14 @@ msgstr ""
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr "حداقل باید ۱ قانون تخصیص برای تیکت وجود داشته باشد"
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr ""
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr ""
@@ -5583,6 +5777,10 @@ msgstr ""
 #: desk/src/components/ticket/TicketMergeModal.vue:79
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
 msgstr ""
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
@@ -5652,7 +5850,7 @@ msgstr "پنج‌شنبه"
 msgid "Ticket"
 msgstr "تیکت"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr ""
 
@@ -5667,6 +5865,10 @@ msgstr "تجزیه و تحلیل تیکت"
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
 msgstr "پیکربندی تیکت"
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
+msgstr ""
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
 msgid "Ticket Info"
@@ -5725,7 +5927,7 @@ msgstr ""
 msgid "Ticket Summary"
 msgstr "خلاصه تیکت"
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr "روند تیکت"
 
@@ -5758,7 +5960,7 @@ msgstr "تیکت موجود نیست."
 msgid "Ticket merged successfully."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr ""
 
@@ -5793,12 +5995,6 @@ msgstr "وضعیت تیکت"
 msgid "Ticket to merged with is required"
 msgstr ""
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr ""
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr ""
@@ -5810,12 +6006,15 @@ msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr "تیکت‌ها"
 
@@ -5827,19 +6026,19 @@ msgstr ""
 msgid "Tickets assigned to you in the last 7 days"
 msgstr "تیکت‌هایی که در ۷ روز گذشته به شما اختصاص داده شده است"
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr "تیکت ها بر اساس اولویت"
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr "تیکت‌ها بر اساس تیم"
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr "تیکت‌ها بر اساس نوع"
 
@@ -5856,6 +6055,7 @@ msgid "Tickets that are awaiting your response"
 msgstr ""
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr "منطقه زمانی"
 
@@ -5945,19 +6145,19 @@ msgstr "کل تعطیلات"
 msgid "Total Ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr "تعداد کل تیکت‌های ایجاد شده"
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr ""
 
@@ -5989,6 +6189,10 @@ msgstr "نوع"
 msgid "Type a message"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr ""
@@ -5998,7 +6202,7 @@ msgstr ""
 msgid "URL/Method"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr ""
 
@@ -6032,6 +6236,8 @@ msgid "Unpublish"
 msgstr "لغو انتشار"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr ""
 
@@ -6049,6 +6255,10 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
 msgstr "تغییرات ذخیره نشده"
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
 msgid "Untitled"
@@ -6076,10 +6286,13 @@ msgstr "آپلود"
 msgid "Upload Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
 msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
+msgstr "آپلود تصویر"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
 msgid "Uploading {0}%"
@@ -6088,17 +6301,13 @@ msgstr "در حال آپلود {0}%"
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6110,6 +6319,10 @@ msgstr "کاربر"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
 msgstr "زمان حل و فصل کاربر"
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
+msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
 msgid "User Signup"
@@ -6128,7 +6341,7 @@ msgstr "کاربران"
 msgid "Valid From"
 msgstr "معتبر از"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "مقدار"
 
@@ -6257,19 +6470,23 @@ msgstr "سالانه"
 msgid "Yellow"
 msgstr "زرد"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr ""
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr "شما مجاز به مشاهده داده‌های این داشبورد نیستید."
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr "شما مجاز به دسترسی به این منبع نیستید."
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr "شما مجاز به افزودن دیدگاه نیستید"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr ""
 
@@ -6297,6 +6514,14 @@ msgstr ""
 msgid "You do not have permission to access Assignment Rules"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr ""
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr ""
@@ -6319,6 +6544,14 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:46
@@ -6349,7 +6582,7 @@ msgstr "ایجاد شده"
 msgid "customize {0}"
 msgstr "سفارشی‌سازی {0}"
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr "روزها"
 
@@ -6400,7 +6633,7 @@ msgstr "اینجا"
 msgid "here."
 msgstr ""
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr "ساعت"
 
@@ -6408,7 +6641,7 @@ msgstr "ساعت"
 msgid "in"
 msgstr "یکی از"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "همین الان"
 
@@ -6441,7 +6674,11 @@ msgstr ""
 msgid "purple"
 msgstr "بنفش"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr "بررسی ها"
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr "ستاره ها"
 
@@ -6458,7 +6695,7 @@ msgstr "تیکت"
 msgid "to enable this integration."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr ""
 
@@ -6466,12 +6703,32 @@ msgstr ""
 msgid "views"
 msgstr "بازدیدها"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr ""
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
 msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:307
@@ -6498,7 +6755,7 @@ msgstr ""
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr ""
 

--- a/helpdesk/locale/fr.po
+++ b/helpdesk/locale/fr.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-15 18:50\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-29 21:57\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: French\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr ""
@@ -108,14 +108,6 @@ msgstr ""
 msgid "A workday with this name already exists"
 msgstr ""
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr ""
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr ""
@@ -132,7 +124,7 @@ msgstr ""
 msgid "Account"
 msgstr "Compte"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr "Informations et sécurité du compte"
 
@@ -152,11 +144,9 @@ msgstr "Action"
 msgid "Action Required"
 msgstr ""
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr ""
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "Actions"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr ""
 msgid "Active"
 msgstr "Actif"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr ""
 
@@ -175,7 +165,7 @@ msgid "Active: The agent is available and working.<br>\n"
 "Unavailable: The agent is off and unavailable."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "Activité"
@@ -193,10 +183,11 @@ msgid "Add Column"
 msgstr "Ajouter une Colonne"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr "Ajouter un e-mail"
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "Ajouter un filtre..."
 
@@ -206,6 +197,10 @@ msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
 msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:148
@@ -244,7 +239,7 @@ msgstr "Ajouter condition"
 msgid "Add condition group"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "Ajouter un filtre"
 
@@ -278,6 +273,12 @@ msgstr ""
 msgid "Add to Holidays"
 msgstr "Ajouter aux vacances"
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr ""
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr ""
@@ -295,17 +296,14 @@ msgid "Administrator"
 msgstr "Administrateur"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -316,6 +314,7 @@ msgstr "Administrateur"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -335,6 +334,7 @@ msgstr ""
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -342,6 +342,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -376,18 +377,9 @@ msgstr ""
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "Tous"
 
@@ -508,6 +500,14 @@ msgstr ""
 msgid "Are you sure you want to delete these articles?"
 msgstr ""
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr ""
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr ""
@@ -543,6 +543,10 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
 msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
@@ -595,16 +599,11 @@ msgstr ""
 msgid "Assign ticket"
 msgstr ""
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr ""
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -618,7 +617,7 @@ msgstr "Cessionnaire"
 msgid "Assignee Rules"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr ""
 
@@ -626,14 +625,14 @@ msgstr ""
 msgid "Assignees"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "Assignment"
-msgstr "Attribution"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:122
 msgid "Assignment Condition"
@@ -692,10 +691,6 @@ msgstr ""
 msgid "Assignment rule {0} updated successfully."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -711,10 +706,6 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
-msgstr ""
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
 msgstr ""
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
@@ -766,7 +757,7 @@ msgid "Automation"
 msgstr "Automatisation"
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr ""
@@ -802,7 +793,7 @@ msgstr "Temps de réponse moyen"
 msgid "Average Time Metrics"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr ""
 
@@ -810,24 +801,36 @@ msgstr ""
 msgid "Average response and resolution metrics not available"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
 msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
@@ -840,11 +843,11 @@ msgstr ""
 msgid "Avg. resolution time"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr ""
 
@@ -867,11 +870,6 @@ msgstr ""
 msgid "Base Support Rotation"
 msgstr ""
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "URL de base"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -885,11 +883,11 @@ msgstr "En fonction de votre politique RH, sélectionnez la date de fin de la p�
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr ""
 
@@ -944,11 +942,6 @@ msgstr ""
 msgid "Busy"
 msgstr "Occupé"
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "Bouton"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr ""
@@ -973,19 +966,31 @@ msgstr ""
 msgid "Caller"
 msgstr "Appelant"
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr "Appels"
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr ""
 
@@ -1025,7 +1030,7 @@ msgstr "Impossible d'activer la règle sans y ajouter des utilisateurs"
 msgid "Cannot merge General category"
 msgstr ""
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr ""
 
@@ -1073,11 +1078,11 @@ msgstr ""
 msgid "Category updated successfully."
 msgstr "Catégorie mise à jour avec succès."
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr ""
 
@@ -1085,7 +1090,7 @@ msgstr ""
 msgid "Change"
 msgstr "la monnaie"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "Changer le Mot de passe"
@@ -1098,9 +1103,8 @@ msgstr "Changer la photo"
 msgid "Change language of the application."
 msgstr "Modifier la langue de l'application."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
@@ -1123,7 +1127,7 @@ msgstr ""
 msgid "Change timezone of the application."
 msgstr "Modifier le fuseau horaire de l'application."
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr "Modifiez le mot de passe de votre compte pour des raisons de sécurité."
 
@@ -1136,7 +1140,7 @@ msgstr ""
 msgid "Child field"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr ""
 
@@ -1189,7 +1193,7 @@ msgstr "Effacer le tri"
 msgid "Clear Table"
 msgstr "Effacer le tableau"
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr ""
 
@@ -1203,6 +1207,10 @@ msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
@@ -1223,7 +1231,7 @@ msgstr ""
 msgid "Closed"
 msgstr "Fermé"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr ""
 
@@ -1250,7 +1258,7 @@ msgstr "Colonnes"
 msgid "Comma separated emails to invite."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr ""
 
@@ -1283,7 +1291,7 @@ msgstr ""
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "Commentaires"
@@ -1296,6 +1304,11 @@ msgstr ""
 msgid "Communication ID is required"
 msgstr ""
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
+msgstr "Société"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
 msgstr "Terminé"
@@ -1307,7 +1320,7 @@ msgstr "Terminé"
 msgid "Condition"
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr "Configurer"
 
@@ -1331,6 +1344,10 @@ msgstr ""
 msgid "Configure your telephony settings."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1356,10 +1373,11 @@ msgstr ""
 msgid "Connect your support email"
 msgstr ""
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1373,26 +1391,30 @@ msgstr "Contact"
 msgid "Contact HTML"
 msgstr "HTML du Contact"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
 msgstr ""
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
 msgstr "Contacts"
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
+msgstr ""
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
 #. Label of the content (Text Editor) field in DocType 'HD Article'
@@ -1415,7 +1437,7 @@ msgstr ""
 msgid "Copy ticket id"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr ""
 
@@ -1423,7 +1445,11 @@ msgstr ""
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr ""
 
@@ -1431,11 +1457,20 @@ msgstr ""
 msgid "Could not send feedback email,due to: {0}"
 msgstr ""
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "Pays"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1446,9 +1481,13 @@ msgstr "Créer"
 msgid "Create & invite a contact"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
-msgstr "Créer un nouveau contact"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
+msgstr "Créer un Client"
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
 msgid "Create View"
@@ -1482,12 +1521,6 @@ msgstr ""
 msgid "Creating a ticket"
 msgstr ""
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr ""
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr "Actions personnalisées"
@@ -1512,12 +1545,21 @@ msgid "Custom Views"
 msgstr ""
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
 msgstr "Client"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
+msgstr ""
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1528,17 +1570,33 @@ msgstr "Nom du client"
 msgid "Customer Portal"
 msgstr ""
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
-msgstr "Client crée avec succès."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr "Type de client"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
 msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
+msgstr "Les clients"
 
 #: desk/src/components/layouts/Sidebar.vue:595
 msgid "Customers & Contacts"
@@ -1565,6 +1623,8 @@ msgstr "Cyan"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr ""
@@ -1665,18 +1725,26 @@ msgstr ""
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr ""
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "Supprimer"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr "Supprimer le contact"
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1693,6 +1761,10 @@ msgstr ""
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
 msgstr "Supprimer {0}"
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
+msgstr ""
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
 #. Label of the description (Text Editor) field in DocType 'HD Holiday'
@@ -1740,7 +1812,7 @@ msgstr ""
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1826,7 +1898,12 @@ msgstr ""
 msgid "Document Type"
 msgstr "Type de document"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr ""
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "Domaine"
@@ -1867,6 +1944,10 @@ msgstr "Dupliquer la politique SLA"
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
@@ -1917,7 +1998,8 @@ msgstr ""
 msgid "Easily invite new agents, managers, or admins."
 msgstr ""
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1926,6 +2008,14 @@ msgstr "Modifier"
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
 msgstr "Modifier le journal d'appel"
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
+msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:70
 #: desk/src/components/Settings/EmailEdit.vue:63
@@ -1944,10 +2034,10 @@ msgstr ""
 msgid "Edit your email account"
 msgstr ""
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "Courriel"
 
@@ -1975,8 +2065,9 @@ msgstr "Comptes de messagerie"
 msgid "Email Content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
 msgstr "Identifiant e-mail"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
@@ -2002,22 +2093,22 @@ msgstr ""
 msgid "Email account updated successfully"
 msgstr ""
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr ""
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr "Paramètres e-mail mis à jour avec succès."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr ""
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "E-mails"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr "E-mails et signature"
 
@@ -2055,8 +2146,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr ""
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2081,8 +2170,6 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2105,20 +2192,24 @@ msgstr "Heure de Fin"
 msgid "Enter a name for this HD Service Holiday List."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr ""
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr ""
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
 msgstr ""
 
 #: helpdesk/api/knowledge_base.py:86
@@ -2129,21 +2220,17 @@ msgstr ""
 msgid "Error processing email at index {0}, message: {1}"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr ""
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "Erreur lors de la connexion au compte Email {0}"
 
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr ""
-
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
 msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
@@ -2172,11 +2259,6 @@ msgstr ""
 msgid "Export Type"
 msgstr "Type d'Exportation"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr ""
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2184,6 +2266,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "Échoué"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2218,11 +2304,11 @@ msgstr ""
 msgid "Failed to save Twilio settings"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr ""
 
@@ -2251,6 +2337,7 @@ msgstr "Favicon"
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2288,12 +2375,16 @@ msgstr ""
 msgid "Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
+msgstr ""
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
 msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
@@ -2338,13 +2429,14 @@ msgid "Field dependency updated successfully."
 msgstr ""
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "Champ"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "Filtres"
@@ -2354,7 +2446,8 @@ msgstr "Filtres"
 msgid "Find out all of the variables that can be used in the content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "Prénom"
 
@@ -2362,6 +2455,10 @@ msgstr "Prénom"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
 msgstr "Première Réponse Le"
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
+msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -2385,10 +2482,6 @@ msgstr "Temps de première réponse"
 #. Name of a report
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -2480,6 +2573,10 @@ msgstr ""
 msgid "Go to Ticket #{0}"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr ""
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2509,19 +2606,12 @@ msgid "Group By Field"
 msgstr "Champ de regroupement"
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr "Invité"
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
 msgstr ""
 
 #. Name of a DocType
@@ -2554,24 +2644,36 @@ msgstr ""
 msgid "HD Comment Reaction"
 msgstr ""
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr ""
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr ""
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
 msgstr ""
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
 msgstr ""
 
 #. Name of a DocType
@@ -2592,21 +2694,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
 msgstr ""
 
 #. Name of a DocType
@@ -2648,11 +2735,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
 msgstr ""
 
 #. Name of a DocType
@@ -2750,12 +2832,6 @@ msgstr ""
 msgid "Helpdesk"
 msgstr ""
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr ""
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2772,11 +2848,6 @@ msgstr ""
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
 msgstr "Cacher "
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr ""
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
@@ -2846,15 +2917,8 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "Adresse IP"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2941,6 +3005,11 @@ msgstr "Boîte de réception"
 msgid "Incoming"
 msgstr "Entrant"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr "Individuel"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr "Initié"
@@ -2954,7 +3023,7 @@ msgstr ""
 msgid "Instantly send e-mail"
 msgstr ""
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "Autorisation Insuffisante Pour {0}"
 
@@ -2968,13 +3037,13 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
-msgstr ""
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
+msgstr "Adresse e-mail invalide"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
 #: desk/src/components/Settings/Holiday/HolidayView.vue:325
@@ -2982,22 +3051,42 @@ msgstr ""
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr "Champs invalides, vérifiez que tous sont renseignés et que les valeurs sont correctes."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr ""
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr ""
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
 msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
@@ -3008,13 +3097,30 @@ msgstr ""
 msgid "Invite agents"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
-msgstr ""
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
+msgstr "Inviter en tant qu'Utilisateur"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
 msgstr "Inviter par email"
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr "Invité"
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
+msgstr ""
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -3030,6 +3136,11 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "Est Défaut"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr ""
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3057,6 +3168,10 @@ msgstr ""
 #. Label of the setup_complete (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
 msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:114
@@ -3093,11 +3208,9 @@ msgstr "Raccourcis clavier"
 msgid "Knowledge Base"
 msgstr "Base de Connaissances"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3131,9 +3244,9 @@ msgstr "Dernier"
 msgid "Last 3 Months"
 msgstr "3 derniers mois"
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr ""
 
@@ -3174,7 +3287,8 @@ msgstr ""
 msgid "Last Month"
 msgstr "Mois dernier"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "Nom de Famille"
 
@@ -3183,24 +3297,33 @@ msgstr "Nom de Famille"
 msgid "Last Week"
 msgstr "Semaine dernière"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr "Dernier utilisateur attribué par cette règle"
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
 msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
+msgstr "Dernier"
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -3216,26 +3339,6 @@ msgstr "En savoir plus sur les conditions"
 #. 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
-msgstr ""
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "Lien"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr "Options du lien"
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -3264,6 +3367,8 @@ msgstr "Charger les colonnes par défaut"
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "Charger plus"
 
@@ -3286,6 +3391,8 @@ msgstr ""
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr "Logo"
@@ -3324,7 +3431,7 @@ msgstr ""
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr "Gérez les e-mails de votre compte et votre signature e-mail pour vos communications."
 
@@ -3342,6 +3449,10 @@ msgstr ""
 
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:11
@@ -3396,6 +3507,20 @@ msgstr ""
 msgid "Mobile App Installation"
 msgstr "Installation de l'application mobile"
 
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr "N° Mobile"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr "Numéro de mobile"
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr ""
+
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
 #. List'
@@ -3436,7 +3561,7 @@ msgid "My Tickets"
 msgstr ""
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3447,8 +3572,9 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3458,6 +3584,10 @@ msgstr "Nom"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
 msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
+msgstr "Le nom est obligatoire"
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
 #. Ticket Status'
@@ -3469,10 +3599,18 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "Jamais"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3581,11 +3719,11 @@ msgstr ""
 msgid "No Data Found"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr ""
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr ""
 
@@ -3597,8 +3735,14 @@ msgstr ""
 msgid "No SLA found"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
 msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
@@ -3633,19 +3777,27 @@ msgstr ""
 msgid "No changes made"
 msgstr "Aucune modification effectuée"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr ""
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr ""
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr ""
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
@@ -3657,7 +3809,11 @@ msgstr ""
 msgid "No feedback"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr ""
 
@@ -3697,19 +3853,25 @@ msgstr ""
 msgid "No recently assigned tickets"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr ""
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
 msgstr "Aucun résultat trouvé"
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
+msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:91
 msgid "No saved replies found"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr ""
@@ -3730,7 +3892,11 @@ msgstr ""
 msgid "No tickets selected"
 msgstr ""
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr ""
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "Non Autorisé"
 
@@ -3742,7 +3908,7 @@ msgstr ""
 msgid "Not Saved"
 msgstr "Non Sauvegardé"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "Non Défini"
 
@@ -3781,11 +3947,6 @@ msgstr "Anciennes conditions"
 msgid "On Hold Since"
 msgstr "En attente depuis"
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr ""
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr ""
@@ -3815,6 +3976,10 @@ msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
@@ -3904,7 +4069,12 @@ msgstr ""
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr ""
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "Mot de Passe"
 
@@ -3942,6 +4112,7 @@ msgid "Pending"
 msgstr "En attente"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr "Invitations en attente"
 
@@ -3951,19 +4122,19 @@ msgstr "Invitations en attente"
 msgid "Pending Tickets"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr ""
 
@@ -3984,13 +4155,14 @@ msgstr "Personnel"
 msgid "Personal mobile no"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "Téléphone"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
 msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
@@ -4047,7 +4219,7 @@ msgstr ""
 msgid "Please enter a valid phone number"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr ""
 
@@ -4090,34 +4262,15 @@ msgstr "Veuillez sélectionnez les jours de congé hebdomadaires"
 msgid "Policy name"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
 msgstr ""
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr "Clé de description du message"
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr "Liste de clés du lien du message"
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr "Chaîne de caractères du lien du message"
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
-msgstr "Clé du titre du message"
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:10
@@ -4151,14 +4304,32 @@ msgstr "Aperçu"
 msgid "Previous ticket"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "Primaire"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "Contact principal"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr ""
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr "Les priorités"
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4166,9 +4337,10 @@ msgstr "Les priorités"
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4248,17 +4420,6 @@ msgstr ""
 msgid "Quarterly"
 msgstr "Trimestriel"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "Options de requête"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr "Chaîne de caractères du lien de requête"
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "Dans la file d'attente"
@@ -4281,14 +4442,14 @@ msgstr ""
 msgid "Rate this ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr ""
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4384,8 +4545,15 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "Supprimer"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4395,9 +4563,18 @@ msgstr ""
 msgid "Remove Photo"
 msgstr "Supprimer la photo"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr "Supprimer l'image"
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
 msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
@@ -4417,6 +4594,15 @@ msgstr ""
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
 msgstr ""
 
 #. Option in a Select field in the tickets Web Form
@@ -4456,16 +4642,13 @@ msgstr ""
 msgid "Reply on a ticket"
 msgstr ""
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr ""
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
 msgstr ""
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
@@ -4486,6 +4669,7 @@ msgid "Reset to Default"
 msgstr "Rétablir les valeurs par défaut"
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr "Résolution"
@@ -4539,18 +4723,6 @@ msgstr "Réponse"
 msgid "Response By"
 msgstr "Réponse de"
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr "Options de réponse"
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr "Chemin de la clé du résultat de réponse"
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr "Le temps de réponse pour la {0} priorité dans la ligne {1} ne peut pas être supérieur au temps de résolution."
@@ -4593,28 +4765,18 @@ msgstr ""
 msgid "Restrict visibility to these teams"
 msgstr ""
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr "Champ d'aperçu du résultat"
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr "Champ du lien du résultat"
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr "Champ du titre du résultat"
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
+msgstr ""
+
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:215
@@ -4622,8 +4784,14 @@ msgid "Ringing"
 msgstr "Sonnerie"
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "Rôle"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr ""
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4722,9 +4890,9 @@ msgstr "Samedi"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4800,17 +4968,19 @@ msgstr ""
 msgid "Search Score"
 msgstr ""
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr "Nom du paramètre de recherche"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "Rechercher des champs..."
 
@@ -4850,6 +5020,7 @@ msgstr "Rechercher..."
 msgid "Searched for:"
 msgstr ""
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr "Recherche..."
@@ -4868,6 +5039,10 @@ msgstr "Sélectionner"
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
 msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
@@ -4890,6 +5065,10 @@ msgstr "Sélectionnez une priorité par défaut."
 msgid "Select a rating"
 msgstr ""
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr ""
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4901,6 +5080,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
+msgstr ""
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
@@ -4927,6 +5110,10 @@ msgstr ""
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
 msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
@@ -4967,13 +5154,17 @@ msgstr ""
 msgid "Service not supported"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "Définir"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:4
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
@@ -4984,12 +5175,21 @@ msgstr ""
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr "Définir comme SLA par défaut"
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr ""
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr ""
 
@@ -5001,7 +5201,7 @@ msgstr ""
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr "Définissez les jours ouvrés, les heures et les congés en sélectionnant un calendrier prédéfini ou en en créant un nouveau."
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr ""
 
@@ -5135,23 +5335,6 @@ msgstr ""
 msgid "Sort"
 msgstr "Trier"
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr "DocType source"
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "Nom de la source"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr "Type de source"
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr ""
@@ -5196,6 +5379,8 @@ msgstr ""
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5262,6 +5447,7 @@ msgstr ""
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5373,21 +5559,16 @@ msgstr "Système"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5426,8 +5607,6 @@ msgstr ""
 msgid "Teal"
 msgstr ""
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5438,7 +5617,6 @@ msgstr ""
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5544,6 +5722,10 @@ msgstr ""
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr ""
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr ""
@@ -5554,6 +5736,10 @@ msgstr "Le jour de vacances {0} n’est pas compris entre la Date Initiale et la
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
@@ -5576,6 +5762,14 @@ msgstr ""
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr ""
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr ""
@@ -5583,6 +5777,10 @@ msgstr ""
 #: desk/src/components/ticket/TicketMergeModal.vue:79
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
 msgstr ""
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
@@ -5652,7 +5850,7 @@ msgstr "Jeudi"
 msgid "Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr ""
 
@@ -5666,6 +5864,10 @@ msgstr ""
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
+msgstr ""
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
 msgstr ""
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
@@ -5725,7 +5927,7 @@ msgstr ""
 msgid "Ticket Summary"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr ""
 
@@ -5758,7 +5960,7 @@ msgstr ""
 msgid "Ticket merged successfully."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr ""
 
@@ -5793,12 +5995,6 @@ msgstr ""
 msgid "Ticket to merged with is required"
 msgstr ""
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr ""
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr ""
@@ -5810,12 +6006,15 @@ msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr ""
 
@@ -5827,19 +6026,19 @@ msgstr ""
 msgid "Tickets assigned to you in the last 7 days"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr ""
 
@@ -5856,6 +6055,7 @@ msgid "Tickets that are awaiting your response"
 msgstr ""
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr ""
 
@@ -5945,19 +6145,19 @@ msgstr "Total des vacances"
 msgid "Total Ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr ""
 
@@ -5989,6 +6189,10 @@ msgstr "Type"
 msgid "Type a message"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr ""
@@ -5998,7 +6202,7 @@ msgstr ""
 msgid "URL/Method"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr ""
 
@@ -6032,6 +6236,8 @@ msgid "Unpublish"
 msgstr "Dépublier"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr ""
 
@@ -6048,6 +6254,10 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:214
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
+msgstr ""
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
@@ -6076,10 +6286,13 @@ msgstr "Charger"
 msgid "Upload Photo"
 msgstr "Téléverser une photo"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
 msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
+msgstr "Téléverser une Image"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
 msgid "Uploading {0}%"
@@ -6088,17 +6301,13 @@ msgstr "Envoi de {0}%"
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6110,6 +6319,10 @@ msgstr "Utilisateur"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
 msgstr "Temps de résolution utilisateur"
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
+msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
 msgid "User Signup"
@@ -6128,7 +6341,7 @@ msgstr "Utilisateurs"
 msgid "Valid From"
 msgstr "Valide à partir de"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "Valeur"
 
@@ -6257,19 +6470,23 @@ msgstr "Annuel"
 msgid "Yellow"
 msgstr "jaune"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr ""
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr ""
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr "Vous n'êtes pas autorisé(e) à accéder à cette ressource."
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr ""
 
@@ -6297,6 +6514,14 @@ msgstr ""
 msgid "You do not have permission to access Assignment Rules"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr ""
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr ""
@@ -6319,6 +6544,14 @@ msgstr "Vos anciennes conditions seront écrasées. Voulez-vous vraiment enregis
 
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:46
@@ -6349,7 +6582,7 @@ msgstr "créé"
 msgid "customize {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr "jours"
 
@@ -6363,7 +6596,7 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:473
 msgid "excellent"
-msgstr ""
+msgstr "excellent"
 
 #: desk/src/components/ticket/TicketSplitModal.vue:8
 msgid "from this email onwards will be moved to new ticket."
@@ -6371,7 +6604,7 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:475
 msgid "good"
-msgstr ""
+msgstr "bon"
 
 #. Option for the 'Type' (Select) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -6400,7 +6633,7 @@ msgstr "ici"
 msgid "here."
 msgstr ""
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr "h"
 
@@ -6408,7 +6641,7 @@ msgstr "h"
 msgid "in"
 msgstr "dans"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "juste maintenant"
 
@@ -6441,7 +6674,11 @@ msgstr ""
 msgid "purple"
 msgstr "violet"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr "évaluations"
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr ""
 
@@ -6458,7 +6695,7 @@ msgstr ""
 msgid "to enable this integration."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr ""
 
@@ -6466,12 +6703,32 @@ msgstr ""
 msgid "views"
 msgstr "vues"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr ""
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
 msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:307
@@ -6498,7 +6755,7 @@ msgstr ""
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr ""
 

--- a/helpdesk/locale/hr.po
+++ b/helpdesk/locale/hr.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-21 20:28\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-30 22:28\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Croatian\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr " komentirao/la"
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr "% ispunjen Ugovor o Razini Usluge"
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr "% kreiranih slučajeva koji su riješeni u okviru Ugovora o Razini Usluge"
@@ -108,14 +108,6 @@ msgstr "Kratki Opis"
 msgid "A workday with this name already exists"
 msgstr "Radni dan s ovim nazivom već postoji"
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr "API"
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr "Pristup svim timskim slučajima"
@@ -132,7 +124,7 @@ msgstr "Pristup samo zahtjevima ovog tima"
 msgid "Account"
 msgstr "Račun"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr "Podaci Računu & Sigurnost"
 
@@ -152,11 +144,9 @@ msgstr "Radnja"
 msgid "Action Required"
 msgstr "Potrebna radnja"
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr "Radnja koja se izvodi klikom na gumb. Dokument će biti dostupan kao `this`"
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "Radnje"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr "Radnja koja se izvodi klikom na gumb. Dokument će biti dostupan kao `th
 msgid "Active"
 msgstr "Aktivan"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr "Aktivan sada"
 
@@ -177,7 +167,7 @@ msgstr "Aktivan: Agent je dostupan i radi.<br>\n"
 "Odsutan: Agent je privremeno nedostupan.<br>\n"
 "Nedostupan: Agent je isključen i nedostupan."
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "Aktivnost"
@@ -195,10 +185,11 @@ msgid "Add Column"
 msgstr "Dodaj Stupac"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr "Dodaj E-poštu"
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "Dodaj Filter..."
 
@@ -209,6 +200,10 @@ msgstr "Dodaj praznik"
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
 msgstr "Dodaj novi Članak"
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
+msgstr "Dodaj Telefonski Broj"
 
 #: desk/src/components/view-controls/SortBy.vue:148
 msgid "Add Sort"
@@ -246,7 +241,7 @@ msgstr "Dodaj uvjet"
 msgid "Add condition group"
 msgstr "Dodaj grupu uvjeta"
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "Dodaj filter"
 
@@ -280,6 +275,12 @@ msgstr "Dodajte vremenske ciljeve oko ključnih događaja u podršci, kao što s
 msgid "Add to Holidays"
 msgstr "Dodaj Praznicima"
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr "Dodaj primateljima"
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr "Dodaj i upravljaj agentima i dodeljuj im uloge."
@@ -297,17 +298,14 @@ msgid "Administrator"
 msgstr "Administrator"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -318,6 +316,7 @@ msgstr "Administrator"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -337,6 +336,7 @@ msgstr "Nadzorna Ploča Agenta"
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -344,6 +344,7 @@ msgstr "Nadzorna Ploča Agenta"
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -378,18 +379,9 @@ msgstr "Agenti više neće moći pregledavati i stvarati spremljene odgovore s g
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "Svi"
 
@@ -510,6 +502,14 @@ msgstr "Jeste li sigurni da želite izbrisati ovaj zapis?"
 msgid "Are you sure you want to delete these articles?"
 msgstr "Jeste li sigurni da želite izbrisati ove članke?"
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr "Jeste li sigurni da želite izbrisati ovaj kontakt? Kontakt će biti trajno izbrisan i njegova će veza biti prekinuta sa svim povezanim klijentima i zahtjevima."
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr "Jeste li sigurni da želite izbrisati ovog klijenta? Referenca na ovog klijenta bit će uklonjena iz svih povezanih zahtjeva."
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr "Jeste li sigurni da želite izbrisati ovaj zahtjev? Ovo je nepovratna radnja i ne može se poništiti."
@@ -546,6 +546,10 @@ msgstr "Jeste li sigurni da želite izaći? Nespremljene promjene bit će izgubl
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
 msgstr "Jeste li sigurni da želite ukloniti logotip?"
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
+msgstr "Jeste li sigurni da želite ukloniti ovaj kontakt od klijenta?"
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
 msgid "Are you sure you want to reset the content? Current content will be overridden."
@@ -597,16 +601,11 @@ msgstr "Dodijeli zahtjev agentu"
 msgid "Assign ticket"
 msgstr "Dodijeli zahtjev"
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr "Dodijeli"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr "Dodijeli sebi"
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -620,7 +619,7 @@ msgstr "Dodijeljeni"
 msgid "Assignee Rules"
 msgstr "Pravila Dodjele"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr "Dodijeljene osobe uspješno ažurirane."
 
@@ -628,7 +627,7 @@ msgstr "Dodijeljene osobe uspješno ažurirane."
 msgid "Assignees"
 msgstr "Dodijeljeni"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr "Dodijeljeni su uspješno ažurirani."
 
@@ -694,10 +693,6 @@ msgstr "Pravilo dodjeljivanja uspješno ažurirano."
 msgid "Assignment rule {0} updated successfully."
 msgstr "Pravilo dodjeljivanja {0} uspješno je ažurirano."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr "Potrebna je barem jedna e-mail adresa"
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -714,10 +709,6 @@ msgstr "Za ocjenu {0} mora biti omogućena barem jedna opcija povratne informaci
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
 msgstr "Potreban je barem jedan tim"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
-msgstr "Barem jedan od prioriteta, tima i tipa zahtjeva je obavezan"
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
@@ -768,7 +759,7 @@ msgid "Automation"
 msgstr "Automatizacija"
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr "Dostupnost"
@@ -804,7 +795,7 @@ msgstr "Prosječno Vreme Odziva"
 msgid "Average Time Metrics"
 msgstr "Pokazatelji prosječnog vremena"
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr "Prosječna ocjena povratnih informacija po danu je oko {0} zvjezdica"
 
@@ -812,25 +803,37 @@ msgstr "Prosječna ocjena povratnih informacija po danu je oko {0} zvjezdica"
 msgid "Average response and resolution metrics not available"
 msgstr "Prosječni pokazatelji odgovora i rezolucije nisu dostupni"
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr "Prosječan broj zahtjeva dnevno je oko {0}"
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr "Prosječna ocjena povratnih informacija"
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr "Prosječne primljene povratne informacije"
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr "Prosječan prvi odgovor"
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr "Prosječno vrijeme prvog odgovora"
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr "Prosječna Rezolucija"
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
-msgstr "Prosječna ocjena povratnih informacija za riješene Zahtjeve"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr "Prosječno vrijeme rješavanja"
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
+msgstr "Prosječna ocjena povratnih informacija za riješene zahtjeve u ovom razdoblju"
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:290
@@ -842,11 +845,11 @@ msgstr "Prosječno vrijeme prvog odgovora"
 msgid "Avg. resolution time"
 msgstr "Prosječno vrijeme rješavanja"
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr "Prosječno vrijeme potrebno za prvi odgovor na Zahtjev"
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr "Prosječno vrijeme potrebno za rješavanje Zahtjeva"
 
@@ -869,11 +872,6 @@ msgstr "Nazad na Zahtjeve"
 msgid "Base Support Rotation"
 msgstr "Rotacija Osnovne Podrške"
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "Osnovni URL"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -887,11 +885,11 @@ msgstr "Na osnovu vaših pravila ljudskih resursa, odaberi datum završetka peri
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr "Na osnovu vaših pravila ljudskih resursa, odaberite datum početka perioda raspodjele odmora"
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr "Skrivena kopija"
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr "Skrivena kopija:"
 
@@ -946,11 +944,6 @@ msgstr "Praznici"
 msgid "Busy"
 msgstr "Zauzeto"
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "Dugme"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr "CSV"
@@ -975,19 +968,31 @@ msgstr "Trajanje poziva u sekundama"
 msgid "Caller"
 msgstr "Pozivatelj"
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr "Pozivi"
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr "Može pozivati nove agente, upravljati zahtjevima, kreirati prilagođene prikaze i upravljati javnim prikazima."
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr "Može upravljati svim aspektima Podrške."
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr "Može podići zahtjeve u ime organizacije i upravljati zahtjevima koje su podigli."
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr "Može pregledavati sve zahtjeve koje je podigla organizacija i dodijeliti drugim članovima ulogu upravitelja."
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr "Možete pregledati zahtjeve koje su podigli svi kontakti klijenta."
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr "Može raditi na slučajima, kreirati prilagođene prikaze i upravljati privatnim prikazima."
 
@@ -1027,7 +1032,7 @@ msgstr "Nije moguće omogućiti pravilo bez dodavanja korisnika"
 msgid "Cannot merge General category"
 msgstr "Nije moguće spojiti opću kategoriju"
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr "Ne može se preimenovati: nepovezani {0} '{1}' već postoji na drugoj strani. Prvo ručno riješite."
 
@@ -1075,11 +1080,11 @@ msgstr "Kategorija mora imati barem jedan članak"
 msgid "Category updated successfully."
 msgstr "Kategorija je uspješno ažurirana."
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr "Kopija"
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr "Kopija:"
 
@@ -1087,7 +1092,7 @@ msgstr "Kopija:"
 msgid "Change"
 msgstr "Promjeni"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "Promjeni Lozinku"
@@ -1100,10 +1105,9 @@ msgstr "Promijeni Sliku"
 msgid "Change language of the application."
 msgstr "Promijenite jezik aplikacije."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
-msgstr "Promijeni sliku"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
+msgstr "Promijeni operatera ({0})"
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
 msgid "Change priority"
@@ -1125,7 +1129,7 @@ msgstr "Promijeni tip zahtjeva"
 msgid "Change timezone of the application."
 msgstr "Promijenite vremensku zonu aplikacije."
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr "Promijenite lozinku računa radi sigurnosti."
 
@@ -1138,7 +1142,7 @@ msgstr "Kanali"
 msgid "Child field"
 msgstr "Podređeno polje"
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr "Odaberi polje"
 
@@ -1191,7 +1195,7 @@ msgstr "Očisti Sortiranje"
 msgid "Clear Table"
 msgstr "Očisti Tabelu"
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr "Obriši sve"
 
@@ -1206,6 +1210,10 @@ msgstr "Obriši sve filtere"
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
 msgstr "Kliknite na Dodaj Praznicima. Ovo će popuniti tabelu praznika sa svim datumima koji padaju na odabrani slobodan sedmični dan. Ponovite postupak za popunjavanje datuma za sve vaše sedmićne praznike"
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
+msgstr "Kliknite za kopiranje"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:47
@@ -1225,7 +1233,7 @@ msgstr "Zatvori Zahtjev"
 msgid "Closed"
 msgstr "Zatvoreno"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr "Zatvorene ili ocijenjene zahtjeve ne mogu ažurirati osobe koje nisu agenti"
 
@@ -1252,7 +1260,7 @@ msgstr "Kolone"
 msgid "Comma separated emails to invite."
 msgstr "Adrese e-pošte za poziv odvojene zarezima."
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr "Vrijednosti odvojene zarezom"
 
@@ -1285,7 +1293,7 @@ msgstr "Komentirao/la"
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "Komentari"
@@ -1298,6 +1306,11 @@ msgstr "Konverzacija"
 msgid "Communication ID is required"
 msgstr "ID komunikacije je obavezan"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
+msgstr "Tvrtka"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
 msgstr "Završeno"
@@ -1309,7 +1322,7 @@ msgstr "Završeno"
 msgid "Condition"
 msgstr "Uslov"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr "Konfiguriraj"
 
@@ -1333,6 +1346,10 @@ msgstr "Ovdje konfigurirajte postavke integracije Twilio telefonije"
 msgid "Configure your telephony settings."
 msgstr "Konfiguriraj postavke telefonije."
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1358,10 +1375,11 @@ msgstr "Potvrdi prepisivanje"
 msgid "Connect your support email"
 msgstr "Povežite adresu e-pošte za podršku"
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1375,26 +1393,30 @@ msgstr "Kontakt"
 msgid "Contact HTML"
 msgstr "Kontakt HTML"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
-msgstr "Kontakt je uspješno kreiran."
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
-msgstr "Kontakt pozvan."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
+msgstr "Kontakt je uspješno uklonjen"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr "Kontakt je uspješno ažuriran."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
-msgstr "Kontakt s adresom e-pošte već postoji"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
+msgstr "Kontakt {0} nema adresu e-pošte"
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
 msgstr "Kontakti"
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
+msgstr "Kontakti su uspješno dodani"
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
 #. Label of the content (Text Editor) field in DocType 'HD Article'
@@ -1417,7 +1439,7 @@ msgstr "Kopiraj URL zahtjeva"
 msgid "Copy ticket id"
 msgstr "Kopiraj Id zahtjeva"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr "Nije moguće poslati e-poštu zbog: {0}"
 
@@ -1425,7 +1447,11 @@ msgstr "Nije moguće poslati e-poštu zbog: {0}"
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr "Nije moguće pronaći stupac `name` u tabHD Zahtjevu"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr "Nije moguće migrirati kontakte za {0} klijenta: {1}. Ispravite temeljne podatke i ponovno pokrenite zakrpu."
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr "Nije moguće poslati e-poštu s potvrdom zbog: {0}"
 
@@ -1433,11 +1459,20 @@ msgstr "Nije moguće poslati e-poštu s potvrdom zbog: {0}"
 msgid "Could not send feedback email,due to: {0}"
 msgstr "Nije moguće poslati e-poštu s povratnim informacijama zbog: {0}"
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "Zemlja"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1448,9 +1483,13 @@ msgstr "Kreiraj"
 msgid "Create & invite a contact"
 msgstr "Kreiraj i pozovi kontakt"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
-msgstr "Kreiraj Novi Kontakt"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr "Izradi Kontakt"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
+msgstr "Kreiraj Klijenta"
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
 msgid "Create View"
@@ -1484,12 +1523,6 @@ msgstr "Izradio/la"
 msgid "Creating a ticket"
 msgstr "Izrada zahtjeva"
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr "Kriterij"
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr "Prilagođene Radnje"
@@ -1514,12 +1547,21 @@ msgid "Custom Views"
 msgstr "Prilagođeni prikazi"
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
 msgstr "Klijent"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
+msgstr "Voditelj za Klijente"
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1530,17 +1572,33 @@ msgstr "Ime Klijenta"
 msgid "Customer Portal"
 msgstr "Korisnički Portal"
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
-msgstr "Klijent je uspješno kreiran."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr "Tip Klijenta"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr "Izradio Klijent"
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
+msgstr "Naziv klijenta ne može biti prazan"
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr "Klijent Portal"
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
-msgstr "Klijent je uspješno ažuriran."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
+msgstr "Klijent ažuriran"
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
+msgstr "Klijenti"
 
 #: desk/src/components/layouts/Sidebar.vue:595
 msgid "Customers & Contacts"
@@ -1567,6 +1625,8 @@ msgstr "Cijan"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "Opasnost"
@@ -1667,18 +1727,26 @@ msgstr "Zadani Tip Zahtjeva"
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr "Definiraj tko prima zahtjeve i kako se one raspoređuju među agentima."
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "Izbriši"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr "Izbriši Kontakt"
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1695,6 +1763,10 @@ msgstr "Izbriši kategoriju?"
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
 msgstr "Izbriši {0}"
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
+msgstr "Izbriši {0} zahtjeva"
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
 #. Label of the description (Text Editor) field in DocType 'HD Holiday'
@@ -1742,7 +1814,7 @@ msgstr "Detaljno objašnjenje"
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1828,7 +1900,12 @@ msgstr "Dokumenti"
 msgid "Document Type"
 msgstr "Tip Dokumenta"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr "Perić"
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "Domena"
@@ -1870,6 +1947,10 @@ msgstr "Dupliciraj pravilo Ugovora o Razini Usluge"
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
 msgstr "Dupliciraj Definisani Odgovor"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
+msgstr "Duplicirani kontakti nisu dopušteni"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
 #: desk/src/pages/call-logs/CallLogModal.vue:68
@@ -1919,7 +2000,8 @@ msgstr "Sustav nije instaliran na vašoj web stranici. Instaliraj Sustav da bist
 msgid "Easily invite new agents, managers, or admins."
 msgstr "Jednostavno pozovite nove agente, upravitelje ili administratore."
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1928,6 +2010,14 @@ msgstr "Uredi"
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
 msgstr "Uredi Zapisnik Poziva"
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr "Uredi Kontakt"
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
+msgstr "Uredi Klijenta"
 
 #: desk/src/components/Settings/EmailAdd.vue:70
 #: desk/src/components/Settings/EmailEdit.vue:63
@@ -1946,10 +2036,10 @@ msgstr "Uredi Naslov"
 msgid "Edit your email account"
 msgstr "Uredi račun e-pošte"
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "E-pošta"
 
@@ -1977,8 +2067,9 @@ msgstr "Računi e-pošte"
 msgid "Email Content"
 msgstr "Sadržaj e-pošte"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
 msgstr "E-pošta"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
@@ -2004,22 +2095,22 @@ msgstr "Naziv računa e-pošte"
 msgid "Email account updated successfully"
 msgstr "Račun e-pošte uspješno ažuriran"
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr "Adresa e-pošte primarnog kontakta"
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr "Postavke e-pošte uspješno su ažurirane."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr "Adresa e-pošte ne smije biti prazna"
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "E-pošta"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr "E-pošta & Potpis"
 
@@ -2057,8 +2148,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr "Omogući povratne informacije za Korisnički Portal"
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2083,8 +2172,6 @@ msgstr "Omogući povratne informacije za Korisnički Portal"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2107,21 +2194,25 @@ msgstr "Vrijeme Završetka"
 msgid "Enter a name for this HD Service Holiday List."
 msgstr "Unesite naziv za ovaj popis usluga za blagdane."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr "Unesi važeću adresu e-pošte"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr "Unesi važeći broj telefona"
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr "Unesite naziv marke"
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr "Unesi adresu e-pošte"
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
 msgstr "Unesi novo ime tima"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr "Unesite adresu e-pošte primarnog kontakta"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
+msgstr "Unesite ime primarnog kontakta"
 
 #: helpdesk/api/knowledge_base.py:86
 msgid "Error moving article to category"
@@ -2131,22 +2222,18 @@ msgstr "Pogreška pri premještanju članka u kategoriju"
 msgid "Error processing email at index {0}, message: {1}"
 msgstr "Pogreška pri obradi e-pošte na indeksu {0}, poruka: {1}"
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr "Greška pri ažuriranju klijenta"
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "Greška prilikom povezivanja na račun e-pošte {0}"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr "Pravilo eskalacije već postoji za ovaj kriterij"
 
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
 msgstr "Excel"
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
+msgstr "Postojeći korisnici se pridružuju odmah. Ostali dobivaju pozivnicu."
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
 #: desk/src/components/Settings/Telephony/Telephony.vue:96
@@ -2174,11 +2261,6 @@ msgstr "Izvezi Sve {0} Zapis(e)"
 msgid "Export Type"
 msgstr "Tip Izvoza"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr "Vanjska veza"
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2186,6 +2268,10 @@ msgstr "Vanjska veza"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "Neuspješno"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr "Neuspjeli Ugovor o Razini Usluge"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2220,11 +2306,11 @@ msgstr "Nije uspjelo spremanje postavki Exotela"
 msgid "Failed to save Twilio settings"
 msgstr "Nije uspjelo spremanje postavki Twilia"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr "Nije uspjelo ažuriranje dodijeljenih osoba."
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr "Nije uspjelo ažuriranje dodijeljenih."
 
@@ -2253,6 +2339,7 @@ msgstr "Favicon"
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2290,13 +2377,17 @@ msgstr "Povratne informacije već postoje"
 msgid "Feedback Rating"
 msgstr "Ocjena povratnih informacija"
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr "Trend povratnih informacija"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
 msgstr "E-pošta s povratnim informacijama je poslana klijentu"
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
+msgstr "Povratne informacije od ovog kontakta pojavit će se ovdje čim budu dostupne."
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
 msgid "Feedback submitted successfully."
@@ -2340,13 +2431,14 @@ msgid "Field dependency updated successfully."
 msgstr "Ovisnost polja uspješno ažurirana."
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "Polja"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "Filteri"
@@ -2356,13 +2448,18 @@ msgstr "Filteri"
 msgid "Find out all of the variables that can be used in the content"
 msgstr "Saznajte sve varijable koje se mogu koristiti u sadržaju"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "Ime"
 
 #. Label of the first_responded_on (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
+msgstr "Prvi Odgovor"
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
 msgstr "Prvi Odgovor"
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
@@ -2388,10 +2485,6 @@ msgstr "Vrijeme Prvog Odgovora"
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
 msgstr "Vrijeme prvog odgovora na Zahtjev"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
-msgstr "Ime ne smije biti prazno"
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
@@ -2482,6 +2575,10 @@ msgstr "Globalno"
 msgid "Go to Ticket #{0}"
 msgstr "Otvori Zahtjev #{0}"
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr "Dodjeli Pristup Upravitelja"
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2511,8 +2608,6 @@ msgid "Group By Field"
 msgstr "Grupiraj po Polju"
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr "Gost"
@@ -2520,11 +2615,6 @@ msgstr "Gost"
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
 msgstr "Vodite korisnike do članaka prije zahtjeva."
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
-msgstr "Radnja"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -2556,25 +2646,37 @@ msgstr "Povratne informacije Članka"
 msgid "HD Comment Reaction"
 msgstr "Reakcija na Komentar"
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr "Klijent"
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr "Upravitelj za Klijente"
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
-msgstr "Zahtjev za račun Radne Površine"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
+msgstr "Član Klijenta"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
 msgstr "Povratne informacije putem e-pošte"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
-msgstr "Pravilo Eskalacije"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -2595,21 +2697,6 @@ msgstr "Blagdan"
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
 msgstr "Obavijest"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr "Organizacija"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr "Kontakt Organizacije"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
-msgstr "Zahtjev za registraciju na portalu"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -2651,11 +2738,6 @@ msgstr "Postavke"
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
 msgstr "Zaustavna riječ"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
-msgstr "Izvor Pretrage Podrške"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_synonym/hd_synonym.json
@@ -2752,12 +2834,6 @@ msgstr "Podrška"
 msgid "Helpdesk"
 msgstr "Podrška"
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr "Kontakt Podrške"
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2774,11 +2850,6 @@ msgstr "Hej"
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
 msgstr "Sakrij "
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr "Sakrij uvjet"
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
@@ -2848,15 +2919,8 @@ msgstr "Razumijem, dodaj uvjete"
 msgid "ID"
 msgstr "ID"
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "IP Adresa"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2943,6 +3007,11 @@ msgstr "Pristigla Pošta"
 msgid "Incoming"
 msgstr "Dolazna"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr "Privatna"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr "Pokrenut"
@@ -2956,7 +3025,7 @@ msgstr "Instaliraj"
 msgid "Instantly send e-mail"
 msgstr "Trenutno pošalji e-poštu"
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "Nedovoljne Dozvole za {0}"
 
@@ -2970,12 +3039,12 @@ msgstr "Cjelobrojna vrijednost"
 msgid "Introduction"
 msgstr "Uvod"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr "Nevažeća dostupnost"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
 msgstr "Nevažeća adresa e-pošte"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
@@ -2984,23 +3053,43 @@ msgstr "Nevažeća adresa e-pošte"
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr "Nevažeća polja, provjerite jesu li sva ispunjena i jesu li vrijednosti ispravne."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr "Nevažeći tip datoteke, dopuštene su samo PNG i JPG slike"
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr "Nevažeća obavijest"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
 msgstr "Nevažeći telefonski broj"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr "Nevažeća uloga {0}"
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr "Pozivnica je istekla"
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr "Pozivnica je uspješno otkazana"
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr "Pozivnica je istekla. Ponovno pošaljite da biste ponovno pozvali."
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
+msgstr "Pozovi"
 
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
 msgstr "Pozovi agente"
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
+msgstr "Pozovi Kontakt"
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
 msgid "Invite agent"
@@ -3010,13 +3099,30 @@ msgstr "Pozovi agenta"
 msgid "Invite agents"
 msgstr "Pozovi agente"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
-msgstr "Pozovi kao korisnika"
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
+msgstr "Kreiraj Korisnika"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
 msgstr "Pozovi putem e-pošte"
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr "Pozivnica poslana. Čeka se da je korisnik prihvati."
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr "Pozovi putem e-pošte"
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr "Pozvani"
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
+msgstr "Pozvao/la"
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -3032,6 +3138,11 @@ msgstr "Je Klijentni Portal"
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "Je Standard"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr "Je Upravitelj"
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3060,6 +3171,10 @@ msgstr "Je prikvačeno"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
 msgstr "Je postavljanje dovršeno"
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
+msgstr "Pero"
 
 #: desk/src/components/command-palette/CP.vue:114
 msgid "Jump to"
@@ -3095,11 +3210,9 @@ msgstr "Prečice Tastature"
 msgid "Knowledge Base"
 msgstr "Baza Znanja"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3133,9 +3246,9 @@ msgstr "Posljednje"
 msgid "Last 3 Months"
 msgstr "Poslednjih 3 Mjeseci"
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr "Posljednja 3 mjeseca"
 
@@ -3176,7 +3289,8 @@ msgstr "Posljednji odgovor klijenta"
 msgid "Last Month"
 msgstr "Prošli Mjesec"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "Prezime"
 
@@ -3185,24 +3299,33 @@ msgstr "Prezime"
 msgid "Last Week"
 msgstr "Prošli Tjedan"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
 msgstr "Prošli mjesec"
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
+msgstr "Zadnji put viđen"
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr "Posljednji korisnik dodijeljen ovim pravilom"
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
 msgstr "Prošli tjedan"
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
+msgstr "Najnovije"
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -3219,26 +3342,6 @@ msgstr "Saznajte više o uvjetima"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
 msgstr "Obavijesti klijente da podnose zahtjev izvan radnog vremena i kada mogu očekivati odgovor."
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "Veza"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr "Opcije Veze"
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr "Link do klijenta"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
-msgstr "Veza do zapisa klijenta"
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #. Label of the list_tab (Tab Break) field in DocType 'HD View'
@@ -3266,6 +3369,8 @@ msgstr "Učitaj Zadane Stupce"
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "Učitaj Još"
 
@@ -3288,6 +3393,8 @@ msgstr "Prijavi se na Frappe Cloud"
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr "Logo"
@@ -3326,7 +3433,7 @@ msgstr "Upravljaj općim postavkama aplikacije."
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr "Upravljajte unaprijed definiranim odgovorima koji se mogu koristiti za odgovaranje na upite klijenta."
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr "Upravljajte e-poštom računa i potpisom e-pošte za komunikaciju."
 
@@ -3345,6 +3452,10 @@ msgstr "Upravljaj svojim osobnim postavkama."
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
 msgstr "Upravljajte informacijama profila."
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
+msgstr "Upravitelj"
 
 #: desk/src/pages/MobileNotifications.vue:11
 #: desk/src/pages/MobileNotifications.vue:14
@@ -3398,6 +3509,20 @@ msgstr "Razno"
 msgid "Mobile App Installation"
 msgstr "Instalacija mobilne aplikacije"
 
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr "Mobilni Broj"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr "Mobilni Broj"
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr "Broj mobilnog telefona primarnog kontakta"
+
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
 #. List'
@@ -3438,7 +3563,7 @@ msgid "My Tickets"
 msgstr "Moji Zahtjevi"
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3449,8 +3574,9 @@ msgstr "Moji Zahtjevi"
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3460,6 +3586,10 @@ msgstr "Naziv"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
 msgstr "Težina Naziva"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
+msgstr "Ime je obavezno"
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
 #. Ticket Status'
@@ -3471,10 +3601,18 @@ msgstr "Ime prikazano na korisničkom portalu<br> (npr. Odgovoreno → Čeka se 
 msgid "Navigation"
 msgstr "Navigacija"
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr "Negativno"
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr "Prvo negativno"
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "Nikad"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3583,11 +3721,11 @@ msgstr "Bez Odgovora"
 msgid "No Data Found"
 msgstr "Nisu Pronađeni Podaci"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr "Nije pronađen račun e-pošte za {0}"
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr "Nema zapisa Agenta za trenutnog korisnika"
 
@@ -3599,9 +3737,15 @@ msgstr "Nije pronađena lista praznika"
 msgid "No SLA found"
 msgstr "Nije pronađen Ugovor o Razini Usluge"
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
 msgstr "Nema Tima"
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
+msgstr "Nema aktivnih zahtjeva"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
 msgid "No additional comments"
@@ -3635,19 +3779,27 @@ msgstr "Nema dostupnih kategorija"
 msgid "No changes made"
 msgstr "Nisu napravljene promjene"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr "Nema promjena za spremanje"
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr "Nije dodan nijedan grafikon"
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr "Nisu pronađeni kontakti"
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr "Nisu pronađeni kontakti za primijenjene filtere. Pokušajte prilagoditi ili izbrisati filtere."
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr "Nema kontakata za dodavanje"
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr "Nijedna zemlja nije pronađena"
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr "Nisu pronađeni klijenti za primijenjene filtere. Pokušajte prilagoditi ili obrisati filtere."
 
@@ -3659,7 +3811,11 @@ msgstr "Nije pronađen račun e-pošte"
 msgid "No feedback"
 msgstr "Nema povratnih informacija"
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr "Još nema povratnih informacija"
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr "Nisu pronađena polja"
 
@@ -3699,19 +3855,25 @@ msgstr "Nema razloga"
 msgid "No recently assigned tickets"
 msgstr "Nema nedavno dodijeljenih slušajeva"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr "Nema rezultata"
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
 msgstr "Nisu pronađeni rezultati"
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
+msgstr "Nisu pronađene recenzije"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:91
 msgid "No saved replies found"
 msgstr "Nisu pronađeni definisani odgovori"
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr "Nisu pronađeni zahtjevi"
@@ -3732,7 +3894,11 @@ msgstr "Nisu pronađeni zahtjevi za pregled."
 msgid "No tickets selected"
 msgstr "Nije odabran nijedna zahtjev"
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr "Nema korisnika povezanog s kontaktom {0}"
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "Nije Dozvoljeno"
 
@@ -3744,7 +3910,7 @@ msgstr "Nije dodijeljeno"
 msgid "Not Saved"
 msgstr "Nespremljeno"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "Nije Postavljeno"
 
@@ -3783,11 +3949,6 @@ msgstr "Stari uvjeti"
 msgid "On Hold Since"
 msgstr "Na čekanju od"
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr "Na klik (Javascript)"
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr "Na Status Zahtjeva"
@@ -3818,6 +3979,10 @@ msgstr "Otvori paletu naredbi"
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
 msgstr "Otvori okvir za komentare"
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
+msgstr "Otvori Klijenta"
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
 msgid "Open help"
@@ -3908,7 +4073,12 @@ msgstr "Nadređeno polje"
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr "Obavezno je nadređeno polje, podređeno polje i mapiranje nadređeno-podređeno."
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr "Partnerstvo"
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "Lozinka"
 
@@ -3946,6 +4116,7 @@ msgid "Pending"
 msgstr "Na Čekanju"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr "Pozivnice na Čekanju"
 
@@ -3955,19 +4126,19 @@ msgstr "Pozivnice na Čekanju"
 msgid "Pending Tickets"
 msgstr "Zahtjevi na čekanju"
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr "Postotak ukupnog broja zahtjeva po kanalu"
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr "Postotak ukupnog broja skučajeva po prioritetu"
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr "Postotak ukupnog broja zahtjeva po timu"
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr "Postotak ukupnog broja zahtjeva po tipu"
 
@@ -3988,14 +4159,15 @@ msgstr "Lična"
 msgid "Personal mobile no"
 msgstr "Broj osobnog mobitela"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "Telefon"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
-msgstr "Brojevi telefona"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
+msgstr "Fotografija"
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
 msgid "Pick an option"
@@ -4051,7 +4223,7 @@ msgstr "Unesi predmet za nastavak"
 msgid "Please enter a valid phone number"
 msgstr "Unesi važeći broj telefona"
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr "Molimo unesite barem jednu važeću adresu e-pošte za slanje pozivnice."
 
@@ -4094,34 +4266,15 @@ msgstr "Odaberi sedmične neradne dane"
 msgid "Policy name"
 msgstr "Naziv Pravila"
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr "Pozitivno"
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
 msgstr "Prvo pozitivno"
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr "Upiši Opisni Ključ"
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr "Postavi Listu Ključa Rute"
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr "Postavi Niz Rute"
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
-msgstr "Postavi Naziv Ključa"
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:10
@@ -4155,14 +4308,32 @@ msgstr "Pregled"
 msgid "Previous ticket"
 msgstr "Prethodni Zahtjev"
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "Primarni"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "Primarni Kontakt"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr "Primarni kontakt mora biti jedan od navedenih kontakata"
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr "Primarni kontakt je ažuriran"
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr "Prioriteti"
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4170,9 +4341,10 @@ msgstr "Prioriteti"
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4252,17 +4424,6 @@ msgstr "Učitavanje e-pošte, može potrajati nekoliko minuta."
 msgid "Quarterly"
 msgstr "Tromjesečno"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "Opcije Upita"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr "Niz Rute Upita"
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "U Redu"
@@ -4285,14 +4446,14 @@ msgstr "Ocijenite Iskustvo s Podrškom"
 msgid "Rate this ticket"
 msgstr "Ocijeni ovaj zahtjev"
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr "Ocijenjeni Zahtjevi"
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4388,8 +4549,15 @@ msgstr "Obnovi Indeks Pretrage"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "Ukloni"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr "Ukloni Kontakt"
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4399,10 +4567,19 @@ msgstr "Ukloni logotip"
 msgid "Remove Photo"
 msgstr "Ukloni Sliku"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr "Ukloni filter"
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
 msgstr "Ukloni sliku"
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
+msgstr "Ukloni primarni"
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
 #: desk/src/components/Settings/Teams/TeamsList.vue:161
@@ -4422,6 +4599,15 @@ msgstr "Preimenuj (⌘ + ⏎)"
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
 msgstr "Preimenuj tim"
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr "Zamijenite filter"
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
+msgstr "Zamijeni sliku"
 
 #. Option in a Select field in the tickets Web Form
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
@@ -4460,17 +4646,14 @@ msgstr "Odgovor kontakta"
 msgid "Reply on a ticket"
 msgstr "Odgovor na zahtjev"
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr "Ključ Zahtjeva"
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
 msgstr "Obavezno"
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
+msgstr "Ponovno pošalji pozivnicu"
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
 msgid "Reset"
@@ -4490,6 +4673,7 @@ msgid "Reset to Default"
 msgstr "Vrati na Zadano"
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr "Rezolucija"
@@ -4543,18 +4727,6 @@ msgstr "Odgovor"
 msgid "Response By"
 msgstr "Odgovor od"
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr "Opcije Odgovora"
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr "Put Ključa Rezultata Odgovora"
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr "Vrijeme Odgovora za {0} prioritet u redu {1} ne može biti veće od Vremena Rezolucije."
@@ -4597,37 +4769,33 @@ msgstr "Ograniči pregled i upravljanje zahtjevima samo od strane članova tima.
 msgid "Restrict visibility to these teams"
 msgstr "Ograniči vidljivost na ove timove"
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr "Polje Pregleda Rezultata"
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr "Polje Rute Rezultata"
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr "Polje Naziva Rezultata"
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
 msgstr "Recenzije"
 
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr "Poništi pozivnicu"
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
+msgstr "Opoziv Pristupa Upravitelju"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:215
 msgid "Ringing"
 msgstr "Zvoni"
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "Uloga"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr "Uloga je uspješno ažurirana"
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4726,9 +4894,9 @@ msgstr "Subota"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4804,17 +4972,19 @@ msgstr "Indeks Pretraživanja Obnovljen"
 msgid "Search Score"
 msgstr "Ocjena Pretrage"
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr "Naziv Parametra Pretrage"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr "Pretraži agente..."
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr "Pretraživanje po ID-u ili Predmetu"
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr "Pretraži zemlju"
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "Polja za Pretragu..."
 
@@ -4854,6 +5024,7 @@ msgstr "Traži..."
 msgid "Searched for:"
 msgstr "Tražilo se:"
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr "Pretraživanje..."
@@ -4873,6 +5044,10 @@ msgstr "Odaberi"
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
 msgstr "Odaberi Kategoriju"
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
+msgstr "Odaberi Klijenta"
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
 msgid "Select Range"
@@ -4894,6 +5069,10 @@ msgstr "Odaberi Standard Prioritet."
 msgid "Select a rating"
 msgstr "Odaberi ocjenu"
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr "Odaberite zemlju"
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4906,6 +5085,10 @@ msgstr "Odaberi timove"
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
 msgstr "Odaberi zahtjev za pregled"
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
+msgstr "Odaberite vremensku zonu"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
 msgid "Select what type all tickets get by default."
@@ -4932,6 +5115,10 @@ msgstr "Pošalji odgovor"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
 msgstr "Pošalji povratne informacije kada"
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
+msgstr "Pošalji e-poštu za poništenje lozinke"
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
 msgid "Send to {0} tickets"
@@ -4971,7 +5158,7 @@ msgstr "Naziv Servisnog Nivoa"
 msgid "Service not supported"
 msgstr "Usluga nije podržana"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "Postavi"
 
@@ -4979,6 +5166,10 @@ msgstr "Postavi"
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
 msgstr "Postavi telefonski broj"
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
+msgstr "Postavi Primarni Kontakt"
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
 msgid "Set Resolution Time for Priority {0} in row {1}."
@@ -4988,12 +5179,21 @@ msgstr "Postavi vrijeme rješavanja za prioritet {0} u retku {1}."
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr "Postavi Vrijeme Odgovora za Prioritet {0} u redu {1}."
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr "Postavi kao Primarni"
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr "Postavi kao zadani Ugovor o Razini Usluge"
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr "Postavi kao Primarni"
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr "Postavi status"
 
@@ -5005,7 +5205,7 @@ msgstr "Postavi zadani status koji se dodjeljuje prilikom kreiranja zahtjeva i s
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr "Postavi radne dane, sate i praznike odabirom unaprijed definiranog rasporeda ili stvaranjem novog."
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr "Podesi dostupnost kako bi vaš tim znao kada ste dostupni."
 
@@ -5139,23 +5339,6 @@ msgstr "Došlo je do pogreške prilikom ažuriranja popisa praznika"
 msgid "Sort"
 msgstr "Sortiraj"
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr "Izvorni DocType"
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "Naziv Izvora"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr "Tip Izvora"
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr "Izvorna i ciljna kategorija ne mogu biti iste"
@@ -5200,6 +5383,8 @@ msgstr "Vrijeme početka ne može biti kasnije od ili jednako vremenu završetka
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5268,6 +5453,7 @@ msgstr "Status zahtjeva, kada je kreiran u sustavu."
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5379,21 +5565,16 @@ msgstr "Sistem"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5432,8 +5613,6 @@ msgstr "Ciljani Zahtjev ne postoji"
 msgid "Teal"
 msgstr "Tirkizna"
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5444,7 +5623,6 @@ msgstr "Tirkizna"
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5550,6 +5728,10 @@ msgstr "Uvjet dodjeljivanja '{0}' nije valjan: {1}"
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr "JSON Uvjet Dodjeljivanja {0}' nije valjan: {1}"
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr "Kontakt {0} je povezan s više klijenata. Molimo odaberite klijenta ručno."
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr "Dijalog za povratne informacije prikazat će se kada korisnik pokuša zatvoriti zahtjev s korisničkog portala."
@@ -5561,6 +5743,10 @@ msgstr "Praznik {0} nije između Od Datuma i Do Datuma"
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
 msgstr "Broj dana mora biti 1 ili više"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
+msgstr "Odabrani klijent {0} nije povezan s kontaktom {1}. Molimo odaberite valjanog klijenta ili ažurirajte povezane klijente kontakta."
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
 msgid "The status for sending feedback must be of <u>Resolved</u> category."
@@ -5582,6 +5768,14 @@ msgstr "Trenutno nema objavljenih kategorija."
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr "Treba postojati barem jedno pravilo dodjele za zahtjev"
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr "Dobit će pristup zahtjevima koje su prikupili svi u organizaciji."
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr "Od sada će vidjeti samo svoje zahtjeve."
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr "Ovo Pravilo Dodjele povezano je s Timom {0}.</br> Korisnik {1} dodan je u Pravilo Dodjele, ali ne i u povezani Tim. Molimo dodajte korisnika u {2} kako biste osigurali pravilnu strukturu tima."
@@ -5590,6 +5784,10 @@ msgstr "Ovo Pravilo Dodjele povezano je s Timom {0}.</br> Korisnik {1} dodan je 
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
 msgstr "Ova radnja je nepovratna."
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
+msgstr "Ovaj kontakt će postati primarna kontakt osoba i moći će vidjeti zahtjeve koje su podnijeli svi ostali kontakti u organizaciji."
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
 msgid "This date is calculated based on configured SLAs, working hours, and holidays."
@@ -5658,7 +5856,7 @@ msgstr "Četvrtak"
 msgid "Ticket"
 msgstr "Zahtjev"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr "Slučaj #{0}: Primili smo vaš zahtjev"
 
@@ -5673,6 +5871,10 @@ msgstr "Analitika Zahtjeva"
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
 msgstr "Konfiguracija Zahtjeva"
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
+msgstr "ID Zahtjeva"
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
 msgid "Ticket Info"
@@ -5731,7 +5933,7 @@ msgstr "Predmet Zahtjeva"
 msgid "Ticket Summary"
 msgstr "Sažetak Zahtjeva"
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr "Trend Zahtjeva"
 
@@ -5764,7 +5966,7 @@ msgstr "Zahtjev ne postoji."
 msgid "Ticket merged successfully."
 msgstr "Zahtjev uspješno spojen."
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr "Zahtjev mora biti riješen povratnom informacijom"
 
@@ -5799,12 +6001,6 @@ msgstr "Status Zahtjeva"
 msgid "Ticket to merged with is required"
 msgstr "Potreban je zahtjv za spajanje s"
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr "Tip Zahtjeva"
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr "Zahtjev uspješno ažuriran."
@@ -5816,12 +6012,15 @@ msgstr "Analiza Pretrage Zahtjeva"
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr "Zahtjevi"
 
@@ -5833,19 +6032,19 @@ msgstr "Zahtjevi koji se približavaju ili krše Ugovor o Razini Usluge"
 msgid "Tickets assigned to you in the last 7 days"
 msgstr "Zahtjevi koji su vam dodijeljeni u posljednjih 7 dana"
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr "Zahtjevi po Kanalu"
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr "Zahtjevi po Prioritetu"
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr "Zahtjevi po Timu"
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr "Slučajevi po Tipu"
 
@@ -5862,6 +6061,7 @@ msgid "Tickets that are awaiting your response"
 msgstr "Zahtjevi koje čekaju vaš odgovor"
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr "Vremenska Zona"
 
@@ -5951,19 +6151,19 @@ msgstr "Ukupno Praznika"
 msgid "Total Ticket"
 msgstr "Ukupano Zahtjeva"
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr "Ukupan broj kreiranih zahtjeva"
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr "Ukupan broj zahtjeva po prioritetu"
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr "Ukupan broj zahtjeva po timu"
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr "Ukupan broj zahtjeva po tipu"
 
@@ -5995,6 +6195,10 @@ msgstr "Tip"
 msgid "Type a message"
 msgstr "Upiši poruku"
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr "Upišite adresu e-pošte"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr "Tip je obavezan"
@@ -6004,7 +6208,7 @@ msgstr "Tip je obavezan"
 msgid "URL/Method"
 msgstr "URL/Metod"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr "Nije moguće poslati e-poštu. Postavite zadani račun odlazne e-pošte."
 
@@ -6038,6 +6242,8 @@ msgid "Unpublish"
 msgstr "Poništi Objavu"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr "Nespremljeno"
 
@@ -6055,6 +6261,10 @@ msgstr "Nespremljeno"
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
 msgstr "Nespremljene promjene"
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
+msgstr "Nepodržani tip dokumenta '{0}' za statistiku zahtjeva."
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
 msgid "Untitled"
@@ -6082,10 +6292,13 @@ msgstr "Učitaj"
 msgid "Upload Photo"
 msgstr "Prenesi Sliku"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
-msgstr "Prenesi sliku"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
+msgstr "Otpremite sliku u PNG ili JPG formatu"
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
+msgstr "Učitaj Sliku"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
 msgid "Uploading {0}%"
@@ -6094,17 +6307,13 @@ msgstr "Prijenos {0}%"
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6116,6 +6325,10 @@ msgstr "Korisnik"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
 msgstr "Korisnikovo Vrijeme Rješenja"
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
+msgstr "Recenzije Korisnika"
 
 #: desk/src/components/Settings/General/General.vue:42
 msgid "User Signup"
@@ -6134,7 +6347,7 @@ msgstr "Korisnici"
 msgid "Valid From"
 msgstr "Važi od"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "Vrijednost"
 
@@ -6263,19 +6476,23 @@ msgstr "Godišnje"
 msgid "Yellow"
 msgstr "Žuta"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr "Nije vam dopušteno pregledavati statistiku drugog agenta."
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr "Nemate dopuštenje za pregled podataka ove nadzorne ploče."
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr "Nije vam dozvoljen pristup ovom resursu."
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr "Nije vam dopušteno dodavanje komentara"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr "Nije vam dopušteno odgovoriti kao agent"
 
@@ -6303,6 +6520,14 @@ msgstr "Ne možete postaviti više od jednog zadanog prioriteta."
 msgid "You do not have permission to access Assignment Rules"
 msgstr "Nemate dopuštenje za pristup Pravilima Dodjele"
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr "Nemate dopuštenje za pristup ovom resursu"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr "Nemate dopuštenje za ažuriranje kontakata"
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr "Nemate pristup ovom zahtjevu ili on više ne postoji."
@@ -6326,6 +6551,14 @@ msgstr "Vaši stari uvjeti bit će prepisani. Jeste li sigurni da želite spremi
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
 msgstr "Vaša učinkovitost je"
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr "aktivni zahtjev"
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
+msgstr "aktivni zahtjevi"
 
 #: desk/src/pages/MobileNotifications.vue:46
 msgid "assigned you a ticket"
@@ -6355,7 +6588,7 @@ msgstr "kreirano"
 msgid "customize {0}"
 msgstr "prilagodi {0}"
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr "dana"
 
@@ -6406,7 +6639,7 @@ msgstr "ovdje"
 msgid "here."
 msgstr "ovdje."
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr "sati"
 
@@ -6414,7 +6647,7 @@ msgstr "sati"
 msgid "in"
 msgstr "u"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "upravo sada"
 
@@ -6447,7 +6680,11 @@ msgstr "objavio/la"
 msgid "purple"
 msgstr "ljubičasta"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr "recenzije"
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr "zvijezde"
 
@@ -6464,7 +6701,7 @@ msgstr "zahtjev"
 msgid "to enable this integration."
 msgstr "da omogući ovu integraciju."
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr "pogledao/la je ovo"
 
@@ -6472,13 +6709,33 @@ msgstr "pogledao/la je ovo"
 msgid "views"
 msgstr "pregledi"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr "{0} Klijenata"
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr "{0} je već dodan"
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr "{0} nije valjana adresa e-pošte"
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr "{0} je trenutno odsutan/na."
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
 msgstr "{0} trenutno nije dostupan/na."
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr "{0} nije postojeći kontakt"
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
+msgstr "{0} nije postojeći korisnik"
 
 #: desk/src/components/ListViewBuilder.vue:307
 msgid "{0} item(s) deleted successfully"
@@ -6504,7 +6761,7 @@ msgstr "Prikaz {0} je trenutno javan. Promjenom u privatni sakrit će se za sve 
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr "Prikaz {0} trenutno je vidljiv u bočnoj traci. Skrivanjem će se ukloniti s bočne trake."
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr "{0} · Zadnja aktivnost {1}"
 

--- a/helpdesk/locale/hu.po
+++ b/helpdesk/locale/hu.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-15 18:50\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-29 21:57\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Hungarian\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr "% SLA teljesítve"
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr "Az SLA-n belül megoldott jegyek százalékos aránya"
@@ -108,14 +108,6 @@ msgstr ""
 msgid "A workday with this name already exists"
 msgstr ""
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr "API"
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr "Hozzáférés az összes csapatjegyhez"
@@ -132,7 +124,7 @@ msgstr "Csak ennek a csapatnak a jegyeihez való hozzáférés"
 msgid "Account"
 msgstr "Fiók"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr "Fiókadatok és biztonság"
 
@@ -152,11 +144,9 @@ msgstr "Művelet"
 msgid "Action Required"
 msgstr "Intézkedés Szükséges"
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr "A gombra kattintva végrehajtandó művelet. A dokumentum \"this\" néven lesz elérhető"
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "Műveletek"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr "A gombra kattintva végrehajtandó művelet. A dokumentum \"this\" néve
 msgid "Active"
 msgstr "Aktív"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr ""
 
@@ -175,7 +165,7 @@ msgid "Active: The agent is available and working.<br>\n"
 "Unavailable: The agent is off and unavailable."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "Tevékenység"
@@ -193,10 +183,11 @@ msgid "Add Column"
 msgstr "Oszlop Hozzáadása"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr "E-mail cím hozzáadása"
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "Szűrő hozzáadása..."
 
@@ -206,6 +197,10 @@ msgstr "Ünnepnap Hozzáadása"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
 msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:148
@@ -244,7 +239,7 @@ msgstr "Feltétel hozzáadása"
 msgid "Add condition group"
 msgstr "Feltételcsoport hozzáadása"
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "Szűrő hozzáadása"
 
@@ -278,6 +273,12 @@ msgstr "Adjon meg időbeli célokat a támogatási mérföldkövek, például az
 msgid "Add to Holidays"
 msgstr ""
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr ""
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr "Ügynökök hozzáadása, kezelése és szerepekörök hozzárendelése."
@@ -295,17 +296,14 @@ msgid "Administrator"
 msgstr "Rendszergazda"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -316,6 +314,7 @@ msgstr "Rendszergazda"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -335,6 +334,7 @@ msgstr ""
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -342,6 +342,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -376,18 +377,9 @@ msgstr ""
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "Összes"
 
@@ -508,6 +500,14 @@ msgstr ""
 msgid "Are you sure you want to delete these articles?"
 msgstr ""
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr ""
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr ""
@@ -544,6 +544,10 @@ msgstr "Biztosan kilépsz? A nem mentett módosítások elvesznek."
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
 msgstr "Biztos vagy a logó törlésében?"
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
+msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
 msgid "Are you sure you want to reset the content? Current content will be overridden."
@@ -595,16 +599,11 @@ msgstr ""
 msgid "Assign ticket"
 msgstr ""
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr ""
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -618,7 +617,7 @@ msgstr "Felelős"
 msgid "Assignee Rules"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr ""
 
@@ -626,7 +625,7 @@ msgstr ""
 msgid "Assignees"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr ""
 
@@ -692,10 +691,6 @@ msgstr ""
 msgid "Assignment rule {0} updated successfully."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -711,10 +706,6 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
-msgstr ""
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
 msgstr ""
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
@@ -766,7 +757,7 @@ msgid "Automation"
 msgstr "Automatizálás"
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr ""
@@ -802,7 +793,7 @@ msgstr ""
 msgid "Average Time Metrics"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr ""
 
@@ -810,24 +801,36 @@ msgstr ""
 msgid "Average response and resolution metrics not available"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
 msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
@@ -840,11 +843,11 @@ msgstr ""
 msgid "Avg. resolution time"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr ""
 
@@ -867,11 +870,6 @@ msgstr ""
 msgid "Base Support Rotation"
 msgstr ""
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "Alapértelmezett URL"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -885,11 +883,11 @@ msgstr ""
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr ""
 
@@ -944,11 +942,6 @@ msgstr ""
 msgid "Busy"
 msgstr ""
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "Gomb"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr "CSV"
@@ -973,19 +966,31 @@ msgstr ""
 msgid "Caller"
 msgstr "Hívó"
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr ""
 
@@ -1025,7 +1030,7 @@ msgstr "Nem lehet engedélyezni a szabályt anélkül, hogy felhasználókat adn
 msgid "Cannot merge General category"
 msgstr ""
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr ""
 
@@ -1073,11 +1078,11 @@ msgstr ""
 msgid "Category updated successfully."
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr ""
 
@@ -1085,7 +1090,7 @@ msgstr ""
 msgid "Change"
 msgstr "Változás"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "Változtass Jelszót"
@@ -1098,9 +1103,8 @@ msgstr "Fénykép módosítása"
 msgid "Change language of the application."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
@@ -1123,7 +1127,7 @@ msgstr ""
 msgid "Change timezone of the application."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr ""
 
@@ -1136,7 +1140,7 @@ msgstr ""
 msgid "Child field"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr ""
 
@@ -1189,7 +1193,7 @@ msgstr "Rendezés törlése"
 msgid "Clear Table"
 msgstr "Tábla törlése"
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr ""
 
@@ -1203,6 +1207,10 @@ msgstr "Összes szűrő törlése"
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
@@ -1223,7 +1231,7 @@ msgstr ""
 msgid "Closed"
 msgstr "Lezárva"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr ""
 
@@ -1250,7 +1258,7 @@ msgstr "Oszlopok"
 msgid "Comma separated emails to invite."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr ""
 
@@ -1283,7 +1291,7 @@ msgstr ""
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "Hozzászólások"
@@ -1294,6 +1302,11 @@ msgstr "Kommunikáció"
 
 #: desk/src/components/ticket/TicketSplitModal.vue:76
 msgid "Communication ID is required"
+msgstr ""
+
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:209
@@ -1307,7 +1320,7 @@ msgstr "Befejezve"
 msgid "Condition"
 msgstr "Feltétel"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr "Konfigurálás"
 
@@ -1331,6 +1344,10 @@ msgstr ""
 msgid "Configure your telephony settings."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1356,10 +1373,11 @@ msgstr ""
 msgid "Connect your support email"
 msgstr ""
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1373,26 +1391,30 @@ msgstr "Névjegy"
 msgid "Contact HTML"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
 msgstr ""
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
 msgstr "Kapcsolatok"
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
+msgstr ""
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
 #. Label of the content (Text Editor) field in DocType 'HD Article'
@@ -1415,7 +1437,7 @@ msgstr ""
 msgid "Copy ticket id"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr ""
 
@@ -1423,7 +1445,11 @@ msgstr ""
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr ""
 
@@ -1431,11 +1457,20 @@ msgstr ""
 msgid "Could not send feedback email,due to: {0}"
 msgstr ""
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "Ország"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1446,8 +1481,12 @@ msgstr "Létrehozás"
 msgid "Create & invite a contact"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
 msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
@@ -1482,12 +1521,6 @@ msgstr ""
 msgid "Creating a ticket"
 msgstr ""
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr ""
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr "Egyéni műveletek"
@@ -1512,11 +1545,20 @@ msgid "Custom Views"
 msgstr ""
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
 msgstr ""
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
@@ -1528,16 +1570,32 @@ msgstr ""
 msgid "Customer Portal"
 msgstr ""
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
-msgstr "Az ügyfél sikeresen létrehozta."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
 msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:595
@@ -1565,6 +1623,8 @@ msgstr "Cián"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "Veszély"
@@ -1665,18 +1725,26 @@ msgstr ""
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr ""
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "Törlés"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr "Névjegy törlése"
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1692,6 +1760,10 @@ msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
+msgstr ""
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
 msgstr ""
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
@@ -1740,7 +1812,7 @@ msgstr ""
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1826,7 +1898,12 @@ msgstr ""
 msgid "Document Type"
 msgstr "Dokumentum Típus"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr ""
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "Domén"
@@ -1867,6 +1944,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
@@ -1917,7 +1998,8 @@ msgstr ""
 msgid "Easily invite new agents, managers, or admins."
 msgstr ""
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1926,6 +2008,14 @@ msgstr "Szerkeszt"
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
 msgstr "Hívásnapló szerkesztése"
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
+msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:70
 #: desk/src/components/Settings/EmailEdit.vue:63
@@ -1944,10 +2034,10 @@ msgstr ""
 msgid "Edit your email account"
 msgstr ""
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "E-mail"
 
@@ -1975,8 +2065,9 @@ msgstr "E-mail fiókok"
 msgid "Email Content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
 msgstr "E-mail azonosító"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
@@ -2002,22 +2093,22 @@ msgstr ""
 msgid "Email account updated successfully"
 msgstr ""
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr ""
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr "Az e-mail beállítások sikeresen frissítve."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr ""
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "E-mailek"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr "E-mailek és aláírás"
 
@@ -2055,8 +2146,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr ""
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2081,8 +2170,6 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2105,20 +2192,24 @@ msgstr "Befejezés dátuma"
 msgid "Enter a name for this HD Service Holiday List."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr ""
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr ""
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
 msgstr ""
 
 #: helpdesk/api/knowledge_base.py:86
@@ -2129,22 +2220,18 @@ msgstr ""
 msgid "Error processing email at index {0}, message: {1}"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr ""
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "Hiba az e-mail fiókhoz való csatlakozáskor {0}"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr ""
 
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
 msgstr "Excel"
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
+msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
 #: desk/src/components/Settings/Telephony/Telephony.vue:96
@@ -2172,11 +2259,6 @@ msgstr ""
 msgid "Export Type"
 msgstr "Export típusa"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr ""
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2184,6 +2266,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "Sikertelen"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2218,11 +2304,11 @@ msgstr ""
 msgid "Failed to save Twilio settings"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr ""
 
@@ -2251,6 +2337,7 @@ msgstr "Weboldal ikon"
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2288,12 +2375,16 @@ msgstr ""
 msgid "Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
+msgstr ""
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
 msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
@@ -2338,13 +2429,14 @@ msgid "Field dependency updated successfully."
 msgstr ""
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "Mezők"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "Szűrők"
@@ -2354,7 +2446,8 @@ msgstr "Szűrők"
 msgid "Find out all of the variables that can be used in the content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "Vezetéknév"
 
@@ -2362,6 +2455,10 @@ msgstr "Vezetéknév"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
 msgstr "Első válasz időpontja"
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
+msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -2385,10 +2482,6 @@ msgstr ""
 #. Name of a report
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -2480,6 +2573,10 @@ msgstr ""
 msgid "Go to Ticket #{0}"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr ""
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2509,19 +2606,12 @@ msgid "Group By Field"
 msgstr "Csoportosítás mező szerint"
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr "Vendég"
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
 msgstr ""
 
 #. Name of a DocType
@@ -2554,24 +2644,36 @@ msgstr ""
 msgid "HD Comment Reaction"
 msgstr ""
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr ""
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr ""
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
 msgstr ""
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
 msgstr ""
 
 #. Name of a DocType
@@ -2592,21 +2694,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
 msgstr ""
 
 #. Name of a DocType
@@ -2648,11 +2735,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
 msgstr ""
 
 #. Name of a DocType
@@ -2750,12 +2832,6 @@ msgstr ""
 msgid "Helpdesk"
 msgstr ""
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr ""
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2772,11 +2848,6 @@ msgstr ""
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
 msgstr "Elrejt "
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr ""
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
@@ -2846,15 +2917,8 @@ msgstr ""
 msgid "ID"
 msgstr "ID"
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "IP Cím"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2941,6 +3005,11 @@ msgstr "Beérkezett Üzenetek"
 msgid "Incoming"
 msgstr "Bejövő"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr "kezdeményezett"
@@ -2954,7 +3023,7 @@ msgstr ""
 msgid "Instantly send e-mail"
 msgstr ""
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "Nincs Jogosultság {0} számára"
 
@@ -2968,13 +3037,13 @@ msgstr ""
 msgid "Introduction"
 msgstr "Bevezetés"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
-msgstr ""
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
+msgstr "Érvénytelen e-mail cím"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
 #: desk/src/components/Settings/Holiday/HolidayView.vue:325
@@ -2982,22 +3051,42 @@ msgstr ""
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr "Érvénytelen mezők, ellenőrizd, hogy minden mező ki van-e töltve, és az értékek helyesek-e."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr ""
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr "Meghívó lejárt"
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr ""
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
+msgstr "Meghívás"
+
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
@@ -3008,12 +3097,29 @@ msgstr ""
 msgid "Invite agents"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
-msgstr ""
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
+msgstr "Meghívás felhasználóként"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
 msgstr ""
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
@@ -3030,6 +3136,11 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "Alapértelmezett"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr ""
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3057,6 +3168,10 @@ msgstr ""
 #. Label of the setup_complete (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
 msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:114
@@ -3093,11 +3208,9 @@ msgstr "Gyorsbillentyűk"
 msgid "Knowledge Base"
 msgstr "Tudásbázis"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3131,9 +3244,9 @@ msgstr "Utolsó"
 msgid "Last 3 Months"
 msgstr "Elmúlt 3 hónap"
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr ""
 
@@ -3174,7 +3287,8 @@ msgstr ""
 msgid "Last Month"
 msgstr "Múlt hónap"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "Vezetéknév"
 
@@ -3183,23 +3297,32 @@ msgstr "Vezetéknév"
 msgid "Last Week"
 msgstr "Múlt héten"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr ""
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
 msgstr ""
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
@@ -3216,26 +3339,6 @@ msgstr ""
 #. 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
-msgstr ""
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "Hivatkozás"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -3264,6 +3367,8 @@ msgstr "Alapértelmezett oszlopok betöltése"
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "Továbbiak Betöltése"
 
@@ -3286,6 +3391,8 @@ msgstr "Bejelentkezés a Frappe Cloudba"
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr "Logó"
@@ -3324,7 +3431,7 @@ msgstr ""
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr "Kezeld a fiókodhoz tartozó e-maileket és e-mail aláírást a kommunikációhoz."
 
@@ -3342,6 +3449,10 @@ msgstr ""
 
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:11
@@ -3396,6 +3507,20 @@ msgstr ""
 msgid "Mobile App Installation"
 msgstr "Mobilalkalmazás telepítése"
 
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr "Mobilszám"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr "Mobil szám"
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr ""
+
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
 #. List'
@@ -3436,7 +3561,7 @@ msgid "My Tickets"
 msgstr ""
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3447,8 +3572,9 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3458,6 +3584,10 @@ msgstr "Név"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
 msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
+msgstr "Név megadása kötelező"
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
 #. Ticket Status'
@@ -3469,10 +3599,18 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "Soha"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3581,11 +3719,11 @@ msgstr ""
 msgid "No Data Found"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr ""
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr ""
 
@@ -3597,8 +3735,14 @@ msgstr ""
 msgid "No SLA found"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
 msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
@@ -3633,19 +3777,27 @@ msgstr ""
 msgid "No changes made"
 msgstr "Nem történt változás"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr ""
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr ""
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr ""
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
@@ -3657,7 +3809,11 @@ msgstr ""
 msgid "No feedback"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr ""
 
@@ -3697,19 +3853,25 @@ msgstr ""
 msgid "No recently assigned tickets"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr ""
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
 msgstr "Nincs találat"
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
+msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:91
 msgid "No saved replies found"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr ""
@@ -3730,7 +3892,11 @@ msgstr ""
 msgid "No tickets selected"
 msgstr ""
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr ""
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "Nem Engedélyezett"
 
@@ -3742,7 +3908,7 @@ msgstr ""
 msgid "Not Saved"
 msgstr "Nincs mentve"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "Nincs beállítva"
 
@@ -3781,11 +3947,6 @@ msgstr ""
 msgid "On Hold Since"
 msgstr ""
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr ""
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr ""
@@ -3815,6 +3976,10 @@ msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
@@ -3904,7 +4069,12 @@ msgstr ""
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr ""
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "Jelszó"
 
@@ -3942,6 +4112,7 @@ msgid "Pending"
 msgstr "Függő"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr "Függőben lévő meghívók"
 
@@ -3951,19 +4122,19 @@ msgstr "Függőben lévő meghívók"
 msgid "Pending Tickets"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr ""
 
@@ -3984,13 +4155,14 @@ msgstr "Személyes"
 msgid "Personal mobile no"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "Telefon"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
 msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
@@ -4047,7 +4219,7 @@ msgstr ""
 msgid "Please enter a valid phone number"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr ""
 
@@ -4090,33 +4262,14 @@ msgstr ""
 msgid "Policy name"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
-msgstr ""
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr ""
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr ""
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr ""
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
 msgstr ""
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
@@ -4151,14 +4304,32 @@ msgstr "Előnézet"
 msgid "Previous ticket"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "Elsődleges"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "Elsődleges kapcsolattartó"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr ""
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr ""
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4166,9 +4337,10 @@ msgstr ""
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4248,17 +4420,6 @@ msgstr ""
 msgid "Quarterly"
 msgstr "Negyedévenként"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "Lekérdezés Beállítások"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr ""
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "Várakozik"
@@ -4281,14 +4442,14 @@ msgstr ""
 msgid "Rate this ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr ""
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4384,8 +4545,15 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "Eltávolítás"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4395,9 +4563,18 @@ msgstr ""
 msgid "Remove Photo"
 msgstr "Fotó eltávolítása"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr "Kép etávolítása"
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
 msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
@@ -4417,6 +4594,15 @@ msgstr ""
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
 msgstr ""
 
 #. Option in a Select field in the tickets Web Form
@@ -4456,16 +4642,13 @@ msgstr ""
 msgid "Reply on a ticket"
 msgstr ""
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr "Kulcs kérése"
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
 msgstr ""
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
@@ -4486,6 +4669,7 @@ msgid "Reset to Default"
 msgstr ""
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr ""
@@ -4539,18 +4723,6 @@ msgstr "Válasz"
 msgid "Response By"
 msgstr ""
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr ""
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr ""
@@ -4593,37 +4765,33 @@ msgstr ""
 msgid "Restrict visibility to these teams"
 msgstr ""
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr ""
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr ""
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
 msgstr "Vélemények"
 
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:215
 msgid "Ringing"
 msgstr "gyűrűzés"
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "Szerepkör"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr ""
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4722,9 +4890,9 @@ msgstr "Szombat"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4800,17 +4968,19 @@ msgstr ""
 msgid "Search Score"
 msgstr ""
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr ""
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "Keresőmezők..."
 
@@ -4850,6 +5020,7 @@ msgstr "Keresés..."
 msgid "Searched for:"
 msgstr ""
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr ""
@@ -4868,6 +5039,10 @@ msgstr "Kijelölés"
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
 msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
@@ -4890,6 +5065,10 @@ msgstr ""
 msgid "Select a rating"
 msgstr ""
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr ""
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4901,6 +5080,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
+msgstr ""
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
@@ -4927,6 +5110,10 @@ msgstr ""
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
 msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
@@ -4967,13 +5154,17 @@ msgstr ""
 msgid "Service not supported"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "Beállít"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:4
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
@@ -4984,12 +5175,21 @@ msgstr ""
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr ""
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr ""
 
@@ -5001,7 +5201,7 @@ msgstr ""
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr "Munkanapok, órák és ünnepnapok beállítása előre definiált ütemterv kiválasztásával vagy új létrehozásával."
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr ""
 
@@ -5098,7 +5298,7 @@ msgstr "Aláírás"
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Simple Python Expression, Example: doc.status == 'Open' and doc.ticket_type == 'Bug'"
-msgstr ""
+msgstr "Simple Python Expression, példa: doc.status == 'Open' and doc.ticket_type == 'Bug'"
 
 #. Label of the skip_email_workflow (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -5134,23 +5334,6 @@ msgstr ""
 #: desk/src/components/view-controls/SortBy.vue:231
 msgid "Sort"
 msgstr "Rendez"
-
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr ""
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "Forrás Neve"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr "Forrás típusa"
 
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
@@ -5196,6 +5379,8 @@ msgstr ""
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5262,6 +5447,7 @@ msgstr ""
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5373,21 +5559,16 @@ msgstr "Rendszer"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5426,8 +5607,6 @@ msgstr ""
 msgid "Teal"
 msgstr ""
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5438,7 +5617,6 @@ msgstr ""
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5544,6 +5722,10 @@ msgstr ""
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr ""
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr ""
@@ -5554,6 +5736,10 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
@@ -5576,6 +5762,14 @@ msgstr ""
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr ""
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr ""
@@ -5583,6 +5777,10 @@ msgstr ""
 #: desk/src/components/ticket/TicketMergeModal.vue:79
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
 msgstr ""
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
@@ -5652,7 +5850,7 @@ msgstr "Csütörtök"
 msgid "Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr ""
 
@@ -5666,6 +5864,10 @@ msgstr ""
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
+msgstr ""
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
 msgstr ""
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
@@ -5725,7 +5927,7 @@ msgstr ""
 msgid "Ticket Summary"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr ""
 
@@ -5758,7 +5960,7 @@ msgstr ""
 msgid "Ticket merged successfully."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr ""
 
@@ -5793,12 +5995,6 @@ msgstr ""
 msgid "Ticket to merged with is required"
 msgstr ""
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr ""
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr ""
@@ -5810,12 +6006,15 @@ msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr ""
 
@@ -5827,19 +6026,19 @@ msgstr ""
 msgid "Tickets assigned to you in the last 7 days"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr ""
 
@@ -5856,6 +6055,7 @@ msgid "Tickets that are awaiting your response"
 msgstr ""
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr ""
 
@@ -5945,19 +6145,19 @@ msgstr "Ünnepek összesen"
 msgid "Total Ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr ""
 
@@ -5989,6 +6189,10 @@ msgstr "Típus"
 msgid "Type a message"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr ""
@@ -5998,7 +6202,7 @@ msgstr ""
 msgid "URL/Method"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr ""
 
@@ -6032,6 +6236,8 @@ msgid "Unpublish"
 msgstr "Közzététel visszavonása"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr ""
 
@@ -6048,6 +6254,10 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:214
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
+msgstr ""
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
@@ -6076,10 +6286,13 @@ msgstr "Feltöltés"
 msgid "Upload Photo"
 msgstr "Fotó feltöltése"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
 msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
+msgstr "Kép feltöltése"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
 msgid "Uploading {0}%"
@@ -6088,17 +6301,13 @@ msgstr ""
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6109,6 +6318,10 @@ msgstr "Felhasználó"
 #. Label of the user_resolution_time (Duration) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
 msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
@@ -6128,7 +6341,7 @@ msgstr "Felhasználók"
 msgid "Valid From"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "Érték"
 
@@ -6257,19 +6470,23 @@ msgstr "Évi"
 msgid "Yellow"
 msgstr "Sárga"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr ""
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr ""
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr "Nincs hozzáférésed ehhez az erőforráshoz."
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr ""
 
@@ -6297,6 +6514,14 @@ msgstr ""
 msgid "You do not have permission to access Assignment Rules"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr "Nincs jogosultsága az erőforrás eléréséhez"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr ""
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr ""
@@ -6319,6 +6544,14 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:46
@@ -6349,7 +6582,7 @@ msgstr ""
 msgid "customize {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr "napok"
 
@@ -6400,7 +6633,7 @@ msgstr "itt"
 msgid "here."
 msgstr ""
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr "óra"
 
@@ -6408,7 +6641,7 @@ msgstr "óra"
 msgid "in"
 msgstr "tartalmazza"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "pont most"
 
@@ -6441,7 +6674,11 @@ msgstr ""
 msgid "purple"
 msgstr "lila"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr ""
 
@@ -6458,7 +6695,7 @@ msgstr ""
 msgid "to enable this integration."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr ""
 
@@ -6466,12 +6703,32 @@ msgstr ""
 msgid "views"
 msgstr "megtekintések"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr ""
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
 msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:307
@@ -6498,7 +6755,7 @@ msgstr ""
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr ""
 

--- a/helpdesk/locale/id.po
+++ b/helpdesk/locale/id.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-15 18:51\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-29 21:58\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Indonesian\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr ""
@@ -108,14 +108,6 @@ msgstr ""
 msgid "A workday with this name already exists"
 msgstr ""
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr ""
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr ""
@@ -132,7 +124,7 @@ msgstr ""
 msgid "Account"
 msgstr "Akun"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr ""
 
@@ -152,11 +144,9 @@ msgstr "Tindakan"
 msgid "Action Required"
 msgstr ""
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr ""
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "Tindakan"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr ""
 msgid "Active"
 msgstr "Aktif"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr ""
 
@@ -175,7 +165,7 @@ msgid "Active: The agent is available and working.<br>\n"
 "Unavailable: The agent is off and unavailable."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "Aktivitas"
@@ -193,10 +183,11 @@ msgid "Add Column"
 msgstr "Tambahkan Kolom"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "Tambah Filter..."
 
@@ -206,6 +197,10 @@ msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
 msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:148
@@ -244,7 +239,7 @@ msgstr "Tambahkan ketentuan"
 msgid "Add condition group"
 msgstr "Tambahkan grup ketentuan"
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "Tambah filter"
 
@@ -278,6 +273,12 @@ msgstr ""
 msgid "Add to Holidays"
 msgstr "Tambah ke Hari Libur"
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr ""
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr ""
@@ -295,17 +296,14 @@ msgid "Administrator"
 msgstr ""
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -316,6 +314,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -335,6 +334,7 @@ msgstr ""
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -342,6 +342,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -376,18 +377,9 @@ msgstr ""
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "Semua"
 
@@ -508,6 +500,14 @@ msgstr ""
 msgid "Are you sure you want to delete these articles?"
 msgstr ""
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr ""
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr ""
@@ -543,6 +543,10 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
 msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
@@ -595,16 +599,11 @@ msgstr ""
 msgid "Assign ticket"
 msgstr ""
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr "Tugaskan ke"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -618,7 +617,7 @@ msgstr "Penerima tugas"
 msgid "Assignee Rules"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr ""
 
@@ -626,7 +625,7 @@ msgstr ""
 msgid "Assignees"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr ""
 
@@ -692,10 +691,6 @@ msgstr ""
 msgid "Assignment rule {0} updated successfully."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -711,10 +706,6 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
-msgstr ""
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
 msgstr ""
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
@@ -766,7 +757,7 @@ msgid "Automation"
 msgstr "Otomatisasi"
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr ""
@@ -802,7 +793,7 @@ msgstr ""
 msgid "Average Time Metrics"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr ""
 
@@ -810,24 +801,36 @@ msgstr ""
 msgid "Average response and resolution metrics not available"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
 msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
@@ -840,11 +843,11 @@ msgstr ""
 msgid "Avg. resolution time"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr ""
 
@@ -867,11 +870,6 @@ msgstr ""
 msgid "Base Support Rotation"
 msgstr ""
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "URL Dasar"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -885,11 +883,11 @@ msgstr ""
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr ""
 
@@ -944,11 +942,6 @@ msgstr ""
 msgid "Busy"
 msgstr ""
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "Tombol"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr ""
@@ -973,19 +966,31 @@ msgstr "Durasi panggilan dalam detik"
 msgid "Caller"
 msgstr "Penelepon"
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr "Panggilan"
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr ""
 
@@ -1025,7 +1030,7 @@ msgstr ""
 msgid "Cannot merge General category"
 msgstr ""
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr ""
 
@@ -1073,11 +1078,11 @@ msgstr ""
 msgid "Category updated successfully."
 msgstr "Kategori berhasil diperbarui."
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr ""
 
@@ -1085,7 +1090,7 @@ msgstr ""
 msgid "Change"
 msgstr "Perubahan"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "Ubah Kata sandi"
@@ -1098,9 +1103,8 @@ msgstr ""
 msgid "Change language of the application."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
@@ -1123,7 +1127,7 @@ msgstr ""
 msgid "Change timezone of the application."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr ""
 
@@ -1136,7 +1140,7 @@ msgstr ""
 msgid "Child field"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr ""
 
@@ -1189,7 +1193,7 @@ msgstr "Hapus Urutan"
 msgid "Clear Table"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr ""
 
@@ -1203,6 +1207,10 @@ msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
@@ -1223,7 +1231,7 @@ msgstr ""
 msgid "Closed"
 msgstr "Ditutup"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr ""
 
@@ -1250,7 +1258,7 @@ msgstr "Kolom"
 msgid "Comma separated emails to invite."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr ""
 
@@ -1283,7 +1291,7 @@ msgstr ""
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "Komentar"
@@ -1296,6 +1304,11 @@ msgstr "Komunikasi"
 msgid "Communication ID is required"
 msgstr ""
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
+msgstr "Perusahaan"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
 msgstr "Selesai"
@@ -1307,7 +1320,7 @@ msgstr "Selesai"
 msgid "Condition"
 msgstr "Kondisi"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr ""
 
@@ -1331,6 +1344,10 @@ msgstr ""
 msgid "Configure your telephony settings."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1356,10 +1373,11 @@ msgstr ""
 msgid "Connect your support email"
 msgstr ""
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1373,26 +1391,30 @@ msgstr "Kontak"
 msgid "Contact HTML"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
 msgstr ""
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
 msgstr "Kontak"
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
+msgstr ""
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
 #. Label of the content (Text Editor) field in DocType 'HD Article'
@@ -1415,7 +1437,7 @@ msgstr ""
 msgid "Copy ticket id"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr ""
 
@@ -1423,7 +1445,11 @@ msgstr ""
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr ""
 
@@ -1431,11 +1457,20 @@ msgstr ""
 msgid "Could not send feedback email,due to: {0}"
 msgstr ""
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "Negara"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1446,9 +1481,13 @@ msgstr "Buat"
 msgid "Create & invite a contact"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
-msgstr "Buat Kontak Baru"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
 msgid "Create View"
@@ -1482,12 +1521,6 @@ msgstr ""
 msgid "Creating a ticket"
 msgstr ""
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr ""
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr ""
@@ -1512,12 +1545,21 @@ msgid "Custom Views"
 msgstr ""
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
 msgstr "Pelanggan"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
+msgstr ""
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1528,16 +1570,32 @@ msgstr "Nama Pelanggan"
 msgid "Customer Portal"
 msgstr ""
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
-msgstr "Pelanggan berhasil dibuat."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
 msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:595
@@ -1565,6 +1623,8 @@ msgstr "Sian"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "Bahaya"
@@ -1665,18 +1725,26 @@ msgstr ""
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr ""
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "Hapus"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1692,6 +1760,10 @@ msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
+msgstr ""
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
 msgstr ""
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
@@ -1740,7 +1812,7 @@ msgstr ""
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1826,7 +1898,12 @@ msgstr ""
 msgid "Document Type"
 msgstr "Jenis Dokumen"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr ""
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr ""
@@ -1867,6 +1944,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
@@ -1917,7 +1998,8 @@ msgstr ""
 msgid "Easily invite new agents, managers, or admins."
 msgstr ""
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1926,6 +2008,14 @@ msgstr "Sunting"
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
 msgstr "Edit Log Panggilan"
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
+msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:70
 #: desk/src/components/Settings/EmailEdit.vue:63
@@ -1944,10 +2034,10 @@ msgstr ""
 msgid "Edit your email account"
 msgstr ""
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "Surel"
 
@@ -1975,8 +2065,9 @@ msgstr "Akun Email"
 msgid "Email Content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
 msgstr "ID Surel"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
@@ -2002,22 +2093,22 @@ msgstr ""
 msgid "Email account updated successfully"
 msgstr "Akun email berhasil diperbarui"
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr ""
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr ""
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "Email"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr ""
 
@@ -2055,8 +2146,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr ""
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2081,8 +2170,6 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2105,20 +2192,24 @@ msgstr "Waktu Selesai"
 msgid "Enter a name for this HD Service Holiday List."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr ""
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr ""
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
 msgstr ""
 
 #: helpdesk/api/knowledge_base.py:86
@@ -2129,21 +2220,17 @@ msgstr ""
 msgid "Error processing email at index {0}, message: {1}"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr ""
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "Kesalahan saat menyambung ke akun email {0}"
 
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr ""
-
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
 msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
@@ -2172,11 +2259,6 @@ msgstr "Ekspor Semua {0} Catatan"
 msgid "Export Type"
 msgstr "Jenis ekspor"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr ""
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2184,6 +2266,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "Gagal"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2218,11 +2304,11 @@ msgstr ""
 msgid "Failed to save Twilio settings"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr ""
 
@@ -2251,6 +2337,7 @@ msgstr "Favicon"
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2288,12 +2375,16 @@ msgstr ""
 msgid "Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
+msgstr ""
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
 msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
@@ -2338,13 +2429,14 @@ msgid "Field dependency updated successfully."
 msgstr ""
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "Kolom"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "Filter"
@@ -2354,13 +2446,18 @@ msgstr "Filter"
 msgid "Find out all of the variables that can be used in the content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "Nama Depan"
 
 #. Label of the first_responded_on (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
+msgstr ""
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
 msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
@@ -2385,10 +2482,6 @@ msgstr "Waktu Respon Pertama"
 #. Name of a report
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -2480,6 +2573,10 @@ msgstr ""
 msgid "Go to Ticket #{0}"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr ""
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2509,19 +2606,12 @@ msgid "Group By Field"
 msgstr "Grup Berdasarkan Bidang"
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
 msgstr ""
 
 #. Name of a DocType
@@ -2554,24 +2644,36 @@ msgstr ""
 msgid "HD Comment Reaction"
 msgstr ""
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr ""
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr ""
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
 msgstr ""
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
 msgstr ""
 
 #. Name of a DocType
@@ -2592,21 +2694,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
 msgstr ""
 
 #. Name of a DocType
@@ -2648,11 +2735,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
 msgstr ""
 
 #. Name of a DocType
@@ -2750,12 +2832,6 @@ msgstr ""
 msgid "Helpdesk"
 msgstr ""
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr ""
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2772,11 +2848,6 @@ msgstr "Hai"
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
 msgstr "Sembunyikan "
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr ""
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
@@ -2846,15 +2917,8 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "Alamat IP"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2941,6 +3005,11 @@ msgstr "Kotak masuk"
 msgid "Incoming"
 msgstr "Masuk"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr "Individu"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr "Diprakarsai"
@@ -2954,7 +3023,7 @@ msgstr ""
 msgid "Instantly send e-mail"
 msgstr ""
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "Izin tidak cukup untuk {0}"
 
@@ -2968,12 +3037,12 @@ msgstr ""
 msgid "Introduction"
 msgstr "Pengantar"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
@@ -2982,22 +3051,42 @@ msgstr ""
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr ""
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr ""
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
 msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
@@ -3008,13 +3097,30 @@ msgstr ""
 msgid "Invite agents"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
-msgstr ""
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
+msgstr "Undang sebagai Pengguna"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
 msgstr "Undang via email"
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
+msgstr ""
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -3030,6 +3136,11 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "Apakah default"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr ""
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3057,6 +3168,10 @@ msgstr ""
 #. Label of the setup_complete (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
 msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:114
@@ -3093,11 +3208,9 @@ msgstr "Pintasan keyboard"
 msgid "Knowledge Base"
 msgstr "Dasar pengetahuan"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3131,9 +3244,9 @@ msgstr ""
 msgid "Last 3 Months"
 msgstr "3 Bulan Terakhir"
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr ""
 
@@ -3174,7 +3287,8 @@ msgstr ""
 msgid "Last Month"
 msgstr "Bulan Lalu"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "Nama Belakang"
 
@@ -3183,24 +3297,33 @@ msgstr "Nama Belakang"
 msgid "Last Week"
 msgstr "Minggu Lalu"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr ""
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
 msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
+msgstr "Terbaru"
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -3216,26 +3339,6 @@ msgstr ""
 #. 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
-msgstr ""
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "Tautan"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -3264,6 +3367,8 @@ msgstr "Muat Kolom Default"
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "Muat lebih banyak"
 
@@ -3286,6 +3391,8 @@ msgstr "Masuk ke Frappe Cloud"
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr ""
@@ -3324,7 +3431,7 @@ msgstr ""
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr ""
 
@@ -3342,6 +3449,10 @@ msgstr ""
 
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:11
@@ -3364,7 +3475,7 @@ msgstr ""
 #. Option for the 'Type' (Select) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "Mention"
-msgstr "Sebutan"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:158
 msgid "Merge"
@@ -3394,6 +3505,20 @@ msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:640
 msgid "Mobile App Installation"
+msgstr ""
+
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr "Nomor Ponsel"
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
 msgstr ""
 
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
@@ -3436,7 +3561,7 @@ msgid "My Tickets"
 msgstr ""
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3447,8 +3572,9 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3458,6 +3584,10 @@ msgstr "Nama"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
 msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
+msgstr "Nama wajib diisi"
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
 #. Ticket Status'
@@ -3469,10 +3599,18 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "Tidak pernah"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3581,11 +3719,11 @@ msgstr ""
 msgid "No Data Found"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr ""
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr ""
 
@@ -3597,8 +3735,14 @@ msgstr ""
 msgid "No SLA found"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
 msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
@@ -3633,19 +3777,27 @@ msgstr ""
 msgid "No changes made"
 msgstr "Tidak ada perubahan yang dilakukan"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr ""
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr ""
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr ""
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
@@ -3657,7 +3809,11 @@ msgstr ""
 msgid "No feedback"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr ""
 
@@ -3697,19 +3853,25 @@ msgstr ""
 msgid "No recently assigned tickets"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr ""
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
 msgstr "Hasil tidak ditemukan"
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
+msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:91
 msgid "No saved replies found"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr ""
@@ -3730,7 +3892,11 @@ msgstr ""
 msgid "No tickets selected"
 msgstr ""
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr ""
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "Tidak Diizinkan"
 
@@ -3742,7 +3908,7 @@ msgstr ""
 msgid "Not Saved"
 msgstr "Tidak Disimpan"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "Tidak Diatur"
 
@@ -3781,11 +3947,6 @@ msgstr ""
 msgid "On Hold Since"
 msgstr ""
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr ""
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr ""
@@ -3815,6 +3976,10 @@ msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
@@ -3904,7 +4069,12 @@ msgstr ""
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr ""
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "Kata sandi"
 
@@ -3942,6 +4112,7 @@ msgid "Pending"
 msgstr "Tertunda"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr "Undangan Tertunda"
 
@@ -3951,19 +4122,19 @@ msgstr "Undangan Tertunda"
 msgid "Pending Tickets"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr ""
 
@@ -3984,13 +4155,14 @@ msgstr "Pribadi"
 msgid "Personal mobile no"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "Telepon"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
 msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
@@ -4047,7 +4219,7 @@ msgstr ""
 msgid "Please enter a valid phone number"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr ""
 
@@ -4090,33 +4262,14 @@ msgstr "Silakan pilih dari hari mingguan"
 msgid "Policy name"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
-msgstr ""
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr ""
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr ""
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr ""
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
 msgstr ""
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
@@ -4151,14 +4304,32 @@ msgstr "Pratayang"
 msgid "Previous ticket"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "Utama"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "Kontak Utama"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr ""
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr ""
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4166,9 +4337,10 @@ msgstr ""
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4248,17 +4420,6 @@ msgstr ""
 msgid "Quarterly"
 msgstr "Triwulan"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "Opsi Kueri"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr ""
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "Diantrikan"
@@ -4281,14 +4442,14 @@ msgstr ""
 msgid "Rate this ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr ""
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4384,8 +4545,15 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "Hapus"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4395,9 +4563,18 @@ msgstr ""
 msgid "Remove Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr "Hapus gambar"
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
 msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
@@ -4417,6 +4594,15 @@ msgstr ""
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
 msgstr ""
 
 #. Option in a Select field in the tickets Web Form
@@ -4456,16 +4642,13 @@ msgstr ""
 msgid "Reply on a ticket"
 msgstr ""
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr ""
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
 msgstr ""
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
@@ -4486,6 +4669,7 @@ msgid "Reset to Default"
 msgstr "Reset ke Pengaturan Default"
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr ""
@@ -4539,18 +4723,6 @@ msgstr "Tanggapan"
 msgid "Response By"
 msgstr ""
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr ""
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr "Waktu Respons untuk {0} prioritas di baris {1} tidak boleh lebih dari Waktu Resolusi."
@@ -4593,28 +4765,18 @@ msgstr ""
 msgid "Restrict visibility to these teams"
 msgstr ""
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr ""
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr ""
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
+msgstr ""
+
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:215
@@ -4622,8 +4784,14 @@ msgid "Ringing"
 msgstr "Dering"
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "Peran"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr ""
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4722,9 +4890,9 @@ msgstr "Sabtu"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4800,17 +4968,19 @@ msgstr ""
 msgid "Search Score"
 msgstr ""
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr ""
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "Cari kolom..."
 
@@ -4850,6 +5020,7 @@ msgstr "Pencarian..."
 msgid "Searched for:"
 msgstr ""
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr "Mencari..."
@@ -4868,6 +5039,10 @@ msgstr "Pilih"
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
 msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
@@ -4890,6 +5065,10 @@ msgstr "Pilih Prioritas Default."
 msgid "Select a rating"
 msgstr ""
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr ""
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4901,6 +5080,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
+msgstr ""
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
@@ -4927,6 +5110,10 @@ msgstr ""
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
 msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
@@ -4967,13 +5154,17 @@ msgstr ""
 msgid "Service not supported"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "Tetapkan"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:4
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
@@ -4984,12 +5175,21 @@ msgstr ""
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr ""
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr ""
 
@@ -5001,7 +5201,7 @@ msgstr ""
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr ""
 
@@ -5135,23 +5335,6 @@ msgstr ""
 msgid "Sort"
 msgstr "Urutkan"
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr ""
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "Nama Sumber"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr ""
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr ""
@@ -5196,6 +5379,8 @@ msgstr ""
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5262,6 +5447,7 @@ msgstr ""
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5373,21 +5559,16 @@ msgstr "Sistem"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5426,8 +5607,6 @@ msgstr ""
 msgid "Teal"
 msgstr ""
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5438,7 +5617,6 @@ msgstr ""
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5544,6 +5722,10 @@ msgstr ""
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr ""
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr ""
@@ -5554,6 +5736,10 @@ msgstr "Liburan di {0} bukan antara Dari Tanggal dan To Date"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
@@ -5576,6 +5762,14 @@ msgstr ""
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr ""
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr ""
@@ -5583,6 +5777,10 @@ msgstr ""
 #: desk/src/components/ticket/TicketMergeModal.vue:79
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
 msgstr ""
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
@@ -5652,7 +5850,7 @@ msgstr "Kamis"
 msgid "Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr ""
 
@@ -5666,6 +5864,10 @@ msgstr ""
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
+msgstr ""
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
 msgstr ""
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
@@ -5725,7 +5927,7 @@ msgstr ""
 msgid "Ticket Summary"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr ""
 
@@ -5758,7 +5960,7 @@ msgstr ""
 msgid "Ticket merged successfully."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr ""
 
@@ -5793,12 +5995,6 @@ msgstr ""
 msgid "Ticket to merged with is required"
 msgstr ""
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr ""
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr ""
@@ -5810,12 +6006,15 @@ msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr ""
 
@@ -5827,19 +6026,19 @@ msgstr ""
 msgid "Tickets assigned to you in the last 7 days"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr ""
 
@@ -5856,6 +6055,7 @@ msgid "Tickets that are awaiting your response"
 msgstr ""
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr ""
 
@@ -5945,19 +6145,19 @@ msgstr ""
 msgid "Total Ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr ""
 
@@ -5989,6 +6189,10 @@ msgstr "Tipe"
 msgid "Type a message"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr ""
@@ -5998,7 +6202,7 @@ msgstr ""
 msgid "URL/Method"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr ""
 
@@ -6032,6 +6236,8 @@ msgid "Unpublish"
 msgstr "Batalkan Penerbitan"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr ""
 
@@ -6048,6 +6254,10 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:214
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
+msgstr ""
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
@@ -6076,10 +6286,13 @@ msgstr "Mengunggah"
 msgid "Upload Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
 msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
+msgstr "Unggah gambar"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
 msgid "Uploading {0}%"
@@ -6088,17 +6301,13 @@ msgstr ""
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6109,6 +6318,10 @@ msgstr "Pengguna"
 #. Label of the user_resolution_time (Duration) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
 msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
@@ -6128,7 +6341,7 @@ msgstr "Pengguna"
 msgid "Valid From"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "Nilai"
 
@@ -6257,19 +6470,23 @@ msgstr "Tahunan"
 msgid "Yellow"
 msgstr "Kuning"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr ""
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr ""
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr "Anda tidak diizinkan mengakses sumber daya ini."
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr ""
 
@@ -6297,6 +6514,14 @@ msgstr ""
 msgid "You do not have permission to access Assignment Rules"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr ""
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr ""
@@ -6319,6 +6544,14 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:46
@@ -6349,7 +6582,7 @@ msgstr ""
 msgid "customize {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr "hari"
 
@@ -6400,7 +6633,7 @@ msgstr "di sini"
 msgid "here."
 msgstr ""
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr "jam"
 
@@ -6408,7 +6641,7 @@ msgstr "jam"
 msgid "in"
 msgstr "di Dalam"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "baru saja"
 
@@ -6441,7 +6674,11 @@ msgstr ""
 msgid "purple"
 msgstr "ungu"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr ""
 
@@ -6458,7 +6695,7 @@ msgstr ""
 msgid "to enable this integration."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr ""
 
@@ -6466,12 +6703,32 @@ msgstr ""
 msgid "views"
 msgstr "tampilan"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr ""
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
 msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:307
@@ -6498,7 +6755,7 @@ msgstr ""
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr ""
 

--- a/helpdesk/locale/it.po
+++ b/helpdesk/locale/it.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-21 20:27\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-29 21:57\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Italian\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr ""
@@ -108,14 +108,6 @@ msgstr ""
 msgid "A workday with this name already exists"
 msgstr ""
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr "API"
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr ""
@@ -132,7 +124,7 @@ msgstr ""
 msgid "Account"
 msgstr "Account"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr ""
 
@@ -152,11 +144,9 @@ msgstr "Azione"
 msgid "Action Required"
 msgstr ""
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr ""
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "Azioni"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr ""
 msgid "Active"
 msgstr "Attivo"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr ""
 
@@ -175,7 +165,7 @@ msgid "Active: The agent is available and working.<br>\n"
 "Unavailable: The agent is off and unavailable."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "Attività"
@@ -193,10 +183,11 @@ msgid "Add Column"
 msgstr "Aggiungi colonna"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "Aggiungi Filtro..."
 
@@ -206,6 +197,10 @@ msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
 msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:148
@@ -244,7 +239,7 @@ msgstr ""
 msgid "Add condition group"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "Aggiungi filtro"
 
@@ -278,6 +273,12 @@ msgstr "Aggiungi obiettivi temporali in base alle tappe fondamentali del support
 msgid "Add to Holidays"
 msgstr ""
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr ""
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr ""
@@ -295,17 +296,14 @@ msgid "Administrator"
 msgstr "Amministratore"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -316,6 +314,7 @@ msgstr "Amministratore"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -335,6 +334,7 @@ msgstr ""
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -342,6 +342,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -376,18 +377,9 @@ msgstr ""
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "Tutti"
 
@@ -508,6 +500,14 @@ msgstr ""
 msgid "Are you sure you want to delete these articles?"
 msgstr ""
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr ""
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr ""
@@ -543,6 +543,10 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
 msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
@@ -595,16 +599,11 @@ msgstr ""
 msgid "Assign ticket"
 msgstr ""
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr ""
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -618,7 +617,7 @@ msgstr "Assegnatario"
 msgid "Assignee Rules"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr ""
 
@@ -626,14 +625,14 @@ msgstr ""
 msgid "Assignees"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "Assignment"
-msgstr "Assegnazione"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:122
 msgid "Assignment Condition"
@@ -692,10 +691,6 @@ msgstr ""
 msgid "Assignment rule {0} updated successfully."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -711,10 +706,6 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
-msgstr ""
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
 msgstr ""
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
@@ -766,7 +757,7 @@ msgid "Automation"
 msgstr "Automazioni"
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr ""
@@ -802,7 +793,7 @@ msgstr ""
 msgid "Average Time Metrics"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr "La valutazione media del feedback al giorno è di circa {0} stelle"
 
@@ -810,24 +801,36 @@ msgstr "La valutazione media del feedback al giorno è di circa {0} stelle"
 msgid "Average response and resolution metrics not available"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
 msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
@@ -840,11 +843,11 @@ msgstr ""
 msgid "Avg. resolution time"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr ""
 
@@ -867,11 +870,6 @@ msgstr ""
 msgid "Base Support Rotation"
 msgstr ""
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "URL di base"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -885,11 +883,11 @@ msgstr ""
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr ""
 
@@ -944,11 +942,6 @@ msgstr ""
 msgid "Busy"
 msgstr "Occupato"
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "Pulsante"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr ""
@@ -973,19 +966,31 @@ msgstr ""
 msgid "Caller"
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr ""
 
@@ -1025,7 +1030,7 @@ msgstr ""
 msgid "Cannot merge General category"
 msgstr ""
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr ""
 
@@ -1073,11 +1078,11 @@ msgstr ""
 msgid "Category updated successfully."
 msgstr "Categoria aggiornata con successo."
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr ""
 
@@ -1085,7 +1090,7 @@ msgstr ""
 msgid "Change"
 msgstr "Monete"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "Cambia Password"
@@ -1098,9 +1103,8 @@ msgstr ""
 msgid "Change language of the application."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
@@ -1123,7 +1127,7 @@ msgstr ""
 msgid "Change timezone of the application."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr ""
 
@@ -1136,7 +1140,7 @@ msgstr ""
 msgid "Child field"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr ""
 
@@ -1189,7 +1193,7 @@ msgstr "Cancella Ordinamento"
 msgid "Clear Table"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr ""
 
@@ -1203,6 +1207,10 @@ msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
@@ -1223,7 +1231,7 @@ msgstr ""
 msgid "Closed"
 msgstr "Chiuso"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr ""
 
@@ -1250,7 +1258,7 @@ msgstr "Colonne"
 msgid "Comma separated emails to invite."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr ""
 
@@ -1283,7 +1291,7 @@ msgstr ""
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "Commenti"
@@ -1296,6 +1304,11 @@ msgstr "Comunicazione"
 msgid "Communication ID is required"
 msgstr ""
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
+msgstr "Azienda"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
 msgstr "Completato"
@@ -1307,7 +1320,7 @@ msgstr "Completato"
 msgid "Condition"
 msgstr "Condizione"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr ""
 
@@ -1331,6 +1344,10 @@ msgstr ""
 msgid "Configure your telephony settings."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1356,10 +1373,11 @@ msgstr ""
 msgid "Connect your support email"
 msgstr ""
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1373,25 +1391,29 @@ msgstr "Contatto"
 msgid "Contact HTML"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
 msgstr ""
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
 msgstr ""
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
@@ -1415,7 +1437,7 @@ msgstr ""
 msgid "Copy ticket id"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr ""
 
@@ -1423,7 +1445,11 @@ msgstr ""
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr ""
 
@@ -1431,11 +1457,20 @@ msgstr ""
 msgid "Could not send feedback email,due to: {0}"
 msgstr ""
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "Paese"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1446,8 +1481,12 @@ msgstr "Creare"
 msgid "Create & invite a contact"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
 msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
@@ -1482,12 +1521,6 @@ msgstr ""
 msgid "Creating a ticket"
 msgstr ""
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr ""
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr ""
@@ -1512,12 +1545,21 @@ msgid "Custom Views"
 msgstr ""
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
 msgstr "Cliente"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
+msgstr ""
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1528,16 +1570,32 @@ msgstr ""
 msgid "Customer Portal"
 msgstr ""
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
-msgstr "Cliente creato con successo."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
 msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:595
@@ -1565,6 +1623,8 @@ msgstr "Ciano"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "Pericolo"
@@ -1665,18 +1725,26 @@ msgstr "Tipo di ticket predefinito"
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr ""
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "Elimina"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1692,6 +1760,10 @@ msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
+msgstr ""
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
 msgstr ""
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
@@ -1740,7 +1812,7 @@ msgstr ""
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1826,7 +1898,12 @@ msgstr ""
 msgid "Document Type"
 msgstr "Tipo Documento"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr ""
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "Dominio"
@@ -1867,6 +1944,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
@@ -1917,7 +1998,8 @@ msgstr ""
 msgid "Easily invite new agents, managers, or admins."
 msgstr ""
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1925,6 +2007,14 @@ msgstr "Modifica"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
 msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:70
@@ -1944,10 +2034,10 @@ msgstr ""
 msgid "Edit your email account"
 msgstr ""
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "Email"
 
@@ -1975,9 +2065,10 @@ msgstr ""
 msgid "Email Content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
-msgstr "Id Email"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
+msgstr "ID e-mail"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
 #. Settings'
@@ -2002,22 +2093,22 @@ msgstr ""
 msgid "Email account updated successfully"
 msgstr ""
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr ""
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr ""
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "E-mail"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr ""
 
@@ -2055,8 +2146,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr ""
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2081,8 +2170,6 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2105,20 +2192,24 @@ msgstr ""
 msgid "Enter a name for this HD Service Holiday List."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr ""
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr ""
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
 msgstr ""
 
 #: helpdesk/api/knowledge_base.py:86
@@ -2129,21 +2220,17 @@ msgstr ""
 msgid "Error processing email at index {0}, message: {1}"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr ""
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "Errore durante la connessione all'account email {0}"
 
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr ""
-
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
 msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
@@ -2172,11 +2259,6 @@ msgstr ""
 msgid "Export Type"
 msgstr "Tipo di esportazione"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr ""
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2184,6 +2266,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "Fallito"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2218,11 +2304,11 @@ msgstr ""
 msgid "Failed to save Twilio settings"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr ""
 
@@ -2251,6 +2337,7 @@ msgstr ""
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2288,12 +2375,16 @@ msgstr ""
 msgid "Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
+msgstr ""
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
 msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
@@ -2338,13 +2429,14 @@ msgid "Field dependency updated successfully."
 msgstr ""
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "Campi"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "Filtri"
@@ -2354,13 +2446,18 @@ msgstr "Filtri"
 msgid "Find out all of the variables that can be used in the content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "Nome"
 
 #. Label of the first_responded_on (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
+msgstr ""
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
 msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
@@ -2385,10 +2482,6 @@ msgstr ""
 #. Name of a report
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -2480,6 +2573,10 @@ msgstr ""
 msgid "Go to Ticket #{0}"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr ""
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2509,19 +2606,12 @@ msgid "Group By Field"
 msgstr ""
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
 msgstr ""
 
 #. Name of a DocType
@@ -2554,24 +2644,36 @@ msgstr ""
 msgid "HD Comment Reaction"
 msgstr ""
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr ""
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr ""
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
 msgstr ""
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
 msgstr ""
 
 #. Name of a DocType
@@ -2592,21 +2694,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
 msgstr ""
 
 #. Name of a DocType
@@ -2648,11 +2735,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
 msgstr ""
 
 #. Name of a DocType
@@ -2750,12 +2832,6 @@ msgstr ""
 msgid "Helpdesk"
 msgstr ""
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr ""
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2772,11 +2848,6 @@ msgstr "EHI"
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
 msgstr "Nascondi "
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr ""
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
@@ -2846,15 +2917,8 @@ msgstr ""
 msgid "ID"
 msgstr "ID"
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "Indirizzo IP"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2941,6 +3005,11 @@ msgstr "Posta in arrivo"
 msgid "Incoming"
 msgstr "In entrata"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr ""
@@ -2954,7 +3023,7 @@ msgstr ""
 msgid "Instantly send e-mail"
 msgstr ""
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "Permesso insufficiente per {0}"
 
@@ -2968,12 +3037,12 @@ msgstr ""
 msgid "Introduction"
 msgstr "Introduzione"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
@@ -2982,22 +3051,42 @@ msgstr ""
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr ""
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr ""
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
+msgstr "Invita"
+
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
@@ -3008,13 +3097,30 @@ msgstr ""
 msgid "Invite agents"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
-msgstr ""
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
+msgstr "Invita come Utente"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
 msgstr "Invita tramite e-mail"
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
+msgstr ""
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -3030,6 +3136,11 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "È Predefinito"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr ""
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3057,6 +3168,10 @@ msgstr ""
 #. Label of the setup_complete (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
 msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:114
@@ -3093,11 +3208,9 @@ msgstr "Scorciatoie Tastiera"
 msgid "Knowledge Base"
 msgstr "Base di Conoscenza"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3131,9 +3244,9 @@ msgstr ""
 msgid "Last 3 Months"
 msgstr "Ultimi 3 mesi"
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr ""
 
@@ -3174,7 +3287,8 @@ msgstr ""
 msgid "Last Month"
 msgstr "Mese scorso"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "Cognome"
 
@@ -3183,23 +3297,32 @@ msgstr "Cognome"
 msgid "Last Week"
 msgstr "Settimana scorsa"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr ""
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
 msgstr ""
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
@@ -3216,26 +3339,6 @@ msgstr ""
 #. 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
-msgstr ""
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "Collegamento"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -3264,6 +3367,8 @@ msgstr ""
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "Carica altro"
 
@@ -3286,6 +3391,8 @@ msgstr "Accedi a Frappe Cloud"
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr "Logo"
@@ -3324,7 +3431,7 @@ msgstr ""
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr ""
 
@@ -3343,6 +3450,10 @@ msgstr ""
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
+msgstr "Responsabile"
 
 #: desk/src/pages/MobileNotifications.vue:11
 #: desk/src/pages/MobileNotifications.vue:14
@@ -3364,7 +3475,7 @@ msgstr ""
 #. Option for the 'Type' (Select) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "Mention"
-msgstr "Menzione"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:158
 msgid "Merge"
@@ -3394,6 +3505,20 @@ msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:640
 msgid "Mobile App Installation"
+msgstr ""
+
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr "Numero di Cellulare"
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
 msgstr ""
 
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
@@ -3436,7 +3561,7 @@ msgid "My Tickets"
 msgstr ""
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3447,8 +3572,9 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3457,6 +3583,10 @@ msgstr "Nome"
 #. Label of the name_weight (Int) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
 msgstr ""
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
@@ -3469,10 +3599,18 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "Mai"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3581,11 +3719,11 @@ msgstr ""
 msgid "No Data Found"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr ""
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr ""
 
@@ -3597,8 +3735,14 @@ msgstr ""
 msgid "No SLA found"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
 msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
@@ -3633,19 +3777,27 @@ msgstr ""
 msgid "No changes made"
 msgstr "Nessuna modifica apportata"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr ""
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr ""
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr ""
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
@@ -3657,7 +3809,11 @@ msgstr "Nessun account email trovato"
 msgid "No feedback"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr ""
 
@@ -3697,12 +3853,17 @@ msgstr ""
 msgid "No recently assigned tickets"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr ""
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
 msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
@@ -3710,6 +3871,7 @@ msgstr ""
 msgid "No saved replies found"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr ""
@@ -3730,7 +3892,11 @@ msgstr ""
 msgid "No tickets selected"
 msgstr ""
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr ""
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "Non Consentito"
 
@@ -3742,7 +3908,7 @@ msgstr ""
 msgid "Not Saved"
 msgstr "Non Salvato"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "Non Impostato"
 
@@ -3781,11 +3947,6 @@ msgstr ""
 msgid "On Hold Since"
 msgstr ""
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr ""
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr ""
@@ -3815,6 +3976,10 @@ msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
@@ -3904,7 +4069,12 @@ msgstr ""
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr ""
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "Password"
 
@@ -3942,6 +4112,7 @@ msgid "Pending"
 msgstr "In Attesa"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr ""
 
@@ -3951,19 +4122,19 @@ msgstr ""
 msgid "Pending Tickets"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr ""
 
@@ -3984,13 +4155,14 @@ msgstr "Personale"
 msgid "Personal mobile no"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "Telefono"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
 msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
@@ -4047,7 +4219,7 @@ msgstr ""
 msgid "Please enter a valid phone number"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr ""
 
@@ -4090,33 +4262,14 @@ msgstr ""
 msgid "Policy name"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
-msgstr ""
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr ""
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr ""
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr ""
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
 msgstr ""
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
@@ -4151,14 +4304,32 @@ msgstr "Anteprima"
 msgid "Previous ticket"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "Primario"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "Contatto Primario"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr ""
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr ""
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4166,9 +4337,10 @@ msgstr ""
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4248,17 +4420,6 @@ msgstr ""
 msgid "Quarterly"
 msgstr "Trimestrale"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "Opzioni query"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr ""
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "In coda"
@@ -4281,14 +4442,14 @@ msgstr ""
 msgid "Rate this ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr ""
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4384,8 +4545,15 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "Rimuovi"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4395,9 +4563,18 @@ msgstr ""
 msgid "Remove Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr "Rimuovi immagine"
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
 msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
@@ -4417,6 +4594,15 @@ msgstr ""
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
 msgstr ""
 
 #. Option in a Select field in the tickets Web Form
@@ -4456,16 +4642,13 @@ msgstr ""
 msgid "Reply on a ticket"
 msgstr ""
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr "Richiedi Key"
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
 msgstr ""
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
@@ -4486,6 +4669,7 @@ msgid "Reset to Default"
 msgstr ""
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr ""
@@ -4539,18 +4723,6 @@ msgstr "Risposta"
 msgid "Response By"
 msgstr ""
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr ""
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr ""
@@ -4593,28 +4765,18 @@ msgstr ""
 msgid "Restrict visibility to these teams"
 msgstr ""
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr ""
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr ""
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
+msgstr ""
+
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:215
@@ -4622,8 +4784,14 @@ msgid "Ringing"
 msgstr "Squillo"
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "Ruolo"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr ""
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4722,9 +4890,9 @@ msgstr "Sabato"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4800,17 +4968,19 @@ msgstr ""
 msgid "Search Score"
 msgstr ""
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr ""
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "Campi di ricerca..."
 
@@ -4850,6 +5020,7 @@ msgstr "Ricerca..."
 msgid "Searched for:"
 msgstr ""
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr ""
@@ -4868,6 +5039,10 @@ msgstr "Seleziona"
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
 msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
@@ -4890,6 +5065,10 @@ msgstr ""
 msgid "Select a rating"
 msgstr ""
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr ""
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4901,6 +5080,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
+msgstr ""
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
@@ -4927,6 +5110,10 @@ msgstr ""
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
 msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
@@ -4967,13 +5154,17 @@ msgstr ""
 msgid "Service not supported"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "Impostato"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:4
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
@@ -4984,12 +5175,21 @@ msgstr ""
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr ""
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr ""
 
@@ -5001,7 +5201,7 @@ msgstr ""
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr ""
 
@@ -5135,23 +5335,6 @@ msgstr ""
 msgid "Sort"
 msgstr ""
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr ""
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "Nome sorgente"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr ""
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr ""
@@ -5196,6 +5379,8 @@ msgstr ""
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5262,6 +5447,7 @@ msgstr ""
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5373,21 +5559,16 @@ msgstr "Sistema"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5426,8 +5607,6 @@ msgstr ""
 msgid "Teal"
 msgstr "Verde Acqua"
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5438,7 +5617,6 @@ msgstr "Verde Acqua"
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5544,6 +5722,10 @@ msgstr ""
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr ""
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr ""
@@ -5554,6 +5736,10 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
@@ -5576,6 +5762,14 @@ msgstr ""
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr ""
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr ""
@@ -5583,6 +5777,10 @@ msgstr ""
 #: desk/src/components/ticket/TicketMergeModal.vue:79
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
 msgstr ""
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
@@ -5652,7 +5850,7 @@ msgstr "Giovedì"
 msgid "Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr ""
 
@@ -5666,6 +5864,10 @@ msgstr ""
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
+msgstr ""
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
 msgstr ""
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
@@ -5725,7 +5927,7 @@ msgstr ""
 msgid "Ticket Summary"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr ""
 
@@ -5758,7 +5960,7 @@ msgstr ""
 msgid "Ticket merged successfully."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr ""
 
@@ -5793,12 +5995,6 @@ msgstr ""
 msgid "Ticket to merged with is required"
 msgstr ""
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr ""
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr ""
@@ -5810,12 +6006,15 @@ msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr ""
 
@@ -5827,19 +6026,19 @@ msgstr ""
 msgid "Tickets assigned to you in the last 7 days"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr ""
 
@@ -5856,6 +6055,7 @@ msgid "Tickets that are awaiting your response"
 msgstr ""
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr ""
 
@@ -5945,19 +6145,19 @@ msgstr ""
 msgid "Total Ticket"
 msgstr "Totale ticket"
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr ""
 
@@ -5989,6 +6189,10 @@ msgstr "Tipo"
 msgid "Type a message"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr ""
@@ -5998,7 +6202,7 @@ msgstr ""
 msgid "URL/Method"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr ""
 
@@ -6032,6 +6236,8 @@ msgid "Unpublish"
 msgstr "Annulla pubblicazione"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr ""
 
@@ -6048,6 +6254,10 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:214
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
+msgstr ""
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
@@ -6076,10 +6286,13 @@ msgstr "Carica"
 msgid "Upload Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
 msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
+msgstr "Carica immagine"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
 msgid "Uploading {0}%"
@@ -6088,17 +6301,13 @@ msgstr ""
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6109,6 +6318,10 @@ msgstr "Utente"
 #. Label of the user_resolution_time (Duration) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
 msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
@@ -6128,7 +6341,7 @@ msgstr "Utenti"
 msgid "Valid From"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "Valore"
 
@@ -6257,19 +6470,23 @@ msgstr "Annuale"
 msgid "Yellow"
 msgstr "Giallo"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr ""
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr ""
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr ""
 
@@ -6297,6 +6514,14 @@ msgstr ""
 msgid "You do not have permission to access Assignment Rules"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr ""
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr ""
@@ -6319,6 +6544,14 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:46
@@ -6349,7 +6582,7 @@ msgstr ""
 msgid "customize {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr "giorni"
 
@@ -6400,7 +6633,7 @@ msgstr ""
 msgid "here."
 msgstr ""
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr "ore"
 
@@ -6408,7 +6641,7 @@ msgstr "ore"
 msgid "in"
 msgstr "in"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "proprio adesso"
 
@@ -6441,7 +6674,11 @@ msgstr ""
 msgid "purple"
 msgstr "viola"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr ""
 
@@ -6458,7 +6695,7 @@ msgstr "biglietto"
 msgid "to enable this integration."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr ""
 
@@ -6466,12 +6703,32 @@ msgstr ""
 msgid "views"
 msgstr "viste"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr ""
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
 msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:307
@@ -6498,7 +6755,7 @@ msgstr ""
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr ""
 

--- a/helpdesk/locale/ko.po
+++ b/helpdesk/locale/ko.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-15 18:50\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-29 21:57\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Korean\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr ""
@@ -108,14 +108,6 @@ msgstr ""
 msgid "A workday with this name already exists"
 msgstr ""
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr ""
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr ""
@@ -132,7 +124,7 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr ""
 
@@ -152,10 +144,8 @@ msgstr ""
 msgid "Action Required"
 msgstr ""
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
 msgstr ""
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
@@ -164,7 +154,7 @@ msgstr ""
 msgid "Active"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr ""
 
@@ -175,7 +165,7 @@ msgid "Active: The agent is available and working.<br>\n"
 "Unavailable: The agent is off and unavailable."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr ""
@@ -193,10 +183,11 @@ msgid "Add Column"
 msgstr ""
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr ""
 
@@ -206,6 +197,10 @@ msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
 msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:148
@@ -244,7 +239,7 @@ msgstr ""
 msgid "Add condition group"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr ""
 
@@ -278,6 +273,12 @@ msgstr ""
 msgid "Add to Holidays"
 msgstr "휴일에 추가"
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr ""
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr ""
@@ -295,17 +296,14 @@ msgid "Administrator"
 msgstr ""
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -316,6 +314,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -335,6 +334,7 @@ msgstr ""
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -342,6 +342,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -376,18 +377,9 @@ msgstr ""
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr ""
 
@@ -508,6 +500,14 @@ msgstr ""
 msgid "Are you sure you want to delete these articles?"
 msgstr ""
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr ""
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr ""
@@ -543,6 +543,10 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
 msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
@@ -595,16 +599,11 @@ msgstr ""
 msgid "Assign ticket"
 msgstr ""
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr ""
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -618,7 +617,7 @@ msgstr ""
 msgid "Assignee Rules"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr ""
 
@@ -626,7 +625,7 @@ msgstr ""
 msgid "Assignees"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr ""
 
@@ -692,10 +691,6 @@ msgstr ""
 msgid "Assignment rule {0} updated successfully."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -711,10 +706,6 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
-msgstr ""
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
 msgstr ""
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
@@ -766,7 +757,7 @@ msgid "Automation"
 msgstr ""
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr ""
@@ -802,7 +793,7 @@ msgstr "평균 응답 시간"
 msgid "Average Time Metrics"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr ""
 
@@ -810,24 +801,36 @@ msgstr ""
 msgid "Average response and resolution metrics not available"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
 msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
@@ -840,11 +843,11 @@ msgstr ""
 msgid "Avg. resolution time"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr ""
 
@@ -867,11 +870,6 @@ msgstr ""
 msgid "Base Support Rotation"
 msgstr ""
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr ""
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -885,11 +883,11 @@ msgstr ""
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr ""
 
@@ -944,11 +942,6 @@ msgstr ""
 msgid "Busy"
 msgstr "바쁘다"
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr ""
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr ""
@@ -973,19 +966,31 @@ msgstr ""
 msgid "Caller"
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr ""
 
@@ -1025,7 +1030,7 @@ msgstr ""
 msgid "Cannot merge General category"
 msgstr ""
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr ""
 
@@ -1073,11 +1078,11 @@ msgstr ""
 msgid "Category updated successfully."
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr ""
 
@@ -1085,7 +1090,7 @@ msgstr ""
 msgid "Change"
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr ""
@@ -1098,9 +1103,8 @@ msgstr ""
 msgid "Change language of the application."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
@@ -1123,7 +1127,7 @@ msgstr ""
 msgid "Change timezone of the application."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr ""
 
@@ -1136,7 +1140,7 @@ msgstr ""
 msgid "Child field"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr ""
 
@@ -1189,7 +1193,7 @@ msgstr ""
 msgid "Clear Table"
 msgstr "테이블 지우기"
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr ""
 
@@ -1203,6 +1207,10 @@ msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
@@ -1223,7 +1231,7 @@ msgstr ""
 msgid "Closed"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr ""
 
@@ -1250,7 +1258,7 @@ msgstr ""
 msgid "Comma separated emails to invite."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr ""
 
@@ -1283,7 +1291,7 @@ msgstr ""
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr ""
@@ -1296,6 +1304,11 @@ msgstr ""
 msgid "Communication ID is required"
 msgstr ""
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
+msgstr "회사"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
 msgstr ""
@@ -1307,7 +1320,7 @@ msgstr ""
 msgid "Condition"
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr ""
 
@@ -1331,6 +1344,10 @@ msgstr ""
 msgid "Configure your telephony settings."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1356,10 +1373,11 @@ msgstr ""
 msgid "Connect your support email"
 msgstr ""
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1373,25 +1391,29 @@ msgstr ""
 msgid "Contact HTML"
 msgstr "HTML 문의하기"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
 msgstr ""
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
 msgstr ""
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
@@ -1415,7 +1437,7 @@ msgstr ""
 msgid "Copy ticket id"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr ""
 
@@ -1423,7 +1445,11 @@ msgstr ""
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr ""
 
@@ -1431,11 +1457,20 @@ msgstr ""
 msgid "Could not send feedback email,due to: {0}"
 msgstr ""
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr ""
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1446,9 +1481,13 @@ msgstr ""
 msgid "Create & invite a contact"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
-msgstr "새 연락처 만들기"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
+msgstr "고객 생성"
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
 msgid "Create View"
@@ -1482,12 +1521,6 @@ msgstr ""
 msgid "Creating a ticket"
 msgstr ""
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr ""
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr ""
@@ -1512,12 +1545,21 @@ msgid "Custom Views"
 msgstr ""
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
 msgstr "고객"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
+msgstr ""
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1528,17 +1570,33 @@ msgstr "고객 이름"
 msgid "Customer Portal"
 msgstr ""
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr "고객 유형"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
 msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
 msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
+msgstr "고객"
 
 #: desk/src/components/layouts/Sidebar.vue:595
 msgid "Customers & Contacts"
@@ -1565,6 +1623,8 @@ msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr ""
@@ -1665,17 +1725,25 @@ msgstr ""
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr ""
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
 msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:530
@@ -1692,6 +1760,10 @@ msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
+msgstr ""
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
 msgstr ""
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
@@ -1740,7 +1812,7 @@ msgstr ""
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1826,7 +1898,12 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr ""
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr ""
@@ -1867,6 +1944,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
@@ -1917,7 +1998,8 @@ msgstr ""
 msgid "Easily invite new agents, managers, or admins."
 msgstr ""
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1925,6 +2007,14 @@ msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
 msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:70
@@ -1944,10 +2034,10 @@ msgstr ""
 msgid "Edit your email account"
 msgstr ""
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr ""
 
@@ -1975,8 +2065,9 @@ msgstr ""
 msgid "Email Content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
 msgstr ""
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
@@ -2002,22 +2093,22 @@ msgstr ""
 msgid "Email account updated successfully"
 msgstr ""
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr ""
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr ""
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr ""
 
@@ -2055,8 +2146,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr ""
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2081,8 +2170,6 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2105,20 +2192,24 @@ msgstr "종료 시간"
 msgid "Enter a name for this HD Service Holiday List."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr ""
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr ""
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
 msgstr ""
 
 #: helpdesk/api/knowledge_base.py:86
@@ -2129,21 +2220,17 @@ msgstr ""
 msgid "Error processing email at index {0}, message: {1}"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr ""
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
-msgstr ""
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
 msgstr ""
 
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
 msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
@@ -2172,17 +2259,16 @@ msgstr ""
 msgid "Export Type"
 msgstr ""
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr ""
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
 #: desk/src/pages/ticket/Tickets.vue:263 desk/src/pages/ticket/Tickets.vue:271
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
+msgstr ""
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
 msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
@@ -2218,11 +2304,11 @@ msgstr ""
 msgid "Failed to save Twilio settings"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr ""
 
@@ -2251,6 +2337,7 @@ msgstr ""
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2288,12 +2375,16 @@ msgstr ""
 msgid "Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
+msgstr ""
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
 msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
@@ -2338,13 +2429,14 @@ msgid "Field dependency updated successfully."
 msgstr ""
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr ""
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr ""
@@ -2354,7 +2446,8 @@ msgstr ""
 msgid "Find out all of the variables that can be used in the content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr ""
 
@@ -2362,6 +2455,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
 msgstr "최초 응답일"
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
+msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -2385,10 +2482,6 @@ msgstr "최초 응답 시간"
 #. Name of a report
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -2480,6 +2573,10 @@ msgstr ""
 msgid "Go to Ticket #{0}"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr ""
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2509,19 +2606,12 @@ msgid "Group By Field"
 msgstr ""
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
 msgstr ""
 
 #. Name of a DocType
@@ -2554,24 +2644,36 @@ msgstr ""
 msgid "HD Comment Reaction"
 msgstr ""
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr ""
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr ""
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
 msgstr ""
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
 msgstr ""
 
 #. Name of a DocType
@@ -2592,21 +2694,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
 msgstr ""
 
 #. Name of a DocType
@@ -2648,11 +2735,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
 msgstr ""
 
 #. Name of a DocType
@@ -2750,12 +2832,6 @@ msgstr ""
 msgid "Helpdesk"
 msgstr ""
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr ""
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2771,11 +2847,6 @@ msgstr ""
 
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
-msgstr ""
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
 msgstr ""
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
@@ -2846,15 +2917,8 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr ""
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2941,6 +3005,11 @@ msgstr ""
 msgid "Incoming"
 msgstr ""
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr "개인"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr "시작됨"
@@ -2954,7 +3023,7 @@ msgstr ""
 msgid "Instantly send e-mail"
 msgstr ""
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr ""
 
@@ -2968,12 +3037,12 @@ msgstr ""
 msgid "Introduction"
 msgstr ""
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
@@ -2982,22 +3051,42 @@ msgstr ""
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr ""
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr ""
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
 msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
@@ -3008,12 +3097,29 @@ msgstr ""
 msgid "Invite agents"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
 msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
 msgstr ""
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
@@ -3029,6 +3135,11 @@ msgstr ""
 #. Label of the is_default (Check) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
+msgstr ""
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
 msgstr ""
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
@@ -3057,6 +3168,10 @@ msgstr ""
 #. Label of the setup_complete (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
 msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:114
@@ -3093,11 +3208,9 @@ msgstr ""
 msgid "Knowledge Base"
 msgstr ""
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3131,9 +3244,9 @@ msgstr ""
 msgid "Last 3 Months"
 msgstr ""
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr ""
 
@@ -3174,7 +3287,8 @@ msgstr ""
 msgid "Last Month"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr ""
 
@@ -3183,24 +3297,33 @@ msgstr ""
 msgid "Last Week"
 msgstr ""
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr ""
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
 msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
+msgstr "최신"
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -3216,26 +3339,6 @@ msgstr ""
 #. 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
-msgstr ""
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr ""
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr "링크 옵션"
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -3264,6 +3367,8 @@ msgstr ""
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr ""
 
@@ -3286,6 +3391,8 @@ msgstr ""
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr "심벌 마크"
@@ -3324,7 +3431,7 @@ msgstr ""
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr ""
 
@@ -3343,6 +3450,10 @@ msgstr ""
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
+msgstr "관리자"
 
 #: desk/src/pages/MobileNotifications.vue:11
 #: desk/src/pages/MobileNotifications.vue:14
@@ -3396,6 +3507,20 @@ msgstr ""
 msgid "Mobile App Installation"
 msgstr ""
 
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr ""
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr ""
+
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
 #. List'
@@ -3436,7 +3561,7 @@ msgid "My Tickets"
 msgstr ""
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3447,8 +3572,9 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3457,6 +3583,10 @@ msgstr ""
 #. Label of the name_weight (Int) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
 msgstr ""
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
@@ -3469,9 +3599,17 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
 msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
@@ -3581,11 +3719,11 @@ msgstr "답변 없음"
 msgid "No Data Found"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr ""
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr ""
 
@@ -3597,8 +3735,14 @@ msgstr ""
 msgid "No SLA found"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
 msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
@@ -3633,19 +3777,27 @@ msgstr ""
 msgid "No changes made"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr ""
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr ""
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr ""
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
@@ -3657,7 +3809,11 @@ msgstr ""
 msgid "No feedback"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr ""
 
@@ -3697,12 +3853,17 @@ msgstr ""
 msgid "No recently assigned tickets"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr ""
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
 msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
@@ -3710,6 +3871,7 @@ msgstr ""
 msgid "No saved replies found"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr ""
@@ -3730,7 +3892,11 @@ msgstr ""
 msgid "No tickets selected"
 msgstr ""
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr ""
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr ""
 
@@ -3742,7 +3908,7 @@ msgstr ""
 msgid "Not Saved"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr ""
 
@@ -3781,11 +3947,6 @@ msgstr ""
 msgid "On Hold Since"
 msgstr "보류 중"
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr ""
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr ""
@@ -3815,6 +3976,10 @@ msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
@@ -3904,7 +4069,12 @@ msgstr ""
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr "공동"
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr ""
 
@@ -3942,6 +4112,7 @@ msgid "Pending"
 msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr ""
 
@@ -3951,19 +4122,19 @@ msgstr ""
 msgid "Pending Tickets"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr ""
 
@@ -3984,13 +4155,14 @@ msgstr ""
 msgid "Personal mobile no"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
 msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
@@ -4047,7 +4219,7 @@ msgstr ""
 msgid "Please enter a valid phone number"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr ""
 
@@ -4090,34 +4262,15 @@ msgstr ""
 msgid "Policy name"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
 msgstr ""
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr "게시물 설명 키"
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr ""
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr ""
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
-msgstr "게시물 제목 키"
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:10
@@ -4151,14 +4304,32 @@ msgstr ""
 msgid "Previous ticket"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr ""
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr ""
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr "우선순위"
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4166,9 +4337,10 @@ msgstr "우선순위"
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4248,17 +4420,6 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr ""
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr "쿼리 경로 문자열"
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr ""
@@ -4281,14 +4442,14 @@ msgstr ""
 msgid "Rate this ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr ""
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4384,7 +4545,14 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
@@ -4395,9 +4563,18 @@ msgstr ""
 msgid "Remove Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr ""
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
 msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
@@ -4417,6 +4594,15 @@ msgstr ""
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
 msgstr ""
 
 #. Option in a Select field in the tickets Web Form
@@ -4456,16 +4642,13 @@ msgstr ""
 msgid "Reply on a ticket"
 msgstr ""
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr ""
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
 msgstr ""
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
@@ -4486,6 +4669,7 @@ msgid "Reset to Default"
 msgstr ""
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr "해결"
@@ -4539,18 +4723,6 @@ msgstr ""
 msgid "Response By"
 msgstr ""
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr "응답 옵션"
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr "응답 결과 키 경로"
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr "행 {1} 의 {0} 우선순위에 대한 응답 시간은 해결 시간보다 클 수 없습니다."
@@ -4593,36 +4765,32 @@ msgstr ""
 msgid "Restrict visibility to these teams"
 msgstr ""
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr ""
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr "결과 경로 필드"
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr "결과 제목 필드"
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
 msgstr "리뷰"
 
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:215
 msgid "Ringing"
 msgstr "울리는"
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
 msgstr ""
 
 #. Label of the route_name (Data) field in DocType 'HD View'
@@ -4722,9 +4890,9 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4800,17 +4968,19 @@ msgstr ""
 msgid "Search Score"
 msgstr ""
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr "검색어 매개변수 이름"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr ""
 
@@ -4850,6 +5020,7 @@ msgstr ""
 msgid "Searched for:"
 msgstr ""
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr ""
@@ -4868,6 +5039,10 @@ msgstr ""
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
 msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
@@ -4890,6 +5065,10 @@ msgstr "기본 우선순위를 선택하세요."
 msgid "Select a rating"
 msgstr ""
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr ""
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4901,6 +5080,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
+msgstr ""
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
@@ -4927,6 +5110,10 @@ msgstr ""
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
 msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
@@ -4967,13 +5154,17 @@ msgstr "서비스 레벨 이름"
 msgid "Service not supported"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:4
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
@@ -4984,12 +5175,21 @@ msgstr ""
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr "{1} 행의 우선순위 {0} 에 대한 응답 시간을 설정합니다."
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr ""
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr ""
 
@@ -5001,7 +5201,7 @@ msgstr ""
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr ""
 
@@ -5135,23 +5335,6 @@ msgstr ""
 msgid "Sort"
 msgstr ""
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr "소스 문서 유형"
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr ""
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr "소스 유형"
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr ""
@@ -5196,6 +5379,8 @@ msgstr ""
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5262,6 +5447,7 @@ msgstr ""
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5373,21 +5559,16 @@ msgstr ""
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5426,8 +5607,6 @@ msgstr ""
 msgid "Teal"
 msgstr ""
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5438,7 +5617,6 @@ msgstr ""
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5544,6 +5722,10 @@ msgstr ""
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr ""
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr ""
@@ -5554,6 +5736,10 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
@@ -5576,6 +5762,14 @@ msgstr ""
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr ""
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr ""
@@ -5583,6 +5777,10 @@ msgstr ""
 #: desk/src/components/ticket/TicketMergeModal.vue:79
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
 msgstr ""
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
@@ -5652,7 +5850,7 @@ msgstr ""
 msgid "Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr ""
 
@@ -5666,6 +5864,10 @@ msgstr ""
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
+msgstr ""
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
 msgstr ""
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
@@ -5725,7 +5927,7 @@ msgstr ""
 msgid "Ticket Summary"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr ""
 
@@ -5758,7 +5960,7 @@ msgstr ""
 msgid "Ticket merged successfully."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr ""
 
@@ -5793,12 +5995,6 @@ msgstr ""
 msgid "Ticket to merged with is required"
 msgstr ""
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr ""
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr ""
@@ -5810,12 +6006,15 @@ msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr ""
 
@@ -5827,19 +6026,19 @@ msgstr ""
 msgid "Tickets assigned to you in the last 7 days"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr ""
 
@@ -5856,6 +6055,7 @@ msgid "Tickets that are awaiting your response"
 msgstr ""
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr ""
 
@@ -5945,19 +6145,19 @@ msgstr "총 휴일 수"
 msgid "Total Ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr ""
 
@@ -5989,6 +6189,10 @@ msgstr ""
 msgid "Type a message"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr ""
@@ -5998,7 +6202,7 @@ msgstr ""
 msgid "URL/Method"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr ""
 
@@ -6032,6 +6236,8 @@ msgid "Unpublish"
 msgstr ""
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr ""
 
@@ -6048,6 +6254,10 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:214
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
+msgstr ""
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
@@ -6076,9 +6286,12 @@ msgstr ""
 msgid "Upload Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
@@ -6088,17 +6301,13 @@ msgstr ""
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6110,6 +6319,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
 msgstr "사용자 해결 시간"
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
+msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
 msgid "User Signup"
@@ -6128,7 +6341,7 @@ msgstr ""
 msgid "Valid From"
 msgstr "유효 기간 시작일"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr ""
 
@@ -6257,19 +6470,23 @@ msgstr ""
 msgid "Yellow"
 msgstr ""
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr ""
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr ""
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr ""
 
@@ -6297,6 +6514,14 @@ msgstr ""
 msgid "You do not have permission to access Assignment Rules"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr ""
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr ""
@@ -6319,6 +6544,14 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:46
@@ -6349,7 +6582,7 @@ msgstr ""
 msgid "customize {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr ""
 
@@ -6400,7 +6633,7 @@ msgstr ""
 msgid "here."
 msgstr ""
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr ""
 
@@ -6408,7 +6641,7 @@ msgstr ""
 msgid "in"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr ""
 
@@ -6441,7 +6674,11 @@ msgstr ""
 msgid "purple"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr ""
 
@@ -6458,7 +6695,7 @@ msgstr ""
 msgid "to enable this integration."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr ""
 
@@ -6466,12 +6703,32 @@ msgstr ""
 msgid "views"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr ""
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
 msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:307
@@ -6498,7 +6755,7 @@ msgstr ""
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr ""
 

--- a/helpdesk/locale/main.pot
+++ b/helpdesk/locale/main.pot
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Helpdesk VERSION\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-21 11:29+0000\n"
-"PO-Revision-Date: 2026-06-21 11:29+0000\n"
+"POT-Creation-Date: 2026-08-02 11:39+0000\n"
+"PO-Revision-Date: 2026-08-02 11:39+0000\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: hello@frappe.io\n"
 "MIME-Version: 1.0\n"
@@ -20,17 +20,21 @@ msgstr ""
 msgid " commented"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:186
 msgid "% SLA Fulfilled"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:191
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr ""
 
 #: desk/src/pages/SearchAgent.vue:120
 msgid "({0}s)"
+msgstr ""
+
+#: desk/src/components/tag/Tags.vue:62
+msgid "+{0} more"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:114
@@ -98,20 +102,20 @@ msgstr ""
 msgid "<span class=\"h4\">Helpdesk Configuration<br></span>"
 msgstr ""
 
+#: desk/src/pages/PersonaForm.vue:224
+msgid "A Frappe partner or consultant"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:223
+msgid "A friend or colleague"
+msgstr ""
+
 #: desk/src/pages/ticket/TicketNew.vue:69
 msgid "A short description"
 msgstr ""
 
 #: desk/src/components/Settings/Sla/Modals/WorkDayModal.vue:268
 msgid "A workday with this name already exists"
-msgstr ""
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
 msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
@@ -130,7 +134,7 @@ msgstr ""
 msgid "Account"
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:108
 msgid "Account Info & Security"
 msgstr ""
 
@@ -150,10 +154,8 @@ msgstr ""
 msgid "Action Required"
 msgstr ""
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
+#: desk/src/pages/contact/Contact.vue:305
+msgid "Actions"
 msgstr ""
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
@@ -162,7 +164,7 @@ msgstr ""
 msgid "Active"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:401
 msgid "Active now"
 msgstr ""
 
@@ -174,16 +176,20 @@ msgid ""
 "Unavailable: The agent is off and unavailable."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:484
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
+msgstr ""
+
+#: desk/src/components/tag/Tags.vue:38 desk/src/components/tag/Tags.vue:43
+msgid "Add"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:9
 msgid "Add Assignee"
 msgstr ""
 
-#: desk/src/pages/knowledge-base/Article.vue:643
+#: desk/src/pages/knowledge-base/Article.vue:638
 msgid "Add Category"
 msgstr ""
 
@@ -191,20 +197,25 @@ msgstr ""
 msgid "Add Column"
 msgstr ""
 
-#: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/Settings/Profile/UserEmailSettings.vue:89
+#: desk/src/components/contact/EditContactDialog.vue:68
 msgid "Add Email"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:112
+#: desk/src/components/view-controls/filter/Filter.vue:120
 msgid "Add Filter..."
 msgstr ""
 
-#: desk/src/components/Settings/Holiday/HolidayView.vue:163
+#: desk/src/components/Settings/Holiday/HolidayView.vue:173
 msgid "Add Holiday"
 msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:97
+msgid "Add Phone"
 msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:148
@@ -217,7 +228,7 @@ msgstr ""
 msgid "Add Weekly Holidays"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:507
+#: desk/src/components/layouts/Sidebar.vue:297
 msgid "Add a comment on a ticket"
 msgstr ""
 
@@ -227,6 +238,10 @@ msgstr ""
 
 #: desk/src/components/Settings/Sla/SlaAssignmentConditions.vue:14
 msgid "Add a custom condition"
+msgstr ""
+
+#: desk/src/components/Questionnaire.vue:266
+msgid "Add a few words so we can continue"
 msgstr ""
 
 #: desk/src/pages/home/Home.vue:91
@@ -243,11 +258,11 @@ msgstr ""
 msgid "Add condition group"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:81
+#: desk/src/components/view-controls/filter/Filter.vue:89
 msgid "Add filter"
 msgstr ""
 
-#: desk/src/components/Settings/Holiday/HolidayView.vue:136
+#: desk/src/components/Settings/Holiday/HolidayView.vue:146
 msgid "Add holidays here to make sure they’re excluded from SLA calculations."
 msgstr ""
 
@@ -256,15 +271,19 @@ msgid "Add members to this team to get started."
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:23
-#: desk/src/components/Settings/EmailAccountList.vue:47
+#: desk/src/components/Settings/EmailAccountList.vue:53
 #: desk/src/components/Settings/Holiday/HolidayList.vue:23
-#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:92
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:74
 #: desk/src/components/Settings/Sla/SlaPolicyList.vue:23
 msgid "Add one to get started."
 msgstr ""
 
-#: desk/src/components/Settings/Holiday/HolidayView.vue:117
+#: desk/src/components/Settings/Holiday/HolidayView.vue:127
 msgid "Add recurring holidays such as weekends."
+msgstr ""
+
+#: desk/src/components/modals/ShortcutsModal.vue:92
+msgid "Add tags"
 msgstr ""
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:183
@@ -275,6 +294,12 @@ msgstr ""
 #. Holiday List'
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Add to Holidays"
+msgstr ""
+
+#: desk/src/components/EmailEditor.vue:37
+#: desk/src/components/EmailEditor.vue:77
+#: desk/src/components/EmailEditor.vue:95
+msgid "Add to recipients"
 msgstr ""
 
 #: desk/src/components/Settings/Agents.vue:4
@@ -294,17 +319,14 @@ msgid "Administrator"
 msgstr ""
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
-#: desk/src/components/layouts/Sidebar.vue:612
+#: desk/src/components/layouts/Sidebar.vue:402
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -315,6 +337,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -327,13 +350,14 @@ msgstr ""
 msgid "Agent Configuration"
 msgstr ""
 
-#: desk/src/pages/dashboard/Dashboard.vue:248
+#: desk/src/pages/dashboard/Dashboard.vue:262
 msgid "Agent Dashboard"
 msgstr ""
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -341,7 +365,9 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
 msgstr ""
@@ -364,7 +390,7 @@ msgstr ""
 msgid "Agents"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:591
+#: desk/src/components/layouts/Sidebar.vue:381
 msgid "Agents & Teams"
 msgstr ""
 
@@ -372,25 +398,14 @@ msgstr ""
 msgid "Agents will no longer be able to view and create saved replies with global scope."
 msgstr ""
 
-#. Name of a role
-#: desk/src/components/SavedRepliesSelectorModal.vue:165
-#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/SavedRepliesSelectorModal.vue:176
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:302
+#: desk/src/components/contact/FeedbackList.vue:118
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr ""
 
-#: desk/src/pages/home/components/PendingTickets.vue:253
+#: desk/src/pages/home/components/PendingTickets.vue:246
 msgid "All SLAs on track"
 msgstr ""
 
@@ -398,10 +413,6 @@ msgstr ""
 #: desk/src/pages/home/components/RecentFeedback.vue:398
 #: desk/src/pages/home/components/RecentFeedback.vue:406
 msgid "All Time"
-msgstr ""
-
-#: desk/src/components/layouts/Sidebar.vue:293
-msgid "All Views"
 msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:322
@@ -412,7 +423,7 @@ msgstr ""
 msgid "All comments and emails from both tickets will be merged into the selected ticket"
 msgstr ""
 
-#: desk/src/pages/home/components/PendingTickets.vue:262
+#: desk/src/pages/home/components/PendingTickets.vue:255
 msgid "All your assigned tickets have been responded to"
 msgstr ""
 
@@ -438,6 +449,14 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Amber"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:225
+msgid "An event or conference"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:217
+msgid "Another Frappe product (ERPNext, Frappe Cloud, etc.)"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:113
@@ -507,26 +526,30 @@ msgstr ""
 msgid "Are you sure you want to delete these articles?"
 msgstr ""
 
-#: desk/src/components/ticket-agent/TicketHeader.vue:204
-msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
+#: desk/src/pages/contact/Contact.vue:104
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
 msgstr ""
 
-#: desk/src/pages/ticket/Tickets.vue:541
-msgid "Are you sure you want to delete this view?"
+#: desk/src/pages/customer/Customer.vue:96
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr ""
+
+#: desk/src/components/ticket-agent/TicketHeader.vue:200
+msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr ""
 
 #: desk/src/pages/knowledge-base/Article.vue:147
 msgid "Are you sure you want to discard changes?"
 msgstr ""
 
-#: desk/src/pages/knowledge-base/NewArticle.vue:144
+#: desk/src/pages/knowledge-base/NewArticle.vue:145
 msgid "Are you sure you want to discard this article?"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:450
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:103
 #: desk/src/components/Settings/FieldDependency/FieldDependency.vue:68
-#: desk/src/components/Settings/Holiday/HolidayView.vue:192
+#: desk/src/components/Settings/Holiday/HolidayView.vue:202
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:218
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:280
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:355
@@ -544,6 +567,10 @@ msgstr ""
 msgid "Are you sure you want to remove the logo?"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
+msgstr ""
+
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
 msgid "Are you sure you want to reset the content? Current content will be overridden."
 msgstr ""
@@ -554,27 +581,27 @@ msgstr ""
 msgid "Article"
 msgstr ""
 
-#: desk/src/pages/knowledge-base/Article.vue:519
+#: desk/src/pages/knowledge-base/Article.vue:514
 msgid "Article body cannot be set as empty."
 msgstr ""
 
-#: desk/src/pages/knowledge-base/NewArticle.vue:117
+#: desk/src/pages/knowledge-base/NewArticle.vue:118
 msgid "Article created successfully."
 msgstr ""
 
-#: desk/src/pages/knowledge-base/Article.vue:558
+#: desk/src/pages/knowledge-base/Article.vue:553
 msgid "Article deleted successfully."
 msgstr ""
 
-#: desk/src/pages/knowledge-base/Article.vue:654
+#: desk/src/pages/knowledge-base/Article.vue:649
 msgid "Article link copied to clipboard"
 msgstr ""
 
-#: desk/src/pages/knowledge-base/Article.vue:514
+#: desk/src/pages/knowledge-base/Article.vue:509
 msgid "Article title cannot be set as empty"
 msgstr ""
 
-#: desk/src/pages/knowledge-base/Article.vue:545
+#: desk/src/pages/knowledge-base/Article.vue:540
 msgid "Article updated successfully."
 msgstr ""
 
@@ -586,7 +613,7 @@ msgstr ""
 msgid "Articles moved successfully."
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:482
+#: desk/src/components/layouts/Sidebar.vue:272
 msgid "Assign a ticket to an agent"
 msgstr ""
 
@@ -594,16 +621,11 @@ msgstr ""
 msgid "Assign ticket"
 msgstr ""
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
+#: desk/src/pages/home/components/RecentActivity.vue:105
+msgid "Assigned"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:39
-msgid "Assign yourself"
-msgstr ""
-
+#: desk/src/components/customer/TicketsTab.vue:233
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -617,16 +639,16 @@ msgstr ""
 msgid "Assignee Rules"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
-msgid "Assignee's updated successfully."
-msgstr ""
-
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:75
 msgid "Assignees"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:576
 msgid "Assignees updated successfully."
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:200
+msgid "Assigning tickets"
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'HD Notification'
@@ -691,10 +713,6 @@ msgstr ""
 msgid "Assignment rule {0} updated successfully."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -710,10 +728,6 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
-msgstr ""
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
 msgstr ""
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
@@ -750,6 +764,12 @@ msgstr ""
 msgid "Auto-generated from the portal view — do not edit directly unless you know what you're doing! "
 msgstr ""
 
+#. Label of the auto_set_customer_from_contact (Check) field in DocType 'HD
+#. Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Auto-set customer from contact"
+msgstr ""
+
 #. Label of the auto_close_tickets (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Automatically Close Tickets when"
@@ -759,13 +779,19 @@ msgstr ""
 msgid "Automatically close stale tickets"
 msgstr ""
 
+#. Description of the 'Auto-set customer from contact' (Check) field in DocType
+#. 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Automatically set the customer on a ticket based on the contact's linked customer(s)"
+msgstr ""
+
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Automation"
 msgstr ""
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:117
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr ""
@@ -801,7 +827,7 @@ msgstr ""
 msgid "Average Time Metrics"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:379
 msgid "Average feedback rating per day is around {0} stars"
 msgstr ""
 
@@ -809,24 +835,36 @@ msgstr ""
 msgid "Average response and resolution metrics not available"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:297
 msgid "Average tickets per day is around {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:242
 msgid "Avg. Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:201
 msgid "Avg. First Response"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:220
 msgid "Avg. Resolution"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:247
+msgid "Avg. feedback rating for tickets resolved in this period"
 msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
@@ -839,11 +877,11 @@ msgstr ""
 msgid "Avg. resolution time"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:207
 msgid "Avg. time taken to first respond to a ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:226
 msgid "Avg. time taken to resolve a ticket"
 msgstr ""
 
@@ -854,6 +892,8 @@ msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:145
 #: desk/src/components/Settings/EmailEdit.vue:134
+#: desk/src/components/command-palette/CommandPalette.vue:149
+#: desk/src/components/command-palette/CommandPalette.vue:249
 msgid "Back"
 msgstr ""
 
@@ -864,11 +904,6 @@ msgstr ""
 #. Label of the base_support_rotation (Link) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Base Support Rotation"
-msgstr ""
-
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
 msgstr ""
 
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
@@ -884,11 +919,11 @@ msgstr ""
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:51
 msgid "Bcc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:85
 msgid "Bcc:"
 msgstr ""
 
@@ -914,16 +949,16 @@ msgstr ""
 msgid "Branding"
 msgstr ""
 
-#: desk/src/components/ListViewBuilder.vue:270
+#: desk/src/components/ListViewBuilder.vue:272
 msgid "Bulk Operation Failed"
 msgstr ""
 
-#: desk/src/components/ListViewBuilder.vue:273
+#: desk/src/components/ListViewBuilder.vue:275
 msgid "Bulk Operation Successful"
 msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:2
-#: desk/src/pages/ticket/Tickets.vue:122
+#: desk/src/pages/ticket/Tickets.vue:116
 msgid "Bulk Reply"
 msgstr ""
 
@@ -943,11 +978,6 @@ msgstr ""
 msgid "Busy"
 msgstr ""
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr ""
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr ""
@@ -956,12 +986,16 @@ msgstr ""
 msgid "Call Details"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:288
+#: desk/src/components/layouts/AppSidebar.vue:204
 msgid "Call Logs"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:81
 msgid "Call Received By"
+msgstr ""
+
+#: desk/src/components/ticket-agent/TicketContact.vue:38
+msgid "Call contact"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:69
@@ -972,23 +1006,35 @@ msgstr ""
 msgid "Caller"
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:502
 msgid "Calls"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr ""
 
-#: desk/src/components/ListViewBuilder.vue:714 desk/src/pages/home/Home.vue:44
+#: desk/src/components/ListViewBuilder.vue:724 desk/src/pages/home/Home.vue:44
 msgid "Cancel"
 msgstr ""
 
@@ -1024,7 +1070,7 @@ msgstr ""
 msgid "Cannot merge General category"
 msgstr ""
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr ""
 
@@ -1046,7 +1092,7 @@ msgstr ""
 msgid "Category '{0}' link copied to clipboard"
 msgstr ""
 
-#: desk/src/pages/knowledge-base/Article.vue:335
+#: desk/src/pages/knowledge-base/Article.vue:330
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:266
 msgid "Category created successfully."
 msgstr ""
@@ -1072,11 +1118,11 @@ msgstr ""
 msgid "Category updated successfully."
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:41
 msgid "Cc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:67
 msgid "Cc:"
 msgstr ""
 
@@ -1084,12 +1130,12 @@ msgstr ""
 msgid "Change"
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:158
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:198
+#: desk/src/components/Settings/Profile/Profile.vue:202
 msgid "Change Photo"
 msgstr ""
 
@@ -1097,13 +1143,8 @@ msgstr ""
 msgid "Change language of the application."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:182
 msgid "Change operator ({0})"
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
@@ -1126,7 +1167,7 @@ msgstr ""
 msgid "Change timezone of the application."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:153
 msgid "Change your account password for security."
 msgstr ""
 
@@ -1139,7 +1180,7 @@ msgstr ""
 msgid "Child field"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:190
+#: desk/src/components/view-controls/filter/Filter.vue:202
 msgid "Choose a field"
 msgstr ""
 
@@ -1183,6 +1224,10 @@ msgstr ""
 msgid "Choose who receives the tickets."
 msgstr ""
 
+#: desk/src/components/command-palette/CommandPalette.vue:248
+msgid "Clear"
+msgstr ""
+
 #: desk/src/components/view-controls/SortBy.vue:160
 msgid "Clear Sort"
 msgstr ""
@@ -1192,7 +1237,7 @@ msgstr ""
 msgid "Clear Table"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:93
+#: desk/src/components/view-controls/filter/Filter.vue:101
 msgid "Clear all"
 msgstr ""
 
@@ -1208,11 +1253,16 @@ msgstr ""
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
 msgstr ""
 
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
+msgstr ""
+
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:47
-#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:194
-#: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:58
-#: desk/src/pages/ticket/MobileTicketAgent.vue:159
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:174
+#: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:56
+#: desk/src/components/command-palette/CommandPalette.vue:250
+#: desk/src/pages/ticket/MobileTicketAgent.vue:191
 #: desk/src/pages/ticket/TicketCustomer.vue:14
 msgid "Close"
 msgstr ""
@@ -1226,12 +1276,8 @@ msgstr ""
 msgid "Closed"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:431
 msgid "Closed or rated tickets cannot be updated by non-agents"
-msgstr ""
-
-#: desk/src/components/layouts/Sidebar.vue:143
-msgid "Collapse"
 msgstr ""
 
 #. Label of the color (Select) field in DocType 'HD Agent Status'
@@ -1253,8 +1299,12 @@ msgstr ""
 msgid "Comma separated emails to invite."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:113
 msgid "Comma separated values"
+msgstr ""
+
+#: desk/src/components/command-palette/CommandPalette.vue:14
+msgid "Command Palette"
 msgstr ""
 
 #. Label of the reference_comment (Link) field in DocType 'HD Notification'
@@ -1262,11 +1312,11 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#: desk/src/components/CommentBox.vue:318
+#: desk/src/components/CommentBox.vue:326
 msgid "Comment cannot be empty."
 msgstr ""
 
-#: desk/src/components/CommentBox.vue:308
+#: desk/src/components/CommentBox.vue:316
 msgid "Comment deleted successfully."
 msgstr ""
 
@@ -1275,8 +1325,12 @@ msgstr ""
 msgid "Comment not found"
 msgstr ""
 
-#: desk/src/components/CommentBox.vue:334
+#: desk/src/components/CommentBox.vue:342
 msgid "Comment updated successfully."
+msgstr ""
+
+#: desk/src/pages/home/components/RecentActivity.vue:103
+msgid "Commented"
 msgstr ""
 
 #. Label of the commented_by (Link) field in DocType 'HD Ticket Comment'
@@ -1286,17 +1340,22 @@ msgstr ""
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:494
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr ""
 
-#: desk/src/components/modals/ShortcutsModal.vue:97
+#: desk/src/components/modals/ShortcutsModal.vue:98
 msgid "Communication"
 msgstr ""
 
 #: desk/src/components/ticket/TicketSplitModal.vue:76
 msgid "Communication ID is required"
+msgstr ""
+
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:209
@@ -1310,7 +1369,7 @@ msgstr ""
 msgid "Condition"
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:143
 msgid "Configure"
 msgstr ""
 
@@ -1334,16 +1393,20 @@ msgstr ""
 msgid "Configure your telephony settings."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
+#: desk/src/components/layouts/CustomerPortalPermissionDialog.vue:45
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
-#: desk/src/pages/knowledge-base/NewArticle.vue:147
-#: desk/src/pages/ticket/MobileTicketAgent.vue:156
+#: desk/src/pages/knowledge-base/NewArticle.vue:148
+#: desk/src/pages/ticket/MobileTicketAgent.vue:188
 #: desk/src/pages/ticket/TicketCustomer.vue:317
-#: desk/src/pages/ticket/Tickets.vue:428 desk/src/pages/ticket/Tickets.vue:550
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.js:27
 msgid "Confirm"
 msgstr ""
 
-#: desk/src/components/ListViewBuilder.vue:698
+#: desk/src/components/ListViewBuilder.vue:708
 msgid "Confirm Changes"
 msgstr ""
 
@@ -1355,14 +1418,19 @@ msgstr ""
 msgid "Confirm overwrite"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:439
+#: desk/src/pages/PersonaForm.vue:235
+msgid "Connect my support email"
+msgstr ""
+
+#: desk/src/components/layouts/Sidebar.vue:229
 msgid "Connect your support email"
 msgstr ""
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
-#: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:42
+#: desk/src/components/layouts/Sidebar.vue:404
+#: desk/src/pages/customer/Customer.vue:169
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1376,25 +1444,29 @@ msgstr ""
 msgid "Contact HTML"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
 msgstr ""
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:328 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:77
+#: desk/src/pages/customer/Customer.vue:153
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
 msgstr ""
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
@@ -1410,15 +1482,15 @@ msgstr ""
 msgid "Content Type"
 msgstr ""
 
-#: desk/src/components/modals/ShortcutsModal.vue:93
+#: desk/src/components/modals/ShortcutsModal.vue:94
 msgid "Copy ticket URL"
 msgstr ""
 
-#: desk/src/components/modals/ShortcutsModal.vue:92
+#: desk/src/components/modals/ShortcutsModal.vue:93
 msgid "Copy ticket id"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:761
 msgid "Could not an email due to: {0}"
 msgstr ""
 
@@ -1426,42 +1498,61 @@ msgstr ""
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:920
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:169
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:170
 msgid "Could not send feedback email,due to: {0}"
+msgstr ""
+
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:35
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
 msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
-#: desk/src/components/layouts/Sidebar.vue:544
+#: desk/src/components/contact/NewContactDialog.vue:102
+#: desk/src/components/customer/NewCustomerDialog.vue:99
+#: desk/src/components/layouts/Sidebar.vue:334
+#: desk/src/components/tag/Tags.vue:182 desk/src/components/tag/Tags.vue:197
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
+#: desk/src/pages/ticket/Tickets.vue:20
 msgid "Create"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:537
-#: desk/src/components/layouts/Sidebar.vue:543
+#: desk/src/components/layouts/Sidebar.vue:327
+#: desk/src/components/layouts/Sidebar.vue:333
 msgid "Create & invite a contact"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
 msgstr ""
 
-#: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
+msgstr ""
+
+#: desk/src/pages/ticket/Tickets.vue:394 desk/src/pages/ticket/Tickets.vue:398
 msgid "Create View"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:472
+#: desk/src/components/layouts/Sidebar.vue:262
 msgid "Create a ticket"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:520
+#: desk/src/components/layouts/Sidebar.vue:310
 msgid "Create an article"
 msgstr ""
 
@@ -1473,6 +1564,10 @@ msgstr ""
 msgid "Create field dependencies to dynamically update options based on user selections. Learn more about field dependencies"
 msgstr ""
 
+#: desk/src/pages/PersonaForm.vue:237
+msgid "Create my first ticket"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaHolidays.vue:57
 msgid "Create new business holiday"
 msgstr ""
@@ -1481,17 +1576,15 @@ msgstr ""
 msgid "Created by"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:583
+#: desk/src/components/layouts/Sidebar.vue:373
 msgid "Creating a ticket"
 msgstr ""
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
+#: desk/src/components/ViewModal.vue:22
+msgid "Current icon"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:627
+#: desk/src/components/layouts/Sidebar.vue:417
 msgid "Custom Actions"
 msgstr ""
 
@@ -1501,8 +1594,8 @@ msgstr ""
 msgid "Custom Outside Working Hours Message"
 msgstr ""
 
-#: desk/src/pages/dashboard/Dashboard.vue:509
-#: desk/src/pages/dashboard/Dashboard.vue:515
+#: desk/src/pages/dashboard/Dashboard.vue:574
+#: desk/src/pages/dashboard/Dashboard.vue:580
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:179
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:200
 #: desk/src/pages/home/components/RecentFeedback.vue:376
@@ -1510,16 +1603,26 @@ msgstr ""
 msgid "Custom Range"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:629
+#: desk/src/components/layouts/Sidebar.vue:419
 msgid "Custom Views"
 msgstr ""
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
-#: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/components/contact/EditContactDialog.vue:120
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
+#: desk/src/components/layouts/Sidebar.vue:405
+#: desk/src/pages/contact/Contact.vue:81
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+#: desk/src/components/layouts/CustomerPortalPermissionDialog.vue:18
+msgid "Customer Manager"
 msgstr ""
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
@@ -1527,23 +1630,52 @@ msgstr ""
 msgid "Customer Name"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:603
+#: desk/src/components/layouts/Sidebar.vue:393
 msgid "Customer Portal"
 msgstr ""
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:30
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:357
+#: desk/src/components/customer/NewCustomerDialog.vue:141
+msgid "Customer created"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:140
+msgid "Customer created · invitation sent to {0}"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
+msgstr ""
+
+#: desk/src/components/layouts/MobileSidebar.vue:109
+#: desk/src/components/layouts/Sidebar.vue:150
 msgid "Customer portal"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
+#: desk/src/components/layouts/CustomerPortalPermissionDialog.vue:4
+msgid "Customer portal permissions have changed"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:595
+#: desk/src/components/layouts/CustomerPortalPermissionBanner.vue:10
+msgid "Customer portal update"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:200
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
+msgstr ""
+
+#: desk/src/components/layouts/Sidebar.vue:385
 msgid "Customers & Contacts"
 msgstr ""
 
@@ -1551,7 +1683,7 @@ msgstr ""
 msgid "Customers are in sync"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:624
+#: desk/src/components/layouts/Sidebar.vue:414
 msgid "Customizations"
 msgstr ""
 
@@ -1566,13 +1698,19 @@ msgstr ""
 msgid "Cyan"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:340
-#: desk/src/components/layouts/Sidebar.vue:391
-#: desk/src/pages/knowledge-base/Article.vue:658
+#: helpdesk/api/dashboard_tags.py:73
+msgid "Daily volume of the top {0} tags"
+msgstr ""
+
+#: desk/src/components/layouts/Sidebar.vue:135
+#: desk/src/components/layouts/Sidebar.vue:184
+#: desk/src/pages/contact/Contact.vue:310
+#: desk/src/pages/customer/Customer.vue:213
+#: desk/src/pages/knowledge-base/Article.vue:653
 msgid "Danger"
 msgstr ""
 
-#: desk/src/pages/dashboard/Dashboard.vue:567
+#: desk/src/pages/dashboard/Dashboard.vue:634
 msgid "Dashboard"
 msgstr ""
 
@@ -1581,6 +1719,7 @@ msgid "Dashboard saved"
 msgstr ""
 
 #. Label of the holiday_date (Date) field in DocType 'HD Holiday'
+#: helpdesk/api/dashboard_tags.py:74
 #: helpdesk/helpdesk/doctype/hd_holiday/hd_holiday.json
 #: helpdesk/helpdesk/report/support_hour_distribution/support_hour_distribution.py:77
 msgid "Date"
@@ -1627,12 +1766,12 @@ msgstr ""
 msgid "Default Ticket Status"
 msgstr ""
 
-#: desk/src/pages/ticket/Tickets.vue:354 desk/src/pages/ticket/Tickets.vue:447
+#: desk/src/pages/ticket/Tickets.vue:351
 msgid "Default Views"
 msgstr ""
 
-#: desk/src/components/ticket-agent/TicketHeader.vue:264
-#: desk/src/components/ticket-agent/TicketHeader.vue:275
+#: desk/src/components/ticket-agent/TicketHeader.vue:259
+#: desk/src/components/ticket-agent/TicketHeader.vue:270
 msgid "Default actions"
 msgstr ""
 
@@ -1668,21 +1807,24 @@ msgstr ""
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr ""
 
-#: desk/src/components/ListViewBuilder.vue:233
-#: desk/src/components/ListViewBuilder.vue:237
-#: desk/src/components/ListViewBuilder.vue:243
-#: desk/src/components/ticket-agent/TicketHeader.vue:209
-#: desk/src/components/ticket-agent/TicketHeader.vue:279
-#: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
+#: desk/src/components/ListViewBuilder.vue:235
+#: desk/src/components/ListViewBuilder.vue:239
+#: desk/src/components/ListViewBuilder.vue:245
+#: desk/src/components/ticket-agent/TicketHeader.vue:205
+#: desk/src/components/ticket-agent/TicketHeader.vue:274
+#: desk/src/components/ticket-agent/TicketHeader.vue:276
+#: desk/src/pages/contact/Contact.vue:314
+#: desk/src/pages/customer/Customer.vue:217
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
-#: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr ""
 
-#: desk/src/pages/ticket/Tickets.vue:530
-msgid "Delete View"
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Delete Contact"
 msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:204
@@ -1693,8 +1835,8 @@ msgstr ""
 msgid "Delete category?"
 msgstr ""
 
-#: desk/src/pages/ticket/Tickets.vue:539
-msgid "Delete {0}"
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
 msgstr ""
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
@@ -1742,8 +1884,8 @@ msgstr ""
 #. Label of the details_section (Section Break) field in DocType 'HD
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
-#: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:113
+#: desk/src/pages/ticket/MobileTicketAgent.vue:478
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1780,13 +1922,13 @@ msgstr ""
 msgid "Disables all email notifications for the ticket - including creation, updates, and alerts."
 msgstr ""
 
-#: desk/src/components/TextEditor.vue:41
+#: desk/src/components/TextEditor.vue:43
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:24
 #: desk/src/pages/knowledge-base/NewArticle.vue:27
 msgid "Discard"
 msgstr ""
 
-#: desk/src/pages/knowledge-base/NewArticle.vue:143
+#: desk/src/pages/knowledge-base/NewArticle.vue:144
 msgid "Discard Article"
 msgstr ""
 
@@ -1820,7 +1962,8 @@ msgstr ""
 msgid "DocType"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:371
+#: desk/src/components/layouts/MobileSidebar.vue:123
+#: desk/src/components/layouts/Sidebar.vue:164
 msgid "Docs"
 msgstr ""
 
@@ -1829,7 +1972,12 @@ msgstr ""
 msgid "Document Type"
 msgstr ""
 
+#: desk/src/components/contact/EditContactDialog.vue:43
+msgid "Doe"
+msgstr ""
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:48
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr ""
@@ -1848,11 +1996,10 @@ msgstr ""
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:138
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:50
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:90
-#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:197
-#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:261
-#: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:61
-#: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:102
-#: desk/src/pages/ticket/Tickets.vue:451
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:177
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:241
+#: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:59
+#: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:100
 msgid "Duplicate"
 msgstr ""
 
@@ -1864,12 +2011,16 @@ msgstr ""
 msgid "Duplicate Holiday List"
 msgstr ""
 
-#: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:42
+#: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:40
 msgid "Duplicate SLA Policy"
 msgstr ""
 
-#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:158
 msgid "Duplicate Saved reply"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
@@ -1916,18 +2067,35 @@ msgstr ""
 msgid "ERPNext is not installed on your site. Please install ERPNext to enable this setting"
 msgstr ""
 
+#: desk/src/components/layouts/CustomerPortalPermissionDialog.vue:10
+msgid "Earlier, every contact could see all the tickets of their company. Now, contacts only see the tickets they raised themselves."
+msgstr ""
+
 #: desk/src/components/Settings/InviteAgents.vue:4
 msgid "Easily invite new agents, managers, or admins."
 msgstr ""
 
-#: desk/src/pages/home/Home.vue:36
-#: desk/src/pages/knowledge-base/Article.vue:626
-#: desk/src/pages/ticket/Tickets.vue:519
+#: desk/src/pages/contact/Contact.vue:33
+#: desk/src/pages/customer/Customer.vue:28 desk/src/pages/home/Home.vue:36
+#: desk/src/pages/knowledge-base/Article.vue:621
 msgid "Edit"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
+msgstr ""
+
+#: desk/src/components/Settings/EmailAdd.vue:70
+#: desk/src/components/Settings/EmailEdit.vue:63
+msgid "Edit Domain"
 msgstr ""
 
 #: desk/src/components/Settings/EmailEdit.vue:3
@@ -1942,16 +2110,16 @@ msgstr ""
 msgid "Edit your email account"
 msgstr ""
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
-#: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
-#: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
+#: desk/src/components/Settings/Profile/UserEmailSettings.vue:57
+#: desk/src/components/contact/EditContactDialog.vue:50
+#: desk/src/components/customer/NewCustomerDialog.vue:80
+#: desk/src/pages/PersonaForm.vue:148 desk/src/pages/SearchAgent.vue:184
 msgid "Email"
 msgstr ""
 
 #. Label of the email_account (Link) field in DocType 'HD Ticket'
 #. Label of a Link in the Helpdesk Workspace
-#: desk/src/components/Settings/Profile/UserEmailSettings.vue:58
+#: desk/src/components/Settings/Profile/UserEmailSettings.vue:56
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Email Account"
@@ -1973,8 +2141,9 @@ msgstr ""
 msgid "Email Content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
 msgstr ""
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
@@ -2000,22 +2169,22 @@ msgstr ""
 msgid "Email account updated successfully"
 msgstr ""
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr ""
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr ""
-
-#: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
+#: desk/src/components/Settings/Profile/UserEmailSettings.vue:38
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:489
 msgid "Emails"
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Emails & Signature"
 msgstr ""
 
@@ -2053,8 +2222,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr ""
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2079,8 +2246,6 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2103,20 +2268,24 @@ msgstr ""
 msgid "Enter a name for this HD Service Holiday List."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr ""
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr ""
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
 msgstr ""
 
 #: helpdesk/api/knowledge_base.py:86
@@ -2127,16 +2296,8 @@ msgstr ""
 msgid "Error processing email at index {0}, message: {1}"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr ""
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
-msgstr ""
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
 msgstr ""
 
 #: desk/src/components/ticket/ExportModal.vue:11
@@ -2144,21 +2305,29 @@ msgstr ""
 msgid "Excel"
 msgstr ""
 
+#: desk/src/components/layouts/CustomerPortalPermissionDialog.vue:73
+msgid "Existing contacts are being made customer managers in the background"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
+msgstr ""
+
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
 #: desk/src/components/Settings/Telephony/Telephony.vue:96
 msgid "Exotel"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:143
-msgid "Expand"
-msgstr ""
-
-#: desk/src/components/layouts/Sidebar.vue:557
+#: desk/src/components/layouts/Sidebar.vue:347
 msgid "Explore customer portal"
 msgstr ""
 
+#: desk/src/pages/PersonaForm.vue:239
+msgid "Explore the product first"
+msgstr ""
+
 #: desk/src/components/ticket/ExportModal.vue:2
-#: desk/src/pages/ticket/Tickets.vue:130
+#: desk/src/pages/ticket/Tickets.vue:124
 msgid "Export"
 msgstr ""
 
@@ -2170,17 +2339,16 @@ msgstr ""
 msgid "Export Type"
 msgstr ""
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr ""
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
-#: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
-#: desk/src/pages/ticket/Tickets.vue:263 desk/src/pages/ticket/Tickets.vue:271
+#: desk/src/pages/ticket/Tickets.vue:214 desk/src/pages/ticket/Tickets.vue:227
+#: desk/src/pages/ticket/Tickets.vue:260 desk/src/pages/ticket/Tickets.vue:268
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
+msgstr ""
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
 msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
@@ -2191,7 +2359,7 @@ msgstr ""
 msgid "Failed to create email account, Invalid credentials"
 msgstr ""
 
-#: desk/src/components/ticket-agent/TicketHeader.vue:222
+#: desk/src/components/ticket-agent/TicketHeader.vue:218
 msgid "Failed to delete ticket."
 msgstr ""
 
@@ -2201,7 +2369,7 @@ msgstr ""
 msgid "Failed to load telephony agent"
 msgstr ""
 
-#: desk/src/components/Settings/EmailEdit.vue:229
+#: desk/src/components/Settings/EmailEdit.vue:422
 msgid "Failed to pull emails"
 msgstr ""
 
@@ -2216,11 +2384,7 @@ msgstr ""
 msgid "Failed to save Twilio settings"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
-msgid "Failed to update Assignee's."
-msgstr ""
-
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:582
 msgid "Failed to update Assignees."
 msgstr ""
 
@@ -2240,6 +2404,10 @@ msgstr ""
 msgid "Failed to update field dependency."
 msgstr ""
 
+#: desk/src/components/tag/Tags.vue:291
+msgid "Failed to update tags"
+msgstr ""
+
 #. Label of the favicon (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:27
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2249,6 +2417,8 @@ msgstr ""
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/ticket-agent/TicketFeedback.vue:2
+#: desk/src/pages/contact/Contact.vue:90 desk/src/pages/contact/Contact.vue:181
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2286,12 +2456,16 @@ msgstr ""
 msgid "Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:386
 msgid "Feedback Trend"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:168
 msgid "Feedback email has been sent to the customer"
+msgstr ""
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
 msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
@@ -2307,7 +2481,7 @@ msgstr ""
 msgid "Field Dependencies"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:628
+#: desk/src/components/layouts/Sidebar.vue:418
 msgid "Field Dependency"
 msgstr ""
 
@@ -2336,14 +2510,14 @@ msgid "Field dependency updated successfully."
 msgstr ""
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:24
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr ""
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:189
+#: desk/src/components/view-controls/filter/Filter.vue:201
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr ""
@@ -2353,13 +2527,26 @@ msgstr ""
 msgid "Find out all of the variables that can be used in the content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/pages/PersonaForm.vue:186
+msgid "Finding past conversations"
+msgstr ""
+
+#: desk/src/components/Questionnaire.vue:129
+msgid "Finish"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:34
+#: desk/src/components/customer/NewCustomerDialog.vue:67
 msgid "First Name"
 msgstr ""
 
 #. Label of the first_responded_on (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
+msgstr ""
+
+#: desk/src/components/customer/TicketsTab.vue:221
+msgid "First Response"
 msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
@@ -2386,17 +2573,21 @@ msgstr ""
 msgid "First Response Time for Tickets"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
-msgstr ""
-
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 msgid "Form"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:637
+#: desk/src/pages/PersonaForm.vue:215
+msgid "Frappe Discuss"
+msgstr ""
+
+#: desk/src/components/layouts/Sidebar.vue:427
 msgid "Frappe Helpdesk Mobile"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:128
+msgid "Freshdesk"
 msgstr ""
 
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
@@ -2408,7 +2599,7 @@ msgid "Friday"
 msgstr ""
 
 #. Label of the user_from (Link) field in DocType 'HD Notification'
-#: desk/src/components/EmailEditor.vue:23
+#: desk/src/components/EmailEditor.vue:17
 #: desk/src/pages/call-logs/CallLogModal.vue:44
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "From"
@@ -2423,7 +2614,7 @@ msgstr ""
 msgid "From Date"
 msgstr ""
 
-#: desk/src/components/Settings/Holiday/HolidayView.vue:71
+#: desk/src/components/Settings/Holiday/HolidayView.vue:72
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:140
 msgid "From date"
 msgstr ""
@@ -2433,13 +2624,14 @@ msgid "From is required"
 msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
-#: desk/src/pages/ticket/Tickets.vue:224 desk/src/pages/ticket/Tickets.vue:263
+#: desk/src/pages/ticket/Tickets.vue:221 desk/src/pages/ticket/Tickets.vue:260
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Fulfilled"
 msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:6
-#: desk/src/components/layouts/Sidebar.vue:528
+#: desk/src/components/command-palette/CommandPalette.vue:406
+#: desk/src/components/layouts/Sidebar.vue:318
 #: desk/src/components/modals/ShortcutsModal.vue:76
 msgid "General"
 msgstr ""
@@ -2462,21 +2654,29 @@ msgstr ""
 msgid "General is a reserved category name. Please use a different name to proceed."
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:578
+#: desk/src/components/layouts/Sidebar.vue:368
 msgid "Getting Started"
 msgstr ""
 
+#: desk/src/pages/PersonaForm.vue:212
+msgid "GitHub"
+msgstr ""
+
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
-#: desk/src/components/SavedRepliesSelectorModal.vue:180
-#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:344
-#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:378
+#: desk/src/components/SavedRepliesSelectorModal.vue:179
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:305
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:345
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:200
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 msgid "Global"
 msgstr ""
 
-#: desk/src/components/command-palette/CP.vue:89
-msgid "Go to Ticket #{0}"
+#: desk/src/pages/PersonaForm.vue:213
+msgid "Google Ads"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
 msgstr ""
 
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
@@ -2486,7 +2686,7 @@ msgstr ""
 msgid "Gray"
 msgstr ""
 
-#: desk/src/pages/home/components/PendingTickets.vue:254
+#: desk/src/pages/home/components/PendingTickets.vue:247
 msgid "Great! All your tickets are within SLA"
 msgstr ""
 
@@ -2507,20 +2707,8 @@ msgstr ""
 msgid "Group By Field"
 msgstr ""
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
-msgid "Guest"
-msgstr ""
-
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
 msgstr ""
 
 #. Name of a DocType
@@ -2553,24 +2741,43 @@ msgstr ""
 msgid "HD Comment Reaction"
 msgstr ""
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "HD Customer"
 msgstr ""
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "HD Customer Manager"
+msgstr ""
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
 msgstr ""
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
 msgstr ""
 
 #. Name of a DocType
@@ -2591,21 +2798,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
 msgstr ""
 
 #. Name of a DocType
@@ -2647,11 +2839,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
 msgstr ""
 
 #. Name of a DocType
@@ -2732,11 +2919,11 @@ msgstr ""
 msgid "Headings Weight"
 msgstr ""
 
-#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:100
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:101
 msgid "Hello {{ contact }}, \\n\\nWe are sorry for the inconvenience, we will get back to you soon. \\n\\nRegards, \\n{{ full_name }}"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:125
+#: desk/src/components/layouts/Sidebar.vue:26
 msgid "Help"
 msgstr ""
 
@@ -2747,12 +2934,6 @@ msgstr ""
 #. Name of a Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk"
-msgstr ""
-
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
 msgstr ""
 
 #. Label of a Card Break in the Helpdesk Workspace
@@ -2772,23 +2953,15 @@ msgstr ""
 msgid "Hide "
 msgstr ""
 
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr ""
-
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Hide from customer"
 msgstr ""
 
-#: desk/src/pages/ticket/Tickets.vue:481
-msgid "Hide from sidebar"
-msgstr ""
-
-#: desk/src/pages/ticket/Tickets.vue:489
-msgid "Hide view from sidebar"
+#. Option for the 'Level' (Select) field in DocType 'HD Ticket Priority'
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "High"
 msgstr ""
 
 #. Option in a Select field in the tickets Web Form
@@ -2808,7 +2981,7 @@ msgstr ""
 msgid "Holiday List Name"
 msgstr ""
 
-#: desk/src/components/Settings/Holiday/HolidayView.vue:355
+#: desk/src/components/Settings/Holiday/HolidayView.vue:365
 msgid "Holiday list created successfully."
 msgstr ""
 
@@ -2820,15 +2993,15 @@ msgstr ""
 msgid "Holiday list duplicated successfully."
 msgstr ""
 
-#: desk/src/components/Settings/Holiday/HolidayView.vue:417
+#: desk/src/components/Settings/Holiday/HolidayView.vue:427
 msgid "Holiday list updated successfully."
 msgstr ""
 
 #. Label of the holidays_section (Section Break) field in DocType 'HD Service
 #. Holiday List'
 #. Label of the holidays (Table) field in DocType 'HD Service Holiday List'
-#: desk/src/components/Settings/Holiday/HolidayView.vue:132
-#: desk/src/components/Settings/Holiday/HolidayView.vue:172
+#: desk/src/components/Settings/Holiday/HolidayView.vue:142
+#: desk/src/components/Settings/Holiday/HolidayView.vue:182
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Holidays"
 msgstr ""
@@ -2837,23 +3010,37 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
+#: desk/src/pages/PersonaForm.vue:108
+msgid "How big is your support team?"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:209
+msgid "How did you hear about Frappe Helpdesk?"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:144
+msgid "How do your customers currently contact your support team?"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:162
+msgid "How would you like your customers to create support tickets in Frappe Helpdesk?"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:115
 msgid "I understand, add conditions"
 msgstr ""
 
-#: desk/src/pages/home/components/PendingTickets.vue:26
+#: desk/src/pages/PersonaForm.vue:172
+msgid "I'm not sure yet"
+msgstr ""
+
+#: desk/src/pages/home/components/PendingTickets.vue:24
 msgid "ID"
 msgstr ""
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr ""
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
+#: desk/src/components/ViewModal.vue:17
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2924,6 +3111,10 @@ msgstr ""
 msgid "In Progress"
 msgstr ""
 
+#: desk/src/pages/PersonaForm.vue:155
+msgid "In person"
+msgstr ""
+
 #: desk/src/components/Settings/Agents.vue:126
 msgid "Inactive"
 msgstr ""
@@ -2940,6 +3131,11 @@ msgstr ""
 msgid "Incoming"
 msgstr ""
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr ""
@@ -2953,37 +3149,31 @@ msgstr ""
 msgid "Instantly send e-mail"
 msgstr ""
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr ""
 
-#. Label of the integer_value (Int) field in DocType 'HD Ticket Priority'
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-msgid "Integer value"
+#: desk/src/pages/PersonaForm.vue:129
+msgid "Intercom"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:570
-#: desk/src/components/layouts/Sidebar.vue:573
+#: desk/src/components/layouts/Sidebar.vue:360
+#: desk/src/components/layouts/Sidebar.vue:363
 msgid "Introduction"
 msgstr ""
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
-#: desk/src/components/Settings/Holiday/HolidayView.vue:325
+#: desk/src/components/Settings/Holiday/HolidayView.vue:335
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:384
 msgid "Invalid fields, check if all are filled in and values are correct."
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
 msgstr ""
 
 #: helpdesk/api/settings/email_notifications.py:112
@@ -2991,28 +3181,74 @@ msgid "Invalid notification"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation Expired"
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:255
+msgid "Invitation expired. Resend to invite again."
+msgstr ""
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
 msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
+msgstr ""
+
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
 msgid "Invite agent"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:450
+#: desk/src/components/layouts/Sidebar.vue:240
 msgid "Invite agents"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
+#: desk/src/components/contact/NewContactDialog.vue:97
+#: desk/src/pages/contact/Contact.vue:271
+msgid "Invite as User"
 msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:238
+msgid "Invite my support team"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:261
+msgid "Invite sent. Waiting for the user to accept."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invited"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
 msgstr ""
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
@@ -3028,6 +3264,11 @@ msgstr ""
 #. Label of the is_default (Check) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
+msgstr ""
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
 msgstr ""
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
@@ -3058,12 +3299,20 @@ msgstr ""
 msgid "Is setup complete"
 msgstr ""
 
-#: desk/src/components/command-palette/CP.vue:114
-msgid "Jump to"
+#: desk/src/pages/PersonaForm.vue:130
+msgid "Jira Service Management"
 msgstr ""
 
-#: desk/src/pages/knowledge-base/Article.vue:672
+#: desk/src/components/contact/EditContactDialog.vue:37
+msgid "John"
+msgstr ""
+
+#: desk/src/pages/knowledge-base/Article.vue:667
 msgid "KB"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:196
+msgid "Keeping track of customer requests"
 msgstr ""
 
 #. Label of the key (Data) field in DocType 'HD Email Feedback'
@@ -3081,22 +3330,19 @@ msgstr ""
 
 #. Label of the knowledge_base_section (Section Break) field in DocType 'HD
 #. Settings'
-#: desk/src/components/command-palette/CP.vue:104
-#: desk/src/components/layouts/Sidebar.vue:599
-#: desk/src/components/layouts/Sidebar.vue:616
-#: desk/src/pages/knowledge-base/Article.vue:672
+#: desk/src/components/layouts/Sidebar.vue:389
+#: desk/src/components/layouts/Sidebar.vue:406
+#: desk/src/pages/knowledge-base/Article.vue:667
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:6
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:462
-#: desk/src/pages/knowledge-base/NewArticle.vue:169
+#: desk/src/pages/knowledge-base/NewArticle.vue:170
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Knowledge Base"
 msgstr ""
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3130,31 +3376,31 @@ msgstr ""
 msgid "Last 3 Months"
 msgstr ""
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:177
+#: desk/src/components/ChartCardBase.vue:179
+#: desk/src/components/ChartCardBase.vue:180
 msgid "Last 3 months"
 msgstr ""
 
-#: desk/src/pages/dashboard/Dashboard.vue:453
-#: desk/src/pages/dashboard/Dashboard.vue:486
-#: desk/src/pages/dashboard/Dashboard.vue:488
-#: desk/src/pages/dashboard/Dashboard.vue:524
+#: desk/src/pages/dashboard/Dashboard.vue:518
+#: desk/src/pages/dashboard/Dashboard.vue:551
+#: desk/src/pages/dashboard/Dashboard.vue:553
+#: desk/src/pages/dashboard/Dashboard.vue:589
 msgid "Last 30 Days"
 msgstr ""
 
-#: desk/src/pages/dashboard/Dashboard.vue:493
-#: desk/src/pages/dashboard/Dashboard.vue:495
+#: desk/src/pages/dashboard/Dashboard.vue:558
+#: desk/src/pages/dashboard/Dashboard.vue:560
 msgid "Last 60 Days"
 msgstr ""
 
-#: desk/src/pages/dashboard/Dashboard.vue:479
-#: desk/src/pages/dashboard/Dashboard.vue:481
+#: desk/src/pages/dashboard/Dashboard.vue:544
+#: desk/src/pages/dashboard/Dashboard.vue:546
 msgid "Last 7 Days"
 msgstr ""
 
-#: desk/src/pages/dashboard/Dashboard.vue:500
-#: desk/src/pages/dashboard/Dashboard.vue:502
+#: desk/src/pages/dashboard/Dashboard.vue:565
+#: desk/src/pages/dashboard/Dashboard.vue:567
 msgid "Last 90 Days"
 msgstr ""
 
@@ -3173,7 +3419,8 @@ msgstr ""
 msgid "Last Month"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:41
+#: desk/src/components/customer/NewCustomerDialog.vue:73
 msgid "Last Name"
 msgstr ""
 
@@ -3182,23 +3429,32 @@ msgstr ""
 msgid "Last Week"
 msgstr ""
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:143
+#: desk/src/components/ChartCardBase.vue:170
+#: desk/src/components/ChartCardBase.vue:172
+#: desk/src/components/ChartCardBase.vue:173
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr ""
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:163
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/ChartCardBase.vue:166
 msgid "Last week"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:119
+msgid "Latest"
 msgstr ""
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
@@ -3211,49 +3467,49 @@ msgstr ""
 msgid "Learn about conditions"
 msgstr ""
 
+#: desk/src/components/layouts/CustomerPortalPermissionBanner.vue:17
+msgid "Learn more"
+msgstr ""
+
+#: desk/src/components/layouts/CustomerPortalPermissionDialog.vue:23
+msgid "Learn more in the"
+msgstr ""
+
 #. Description of the 'Apply outside working hours' (Check) field in DocType
 #. 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
 msgstr ""
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
+#. Label of the level (Select) field in DocType 'HD Ticket Priority'
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "Level"
 msgstr ""
 
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
+#: desk/src/pages/PersonaForm.vue:220
+msgid "LinkedIn"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #. Label of the list_tab (Tab Break) field in DocType 'HD View'
-#: desk/src/components/ListViewBuilder.vue:799
-#: desk/src/components/ListViewBuilder.vue:841
-#: desk/src/pages/ticket/Tickets.vue:623 desk/src/pages/ticket/Tickets.vue:637
-#: desk/src/pages/ticket/Tickets.vue:667
+#: desk/src/components/ListViewBuilder.vue:790
+#: desk/src/components/ListViewBuilder.vue:881
+#: desk/src/pages/ticket/Tickets.vue:438
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "List"
 msgstr ""
 
-#: desk/src/pages/ticket/Tickets.vue:357
+#: desk/src/pages/ticket/Tickets.vue:354
 msgid "List View"
 msgstr ""
 
 #: desk/src/components/CallArea.vue:72
 msgid "Listen"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:152 desk/src/pages/PersonaForm.vue:171
+msgid "Live chat"
 msgstr ""
 
 #. Label of the load_default_columns (Check) field in DocType 'HD View'
@@ -3263,10 +3519,12 @@ msgstr ""
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:81
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:93
+#: desk/src/components/ticket-agent/AssignTo.vue:106
 msgid "Loading..."
 msgstr ""
 
@@ -3274,45 +3532,44 @@ msgstr ""
 msgid "Log a Call"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:344
-#: desk/src/components/layouts/Sidebar.vue:395
+#: desk/src/components/layouts/MobileSidebar.vue:99
+#: desk/src/components/layouts/MobileSidebar.vue:128
+#: desk/src/components/layouts/Sidebar.vue:139
+#: desk/src/components/layouts/Sidebar.vue:188
 msgid "Log out"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:375
+#: desk/src/components/layouts/Sidebar.vue:168
 msgid "Login to Frappe Cloud"
 msgstr ""
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr ""
 
-#. Description of the 'Integer value' (Int) field in DocType 'HD Ticket
-#. Priority'
+#. Option for the 'Level' (Select) field in DocType 'HD Ticket Priority'
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-msgid "Lower the Integer value, higher is the priority of the issue"
-msgstr ""
-
-#: desk/src/pages/ticket/Tickets.vue:501
-msgid "Make Private"
-msgstr ""
-
-#: desk/src/pages/ticket/Tickets.vue:501
-msgid "Make Public"
+msgid "Low"
 msgstr ""
 
 #: desk/src/components/ticket/ActivityHeader.vue:60
 msgid "Make a Call"
 msgstr ""
 
+#: desk/src/components/layouts/CustomerPortalPermissionDialog.vue:34
+msgid "Make all existing contacts customer managers"
+msgstr ""
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:10
 msgid "Make feedback mandatory"
 msgstr ""
 
-#: desk/src/pages/ticket/Tickets.vue:509
-msgid "Make view private"
+#: desk/src/components/ViewModal.vue:50
+msgid "Make it public"
 msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:2
@@ -3323,7 +3580,7 @@ msgstr ""
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:136
 msgid "Manage your account emails and email signature for communication."
 msgstr ""
 
@@ -3343,13 +3600,30 @@ msgstr ""
 msgid "Manage your profile information."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:182
+msgid "Managing customer conversations across channels"
+msgstr ""
+
 #: desk/src/pages/MobileNotifications.vue:11
 #: desk/src/pages/MobileNotifications.vue:14
 msgid "Mark all as read"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:608
+#: desk/src/components/layouts/Sidebar.vue:398
 msgid "Masters"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:190
+msgid "Measuring team performance"
+msgstr ""
+
+#. Option for the 'Level' (Select) field in DocType 'HD Ticket Priority'
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "Medium"
 msgstr ""
 
 #: desk/src/components/Settings/Teams/NewTeam.vue:38
@@ -3369,7 +3643,7 @@ msgstr ""
 msgid "Merge"
 msgstr ""
 
-#: desk/src/components/ticket-agent/TicketHeader.vue:255
+#: desk/src/components/ticket-agent/TicketHeader.vue:250
 #: desk/src/components/ticket/TicketAgentSidebar.vue:18
 msgid "Merge Ticket"
 msgstr ""
@@ -3391,8 +3665,26 @@ msgstr ""
 msgid "Misc"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:640
+#: desk/src/pages/PersonaForm.vue:194
+msgid "Missing or delayed responses"
+msgstr ""
+
+#: desk/src/components/layouts/Sidebar.vue:430
 msgid "Mobile App Installation"
+msgstr ""
+
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:89
+msgid "Mobile Number"
+msgstr ""
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
 msgstr ""
 
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
@@ -3407,26 +3699,39 @@ msgstr ""
 msgid "Monthly"
 msgstr ""
 
-#: desk/src/pages/knowledge-base/Article.vue:636
+#: desk/src/components/ticket-agent/TicketDetailsTab.vue:81
+msgid "More Details"
+msgstr ""
+
+#: helpdesk/api/dashboard_tags.py:47
+msgid "Most used tags in this period"
+msgstr ""
+
+#: desk/src/pages/knowledge-base/Article.vue:631
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:191
 msgid "Move To"
 msgstr ""
 
-#: desk/src/pages/dashboard/Dashboard.vue:249
+#: desk/src/pages/dashboard/Dashboard.vue:263
 msgid "My Dashboard"
 msgstr ""
 
-#: desk/src/pages/dashboard/Dashboard.vue:302
+#: desk/src/pages/dashboard/Dashboard.vue:359
 msgid "My Organization"
 msgstr ""
 
-#: desk/src/pages/dashboard/Dashboard.vue:307
+#: desk/src/pages/home/Home.vue:365
+#: desk/src/pages/home/components/RecentActivity.vue:6
+msgid "My Recent Activity"
+msgstr ""
+
+#: desk/src/pages/dashboard/Dashboard.vue:364
 msgid "My Stats"
 msgstr ""
 
-#: desk/src/components/SavedRepliesSelectorModal.vue:175
-#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:337
-msgid "My Team"
+#: desk/src/components/SavedRepliesSelectorModal.vue:178
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:304
+msgid "My Team(s)"
 msgstr ""
 
 #: desk/src/pages/home/Home.vue:293
@@ -3435,7 +3740,7 @@ msgid "My Tickets"
 msgstr ""
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3446,8 +3751,10 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/ViewModal.vue:7
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3458,19 +3765,35 @@ msgstr ""
 msgid "Name Weight"
 msgstr ""
 
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
+msgstr ""
+
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
 #. Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Name shown on the customer portal<br> (e.g., Replied → Awaiting Response)."
 msgstr ""
 
-#: desk/src/components/modals/ShortcutsModal.vue:105
+#: desk/src/components/command-palette/CommandPalette.vue:137
+msgid "Navigate"
+msgstr ""
+
+#: desk/src/components/modals/ShortcutsModal.vue:106
 msgid "Navigation"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:121
+msgid "Negative"
 msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
 msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
@@ -3486,8 +3809,8 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: desk/src/pages/knowledge-base/NewArticle.vue:174
-#: desk/src/pages/knowledge-base/NewArticle.vue:181
+#: desk/src/pages/knowledge-base/NewArticle.vue:175
+#: desk/src/pages/knowledge-base/NewArticle.vue:182
 msgid "New Article"
 msgstr ""
 
@@ -3523,7 +3846,7 @@ msgstr ""
 msgid "New SLA Policy"
 msgstr ""
 
-#: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:48
+#: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:46
 msgid "New SLA Policy Name"
 msgstr ""
 
@@ -3531,11 +3854,11 @@ msgstr ""
 msgid "New Saved Reply"
 msgstr ""
 
-#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:184
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:164
 msgid "New Saved reply Name"
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:141
+#: desk/src/pages/ticket/MobileTicketAgent.vue:173
 msgid "New Subject"
 msgstr ""
 
@@ -3543,8 +3866,8 @@ msgstr ""
 msgid "New Team"
 msgstr ""
 
-#: desk/src/pages/ticket/TicketNew.vue:302
-#: desk/src/pages/ticket/TicketNew.vue:312
+#: desk/src/pages/ticket/TicketNew.vue:304
+#: desk/src/pages/ticket/TicketNew.vue:314
 msgid "New Ticket"
 msgstr ""
 
@@ -3568,7 +3891,11 @@ msgstr ""
 msgid "New users will have to be manually registered by system managers."
 msgstr ""
 
-#: desk/src/components/modals/ShortcutsModal.vue:107
+#: desk/src/components/Questionnaire.vue:129
+msgid "Next"
+msgstr ""
+
+#: desk/src/components/modals/ShortcutsModal.vue:108
 msgid "Next ticket"
 msgstr ""
 
@@ -3576,15 +3903,15 @@ msgstr ""
 msgid "No Answer"
 msgstr ""
 
-#: desk/src/components/ListViewBuilder.vue:345
+#: desk/src/components/ListViewBuilder.vue:347
 msgid "No Data Found"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:588
 msgid "No Email Account found for {0}"
 msgstr ""
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr ""
 
@@ -3596,15 +3923,21 @@ msgstr ""
 msgid "No SLA found"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:458
 msgid "No Team"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
 msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
 msgid "No additional comments"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:144
+#: desk/src/components/ticket-agent/AssignTo.vue:159
 msgid "No agents found"
 msgstr ""
 
@@ -3632,23 +3965,35 @@ msgstr ""
 msgid "No changes made"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr ""
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/command-palette/CommandPalette.vue:233
+msgid "No commands found"
+msgstr ""
+
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr ""
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:110
+msgid "No country found"
+msgstr ""
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
-#: desk/src/components/Settings/EmailAccountList.vue:46
+#: desk/src/components/Settings/EmailAccountList.vue:52
 msgid "No email account found"
 msgstr ""
 
@@ -3656,7 +4001,11 @@ msgstr ""
 msgid "No feedback"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:50
 msgid "No fields found"
 msgstr ""
 
@@ -3664,64 +4013,74 @@ msgstr ""
 msgid "No members found"
 msgstr ""
 
-#: desk/src/pages/MobileNotifications.vue:68
+#: desk/src/pages/MobileNotifications.vue:71
 msgid "No new notifications"
 msgstr ""
 
-#: desk/src/pages/home/components/PendingTickets.vue:258
+#: desk/src/pages/home/components/PendingTickets.vue:251
 msgid "No new tickets assigned to you in the last 7 days"
 msgstr ""
 
-#: desk/src/components/ticket-agent/TicketNavigation.vue:25
-msgid "No next ticket"
-msgstr ""
-
-#: desk/src/components/ticket-agent/AssignTo.vue:33
+#: desk/src/components/ticket-agent/AssignTo.vue:48
 msgid "No one"
 msgstr ""
 
-#: desk/src/pages/home/components/PendingTickets.vue:261
+#: desk/src/pages/home/components/PendingTickets.vue:254
 msgid "No pending tickets"
 msgstr ""
 
-#: desk/src/components/ticket-agent/TicketNavigation.vue:10
-msgid "No previous ticket"
-msgstr ""
-
-#: desk/src/pages/home/components/PendingTickets.vue:94
+#: desk/src/pages/home/components/PendingTickets.vue:89
 msgid "No reason"
 msgstr ""
 
-#: desk/src/pages/home/components/PendingTickets.vue:257
+#: desk/src/pages/home/components/RecentActivity.vue:57
+msgid "No recent activity"
+msgstr ""
+
+#: desk/src/pages/home/components/PendingTickets.vue:250
 msgid "No recently assigned tickets"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:87
 msgid "No results"
 msgstr ""
 
+#: desk/src/components/command-palette/CommandPalette.vue:231
+msgid "No results for \"{0}\""
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
 msgstr ""
 
-#: desk/src/components/SavedRepliesSelectorModal.vue:113
-#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:91
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
+msgstr ""
+
+#: desk/src/components/SavedRepliesSelectorModal.vue:122
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:73
 msgid "No saved replies found"
 msgstr ""
 
-#: desk/src/pages/ticket/Tickets.vue:192
+#: desk/src/components/tag/Tags.vue:78
+msgid "No tags yet, type to create one"
+msgstr ""
+
+#: desk/src/components/customer/TicketsTab.vue:51
+#: desk/src/pages/ticket/Tickets.vue:189
 msgid "No tickets found"
 msgstr ""
 
-#: desk/src/pages/ticket/Tickets.vue:202
+#: desk/src/pages/ticket/Tickets.vue:199
 msgid "No tickets found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
-#: desk/src/pages/ticket/Tickets.vue:198
+#: desk/src/pages/ticket/Tickets.vue:195
 msgid "No tickets found for this view. Try adjusting your filters or creating a new view."
 msgstr ""
 
-#: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:99
+#: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:104
 msgid "No tickets found to preview."
 msgstr ""
 
@@ -3729,11 +4088,15 @@ msgstr ""
 msgid "No tickets selected"
 msgstr ""
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr ""
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187 helpdesk/utils.py:207
 msgid "Not Allowed"
 msgstr ""
 
-#: desk/src/pages/home/components/PendingTickets.vue:69
+#: desk/src/pages/home/components/PendingTickets.vue:64
 msgid "Not Assigned"
 msgstr ""
 
@@ -3741,7 +4104,7 @@ msgstr ""
 msgid "Not Saved"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:233
 msgid "Not Set"
 msgstr ""
 
@@ -3755,15 +4118,24 @@ msgstr ""
 msgid "Not installed"
 msgstr ""
 
+#: desk/src/components/command-palette/CommandPalette.vue:232
+msgid "Nothing left in {0}"
+msgstr ""
+
 #. Label of a Link in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Notification Settings"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:36
+#: desk/src/components/layouts/AppSidebar.vue:229
+#: desk/src/components/layouts/AppSidebar.vue:238
 #: desk/src/components/notifications/Notifications.vue:16
 #: desk/src/pages/MobileNotifications.vue:6
 msgid "Notifications"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:126
+msgid "Notion"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:146
@@ -3778,11 +4150,6 @@ msgstr ""
 #. Label of the on_hold_since (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "On Hold Since"
-msgstr ""
-
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
 msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
@@ -3801,6 +4168,10 @@ msgstr ""
 msgid "Only the 'color' and 'order' fields of the 'Closed' status can be modified."
 msgstr ""
 
+#: desk/src/components/layouts/CustomerPortalPermissionDialog.vue:16
+msgid "Only users with the role of "
+msgstr ""
+
 #. Option for the 'Category' (Select) field in DocType 'HD Ticket Status'
 #. Option in a Select field in the tickets Web Form
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
@@ -3808,12 +4179,17 @@ msgstr ""
 msgid "Open"
 msgstr ""
 
+#: desk/src/components/command-palette/CommandPalette.vue:405
 #: desk/src/components/modals/ShortcutsModal.vue:78
 msgid "Open command palette"
 msgstr ""
 
-#: desk/src/components/modals/ShortcutsModal.vue:100
+#: desk/src/components/modals/ShortcutsModal.vue:101
 msgid "Open comment box"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:145
+msgid "Open customer"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
@@ -3824,7 +4200,7 @@ msgstr ""
 msgid "Open in Desk"
 msgstr ""
 
-#: desk/src/components/modals/ShortcutsModal.vue:99
+#: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open reply box"
 msgstr ""
 
@@ -3868,11 +4244,13 @@ msgstr ""
 msgid "Order By"
 msgstr ""
 
-#: desk/src/pages/dashboard/Dashboard.vue:249
+#: desk/src/pages/dashboard/Dashboard.vue:263
 msgid "Organization Dashboard"
 msgstr ""
 
-#: desk/src/pages/ticket/TicketFeedback.vue:50
+#: desk/src/pages/PersonaForm.vue:138 desk/src/pages/PersonaForm.vue:156
+#: desk/src/pages/PersonaForm.vue:203 desk/src/pages/PersonaForm.vue:226
+#: desk/src/pages/ticket/TicketFeedback.vue:52
 msgid "Other"
 msgstr ""
 
@@ -3888,7 +4266,11 @@ msgstr ""
 msgid "Outside working hours notice"
 msgstr ""
 
-#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:105
+#: desk/src/components/ticket-agent/TicketDetailsTab.vue:30
+msgid "Overview"
+msgstr ""
+
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:87
 msgid "Owner"
 msgstr ""
 
@@ -3904,7 +4286,12 @@ msgstr ""
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr ""
+
+#: desk/src/components/Settings/Profile/Profile.vue:150
 msgid "Password"
 msgstr ""
 
@@ -3931,39 +4318,40 @@ msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #. Option for the 'Category' (Select) field in DocType 'HD Ticket Status'
-#: desk/src/pages/ticket/Tickets.vue:253
+#: desk/src/pages/ticket/Tickets.vue:250
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Paused"
 msgstr ""
 
-#: desk/src/pages/home/components/PendingTickets.vue:222
+#: desk/src/pages/home/components/PendingTickets.vue:215
 msgid "Pending"
 msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr ""
 
 #: desk/src/pages/home/Home.vue:353
-#: desk/src/pages/home/components/PendingTickets.vue:234
-#: desk/src/pages/home/components/PendingTickets.vue:238
+#: desk/src/pages/home/components/PendingTickets.vue:227
+#: desk/src/pages/home/components/PendingTickets.vue:231
 msgid "Pending Tickets"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:577
 msgid "Percentage of total tickets by channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:535
 msgid "Percentage of total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:465
 msgid "Percentage of total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:500
 msgid "Percentage of total tickets by type"
 msgstr ""
 
@@ -3971,10 +4359,15 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
+#. Label of the persona_captured (Check) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Persona Captured"
+msgstr ""
+
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
-#: desk/src/components/SavedRepliesSelectorModal.vue:170
-#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:330
-#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:370
+#: desk/src/components/SavedRepliesSelectorModal.vue:177
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:303
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:337
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:190
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 msgid "Personal"
@@ -3984,21 +4377,26 @@ msgstr ""
 msgid "Personal mobile no"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:80
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
+#: desk/src/pages/PersonaForm.vue:151
+msgid "Phone calls"
 msgstr ""
 
-#: desk/src/pages/ticket/TicketFeedback.vue:36
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:41
+msgid "Photo"
+msgstr ""
+
+#: desk/src/pages/ticket/TicketFeedback.vue:38
 msgid "Pick an option"
 msgstr ""
 
-#: desk/src/pages/ticket/Tickets.vue:468
-msgid "Pin View"
+#: desk/src/components/ViewModal.vue:43
+msgid "Pin to sidebar"
 msgstr ""
 
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
@@ -4034,7 +4432,7 @@ msgstr ""
 msgid "Please configure your Twilio settings correctly"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:658
+#: desk/src/components/layouts/Sidebar.vue:448
 msgid "Please create a new ticket to proceed with the next step."
 msgstr ""
 
@@ -4047,7 +4445,7 @@ msgstr ""
 msgid "Please enter a valid phone number"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr ""
 
@@ -4090,33 +4488,14 @@ msgstr ""
 msgid "Policy name"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:120
+msgid "Positive"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
-msgstr ""
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr ""
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr ""
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr ""
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
 msgstr ""
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
@@ -4133,7 +4512,7 @@ msgstr ""
 msgid "Preferences updated successfully."
 msgstr ""
 
-#: desk/src/pages/dashboard/Dashboard.vue:468
+#: desk/src/pages/dashboard/Dashboard.vue:533
 msgid "Presets"
 msgstr ""
 
@@ -4147,8 +4526,28 @@ msgstr ""
 msgid "Preview"
 msgstr ""
 
-#: desk/src/components/modals/ShortcutsModal.vue:108
+#: desk/src/components/modals/ShortcutsModal.vue:109
 msgid "Previous ticket"
+msgstr ""
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr ""
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:62
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
 msgstr ""
 
 #. Label of the priorities (Table) field in DocType 'HD Service Level
@@ -4157,8 +4556,6 @@ msgstr ""
 msgid "Priorities"
 msgstr ""
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4166,9 +4563,10 @@ msgstr ""
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:218
+#: desk/src/components/customer/TicketsTab.vue:251
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
-#: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
+#: desk/src/pages/home/components/PendingTickets.vue:33
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4185,8 +4583,8 @@ msgstr ""
 msgid "Priority {0} has been repeated."
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:309
-#: desk/src/pages/ticket/Tickets.vue:377
+#: desk/src/components/layouts/AppSidebar.vue:266
+#: desk/src/pages/ticket/Tickets.vue:374
 msgid "Private Views"
 msgstr ""
 
@@ -4203,7 +4601,7 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:228
+#: desk/src/components/Settings/Profile/Profile.vue:232
 msgid "Profile updated successfully."
 msgstr ""
 
@@ -4212,8 +4610,8 @@ msgstr ""
 msgid "Public"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:301
-#: desk/src/pages/ticket/Tickets.vue:392
+#: desk/src/components/layouts/AppSidebar.vue:259
+#: desk/src/pages/ticket/Tickets.vue:389
 msgid "Public Views"
 msgstr ""
 
@@ -4236,27 +4634,21 @@ msgstr ""
 msgid "Published articles must have content."
 msgstr ""
 
-#: desk/src/components/Settings/EmailEdit.vue:87
+#: desk/src/components/Settings/EmailEdit.vue:149
 msgid "Pull Emails"
 msgstr ""
 
-#: desk/src/components/Settings/EmailEdit.vue:214
+#: desk/src/components/Settings/EmailEdit.vue:407
 msgid "Pulling emails, this may take a few minutes."
+msgstr ""
+
+#. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+msgid "Purple"
 msgstr ""
 
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:36
 msgid "Quarterly"
-msgstr ""
-
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr ""
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:213
@@ -4281,14 +4673,14 @@ msgstr ""
 msgid "Rate this ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:389
 msgid "Rated Tickets"
 msgstr ""
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:400
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4317,15 +4709,16 @@ msgstr ""
 msgid "Read"
 msgstr ""
 
-#: desk/src/pages/home/components/PendingTickets.vue:41
+#: desk/src/pages/home/components/PendingTickets.vue:39
 msgid "Reason"
 msgstr ""
 
-#: desk/src/pages/home/components/PendingTickets.vue:226
+#: desk/src/pages/home/components/PendingTickets.vue:219
 msgid "Recent"
 msgstr ""
 
-#: desk/src/pages/home/components/PendingTickets.vue:233
+#: desk/src/components/ticket-agent/TicketDetailsTab.vue:284
+#: desk/src/pages/home/components/PendingTickets.vue:226
 msgid "Recent Tickets"
 msgstr ""
 
@@ -4334,13 +4727,13 @@ msgstr ""
 msgid "Record Calls"
 msgstr ""
 
-#: desk/src/components/Settings/Holiday/HolidayView.vue:114
+#: desk/src/components/Settings/Holiday/HolidayView.vue:124
 msgid "Recurring Holidays"
 msgstr ""
 
 #. Label of the recurring_holidays (JSON) field in DocType 'HD Service Holiday
 #. List'
-#: desk/src/components/Settings/Holiday/HolidayView.vue:178
+#: desk/src/components/Settings/Holiday/HolidayView.vue:188
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Recurring holidays"
 msgstr ""
@@ -4350,6 +4743,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Red"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:222
+msgid "Reddit"
 msgstr ""
 
 #. Label of the reference_tab (Tab Break) field in DocType 'HD Ticket'
@@ -4383,32 +4780,47 @@ msgid "Regenerate Search Index"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
-#: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/Settings/Profile/UserEmailSettings.vue:73
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:197
+#: desk/src/components/Settings/Profile/Profile.vue:201
 msgid "Remove Photo"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:66
-#: desk/src/components/view-controls/filter/Filter.vue:67
+#: desk/src/components/command-palette/CommandPalette.vue:250
+msgid "Remove context"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:74
+#: desk/src/components/view-controls/filter/Filter.vue:75
 msgid "Remove filter"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr ""
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
 msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
 #: desk/src/components/Settings/Teams/TeamsList.vue:161
 #: desk/src/components/ticket-agent/TicketSubjectModal.vue:21
-#: desk/src/pages/ticket/MobileTicketAgent.vue:132
+#: desk/src/pages/ticket/MobileTicketAgent.vue:164
 msgid "Rename"
 msgstr ""
 
@@ -4424,12 +4836,21 @@ msgstr ""
 msgid "Rename team"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:58
-#: desk/src/components/view-controls/filter/Filter.vue:59
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
 msgid "Replace filter"
 msgstr ""
 
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
+msgstr ""
+
+#: desk/src/components/ViewModal.vue:32
+msgid "Replace with an icon..."
+msgstr ""
+
 #. Option in a Select field in the tickets Web Form
+#: desk/src/pages/home/components/RecentActivity.vue:102
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
 msgid "Replied"
 msgstr ""
@@ -4462,20 +4883,17 @@ msgstr ""
 msgid "Reply from contact"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:494
+#: desk/src/components/layouts/Sidebar.vue:284
 msgid "Reply on a ticket"
-msgstr ""
-
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
 msgstr ""
 
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:281
+msgid "Resend Invite"
 msgstr ""
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
@@ -4496,6 +4914,7 @@ msgid "Reset to Default"
 msgstr ""
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:227
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr ""
@@ -4539,7 +4958,7 @@ msgid "Resolved"
 msgstr ""
 
 #. Label of the response_tab (Tab Break) field in DocType 'HD Ticket'
-#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:89
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:90
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Response"
 msgstr ""
@@ -4547,18 +4966,6 @@ msgstr ""
 #. Label of the response_by (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Response By"
-msgstr ""
-
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr ""
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
@@ -4599,26 +5006,8 @@ msgstr ""
 msgid "Restrict tickets to be viewed and managed by team members only."
 msgstr ""
 
-#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:83
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:84
 msgid "Restrict visibility to these teams"
-msgstr ""
-
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr ""
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr ""
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
 msgstr ""
 
 #: desk/src/pages/home/Home.vue:341
@@ -4627,12 +5016,26 @@ msgstr ""
 msgid "Reviews"
 msgstr ""
 
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:215
 msgid "Ringing"
 msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
 msgstr ""
 
 #. Label of the route_name (Data) field in DocType 'HD View'
@@ -4651,13 +5054,13 @@ msgstr ""
 
 #. Label of the sla (Link) field in DocType 'HD Ticket'
 #. Label of the sla_tab (Tab Break) field in DocType 'HD Ticket'
-#: desk/src/pages/home/components/PendingTickets.vue:218
-#: desk/src/pages/ticket/MobileTicketAgent.vue:76
+#: desk/src/pages/home/components/PendingTickets.vue:211
+#: desk/src/pages/ticket/MobileTicketAgent.vue:108
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "SLA"
 msgstr ""
 
-#: desk/src/pages/home/components/PendingTickets.vue:232
+#: desk/src/pages/home/components/PendingTickets.vue:225
 msgid "SLA Alerts"
 msgstr ""
 
@@ -4682,15 +5085,15 @@ msgstr ""
 msgid "SLA policy created successfully."
 msgstr ""
 
-#: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:167
+#: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:165
 msgid "SLA policy deleted successfully."
 msgstr ""
 
-#: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:139
+#: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:137
 msgid "SLA policy duplicated successfully."
 msgstr ""
 
-#: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:184
+#: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:182
 msgid "SLA policy status updated successfully."
 msgstr ""
 
@@ -4702,12 +5105,16 @@ msgstr ""
 msgid "SLA set as default cannot be disabled"
 msgstr ""
 
-#: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:174
+#: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:172
 msgid "SLA set as default cannot be disabled."
 msgstr ""
 
 #: desk/src/components/Settings/Sla/SlaPolicies.vue:11
 msgid "SLAs align your team and customers with defined timelines for a reliable experience. Learn more about SLA "
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:132
+msgid "Salesforce Service Cloud"
 msgstr ""
 
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
@@ -4719,7 +5126,7 @@ msgid "Saturday"
 msgstr ""
 
 #. Button label of the email-feedback Web Form
-#: desk/src/components/ListViewBuilder.vue:704
+#: desk/src/components/ListViewBuilder.vue:714
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:20
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:39
 #: desk/src/components/Settings/FieldDependency/FieldDependency.vue:19
@@ -4732,9 +5139,9 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:166
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4747,19 +5154,19 @@ msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:12
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:3
-#: desk/src/components/layouts/Sidebar.vue:617
+#: desk/src/components/layouts/Sidebar.vue:407
 msgid "Saved Replies"
 msgstr ""
 
-#: desk/src/pages/ticket/Tickets.vue:371
+#: desk/src/pages/ticket/Tickets.vue:368
 msgid "Saved Views"
 msgstr ""
 
-#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:286
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:266
 msgid "Saved reply deleted successfully."
 msgstr ""
 
-#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:303
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:283
 msgid "Saved reply duplicated successfully."
 msgstr ""
 
@@ -4771,13 +5178,16 @@ msgstr ""
 msgid "Saved reply updated successfully."
 msgstr ""
 
+#: desk/src/pages/PersonaForm.vue:193
+msgid "Scaling support as we grow"
+msgstr ""
+
 #: desk/src/components/Settings/Holiday/HolidayList.vue:29
 msgid "Schedule name"
 msgstr ""
 
 #. Label of the scope (Select) field in DocType 'HD Saved Reply'
-#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:106
-#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:57
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:88
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 msgid "Scope"
 msgstr ""
@@ -4796,8 +5206,8 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:26
 #: desk/src/components/Settings/Sla/SlaPolicies.vue:41
 #: desk/src/components/Settings/Teams/TeamsList.vue:26
-#: desk/src/components/command-palette/CP.vue:121
-#: desk/src/components/layouts/Sidebar.vue:14 desk/src/pages/SearchAgent.vue:7
+#: desk/src/components/layouts/AppSidebar.vue:217
+#: desk/src/pages/SearchAgent.vue:7
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Search"
 msgstr ""
@@ -4810,22 +5220,28 @@ msgstr ""
 msgid "Search Score"
 msgstr ""
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr ""
-
-#: desk/src/components/ticket-agent/AssignTo.vue:62
+#: desk/src/components/ticket-agent/AssignTo.vue:86
 msgid "Search agents..."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:112
-msgid "Search fields..."
+#: desk/src/components/customer/TicketsTab.vue:9
+msgid "Search by ID or Subject"
 msgstr ""
 
-#: desk/src/components/command-palette/CP.vue:126
-msgid "Search for \"{0}\""
+#: desk/src/components/command-palette/CommandPalette.vue:55
+msgid "Search commands"
+msgstr ""
+
+#: desk/src/components/command-palette/CommandPalette.vue:54
+msgid "Search commands for {0}"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:73
+msgid "Search country"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:120
+msgid "Search fields..."
 msgstr ""
 
 #: desk/src/pages/SearchAgent.vue:100
@@ -4836,6 +5252,10 @@ msgstr ""
 msgid "Search index not available. Please contact administrator."
 msgstr ""
 
+#: desk/src/components/tag/Tags.vue:15
+msgid "Search or create tags"
+msgstr ""
+
 #: helpdesk/api/search.py:17
 msgid "Search query must be at least 2 characters"
 msgstr ""
@@ -4844,15 +5264,15 @@ msgstr ""
 msgid "Search ticket"
 msgstr ""
 
+#: desk/src/components/command-palette/CommandPalette.vue:253
+msgid "Search tickets or type a command…"
+msgstr ""
+
 #: desk/src/pages/SearchAgent.vue:16
 msgid "Search tickets, comments, and communications..."
 msgstr ""
 
-#: desk/src/components/command-palette/CP.vue:12
-msgid "Search tickets, emails, comments, or #234 to navigate to ticket"
-msgstr ""
-
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:33
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:37
 msgid "Search..."
 msgstr ""
 
@@ -4860,15 +5280,25 @@ msgstr ""
 msgid "Searched for:"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:81
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr ""
 
-#: desk/src/pages/home/components/PendingTickets.vue:147
+#: desk/src/components/command-palette/CommandPalette.vue:230
+#: desk/src/components/command-palette/CommandPalette.vue:237
+msgid "Searching…"
+msgstr ""
+
+#: desk/src/components/command-palette/CommandPalette.vue:253
+msgid "Search…"
+msgstr ""
+
+#: desk/src/pages/home/components/PendingTickets.vue:142
 msgid "See all {0} tickets"
 msgstr ""
 
+#: desk/src/components/command-palette/CommandPalette.vue:141
 #: desk/src/pages/call-logs/CallLogModal.vue:28
 #: desk/src/pages/call-logs/CallLogModal.vue:57
 #: desk/src/pages/call-logs/CallLogModal.vue:80
@@ -4879,6 +5309,10 @@ msgstr ""
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:159
+msgid "Select Customer"
 msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
@@ -4897,8 +5331,16 @@ msgstr ""
 msgid "Select a Default Priority."
 msgstr ""
 
-#: desk/src/pages/ticket/TicketFeedback.vue:26
+#: desk/src/pages/ticket/TicketFeedback.vue:27
 msgid "Select a rating"
+msgstr ""
+
+#: desk/src/components/ViewModal.vue:33
+msgid "Select an icon..."
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:17
+msgid "Select country"
 msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
@@ -4906,12 +5348,20 @@ msgstr ""
 msgid "Select range"
 msgstr ""
 
-#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:78
+#: desk/src/pages/PersonaForm.vue:109
+msgid "Select team size"
+msgstr ""
+
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:79
 msgid "Select teams"
 msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
+msgstr ""
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
@@ -4940,6 +5390,10 @@ msgstr ""
 msgid "Send feedback when"
 msgstr ""
 
+#: desk/src/pages/contact/Contact.vue:296
+msgid "Send reset password email"
+msgstr ""
+
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
 msgid "Send to {0} tickets"
 msgstr ""
@@ -4960,7 +5414,7 @@ msgstr ""
 msgid "Sent to the user who has raised the ticket after the ticket is closed or resolved."
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:618
+#: desk/src/components/layouts/Sidebar.vue:408
 msgid "Service Level Agreement"
 msgstr ""
 
@@ -4978,13 +5432,21 @@ msgstr ""
 msgid "Service not supported"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:232
 msgid "Set"
+msgstr ""
+
+#: desk/src/components/ticket-agent/AssignTo.vue:45
+msgid "Set Assignee"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:4
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
@@ -4995,12 +5457,26 @@ msgstr ""
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr ""
+
+#. Description of the 'Persona Captured' (Check) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Set once an admin completes the onboarding persona questionnaire"
+msgstr ""
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/layouts/MobileSidebar.vue:81
 msgid "Set status"
 msgstr ""
 
@@ -5008,11 +5484,15 @@ msgstr ""
 msgid "Set the default status assigned when a ticket is created, and the status to apply when a ticket is reopened. If not specified, the default status from HD Settings will be used."
 msgstr ""
 
+#: desk/src/pages/PersonaForm.vue:236
+msgid "Set up a customer portal"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaHolidays.vue:9
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:121
 msgid "Set your availability so your team knows when you're reachable."
 msgstr ""
 
@@ -5024,13 +5504,13 @@ msgstr ""
 msgid "Setting <strong>{0}</strong> as the default SLA removes <strong>{1}</strong> as the default SLA. You’ll need to add a condition in <strong>{1}</strong> for the SLA to work."
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:574
+#: desk/src/components/layouts/Sidebar.vue:364
 msgid "Setting up"
 msgstr ""
 
 #. Label of the column_break_feto (Column Break) field in DocType 'HD Team'
-#: desk/src/components/layouts/Sidebar.vue:386
-#: desk/src/components/layouts/Sidebar.vue:632
+#: desk/src/components/layouts/Sidebar.vue:179
+#: desk/src/components/layouts/Sidebar.vue:422
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Settings"
 msgstr ""
@@ -5057,11 +5537,11 @@ msgstr ""
 msgid "Setup Email"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:461
+#: desk/src/components/layouts/Sidebar.vue:251
 msgid "Setup SLA"
 msgstr ""
 
-#: desk/src/pages/knowledge-base/Article.vue:649
+#: desk/src/pages/knowledge-base/Article.vue:644
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:167
 msgid "Share"
 msgstr ""
@@ -5076,7 +5556,11 @@ msgstr ""
 msgid "Share feedback"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:381
+#: desk/src/pages/PersonaForm.vue:135
+msgid "Shared email inbox (Gmail, Outlook, etc.)"
+msgstr ""
+
+#: desk/src/components/layouts/Sidebar.vue:174
 msgid "Shortcuts"
 msgstr ""
 
@@ -5084,25 +5568,39 @@ msgstr ""
 msgid "Show "
 msgstr ""
 
+#. Label of the show_customer_portal_permission_notice (Check) field in DocType
+#. 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Show Customer Portal Permission Notice"
+msgstr ""
+
 #. Label of the different_view (Check) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Show end users a different view"
-msgstr ""
-
-#: desk/src/pages/ticket/Tickets.vue:481
-msgid "Show in sidebar"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:80
 msgid "Show keyboard shortcuts"
 msgstr ""
 
-#: desk/src/pages/home/components/PendingTickets.vue:154
+#: desk/src/components/ticket-agent/TicketFeedback.vue:20
+msgid "Show less"
+msgstr ""
+
+#: desk/src/components/ticket-agent/TicketFeedback.vue:20
+msgid "Show more"
+msgstr ""
+
+#: desk/src/pages/home/components/PendingTickets.vue:149
 msgid "Showing {0} of {1} {2}"
 msgstr ""
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:22
 msgid "Signature"
+msgstr ""
+
+#: desk/src/components/ticket-agent/TicketDetailsTab.vue:293
+msgid "Similar Tickets"
 msgstr ""
 
 #. Description of the 'Condition' (Code) field in DocType 'HD Service Level
@@ -5120,11 +5618,19 @@ msgstr ""
 msgid "Skip email workflow"
 msgstr ""
 
+#: desk/src/components/Questionnaire.vue:138
+msgid "Skip for now"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:154
+msgid "Social media"
+msgstr ""
+
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:617
 msgid "Some error occurred while renaming assignment rule"
 msgstr ""
 
-#: desk/src/components/Settings/Holiday/HolidayView.vue:399
+#: desk/src/components/Settings/Holiday/HolidayView.vue:409
 msgid "Some error occurred while renaming holiday list"
 msgstr ""
 
@@ -5136,7 +5642,7 @@ msgstr ""
 msgid "Some error occurred while updating assignment rule"
 msgstr ""
 
-#: desk/src/components/Settings/Holiday/HolidayView.vue:389
+#: desk/src/components/Settings/Holiday/HolidayView.vue:399
 msgid "Some error occurred while updating holiday list"
 msgstr ""
 
@@ -5144,23 +5650,6 @@ msgstr ""
 #: desk/src/components/view-controls/SortBy.vue:22
 #: desk/src/components/view-controls/SortBy.vue:231
 msgid "Sort"
-msgstr ""
-
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr ""
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr ""
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
 msgstr ""
 
 #: helpdesk/api/knowledge_base.py:125
@@ -5179,6 +5668,10 @@ msgstr ""
 #. Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Split and Merge"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:125
+msgid "Spreadsheets"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.js:9
@@ -5207,9 +5700,11 @@ msgstr ""
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:217
+#: desk/src/components/customer/TicketsTab.vue:246
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
-#: desk/src/pages/home/components/PendingTickets.vue:32
+#: desk/src/pages/home/components/PendingTickets.vue:30
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5276,7 +5771,8 @@ msgstr ""
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
-#: desk/src/pages/home/components/PendingTickets.vue:29
+#: desk/src/components/customer/TicketsTab.vue:216
+#: desk/src/pages/home/components/PendingTickets.vue:27
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_search_analysis/ticket_search_analysis.py:30
@@ -5295,7 +5791,7 @@ msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:8
 #: desk/src/pages/ticket/TicketNew.vue:96
-#: desk/src/pages/ticket/TicketNew.vue:120
+#: desk/src/pages/ticket/TicketNew.vue:121
 msgid "Submit"
 msgstr ""
 
@@ -5312,7 +5808,8 @@ msgstr ""
 msgid "Sunday"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:366
+#: desk/src/components/layouts/MobileSidebar.vue:118
+#: desk/src/components/layouts/Sidebar.vue:159
 msgid "Support"
 msgstr ""
 
@@ -5332,11 +5829,15 @@ msgstr ""
 msgid "Support Team"
 msgstr ""
 
-#: desk/src/components/Settings/Preferences/components/ThemeSwitcher.vue:11
+#: desk/src/pages/PersonaForm.vue:149
+msgid "Support portal"
+msgstr ""
+
+#: desk/src/components/Settings/Preferences/components/ThemeSwitcher.vue:9
 msgid "Switch between light, dark, or system theme"
 msgstr ""
 
-#: desk/src/components/Settings/Profile/UserEmailSettings.vue:44
+#: desk/src/components/Settings/Profile/UserEmailSettings.vue:42
 msgid "Switch between outgoing email accounts when sending emails from your configured accounts."
 msgstr ""
 
@@ -5387,21 +5888,16 @@ msgstr ""
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5425,6 +5921,22 @@ msgstr ""
 msgid "System types can not be deleted"
 msgstr ""
 
+#: helpdesk/api/dashboard_tags.py:48
+msgid "Tag"
+msgstr ""
+
+#: helpdesk/api/dashboard_tags.py:72
+msgid "Tag Trend"
+msgstr ""
+
+#: desk/src/components/tag/Tags.vue:234 helpdesk/api/tags.py:55
+msgid "Tag cannot contain commas"
+msgstr ""
+
+#: helpdesk/api/tags.py:52
+msgid "Tag label is required"
+msgstr ""
+
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:22
 msgid "Tampered Access"
 msgstr ""
@@ -5440,19 +5952,17 @@ msgstr ""
 msgid "Teal"
 msgstr ""
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
 #. Label of a Link in the Helpdesk Workspace
-#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:374
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:341
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:195
-#: desk/src/components/layouts/Sidebar.vue:613
+#: desk/src/components/layouts/Sidebar.vue:403
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
-#: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
+#: desk/src/pages/home/components/PendingTickets.vue:36
+#: desk/src/pages/ticket/MobileTicketAgent.vue:63
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5508,7 +6018,7 @@ msgid "Team will only see their own tickets."
 msgstr ""
 
 #. Label of the teams (Table MultiSelect) field in DocType 'HD Saved Reply'
-#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:74
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:75
 #: desk/src/components/Settings/Teams/TeamsList.vue:3
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 msgid "Teams"
@@ -5524,7 +6034,12 @@ msgstr ""
 msgid "Telephony settings updated successfully."
 msgstr ""
 
-#: desk/src/pages/ticket/TicketFeedback.vue:54
+#: desk/src/pages/PersonaForm.vue:101
+msgid "Tell us about your organization"
+msgstr ""
+
+#: desk/src/components/Questionnaire.vue:194
+#: desk/src/pages/ticket/TicketFeedback.vue:56
 msgid "Tell us more"
 msgstr ""
 
@@ -5558,6 +6073,10 @@ msgstr ""
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr ""
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr ""
@@ -5570,6 +6089,10 @@ msgstr ""
 msgid "The number of days must be 1 or more"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
+msgstr ""
+
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
 msgid "The status for sending feedback must be of <u>Resolved</u> category."
 msgstr ""
@@ -5578,7 +6101,7 @@ msgstr ""
 msgid "The ticket status will automatically change whenever the agent respond to a ticket."
 msgstr ""
 
-#: desk/src/components/Settings/Preferences/components/ThemeSwitcher.vue:6
+#: desk/src/components/Settings/Preferences/components/ThemeSwitcher.vue:5
 msgid "Theme"
 msgstr ""
 
@@ -5590,6 +6113,14 @@ msgstr ""
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr ""
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr ""
@@ -5599,7 +6130,11 @@ msgstr ""
 msgid "This action is irreversible."
 msgstr ""
 
-#: desk/src/components/ticket/TicketCustomerSidebar.vue:68
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
+msgstr ""
+
+#: desk/src/components/ticket/TicketCustomerSidebar.vue:73
 msgid "This date is calculated based on configured SLAs, working hours, and holidays."
 msgstr ""
 
@@ -5620,6 +6155,10 @@ msgstr ""
 msgid "This field is used to skip email-related workflows for tickets. If this field is checked, no emails will be sent related to tickets, such as new ticket creation, status updates, or notifications."
 msgstr ""
 
+#: desk/src/components/Questionnaire.vue:25
+msgid "This helps us personalize your Helpdesk experience."
+msgstr ""
+
 #: helpdesk/www/helpdesk/index.py:26
 msgid "This method is only meant for developer mode"
 msgstr ""
@@ -5632,16 +6171,16 @@ msgstr ""
 msgid "This ticket has been split to a new ticket. Please follow up on ticket <a href={0}>#{1}</a>."
 msgstr ""
 
-#: desk/src/pages/ticket/Tickets.vue:544
-msgid "This view is public, and will be removed for all users."
-msgstr ""
-
-#: desk/src/components/ListViewBuilder.vue:699
+#: desk/src/components/ListViewBuilder.vue:709
 msgid "This view is public. Changes made will be visible to everyone."
 msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:249
 msgid "This will reset the content to the default message."
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:169
+msgid "Through a support portal"
 msgstr ""
 
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
@@ -5656,7 +6195,9 @@ msgstr ""
 #. Label of the reference_ticket (Link) field in DocType 'HD Notification'
 #. Label of the ticket_tab (Tab Break) field in DocType 'HD Settings'
 #. Title of the tickets Web Form
-#: desk/src/components/layouts/Sidebar.vue:611
+#: desk/src/components/command-palette/CommandPalette.vue:27
+#: desk/src/components/command-palette/CommandPalette.vue:82
+#: desk/src/components/layouts/Sidebar.vue:401
 #: desk/src/components/ticket/TicketMergeModal.vue:57
 #: desk/src/pages/call-logs/CallLogModal.vue:102
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
@@ -5666,7 +6207,7 @@ msgstr ""
 msgid "Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:907
 msgid "Ticket #{0}: We've received your request"
 msgstr ""
 
@@ -5682,8 +6223,8 @@ msgstr ""
 msgid "Ticket Configuration"
 msgstr ""
 
-#: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
-msgid "Ticket Info"
+#: desk/src/components/customer/TicketsTab.vue:215
+msgid "Ticket ID"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:85
@@ -5699,7 +6240,7 @@ msgstr ""
 msgid "Ticket Not Found"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:620
+#: desk/src/components/layouts/Sidebar.vue:410
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:50
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:77
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:37
@@ -5715,7 +6256,10 @@ msgstr ""
 msgid "Ticket Reopen status"
 msgstr ""
 
+#. Label of the ticket_routing_section (Section Break) field in DocType 'HD
+#. Settings'
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:18
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Ticket Routing"
 msgstr ""
 
@@ -5739,7 +6283,7 @@ msgstr ""
 msgid "Ticket Summary"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:304
 msgid "Ticket Trend"
 msgstr ""
 
@@ -5747,7 +6291,7 @@ msgstr ""
 #. Settings'
 #. Label of the ticket_type (Link) field in DocType 'HD Ticket'
 #. Label of a Link in the Helpdesk Workspace
-#: desk/src/components/layouts/Sidebar.vue:619
+#: desk/src/components/layouts/Sidebar.vue:409
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:66
@@ -5760,7 +6304,7 @@ msgstr ""
 msgid "Ticket closed successfully."
 msgstr ""
 
-#: desk/src/components/ticket-agent/TicketHeader.vue:218
+#: desk/src/components/ticket-agent/TicketHeader.vue:214
 msgid "Ticket deleted successfully."
 msgstr ""
 
@@ -5772,7 +6316,7 @@ msgstr ""
 msgid "Ticket merged successfully."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:421
 msgid "Ticket must be resolved with a feedback"
 msgstr ""
 
@@ -5807,12 +6351,6 @@ msgstr ""
 msgid "Ticket to merged with is required"
 msgstr ""
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr ""
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr ""
@@ -5822,38 +6360,41 @@ msgstr ""
 msgid "Ticket-Search Analysis"
 msgstr ""
 
-#: desk/src/components/command-palette/CP.vue:98
-#: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/components/ticket-agent/TicketHeader.vue:169
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:73
+#: desk/src/pages/contact/Contact.vue:175
+#: desk/src/pages/customer/Customer.vue:68
+#: desk/src/pages/customer/Customer.vue:147
+#: desk/src/pages/ticket/MobileTicketAgent.vue:454
 #: desk/src/pages/ticket/TicketCustomer.vue:354
-#: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/TicketNew.vue:298 desk/src/pages/ticket/Tickets.vue:6
+#: desk/src/pages/ticket/Tickets.vue:457 helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:307 helpdesk/api/dashboard_tags.py:49
+#: helpdesk/api/dashboard_tags.py:75
 msgid "Tickets"
 msgstr ""
 
-#: desk/src/pages/home/components/PendingTickets.vue:242
+#: desk/src/pages/home/components/PendingTickets.vue:235
 msgid "Tickets approaching or breached SLA"
 msgstr ""
 
-#: desk/src/pages/home/components/PendingTickets.vue:243
+#: desk/src/pages/home/components/PendingTickets.vue:236
 msgid "Tickets assigned to you in the last 7 days"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:576
 msgid "Tickets by Channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:534 helpdesk/api/dashboard.py:543
 msgid "Tickets by Priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:464 helpdesk/api/dashboard.py:473
 msgid "Tickets by Team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:499 helpdesk/api/dashboard.py:508
 msgid "Tickets by Type"
 msgstr ""
 
@@ -5865,18 +6406,31 @@ msgstr ""
 msgid "Tickets must meet the following conditions:"
 msgstr ""
 
-#: desk/src/pages/home/components/PendingTickets.vue:244
+#: desk/src/components/ticket-agent/TicketDetailsTab.vue:285
+msgid "Tickets recently raised by this contact/customer"
+msgstr ""
+
+#: desk/src/pages/home/components/PendingTickets.vue:237
 msgid "Tickets that are awaiting your response"
 msgstr ""
 
+#: desk/src/components/ticket-agent/TicketDetailsTab.vue:294
+msgid "Tickets with similar queries"
+msgstr ""
+
+#: desk/src/pages/home/components/RecentActivity.vue:58
+msgid "Tickets you act on will show up here"
+msgstr ""
+
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:109
 msgid "Timezone"
 msgstr ""
 
 #. Label of the title (Data) field in DocType 'HD Article'
 #. Label of the title (Data) field in DocType 'HD Saved Reply'
 #: desk/src/components/Settings/NewTeamModal.vue:19
-#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:104
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:86
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:10
 #: desk/src/pages/knowledge-base/Article.vue:48
 #: desk/src/pages/knowledge-base/NewArticle.vue:39
@@ -5896,7 +6450,7 @@ msgid "Title is required"
 msgstr ""
 
 #. Label of the user_to (Link) field in DocType 'HD Notification'
-#: desk/src/components/EmailEditor.vue:34
+#: desk/src/components/EmailEditor.vue:28
 #: desk/src/pages/call-logs/CallLogModal.vue:33
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "To"
@@ -5915,7 +6469,7 @@ msgstr ""
 msgid "To Date cannot be before From Date"
 msgstr ""
 
-#: desk/src/components/Settings/Holiday/HolidayView.vue:92
+#: desk/src/components/Settings/Holiday/HolidayView.vue:98
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:157
 msgid "To date"
 msgstr ""
@@ -5924,21 +6478,26 @@ msgstr ""
 msgid "To is required"
 msgstr ""
 
-#: desk/src/components/Settings/EmailEdit.vue:147
+#: desk/src/components/Settings/EmailEdit.vue:268
 msgid "To know more about setting up email accounts, click"
 msgstr ""
 
-#: desk/src/pages/dashboard/Dashboard.vue:472
-#: desk/src/pages/dashboard/Dashboard.vue:474
+#: desk/src/pages/dashboard/Dashboard.vue:537
+#: desk/src/pages/dashboard/Dashboard.vue:539
 msgid "Today"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:262
+#: desk/src/components/layouts/MobileSidebar.vue:91
+#: desk/src/components/layouts/Sidebar.vue:125
 msgid "Toggle theme"
 msgstr ""
 
 #: helpdesk/helpdesk/report/ticket_search_analysis/ticket_search_analysis.py:35
 msgid "Top Result"
+msgstr ""
+
+#: helpdesk/api/dashboard_tags.py:46
+msgid "Top Tags"
 msgstr ""
 
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:98
@@ -5959,19 +6518,19 @@ msgstr ""
 msgid "Total Ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:164
 msgid "Total number of tickets created"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:544
 msgid "Total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:474
 msgid "Total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:509
 msgid "Total tickets by type"
 msgstr ""
 
@@ -6003,6 +6562,10 @@ msgstr ""
 msgid "Type a message"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr ""
@@ -6012,7 +6575,7 @@ msgstr ""
 msgid "URL/Method"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:742
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr ""
 
@@ -6033,12 +6596,8 @@ msgstr ""
 msgid "Unavailable"
 msgstr ""
 
-#: desk/src/components/layouts/Sidebar.vue:587
+#: desk/src/components/layouts/Sidebar.vue:377
 msgid "Understanding ticket view"
-msgstr ""
-
-#: desk/src/pages/ticket/Tickets.vue:468
-msgid "Unpin View"
 msgstr ""
 
 #: desk/src/pages/knowledge-base/Article.vue:21
@@ -6046,6 +6605,8 @@ msgid "Unpublish"
 msgstr ""
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr ""
 
@@ -6053,7 +6614,7 @@ msgstr ""
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:449
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:101
 #: desk/src/components/Settings/FieldDependency/FieldDependency.vue:66
-#: desk/src/components/Settings/Holiday/HolidayView.vue:190
+#: desk/src/components/Settings/Holiday/HolidayView.vue:200
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:217
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:279
 #: desk/src/components/Settings/SettingsModal.vue:72
@@ -6064,7 +6625,12 @@ msgstr ""
 msgid "Unsaved changes"
 msgstr ""
 
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:8
+#: desk/src/pages/home/components/RecentActivity.vue:33
 msgid "Untitled"
 msgstr ""
 
@@ -6073,7 +6639,7 @@ msgstr ""
 msgid "Update"
 msgstr ""
 
-#: desk/src/components/Settings/EmailEdit.vue:80
+#: desk/src/components/Settings/EmailEdit.vue:142
 msgid "Update Account"
 msgstr ""
 
@@ -6086,33 +6652,37 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:198
+#: desk/src/components/Settings/Profile/Profile.vue:202
 msgid "Upload Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
 msgid "Uploading {0}%"
 msgstr ""
 
+#. Option for the 'Level' (Select) field in DocType 'HD Ticket Priority'
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "Urgent"
+msgstr ""
+
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6123,6 +6693,10 @@ msgstr ""
 #. Label of the user_resolution_time (Duration) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
 msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
@@ -6142,7 +6716,7 @@ msgstr ""
 msgid "Valid From"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:113
 msgid "Value"
 msgstr ""
 
@@ -6153,12 +6727,20 @@ msgstr ""
 msgid "Via Customer Portal"
 msgstr ""
 
+#: desk/src/pages/PersonaForm.vue:170
+msgid "Via WhatsApp"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:168
+msgid "Via email"
+msgstr ""
+
 #: desk/src/components/Settings/Teams/TeamEdit.vue:241
 msgid "View Assignment rule"
 msgstr ""
 
-#: desk/src/pages/ticket/Tickets.vue:652
-msgid "View {0}"
+#: desk/src/pages/home/components/RecentActivity.vue:104
+msgid "Viewed"
 msgstr ""
 
 #. Label of the views (Int) field in DocType 'HD Article'
@@ -6175,6 +6757,18 @@ msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:10
 msgid "Was this article Helpful?"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:133
+msgid "We don't use any helpdesk yet"
+msgstr ""
+
+#: desk/src/components/layouts/CustomerPortalPermissionBanner.vue:13
+msgid "We have changed how customer portal permissions work"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:153
+msgid "Web form"
 msgstr ""
 
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
@@ -6196,10 +6790,50 @@ msgstr ""
 msgid "Weekly Off"
 msgstr ""
 
+#: desk/src/pages/PersonaForm.vue:244
+msgid "Welcome to Frappe Helpdesk"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:122
+msgid "What do you currently use to manage customer support?"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:103
+msgid "What is your organization's name?"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:205
+msgid "What makes support hard right now?"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:232
+msgid "What would you like to do first in Frappe Helpdesk?"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:177
+msgid "What's your biggest support challenge today?"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:150
+msgid "WhatsApp"
+msgstr ""
+
 #. Description of the 'Auto update status' (Check) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "When enabled, the ticket status will automatically change to the status selected below whenever the agent responds to a ticket.\n"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:228
+msgid "Where did you hear about us?"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:158
+msgid "Which channel do they use?"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:140
+msgid "Which tool does your team use?"
 msgstr ""
 
 #. Label of the word (Data) field in DocType 'HD Stopword'
@@ -6247,8 +6881,8 @@ msgstr ""
 msgid "Working Hours"
 msgstr ""
 
-#: desk/src/pages/knowledge-base/Article.vue:172
-#: desk/src/pages/knowledge-base/NewArticle.vue:55
+#: desk/src/pages/knowledge-base/Article.vue:170
+#: desk/src/pages/knowledge-base/NewArticle.vue:56
 msgid "Write your article here..."
 msgstr ""
 
@@ -6258,6 +6892,10 @@ msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:13
 msgid "Write your reply..."
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:221
+msgid "X (Twitter)"
 msgstr ""
 
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:37
@@ -6271,32 +6909,40 @@ msgstr ""
 msgid "Yellow"
 msgstr ""
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr ""
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr ""
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186 helpdesk/utils.py:206
 msgid "You are not permitted to access this resource."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:655
 msgid "You are not permitted to add a comment"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:681
 msgid "You are not permitted to reply as an agent"
 msgstr ""
 
-#: desk/src/App.vue:41
+#: desk/src/App.vue:40
 msgid "You are now offline."
 msgstr ""
 
-#: desk/src/App.vue:34
+#: desk/src/App.vue:33
 msgid "You are now online."
 msgstr ""
 
 #: desk/src/components/telephony/CallUI.vue:33
 msgid "You can change the default calling medium from the settings"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:294
+msgid "You can only raise tickets for your own contact."
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:138
@@ -6309,6 +6955,14 @@ msgstr ""
 
 #: helpdesk/api/assignment_rule.py:8
 msgid "You do not have permission to access Assignment Rules"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
 msgstr ""
 
 #: desk/src/pages/ticket/TicketAgent.vue:37
@@ -6327,6 +6981,14 @@ msgstr ""
 msgid "You must set one SLA as Default. Please check the Default SLA option."
 msgstr ""
 
+#: desk/src/components/layouts/CustomerPortalPermissionDialog.vue:37
+msgid "You won't see this notice again."
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:214
+msgid "YouTube"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:394
 msgid "Your old conditions will be overwritten. Are you sure you want to save?"
 msgstr ""
@@ -6335,11 +6997,27 @@ msgstr ""
 msgid "Your performance is"
 msgstr ""
 
+#: desk/src/pages/PersonaForm.vue:127
+msgid "Zendesk"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:131
+msgid "Zoho Desk"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
+msgstr ""
+
 #: desk/src/pages/MobileNotifications.vue:46
 msgid "assigned you a ticket"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:29
+#: desk/src/components/ticket-agent/AssignTo.vue:40
 msgid "assignees"
 msgstr ""
 
@@ -6351,24 +7029,28 @@ msgstr ""
 msgid "back to email event list"
 msgstr ""
 
-#: desk/src/components/HistoryBox.vue:12
-msgid "changes from"
+#: desk/src/components/layouts/CustomerPortalPermissionDialog.vue:21
+msgid "can see every ticket of their company and manage its contacts."
 msgstr ""
 
-#: desk/src/pages/ticket/Tickets.vue:651
-msgid "created"
+#: desk/src/components/HistoryBox.vue:12
+msgid "changes from"
 msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:42
 msgid "customize {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:222 helpdesk/api/dashboard.py:224
 msgid "days"
 msgstr ""
 
-#: desk/src/pages/ticket/Tickets.vue:563
-msgid "deleted"
+#: desk/src/components/layouts/CustomerPortalPermissionDialog.vue:28
+msgid "documentation"
+msgstr ""
+
+#: desk/src/pages/PersonaForm.vue:104
+msgid "e.g. Acme Inc."
 msgstr ""
 
 #: desk/src/components/ticket/TicketSplitModal.vue:7
@@ -6414,15 +7096,16 @@ msgstr ""
 msgid "here."
 msgstr ""
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:203 helpdesk/api/dashboard.py:205
 msgid "hrs"
 msgstr ""
 
+#: desk/src/components/ticket-agent/TicketSLA.vue:100
 #: desk/src/pages/knowledge-base/NewArticle.vue:15
 msgid "in"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:413
 msgid "just now"
 msgstr ""
 
@@ -6444,18 +7127,20 @@ msgstr ""
 msgid "poor"
 msgstr ""
 
-#: desk/src/pages/knowledge-base/Article.vue:197
+#: desk/src/pages/knowledge-base/Article.vue:195
 msgid "published by"
 msgstr ""
 
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
-#. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "purple"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:246
 msgid "stars"
 msgstr ""
 
@@ -6464,7 +7149,7 @@ msgstr ""
 msgid "synonym"
 msgstr ""
 
-#: desk/src/pages/home/components/PendingTickets.vue:158
+#: desk/src/pages/home/components/PendingTickets.vue:153
 msgid "ticket"
 msgstr ""
 
@@ -6472,7 +7157,15 @@ msgstr ""
 msgid "to enable this integration."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/components/ticket-agent/TicketContact.vue:33
+msgid "via Email"
+msgstr ""
+
+#: desk/src/components/ticket-agent/TicketContact.vue:33
+msgid "via Portal"
+msgstr ""
+
+#: desk/src/pages/ticket/MobileTicketAgent.vue:563
 msgid "viewed this"
 msgstr ""
 
@@ -6480,19 +7173,39 @@ msgstr ""
 msgid "views"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:69
+msgid "{0} Customers"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr ""
+
+#: desk/src/components/ticket-agent/AssignTo.vue:545
 msgid "{0} is currently away."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:544
 msgid "{0} is currently unavailable."
 msgstr ""
 
-#: desk/src/components/ListViewBuilder.vue:307
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
+msgstr ""
+
+#: desk/src/components/ListViewBuilder.vue:309
 msgid "{0} item(s) deleted successfully"
 msgstr ""
 
-#: desk/src/components/ListViewBuilder.vue:321
+#: desk/src/components/ListViewBuilder.vue:323
 msgid "{0} item(s) queued for deletion"
 msgstr ""
 
@@ -6500,19 +7213,19 @@ msgstr ""
 msgid "{0} matches"
 msgstr ""
 
+#: helpdesk/overrides/user_invitation.py:18
+msgid "{0} on {1}"
+msgstr ""
+
+#: desk/src/components/command-palette/CommandPalette.vue:239
+msgid "{0} results"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:46
 msgid "{0} reviews"
 msgstr ""
 
-#: desk/src/pages/ticket/Tickets.vue:510
-msgid "{0} view is currently public. Changing it to private will hide it for all the users."
-msgstr ""
-
-#: desk/src/pages/ticket/Tickets.vue:490
-msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
-msgstr ""
-
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:414
 msgid "{0} · Last active {1}"
 msgstr ""
 

--- a/helpdesk/locale/my.po
+++ b/helpdesk/locale/my.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-15 18:51\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-29 21:58\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Burmese\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr ""
@@ -108,14 +108,6 @@ msgstr ""
 msgid "A workday with this name already exists"
 msgstr ""
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr ""
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr ""
@@ -132,7 +124,7 @@ msgstr ""
 msgid "Account"
 msgstr "အကောင့်"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr ""
 
@@ -152,11 +144,9 @@ msgstr "လုပ်ဆောင်ချက်"
 msgid "Action Required"
 msgstr "လုပ်ဆောင်ရန် လိုအပ်ပါသည်။"
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr ""
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "လုပ်ဆောင်ချက်များ"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr ""
 msgid "Active"
 msgstr "အသက်ဝင်နေသည်"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr ""
 
@@ -175,7 +165,7 @@ msgid "Active: The agent is available and working.<br>\n"
 "Unavailable: The agent is off and unavailable."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "လှုပ်ရှားမှု"
@@ -193,10 +183,11 @@ msgid "Add Column"
 msgstr "ကော်လံ ထည့်ပါ"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr ""
 
@@ -206,6 +197,10 @@ msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
 msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:148
@@ -244,7 +239,7 @@ msgstr "အခြေအနေထည့်ပါ။"
 msgid "Add condition group"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr ""
 
@@ -278,6 +273,12 @@ msgstr ""
 msgid "Add to Holidays"
 msgstr "ပိတ်ရက် ထည့်သွင်းမည်"
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr ""
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr " ကိုယ်စားလှယ်များထည့်သွင်းပြီး၊ လုပ်ပိုင်ခွင့်များသတ်မှတ်ပါ။"
@@ -295,17 +296,14 @@ msgid "Administrator"
 msgstr "စီမံခန့်ခွဲသူ"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -316,6 +314,7 @@ msgstr "စီမံခန့်ခွဲသူ"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -335,6 +334,7 @@ msgstr ""
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -342,6 +342,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -376,18 +377,9 @@ msgstr ""
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "အားလုံး"
 
@@ -508,6 +500,14 @@ msgstr ""
 msgid "Are you sure you want to delete these articles?"
 msgstr ""
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr ""
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr ""
@@ -543,6 +543,10 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
 msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
@@ -595,16 +599,11 @@ msgstr ""
 msgid "Assign ticket"
 msgstr ""
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr "တာဝန်ပေးရန်"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -618,7 +617,7 @@ msgstr "တာဝန်ခံ"
 msgid "Assignee Rules"
 msgstr "တာဝန်ပေးမည့် သတ်မှတ်ချက်များ"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr ""
 
@@ -626,7 +625,7 @@ msgstr ""
 msgid "Assignees"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr ""
 
@@ -692,10 +691,6 @@ msgstr ""
 msgid "Assignment rule {0} updated successfully."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -711,10 +706,6 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
-msgstr ""
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
 msgstr ""
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
@@ -766,7 +757,7 @@ msgid "Automation"
 msgstr ""
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr ""
@@ -802,7 +793,7 @@ msgstr ""
 msgid "Average Time Metrics"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr ""
 
@@ -810,24 +801,36 @@ msgstr ""
 msgid "Average response and resolution metrics not available"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
 msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
@@ -840,11 +843,11 @@ msgstr ""
 msgid "Avg. resolution time"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr ""
 
@@ -867,11 +870,6 @@ msgstr ""
 msgid "Base Support Rotation"
 msgstr ""
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "အခြေခံ URL"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -885,11 +883,11 @@ msgstr ""
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr ""
 
@@ -944,11 +942,6 @@ msgstr ""
 msgid "Busy"
 msgstr ""
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "ခလုတ်"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr ""
@@ -973,19 +966,31 @@ msgstr ""
 msgid "Caller"
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr ""
 
@@ -1025,7 +1030,7 @@ msgstr ""
 msgid "Cannot merge General category"
 msgstr ""
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr ""
 
@@ -1073,11 +1078,11 @@ msgstr ""
 msgid "Category updated successfully."
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr ""
 
@@ -1085,7 +1090,7 @@ msgstr ""
 msgid "Change"
 msgstr "အကြွေစေ့"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "စကားဝှက်ကိုပြောင်းရန်"
@@ -1098,9 +1103,8 @@ msgstr ""
 msgid "Change language of the application."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
@@ -1123,7 +1127,7 @@ msgstr ""
 msgid "Change timezone of the application."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr ""
 
@@ -1136,7 +1140,7 @@ msgstr ""
 msgid "Child field"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr ""
 
@@ -1189,7 +1193,7 @@ msgstr ""
 msgid "Clear Table"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr ""
 
@@ -1203,6 +1207,10 @@ msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
@@ -1223,7 +1231,7 @@ msgstr ""
 msgid "Closed"
 msgstr "ပိတ်ထားသော"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr ""
 
@@ -1250,7 +1258,7 @@ msgstr "ကော်လံများ"
 msgid "Comma separated emails to invite."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr ""
 
@@ -1283,7 +1291,7 @@ msgstr ""
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "မှတ်ချက်များ"
@@ -1296,6 +1304,11 @@ msgstr "ဆက်သွယ်ရေး"
 msgid "Communication ID is required"
 msgstr ""
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
+msgstr "လုပ်ငန်း"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
 msgstr "ပြီးဆုံးပြီ"
@@ -1307,7 +1320,7 @@ msgstr "ပြီးဆုံးပြီ"
 msgid "Condition"
 msgstr "အခြေအနေ"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr ""
 
@@ -1331,6 +1344,10 @@ msgstr ""
 msgid "Configure your telephony settings."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1356,10 +1373,11 @@ msgstr ""
 msgid "Connect your support email"
 msgstr ""
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1373,25 +1391,29 @@ msgstr "အဆက်အသွယ်"
 msgid "Contact HTML"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
 msgstr ""
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
 msgstr ""
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
@@ -1415,7 +1437,7 @@ msgstr ""
 msgid "Copy ticket id"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr ""
 
@@ -1423,7 +1445,11 @@ msgstr ""
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr ""
 
@@ -1431,11 +1457,20 @@ msgstr ""
 msgid "Could not send feedback email,due to: {0}"
 msgstr ""
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "နိုင်ငံ"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1446,9 +1481,13 @@ msgstr "ဖန်တီးရန်"
 msgid "Create & invite a contact"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
 msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
+msgstr "ဝယ်သူ (ဖောက်သည်) ထည့်သွင်းရန်"
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
 msgid "Create View"
@@ -1482,12 +1521,6 @@ msgstr ""
 msgid "Creating a ticket"
 msgstr ""
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr ""
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr ""
@@ -1512,12 +1545,21 @@ msgid "Custom Views"
 msgstr ""
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
 msgstr "ဝယ်သူ"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
+msgstr ""
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1528,16 +1570,32 @@ msgstr "ဝယ်သူအမည်"
 msgid "Customer Portal"
 msgstr ""
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
 msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
 msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:595
@@ -1565,6 +1623,8 @@ msgstr "စိမ်းပြာရောင်"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "အန္တရာယ်"
@@ -1665,18 +1725,26 @@ msgstr ""
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr ""
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "ဖျက်ရန်"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1692,6 +1760,10 @@ msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
+msgstr ""
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
 msgstr ""
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
@@ -1740,7 +1812,7 @@ msgstr ""
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1826,7 +1898,12 @@ msgstr ""
 msgid "Document Type"
 msgstr "စာရွက်စာတမ်း အမျိုးအစား"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr ""
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "ဒိုမိန်း"
@@ -1867,6 +1944,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
@@ -1917,7 +1998,8 @@ msgstr ""
 msgid "Easily invite new agents, managers, or admins."
 msgstr ""
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1925,6 +2007,14 @@ msgstr "တည်းဖြတ်"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
 msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:70
@@ -1944,10 +2034,10 @@ msgstr ""
 msgid "Edit your email account"
 msgstr ""
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "အီးမေးလ်"
 
@@ -1975,9 +2065,10 @@ msgstr ""
 msgid "Email Content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
-msgstr "အီးမေးလ် Id"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
+msgstr "အီးမေးလ် ID"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
 #. Settings'
@@ -2002,22 +2093,22 @@ msgstr ""
 msgid "Email account updated successfully"
 msgstr ""
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr ""
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr ""
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "အီးမေးလ်များ"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr ""
 
@@ -2055,8 +2146,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr ""
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2081,8 +2170,6 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2105,20 +2192,24 @@ msgstr ""
 msgid "Enter a name for this HD Service Holiday List."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr ""
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr ""
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
 msgstr ""
 
 #: helpdesk/api/knowledge_base.py:86
@@ -2129,21 +2220,17 @@ msgstr ""
 msgid "Error processing email at index {0}, message: {1}"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr ""
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "အီးမေးလ်အကောင့် {0} သို့ ချိတ်ဆက်ရာတွင် အမှားဖြစ်ပွားခဲ့သည်"
 
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr ""
-
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
 msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
@@ -2172,11 +2259,6 @@ msgstr ""
 msgid "Export Type"
 msgstr "ထုတ်ယူမှုအမျိုးအစား"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr ""
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2184,6 +2266,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "မအောင်မြင်ပါ"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2218,11 +2304,11 @@ msgstr ""
 msgid "Failed to save Twilio settings"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr ""
 
@@ -2251,6 +2337,7 @@ msgstr ""
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2288,12 +2375,16 @@ msgstr ""
 msgid "Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
+msgstr ""
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
 msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
@@ -2338,13 +2429,14 @@ msgid "Field dependency updated successfully."
 msgstr ""
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "အကွက်များ"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "စစ်ထုတ်မှုများ"
@@ -2354,13 +2446,18 @@ msgstr "စစ်ထုတ်မှုများ"
 msgid "Find out all of the variables that can be used in the content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "အမည်"
 
 #. Label of the first_responded_on (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
+msgstr ""
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
 msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
@@ -2385,10 +2482,6 @@ msgstr ""
 #. Name of a report
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -2480,6 +2573,10 @@ msgstr ""
 msgid "Go to Ticket #{0}"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr ""
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2509,19 +2606,12 @@ msgid "Group By Field"
 msgstr ""
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
 msgstr ""
 
 #. Name of a DocType
@@ -2554,24 +2644,36 @@ msgstr ""
 msgid "HD Comment Reaction"
 msgstr ""
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr ""
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr ""
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
 msgstr ""
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
 msgstr ""
 
 #. Name of a DocType
@@ -2592,21 +2694,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
 msgstr ""
 
 #. Name of a DocType
@@ -2648,11 +2735,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
 msgstr ""
 
 #. Name of a DocType
@@ -2750,12 +2832,6 @@ msgstr ""
 msgid "Helpdesk"
 msgstr ""
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr ""
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2771,11 +2847,6 @@ msgstr ""
 
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
-msgstr ""
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
 msgstr ""
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
@@ -2846,15 +2917,8 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "IP လိပ်စာ"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2941,6 +3005,11 @@ msgstr "ဝင်စာပုံး"
 msgid "Incoming"
 msgstr "ဝင်လာသော"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr ""
@@ -2954,7 +3023,7 @@ msgstr ""
 msgid "Instantly send e-mail"
 msgstr ""
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "{0} အတွက် ခွင့်ပြုချက် မလုံလောက်ပါ"
 
@@ -2968,12 +3037,12 @@ msgstr ""
 msgid "Introduction"
 msgstr "မိတ်ဆက်"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
@@ -2982,22 +3051,42 @@ msgstr ""
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr ""
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr ""
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
 msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
@@ -3008,12 +3097,29 @@ msgstr ""
 msgid "Invite agents"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
-msgstr ""
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
+msgstr "အသုံးပြုသူအဖြစ် ဖိတ်ကြားရန်"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
 msgstr ""
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
@@ -3030,6 +3136,11 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "မူရင်းဖြစ်သည်"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr ""
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3057,6 +3168,10 @@ msgstr ""
 #. Label of the setup_complete (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
 msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:114
@@ -3093,11 +3208,9 @@ msgstr "ကီးဘုတ်ဖြတ်လမ်းများ"
 msgid "Knowledge Base"
 msgstr "အသိပညာအခြေခံ"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3131,9 +3244,9 @@ msgstr ""
 msgid "Last 3 Months"
 msgstr ""
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr ""
 
@@ -3174,7 +3287,8 @@ msgstr ""
 msgid "Last Month"
 msgstr "ပြီးခဲ့သောလ"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "မျိုးနွယ်အမည်"
 
@@ -3183,23 +3297,32 @@ msgstr "မျိုးနွယ်အမည်"
 msgid "Last Week"
 msgstr "ပြီးခဲ့သောအပတ်"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr ""
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
 msgstr ""
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
@@ -3216,26 +3339,6 @@ msgstr ""
 #. 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
-msgstr ""
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "လင့်ခ်"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -3264,6 +3367,8 @@ msgstr ""
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "နောက်ထပ်ဖွင့်ရန်"
 
@@ -3286,6 +3391,8 @@ msgstr ""
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr ""
@@ -3324,7 +3431,7 @@ msgstr ""
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr ""
 
@@ -3342,6 +3449,10 @@ msgstr ""
 
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:11
@@ -3396,6 +3507,20 @@ msgstr ""
 msgid "Mobile App Installation"
 msgstr ""
 
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr ""
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr ""
+
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
 #. List'
@@ -3436,7 +3561,7 @@ msgid "My Tickets"
 msgstr ""
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3447,8 +3572,9 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3457,6 +3583,10 @@ msgstr "အမည်"
 #. Label of the name_weight (Int) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
 msgstr ""
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
@@ -3469,10 +3599,18 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "ဘယ်တော့မှ"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3581,11 +3719,11 @@ msgstr ""
 msgid "No Data Found"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr ""
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr ""
 
@@ -3597,8 +3735,14 @@ msgstr ""
 msgid "No SLA found"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
 msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
@@ -3633,19 +3777,27 @@ msgstr ""
 msgid "No changes made"
 msgstr "ပြောင်းလဲမှုများ မပြုလုပ်ပါ"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr ""
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr ""
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr ""
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
@@ -3657,7 +3809,11 @@ msgstr ""
 msgid "No feedback"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr ""
 
@@ -3697,12 +3853,17 @@ msgstr ""
 msgid "No recently assigned tickets"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr ""
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
 msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
@@ -3710,6 +3871,7 @@ msgstr ""
 msgid "No saved replies found"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr ""
@@ -3730,7 +3892,11 @@ msgstr ""
 msgid "No tickets selected"
 msgstr ""
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr ""
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "ခွင့်မပြု"
 
@@ -3742,7 +3908,7 @@ msgstr ""
 msgid "Not Saved"
 msgstr "မသိမ်းဆည်းရသေးပါ"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "သတ်မှတ်မထားပါ"
 
@@ -3781,11 +3947,6 @@ msgstr ""
 msgid "On Hold Since"
 msgstr ""
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr ""
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr ""
@@ -3815,6 +3976,10 @@ msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
@@ -3904,7 +4069,12 @@ msgstr ""
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr ""
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "စကားဝှက်"
 
@@ -3942,6 +4112,7 @@ msgid "Pending"
 msgstr "ဆိုင်းငံ့ထားသည်"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr ""
 
@@ -3951,19 +4122,19 @@ msgstr ""
 msgid "Pending Tickets"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr ""
 
@@ -3984,13 +4155,14 @@ msgstr "ကိုယ်ပိုင်"
 msgid "Personal mobile no"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "ဖုန်း"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
 msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
@@ -4047,7 +4219,7 @@ msgstr ""
 msgid "Please enter a valid phone number"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr ""
 
@@ -4090,33 +4262,14 @@ msgstr ""
 msgid "Policy name"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
-msgstr ""
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr ""
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr ""
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr ""
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
 msgstr ""
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
@@ -4151,14 +4304,32 @@ msgstr "အကြိုကြည့်ရှုခြင်း"
 msgid "Previous ticket"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "အဓိက"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "အဓိက အဆက်အသွယ်"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr ""
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr ""
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4166,9 +4337,10 @@ msgstr ""
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4248,17 +4420,6 @@ msgstr ""
 msgid "Quarterly"
 msgstr "သုံးလတစ်ကြိမ်"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "မေးမြန်းချက် ရွေးချယ်စရာများ"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr ""
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "တန်းစီနေသည်"
@@ -4281,14 +4442,14 @@ msgstr ""
 msgid "Rate this ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr ""
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4384,8 +4545,15 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "ဖယ်ရှားရန်"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4395,9 +4563,18 @@ msgstr ""
 msgid "Remove Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr ""
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
 msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
@@ -4417,6 +4594,15 @@ msgstr ""
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
 msgstr ""
 
 #. Option in a Select field in the tickets Web Form
@@ -4456,16 +4642,13 @@ msgstr ""
 msgid "Reply on a ticket"
 msgstr ""
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr ""
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
 msgstr ""
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
@@ -4486,6 +4669,7 @@ msgid "Reset to Default"
 msgstr ""
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr ""
@@ -4539,18 +4723,6 @@ msgstr "တုံ့ပြန်မှု"
 msgid "Response By"
 msgstr ""
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr ""
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr ""
@@ -4593,28 +4765,18 @@ msgstr ""
 msgid "Restrict visibility to these teams"
 msgstr ""
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr ""
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr ""
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
+msgstr ""
+
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:215
@@ -4622,8 +4784,14 @@ msgid "Ringing"
 msgstr "မြည်နေသည်"
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "အခန်းကဏ္ဍ"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr ""
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4722,9 +4890,9 @@ msgstr "စနေနေ့"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4800,17 +4968,19 @@ msgstr ""
 msgid "Search Score"
 msgstr ""
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr ""
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr ""
 
@@ -4850,6 +5020,7 @@ msgstr "ရှာဖွေရန်..."
 msgid "Searched for:"
 msgstr ""
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr ""
@@ -4868,6 +5039,10 @@ msgstr "ရွေးချယ်ပါ"
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
 msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
@@ -4890,6 +5065,10 @@ msgstr ""
 msgid "Select a rating"
 msgstr ""
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr ""
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4901,6 +5080,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
+msgstr ""
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
@@ -4927,6 +5110,10 @@ msgstr ""
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
 msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
@@ -4967,13 +5154,17 @@ msgstr ""
 msgid "Service not supported"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "သတ်မှတ်ထားသည်"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:4
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
@@ -4984,12 +5175,21 @@ msgstr ""
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr ""
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr ""
 
@@ -5001,7 +5201,7 @@ msgstr ""
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr ""
 
@@ -5135,23 +5335,6 @@ msgstr ""
 msgid "Sort"
 msgstr ""
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr ""
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "ရင်းမြစ်အမည်"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr ""
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr ""
@@ -5196,6 +5379,8 @@ msgstr ""
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5262,6 +5447,7 @@ msgstr ""
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5373,21 +5559,16 @@ msgstr "စနစ်"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5426,8 +5607,6 @@ msgstr ""
 msgid "Teal"
 msgstr ""
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5438,7 +5617,6 @@ msgstr ""
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5544,6 +5722,10 @@ msgstr ""
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr ""
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr ""
@@ -5554,6 +5736,10 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
@@ -5576,6 +5762,14 @@ msgstr ""
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr ""
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr ""
@@ -5583,6 +5777,10 @@ msgstr ""
 #: desk/src/components/ticket/TicketMergeModal.vue:79
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
 msgstr ""
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
@@ -5652,7 +5850,7 @@ msgstr "ကြာသပတေး"
 msgid "Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr ""
 
@@ -5666,6 +5864,10 @@ msgstr ""
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
+msgstr ""
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
 msgstr ""
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
@@ -5725,7 +5927,7 @@ msgstr ""
 msgid "Ticket Summary"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr ""
 
@@ -5758,7 +5960,7 @@ msgstr ""
 msgid "Ticket merged successfully."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr ""
 
@@ -5793,12 +5995,6 @@ msgstr ""
 msgid "Ticket to merged with is required"
 msgstr ""
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr ""
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr ""
@@ -5810,12 +6006,15 @@ msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr ""
 
@@ -5827,19 +6026,19 @@ msgstr ""
 msgid "Tickets assigned to you in the last 7 days"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr ""
 
@@ -5856,6 +6055,7 @@ msgid "Tickets that are awaiting your response"
 msgstr ""
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr ""
 
@@ -5945,19 +6145,19 @@ msgstr ""
 msgid "Total Ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr ""
 
@@ -5989,6 +6189,10 @@ msgstr "အမျိုးအစား"
 msgid "Type a message"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr ""
@@ -5998,7 +6202,7 @@ msgstr ""
 msgid "URL/Method"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr ""
 
@@ -6032,6 +6236,8 @@ msgid "Unpublish"
 msgstr "ထုတ်ဝေမှု ပြန်ရုပ်သိမ်းပါ"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr ""
 
@@ -6048,6 +6254,10 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:214
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
+msgstr ""
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
@@ -6076,9 +6286,12 @@ msgstr "အပ်လုဒ်တင်"
 msgid "Upload Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
@@ -6088,17 +6301,13 @@ msgstr ""
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6109,6 +6318,10 @@ msgstr "အသုံးပြုသူ"
 #. Label of the user_resolution_time (Duration) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
 msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
@@ -6128,7 +6341,7 @@ msgstr "အသုံးပြုသူများ"
 msgid "Valid From"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "တန်ဖိုး"
 
@@ -6257,19 +6470,23 @@ msgstr "နှစ်စဉ်"
 msgid "Yellow"
 msgstr "အဝါ"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr ""
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr ""
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr ""
 
@@ -6297,6 +6514,14 @@ msgstr ""
 msgid "You do not have permission to access Assignment Rules"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr ""
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr ""
@@ -6319,6 +6544,14 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:46
@@ -6349,7 +6582,7 @@ msgstr ""
 msgid "customize {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr ""
 
@@ -6400,7 +6633,7 @@ msgstr ""
 msgid "here."
 msgstr ""
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr ""
 
@@ -6408,7 +6641,7 @@ msgstr ""
 msgid "in"
 msgstr "တွင်"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "ယခုလေးတင်"
 
@@ -6441,7 +6674,11 @@ msgstr ""
 msgid "purple"
 msgstr "ခရမ်းရောင်"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr ""
 
@@ -6458,7 +6695,7 @@ msgstr ""
 msgid "to enable this integration."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr ""
 
@@ -6466,12 +6703,32 @@ msgstr ""
 msgid "views"
 msgstr "မြင်ကွင်းများ"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr ""
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
 msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:307
@@ -6498,7 +6755,7 @@ msgstr ""
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr ""
 

--- a/helpdesk/locale/nb.po
+++ b/helpdesk/locale/nb.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-15 18:51\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-29 21:58\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Norwegian Bokmal\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr ""
@@ -108,14 +108,6 @@ msgstr ""
 msgid "A workday with this name already exists"
 msgstr ""
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr "API"
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr ""
@@ -132,7 +124,7 @@ msgstr ""
 msgid "Account"
 msgstr "Konto"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr ""
 
@@ -152,11 +144,9 @@ msgstr "Handling"
 msgid "Action Required"
 msgstr ""
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr ""
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "Handlinger"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr ""
 msgid "Active"
 msgstr "Aktiv"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr ""
 
@@ -175,7 +165,7 @@ msgid "Active: The agent is available and working.<br>\n"
 "Unavailable: The agent is off and unavailable."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "Aktivitet"
@@ -193,10 +183,11 @@ msgid "Add Column"
 msgstr "Legg til Kolonne"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "Legg til Filter..."
 
@@ -206,6 +197,10 @@ msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
 msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:148
@@ -244,7 +239,7 @@ msgstr ""
 msgid "Add condition group"
 msgstr "Legg til betingelsesgruppe"
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "Legg til filter"
 
@@ -278,6 +273,12 @@ msgstr ""
 msgid "Add to Holidays"
 msgstr "Legg til i fridager"
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr ""
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr ""
@@ -295,17 +296,14 @@ msgid "Administrator"
 msgstr "Administrator"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -316,6 +314,7 @@ msgstr "Administrator"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -335,6 +334,7 @@ msgstr ""
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -342,6 +342,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -376,18 +377,9 @@ msgstr ""
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "Alle"
 
@@ -508,6 +500,14 @@ msgstr ""
 msgid "Are you sure you want to delete these articles?"
 msgstr ""
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr ""
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr ""
@@ -543,6 +543,10 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
 msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
@@ -595,16 +599,11 @@ msgstr ""
 msgid "Assign ticket"
 msgstr ""
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr ""
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -618,7 +617,7 @@ msgstr "Oppdragstaker"
 msgid "Assignee Rules"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr ""
 
@@ -626,7 +625,7 @@ msgstr ""
 msgid "Assignees"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr ""
 
@@ -692,10 +691,6 @@ msgstr ""
 msgid "Assignment rule {0} updated successfully."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -711,10 +706,6 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
-msgstr ""
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
 msgstr ""
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
@@ -766,7 +757,7 @@ msgid "Automation"
 msgstr "Automatisering"
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr ""
@@ -802,7 +793,7 @@ msgstr ""
 msgid "Average Time Metrics"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr ""
 
@@ -810,24 +801,36 @@ msgstr ""
 msgid "Average response and resolution metrics not available"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
 msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
@@ -840,11 +843,11 @@ msgstr ""
 msgid "Avg. resolution time"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr ""
 
@@ -867,11 +870,6 @@ msgstr ""
 msgid "Base Support Rotation"
 msgstr ""
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "Grunnleggende URL"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -885,11 +883,11 @@ msgstr ""
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr ""
 
@@ -944,11 +942,6 @@ msgstr ""
 msgid "Busy"
 msgstr ""
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "Knapp"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr "CSV"
@@ -973,19 +966,31 @@ msgstr ""
 msgid "Caller"
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr ""
 
@@ -1025,7 +1030,7 @@ msgstr ""
 msgid "Cannot merge General category"
 msgstr ""
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr ""
 
@@ -1073,11 +1078,11 @@ msgstr ""
 msgid "Category updated successfully."
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr ""
 
@@ -1085,7 +1090,7 @@ msgstr ""
 msgid "Change"
 msgstr "Endre"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "Endre passord"
@@ -1098,9 +1103,8 @@ msgstr ""
 msgid "Change language of the application."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
@@ -1123,7 +1127,7 @@ msgstr ""
 msgid "Change timezone of the application."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr ""
 
@@ -1136,7 +1140,7 @@ msgstr ""
 msgid "Child field"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr ""
 
@@ -1189,7 +1193,7 @@ msgstr ""
 msgid "Clear Table"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr ""
 
@@ -1204,6 +1208,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
 msgstr "Klikk på Legg til i helligdager. Dette vil fylle ut helligdagstabellen med alle datoene som faller på den valgte ukentlige fridagen. Gjenta prosessen for å fylle ut datoene for alle de ukentlige fridagene dine"
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:47
@@ -1223,7 +1231,7 @@ msgstr ""
 msgid "Closed"
 msgstr "Lukket"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr ""
 
@@ -1250,7 +1258,7 @@ msgstr "Kolonner"
 msgid "Comma separated emails to invite."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr ""
 
@@ -1283,7 +1291,7 @@ msgstr ""
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "Kommentarer"
@@ -1296,6 +1304,11 @@ msgstr "Kommunikasjon"
 msgid "Communication ID is required"
 msgstr ""
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
+msgstr "Selskap"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
 msgstr "Fullført"
@@ -1307,7 +1320,7 @@ msgstr "Fullført"
 msgid "Condition"
 msgstr "Betingelse"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr ""
 
@@ -1331,6 +1344,10 @@ msgstr ""
 msgid "Configure your telephony settings."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1356,10 +1373,11 @@ msgstr ""
 msgid "Connect your support email"
 msgstr ""
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1373,25 +1391,29 @@ msgstr "Kontakt"
 msgid "Contact HTML"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
 msgstr ""
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
 msgstr ""
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
@@ -1415,7 +1437,7 @@ msgstr ""
 msgid "Copy ticket id"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr ""
 
@@ -1423,7 +1445,11 @@ msgstr ""
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr ""
 
@@ -1431,11 +1457,20 @@ msgstr ""
 msgid "Could not send feedback email,due to: {0}"
 msgstr ""
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "Land"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1446,8 +1481,12 @@ msgstr "Opprett"
 msgid "Create & invite a contact"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
 msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
@@ -1482,12 +1521,6 @@ msgstr ""
 msgid "Creating a ticket"
 msgstr ""
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr ""
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr ""
@@ -1512,12 +1545,21 @@ msgid "Custom Views"
 msgstr ""
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
 msgstr "Kunde"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
+msgstr ""
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1528,16 +1570,32 @@ msgstr ""
 msgid "Customer Portal"
 msgstr ""
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
 msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
 msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:595
@@ -1565,6 +1623,8 @@ msgstr "Cyan"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "Fare"
@@ -1665,18 +1725,26 @@ msgstr ""
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr ""
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "Slett"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1692,6 +1760,10 @@ msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
+msgstr ""
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
 msgstr ""
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
@@ -1740,7 +1812,7 @@ msgstr ""
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1826,7 +1898,12 @@ msgstr ""
 msgid "Document Type"
 msgstr "Dokumenttype (DocType)"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr ""
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "Domene"
@@ -1867,6 +1944,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
@@ -1917,7 +1998,8 @@ msgstr ""
 msgid "Easily invite new agents, managers, or admins."
 msgstr ""
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1925,6 +2007,14 @@ msgstr "Rediger"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
 msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:70
@@ -1944,10 +2034,10 @@ msgstr ""
 msgid "Edit your email account"
 msgstr ""
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "E-post"
 
@@ -1975,8 +2065,9 @@ msgstr ""
 msgid "Email Content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
 msgstr "E-post-ID"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
@@ -2002,22 +2093,22 @@ msgstr ""
 msgid "Email account updated successfully"
 msgstr ""
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr ""
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr ""
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "E-poster"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr ""
 
@@ -2055,8 +2146,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr ""
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2081,8 +2170,6 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2105,20 +2192,24 @@ msgstr ""
 msgid "Enter a name for this HD Service Holiday List."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr ""
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr ""
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
 msgstr ""
 
 #: helpdesk/api/knowledge_base.py:86
@@ -2129,22 +2220,18 @@ msgstr ""
 msgid "Error processing email at index {0}, message: {1}"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr ""
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "Feil under tilkobling til e-postkonto {0}"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr ""
 
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
 msgstr "Excel"
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
+msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
 #: desk/src/components/Settings/Telephony/Telephony.vue:96
@@ -2172,11 +2259,6 @@ msgstr ""
 msgid "Export Type"
 msgstr "Eksporttype"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr ""
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2184,6 +2266,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "Feilet"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2218,11 +2304,11 @@ msgstr ""
 msgid "Failed to save Twilio settings"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr ""
 
@@ -2251,6 +2337,7 @@ msgstr "Favicon"
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2288,12 +2375,16 @@ msgstr ""
 msgid "Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
+msgstr ""
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
 msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
@@ -2338,13 +2429,14 @@ msgid "Field dependency updated successfully."
 msgstr ""
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "Felt"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "Filtre"
@@ -2354,13 +2446,18 @@ msgstr "Filtre"
 msgid "Find out all of the variables that can be used in the content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "Fornavn"
 
 #. Label of the first_responded_on (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
+msgstr ""
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
 msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
@@ -2385,10 +2482,6 @@ msgstr ""
 #. Name of a report
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -2480,6 +2573,10 @@ msgstr ""
 msgid "Go to Ticket #{0}"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr ""
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2509,19 +2606,12 @@ msgid "Group By Field"
 msgstr ""
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr "Gjest"
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
 msgstr ""
 
 #. Name of a DocType
@@ -2554,24 +2644,36 @@ msgstr ""
 msgid "HD Comment Reaction"
 msgstr ""
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr ""
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr ""
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
 msgstr ""
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
 msgstr ""
 
 #. Name of a DocType
@@ -2592,21 +2694,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
 msgstr ""
 
 #. Name of a DocType
@@ -2648,11 +2735,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
 msgstr ""
 
 #. Name of a DocType
@@ -2750,12 +2832,6 @@ msgstr ""
 msgid "Helpdesk"
 msgstr ""
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr ""
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2772,11 +2848,6 @@ msgstr ""
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
 msgstr "Skjul "
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr ""
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
@@ -2846,15 +2917,8 @@ msgstr "Jeg forstår, legg til betingelser"
 msgid "ID"
 msgstr "ID"
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "IP-adresse"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2941,6 +3005,11 @@ msgstr "Innboks"
 msgid "Incoming"
 msgstr "Innkommende"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr ""
@@ -2954,7 +3023,7 @@ msgstr ""
 msgid "Instantly send e-mail"
 msgstr ""
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "Utilstrekkelige rettigheter for {0}"
 
@@ -2968,12 +3037,12 @@ msgstr ""
 msgid "Introduction"
 msgstr "Introduksjon"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
@@ -2982,22 +3051,42 @@ msgstr ""
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr ""
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr ""
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
+msgstr "Invitere"
+
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
@@ -3008,13 +3097,30 @@ msgstr ""
 msgid "Invite agents"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
-msgstr ""
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
+msgstr "Inviter som bruker"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
 msgstr "Invitasjon via e-post"
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
+msgstr ""
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -3030,6 +3136,11 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "Er standard"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr ""
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3057,6 +3168,10 @@ msgstr ""
 #. Label of the setup_complete (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
 msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:114
@@ -3093,11 +3208,9 @@ msgstr "Tastatursnarveier"
 msgid "Knowledge Base"
 msgstr "Kunnskapsbase"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3131,9 +3244,9 @@ msgstr ""
 msgid "Last 3 Months"
 msgstr "Siste 3 måneder"
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr ""
 
@@ -3174,7 +3287,8 @@ msgstr ""
 msgid "Last Month"
 msgstr "Forrige måned"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "Etternavn"
 
@@ -3183,23 +3297,32 @@ msgstr "Etternavn"
 msgid "Last Week"
 msgstr "Siste uke"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr ""
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
 msgstr ""
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
@@ -3216,26 +3339,6 @@ msgstr ""
 #. 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
-msgstr ""
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "Lenke"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -3264,6 +3367,8 @@ msgstr ""
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "Last inn flere"
 
@@ -3286,6 +3391,8 @@ msgstr ""
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr ""
@@ -3324,7 +3431,7 @@ msgstr ""
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr ""
 
@@ -3342,6 +3449,10 @@ msgstr ""
 
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:11
@@ -3396,6 +3507,20 @@ msgstr ""
 msgid "Mobile App Installation"
 msgstr ""
 
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr "Mobile No"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr ""
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr ""
+
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
 #. List'
@@ -3436,7 +3561,7 @@ msgid "My Tickets"
 msgstr ""
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3447,8 +3572,9 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3457,6 +3583,10 @@ msgstr "Navn"
 #. Label of the name_weight (Int) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
 msgstr ""
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
@@ -3469,10 +3599,18 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "Aldri"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3581,11 +3719,11 @@ msgstr ""
 msgid "No Data Found"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr ""
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr ""
 
@@ -3597,8 +3735,14 @@ msgstr ""
 msgid "No SLA found"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
 msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
@@ -3633,19 +3777,27 @@ msgstr ""
 msgid "No changes made"
 msgstr "Ingen endringer er gjort"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr ""
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr ""
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr ""
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
@@ -3657,7 +3809,11 @@ msgstr ""
 msgid "No feedback"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr ""
 
@@ -3697,12 +3853,17 @@ msgstr ""
 msgid "No recently assigned tickets"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr ""
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
 msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
@@ -3710,6 +3871,7 @@ msgstr ""
 msgid "No saved replies found"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr ""
@@ -3730,7 +3892,11 @@ msgstr ""
 msgid "No tickets selected"
 msgstr ""
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr ""
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "Ikke tillatt"
 
@@ -3742,7 +3908,7 @@ msgstr ""
 msgid "Not Saved"
 msgstr "Ikke lagret"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "Ikke angitt"
 
@@ -3781,11 +3947,6 @@ msgstr ""
 msgid "On Hold Since"
 msgstr ""
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr ""
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr ""
@@ -3815,6 +3976,10 @@ msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
@@ -3904,7 +4069,12 @@ msgstr ""
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr ""
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "Passord"
 
@@ -3942,6 +4112,7 @@ msgid "Pending"
 msgstr "Avventer"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr ""
 
@@ -3951,19 +4122,19 @@ msgstr ""
 msgid "Pending Tickets"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr ""
 
@@ -3984,13 +4155,14 @@ msgstr "Personlig"
 msgid "Personal mobile no"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "Telefon"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
 msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
@@ -4047,7 +4219,7 @@ msgstr ""
 msgid "Please enter a valid phone number"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr ""
 
@@ -4090,33 +4262,14 @@ msgstr "Vennligst velg ukentlig fridag"
 msgid "Policy name"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
-msgstr ""
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr ""
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr ""
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr ""
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
 msgstr ""
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
@@ -4151,14 +4304,32 @@ msgstr "Forhåndsvisning"
 msgid "Previous ticket"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "Primær"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "Primærkontakt"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr ""
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr ""
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4166,9 +4337,10 @@ msgstr ""
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4248,17 +4420,6 @@ msgstr ""
 msgid "Quarterly"
 msgstr "Kvartalsvis"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "Spørringsvalg"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr ""
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "I kø"
@@ -4281,14 +4442,14 @@ msgstr ""
 msgid "Rate this ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr ""
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4384,8 +4545,15 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "Fjern"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4395,9 +4563,18 @@ msgstr ""
 msgid "Remove Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr ""
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
 msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
@@ -4417,6 +4594,15 @@ msgstr ""
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
 msgstr ""
 
 #. Option in a Select field in the tickets Web Form
@@ -4456,16 +4642,13 @@ msgstr ""
 msgid "Reply on a ticket"
 msgstr ""
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr "Forespørselsnøkkel"
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
 msgstr ""
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
@@ -4486,6 +4669,7 @@ msgid "Reset to Default"
 msgstr ""
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr ""
@@ -4539,18 +4723,6 @@ msgstr "Respons"
 msgid "Response By"
 msgstr ""
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr ""
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr ""
@@ -4593,28 +4765,18 @@ msgstr ""
 msgid "Restrict visibility to these teams"
 msgstr ""
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr ""
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr ""
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
+msgstr ""
+
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:215
@@ -4622,8 +4784,14 @@ msgid "Ringing"
 msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "Rolle"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr ""
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4722,9 +4890,9 @@ msgstr "Lørdag"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4800,17 +4968,19 @@ msgstr ""
 msgid "Search Score"
 msgstr ""
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr ""
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "Søkefelt..."
 
@@ -4850,6 +5020,7 @@ msgstr "Søk..."
 msgid "Searched for:"
 msgstr ""
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr "Søker..."
@@ -4868,6 +5039,10 @@ msgstr "Velg"
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
 msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
@@ -4890,6 +5065,10 @@ msgstr ""
 msgid "Select a rating"
 msgstr ""
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr ""
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4901,6 +5080,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
+msgstr ""
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
@@ -4927,6 +5110,10 @@ msgstr ""
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
 msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
@@ -4967,13 +5154,17 @@ msgstr ""
 msgid "Service not supported"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "Angi"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:4
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
@@ -4984,12 +5175,21 @@ msgstr ""
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr ""
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr ""
 
@@ -5001,7 +5201,7 @@ msgstr ""
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr ""
 
@@ -5135,23 +5335,6 @@ msgstr ""
 msgid "Sort"
 msgstr ""
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr "Kilde-DocType"
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "Kildenavn"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr ""
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr ""
@@ -5196,6 +5379,8 @@ msgstr ""
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5262,6 +5447,7 @@ msgstr ""
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5373,21 +5559,16 @@ msgstr "System"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5426,8 +5607,6 @@ msgstr ""
 msgid "Teal"
 msgstr ""
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5438,7 +5617,6 @@ msgstr ""
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5544,6 +5722,10 @@ msgstr ""
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr ""
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr ""
@@ -5554,6 +5736,10 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
@@ -5576,6 +5762,14 @@ msgstr ""
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr ""
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr ""
@@ -5583,6 +5777,10 @@ msgstr ""
 #: desk/src/components/ticket/TicketMergeModal.vue:79
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
 msgstr ""
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
@@ -5652,7 +5850,7 @@ msgstr "Torsdag"
 msgid "Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr ""
 
@@ -5666,6 +5864,10 @@ msgstr ""
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
+msgstr ""
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
 msgstr ""
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
@@ -5725,7 +5927,7 @@ msgstr ""
 msgid "Ticket Summary"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr ""
 
@@ -5758,7 +5960,7 @@ msgstr ""
 msgid "Ticket merged successfully."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr ""
 
@@ -5793,12 +5995,6 @@ msgstr ""
 msgid "Ticket to merged with is required"
 msgstr ""
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr ""
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr ""
@@ -5810,12 +6006,15 @@ msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr ""
 
@@ -5827,19 +6026,19 @@ msgstr ""
 msgid "Tickets assigned to you in the last 7 days"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr ""
 
@@ -5856,6 +6055,7 @@ msgid "Tickets that are awaiting your response"
 msgstr ""
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr ""
 
@@ -5945,19 +6145,19 @@ msgstr ""
 msgid "Total Ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr ""
 
@@ -5989,6 +6189,10 @@ msgstr "Type"
 msgid "Type a message"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr ""
@@ -5998,7 +6202,7 @@ msgstr ""
 msgid "URL/Method"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr ""
 
@@ -6032,6 +6236,8 @@ msgid "Unpublish"
 msgstr "Avpubliser"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr ""
 
@@ -6048,6 +6254,10 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:214
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
+msgstr ""
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
@@ -6076,9 +6286,12 @@ msgstr "Last opp"
 msgid "Upload Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
@@ -6088,17 +6301,13 @@ msgstr ""
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6109,6 +6318,10 @@ msgstr "Bruker"
 #. Label of the user_resolution_time (Duration) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
 msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
@@ -6128,7 +6341,7 @@ msgstr "Brukere"
 msgid "Valid From"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "Verdi"
 
@@ -6257,19 +6470,23 @@ msgstr "Årlig"
 msgid "Yellow"
 msgstr "Gul"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr ""
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr ""
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr ""
 
@@ -6297,6 +6514,14 @@ msgstr ""
 msgid "You do not have permission to access Assignment Rules"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr ""
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr ""
@@ -6319,6 +6544,14 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:46
@@ -6349,7 +6582,7 @@ msgstr ""
 msgid "customize {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr "dager"
 
@@ -6400,7 +6633,7 @@ msgstr ""
 msgid "here."
 msgstr ""
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr ""
 
@@ -6408,7 +6641,7 @@ msgstr ""
 msgid "in"
 msgstr "i"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "akkurat nå"
 
@@ -6441,7 +6674,11 @@ msgstr ""
 msgid "purple"
 msgstr "lilla"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr ""
 
@@ -6458,7 +6695,7 @@ msgstr ""
 msgid "to enable this integration."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr ""
 
@@ -6466,12 +6703,32 @@ msgstr ""
 msgid "views"
 msgstr "visninger"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr ""
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
 msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:307
@@ -6498,7 +6755,7 @@ msgstr ""
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr ""
 

--- a/helpdesk/locale/nl.po
+++ b/helpdesk/locale/nl.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-15 18:50\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-29 21:57\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Dutch\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr ""
@@ -108,14 +108,6 @@ msgstr ""
 msgid "A workday with this name already exists"
 msgstr ""
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr "API"
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr ""
@@ -132,7 +124,7 @@ msgstr ""
 msgid "Account"
 msgstr "Rekening"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr ""
 
@@ -152,11 +144,9 @@ msgstr "Actie"
 msgid "Action Required"
 msgstr ""
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr ""
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "Acties"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr ""
 msgid "Active"
 msgstr "Actief"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr ""
 
@@ -175,7 +165,7 @@ msgid "Active: The agent is available and working.<br>\n"
 "Unavailable: The agent is off and unavailable."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "Activiteit"
@@ -193,10 +183,11 @@ msgid "Add Column"
 msgstr "Kolom toevoegen"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "Filter toevoegen..."
 
@@ -206,6 +197,10 @@ msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
 msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:148
@@ -244,7 +239,7 @@ msgstr "Voorwaarde toevoegen"
 msgid "Add condition group"
 msgstr "Voorwaardengroep toevoegen"
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "Voeg filter toe"
 
@@ -278,6 +273,12 @@ msgstr ""
 msgid "Add to Holidays"
 msgstr "Voeg toe aan vakanties"
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr ""
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr ""
@@ -295,17 +296,14 @@ msgid "Administrator"
 msgstr "Beheerder"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -316,6 +314,7 @@ msgstr "Beheerder"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -335,6 +334,7 @@ msgstr ""
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -342,6 +342,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -376,18 +377,9 @@ msgstr ""
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "Allemaal"
 
@@ -508,6 +500,14 @@ msgstr ""
 msgid "Are you sure you want to delete these articles?"
 msgstr ""
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr ""
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr ""
@@ -543,6 +543,10 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
 msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
@@ -595,16 +599,11 @@ msgstr ""
 msgid "Assign ticket"
 msgstr ""
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr "Assign to"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -618,7 +617,7 @@ msgstr "Toegewezene"
 msgid "Assignee Rules"
 msgstr "Toegewezen regels"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr ""
 
@@ -626,7 +625,7 @@ msgstr ""
 msgid "Assignees"
 msgstr "Toegewezenen"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr ""
 
@@ -692,10 +691,6 @@ msgstr ""
 msgid "Assignment rule {0} updated successfully."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -711,10 +706,6 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
-msgstr ""
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
 msgstr ""
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
@@ -766,7 +757,7 @@ msgid "Automation"
 msgstr "Automatisering"
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr ""
@@ -802,7 +793,7 @@ msgstr "Gemiddelde reactietijd"
 msgid "Average Time Metrics"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr ""
 
@@ -810,24 +801,36 @@ msgstr ""
 msgid "Average response and resolution metrics not available"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
 msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
@@ -840,11 +843,11 @@ msgstr ""
 msgid "Avg. resolution time"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr ""
 
@@ -867,11 +870,6 @@ msgstr ""
 msgid "Base Support Rotation"
 msgstr ""
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "Basis-URL"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -885,11 +883,11 @@ msgstr "Selecteer op basis van uw HR-beleid de einddatum van uw verlofperiode."
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr "Selecteer op basis van uw HR-beleid de startdatum van uw verlofperiode."
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr ""
 
@@ -944,11 +942,6 @@ msgstr ""
 msgid "Busy"
 msgstr "Druk bezig"
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "Knop"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr "CSV"
@@ -973,19 +966,31 @@ msgstr "Gespreksduur in seconden"
 msgid "Caller"
 msgstr "Beller"
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr "Oproepen"
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr ""
 
@@ -1025,7 +1030,7 @@ msgstr "Kan regel niet inschakelen zonder gebruikers toe te voegen"
 msgid "Cannot merge General category"
 msgstr ""
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr ""
 
@@ -1073,11 +1078,11 @@ msgstr ""
 msgid "Category updated successfully."
 msgstr "Categorie succesvol bijgewerkt."
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr ""
 
@@ -1085,7 +1090,7 @@ msgstr ""
 msgid "Change"
 msgstr "Verandering"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "Wachtwoord wijzigen"
@@ -1098,9 +1103,8 @@ msgstr ""
 msgid "Change language of the application."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
@@ -1123,7 +1127,7 @@ msgstr ""
 msgid "Change timezone of the application."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr ""
 
@@ -1136,7 +1140,7 @@ msgstr ""
 msgid "Child field"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr ""
 
@@ -1189,7 +1193,7 @@ msgstr "Wis sortering"
 msgid "Clear Table"
 msgstr "Tafel leegmaken"
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr ""
 
@@ -1204,6 +1208,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
 msgstr "Klik op 'Toevoegen aan feestdagen'. Hiermee wordt de tabel met feestdagen gevuld met alle datums die op de geselecteerde vrije week vallen. Herhaal dit proces om de datums voor al uw wekelijkse feestdagen in te vullen."
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:47
@@ -1223,7 +1231,7 @@ msgstr ""
 msgid "Closed"
 msgstr "Gesloten"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr ""
 
@@ -1250,7 +1258,7 @@ msgstr "Kolommen"
 msgid "Comma separated emails to invite."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr ""
 
@@ -1283,7 +1291,7 @@ msgstr ""
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "Reacties"
@@ -1296,6 +1304,11 @@ msgstr "Communicatie"
 msgid "Communication ID is required"
 msgstr ""
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
+msgstr "Bedrijf"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
 msgstr "Voltooid"
@@ -1307,7 +1320,7 @@ msgstr "Voltooid"
 msgid "Condition"
 msgstr "Voorwaarde"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr ""
 
@@ -1331,6 +1344,10 @@ msgstr ""
 msgid "Configure your telephony settings."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1356,10 +1373,11 @@ msgstr "Bevestig overschrijven"
 msgid "Connect your support email"
 msgstr ""
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1373,26 +1391,30 @@ msgstr "Contact"
 msgid "Contact HTML"
 msgstr "Contact HTML"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
 msgstr ""
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
 msgstr "Contactpersonen"
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
+msgstr ""
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
 #. Label of the content (Text Editor) field in DocType 'HD Article'
@@ -1415,7 +1437,7 @@ msgstr ""
 msgid "Copy ticket id"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr ""
 
@@ -1423,7 +1445,11 @@ msgstr ""
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr ""
 
@@ -1431,11 +1457,20 @@ msgstr ""
 msgid "Could not send feedback email,due to: {0}"
 msgstr ""
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "Land"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1446,9 +1481,13 @@ msgstr "Creëren"
 msgid "Create & invite a contact"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
-msgstr "Nieuw contact maken"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
 msgid "Create View"
@@ -1482,12 +1521,6 @@ msgstr ""
 msgid "Creating a ticket"
 msgstr ""
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr ""
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr ""
@@ -1512,12 +1545,21 @@ msgid "Custom Views"
 msgstr ""
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
 msgstr "Klant"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
+msgstr ""
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1528,17 +1570,33 @@ msgstr "klantnaam"
 msgid "Customer Portal"
 msgstr ""
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
-msgstr "Klant succesvol aangemaakt."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr "Klanttype"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
 msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
+msgstr "Klanten"
 
 #: desk/src/components/layouts/Sidebar.vue:595
 msgid "Customers & Contacts"
@@ -1565,6 +1623,8 @@ msgstr "Cyaan"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "Gevaar"
@@ -1665,18 +1725,26 @@ msgstr ""
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr ""
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "Verwijder"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1692,6 +1760,10 @@ msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
+msgstr ""
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
 msgstr ""
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
@@ -1740,7 +1812,7 @@ msgstr ""
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1826,7 +1898,12 @@ msgstr ""
 msgid "Document Type"
 msgstr "Soort document"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr ""
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "Domein"
@@ -1867,6 +1944,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
@@ -1917,7 +1998,8 @@ msgstr ""
 msgid "Easily invite new agents, managers, or admins."
 msgstr ""
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1926,6 +2008,14 @@ msgstr "Bewerk"
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
 msgstr "Oproeplog bewerken"
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
+msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:70
 #: desk/src/components/Settings/EmailEdit.vue:63
@@ -1944,10 +2034,10 @@ msgstr ""
 msgid "Edit your email account"
 msgstr ""
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "E-mail"
 
@@ -1975,9 +2065,10 @@ msgstr "E-mail account"
 msgid "Email Content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
-msgstr "E-mail-ID"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
+msgstr "E-mailadres"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
 #. Settings'
@@ -2002,22 +2093,22 @@ msgstr ""
 msgid "Email account updated successfully"
 msgstr "E-mailaccount succesvol bijgewerkt"
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr ""
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr ""
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "E-mails"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr ""
 
@@ -2055,8 +2146,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr ""
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2081,8 +2170,6 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2105,20 +2192,24 @@ msgstr "Eindtijd"
 msgid "Enter a name for this HD Service Holiday List."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr ""
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr "Voer merknaam in"
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr ""
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
 msgstr ""
 
 #: helpdesk/api/knowledge_base.py:86
@@ -2129,22 +2220,18 @@ msgstr ""
 msgid "Error processing email at index {0}, message: {1}"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr ""
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "Fout bij het verbinden met e-mailaccount {0}"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr ""
 
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
 msgstr "Excel"
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
+msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
 #: desk/src/components/Settings/Telephony/Telephony.vue:96
@@ -2172,11 +2259,6 @@ msgstr "Exporteer alle {0} Record(s)"
 msgid "Export Type"
 msgstr "Exporttype"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr ""
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2184,6 +2266,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "Gefaald"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2218,11 +2304,11 @@ msgstr ""
 msgid "Failed to save Twilio settings"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr ""
 
@@ -2251,6 +2337,7 @@ msgstr "Favicon"
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2288,12 +2375,16 @@ msgstr ""
 msgid "Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
+msgstr ""
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
 msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
@@ -2338,13 +2429,14 @@ msgid "Field dependency updated successfully."
 msgstr ""
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "Velden"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "Filters"
@@ -2354,7 +2446,8 @@ msgstr "Filters"
 msgid "Find out all of the variables that can be used in the content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "Voornaam"
 
@@ -2362,6 +2455,10 @@ msgstr "Voornaam"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
 msgstr "Eerste reactie op"
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
+msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -2385,10 +2482,6 @@ msgstr "Eerste reactietijd"
 #. Name of a report
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -2480,6 +2573,10 @@ msgstr ""
 msgid "Go to Ticket #{0}"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr ""
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2509,19 +2606,12 @@ msgid "Group By Field"
 msgstr "Groepeer op veld"
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr "Gast"
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
 msgstr ""
 
 #. Name of a DocType
@@ -2554,24 +2644,36 @@ msgstr ""
 msgid "HD Comment Reaction"
 msgstr ""
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr ""
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr ""
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
 msgstr ""
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
 msgstr ""
 
 #. Name of a DocType
@@ -2592,21 +2694,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
 msgstr ""
 
 #. Name of a DocType
@@ -2648,11 +2735,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
 msgstr ""
 
 #. Name of a DocType
@@ -2750,12 +2832,6 @@ msgstr ""
 msgid "Helpdesk"
 msgstr "Helpdesk"
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr ""
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2772,11 +2848,6 @@ msgstr "Hoi"
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
 msgstr "Verberg "
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr ""
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
@@ -2846,15 +2917,8 @@ msgstr "Ik begrijp het, voeg voorwaarden toe"
 msgid "ID"
 msgstr "ID"
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "IP-adres"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2941,6 +3005,11 @@ msgstr "Postvak IN"
 msgid "Incoming"
 msgstr "Inkomend"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr "Individueel"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr "geïnitieerd"
@@ -2954,7 +3023,7 @@ msgstr ""
 msgid "Instantly send e-mail"
 msgstr ""
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "Onvoldoende Toestemming voor {0}"
 
@@ -2968,12 +3037,12 @@ msgstr ""
 msgid "Introduction"
 msgstr "Invoering"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
@@ -2982,22 +3051,42 @@ msgstr ""
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr "Ongeldige velden, controleer of alle velden zijn ingevuld en de waarden correct zijn."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr ""
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr ""
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
+msgstr "Nodig uit"
+
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
@@ -3008,12 +3097,29 @@ msgstr "Agent uitnodigen"
 msgid "Invite agents"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
-msgstr ""
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
+msgstr "Uitnodigen als gebruiker"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
 msgstr ""
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
@@ -3030,6 +3136,11 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "Is Standaard"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr ""
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3057,6 +3168,10 @@ msgstr ""
 #. Label of the setup_complete (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
 msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:114
@@ -3093,11 +3208,9 @@ msgstr "Toetsenbord sneltoetsen"
 msgid "Knowledge Base"
 msgstr "Kennis basis"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3131,9 +3244,9 @@ msgstr "Laatste"
 msgid "Last 3 Months"
 msgstr "Laatste 3 maanden"
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr ""
 
@@ -3174,7 +3287,8 @@ msgstr ""
 msgid "Last Month"
 msgstr "Vorige maand"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "Achternaam"
 
@@ -3183,24 +3297,33 @@ msgstr "Achternaam"
 msgid "Last Week"
 msgstr "Vorige week"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr "Laatst gebruiker toegewezen door deze regel"
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
 msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
+msgstr "laatst"
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -3216,26 +3339,6 @@ msgstr "Lees meer over de voorwaarden"
 #. 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
-msgstr ""
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "Link"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr "Linkopties"
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -3264,6 +3367,8 @@ msgstr "Laad standaard Kolommen"
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "Meer laden"
 
@@ -3286,6 +3391,8 @@ msgstr "Inloggen bij Frappe Cloud"
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr "Logo"
@@ -3324,7 +3431,7 @@ msgstr ""
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr ""
 
@@ -3343,6 +3450,10 @@ msgstr ""
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
+msgstr "Manager"
 
 #: desk/src/pages/MobileNotifications.vue:11
 #: desk/src/pages/MobileNotifications.vue:14
@@ -3396,6 +3507,20 @@ msgstr ""
 msgid "Mobile App Installation"
 msgstr ""
 
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr "Mobiel nummer"
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr ""
+
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
 #. List'
@@ -3436,7 +3561,7 @@ msgid "My Tickets"
 msgstr ""
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3447,8 +3572,9 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3458,6 +3584,10 @@ msgstr "Naam"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
 msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
+msgstr "Naam is vereist"
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
 #. Ticket Status'
@@ -3469,10 +3599,18 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "Nooit"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3581,11 +3719,11 @@ msgstr "Geen antwoord"
 msgid "No Data Found"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr ""
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr ""
 
@@ -3597,8 +3735,14 @@ msgstr ""
 msgid "No SLA found"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
 msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
@@ -3633,19 +3777,27 @@ msgstr ""
 msgid "No changes made"
 msgstr "Geen wijzigingen aangebracht"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr ""
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr ""
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr ""
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
@@ -3657,7 +3809,11 @@ msgstr ""
 msgid "No feedback"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr ""
 
@@ -3697,19 +3853,25 @@ msgstr ""
 msgid "No recently assigned tickets"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr ""
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
 msgstr "No results found"
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
+msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:91
 msgid "No saved replies found"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr ""
@@ -3730,7 +3892,11 @@ msgstr ""
 msgid "No tickets selected"
 msgstr ""
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr ""
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "Niet Toegestaan"
 
@@ -3742,7 +3908,7 @@ msgstr ""
 msgid "Not Saved"
 msgstr "Niet opgeslagen"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "niet ingesteld"
 
@@ -3781,11 +3947,6 @@ msgstr ""
 msgid "On Hold Since"
 msgstr "In de wacht sinds"
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr ""
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr ""
@@ -3815,6 +3976,10 @@ msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
@@ -3904,7 +4069,12 @@ msgstr ""
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr "Partnerschap"
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "Wachtwoord"
 
@@ -3942,6 +4112,7 @@ msgid "Pending"
 msgstr "In afwachting van"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr "In afwachting van uitnodigingen"
 
@@ -3951,19 +4122,19 @@ msgstr "In afwachting van uitnodigingen"
 msgid "Pending Tickets"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr ""
 
@@ -3984,13 +4155,14 @@ msgstr "Persoonlijk"
 msgid "Personal mobile no"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "Telefoon"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
 msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
@@ -4047,7 +4219,7 @@ msgstr ""
 msgid "Please enter a valid phone number"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr ""
 
@@ -4090,34 +4262,15 @@ msgstr "Selecteer wekelijkse vrije dag"
 msgid "Policy name"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
 msgstr ""
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr "Legenda voor berichtbeschrijving"
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr "Lijst met route-sleutels voor berichten"
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr "Postroute String"
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
-msgstr "Legenda voor berichttitels"
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:10
@@ -4151,14 +4304,32 @@ msgstr "Voorbeeld"
 msgid "Previous ticket"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "Primair"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "Primaire contactpersoon"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr ""
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr "Prioriteiten"
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4166,9 +4337,10 @@ msgstr "Prioriteiten"
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4248,17 +4420,6 @@ msgstr ""
 msgid "Quarterly"
 msgstr "Kwartaal"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "Zoekopties"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr "Queryroute-string"
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "Wachtrij"
@@ -4281,14 +4442,14 @@ msgstr ""
 msgid "Rate this ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr ""
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4384,8 +4545,15 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "Verwijderen"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4395,9 +4563,18 @@ msgstr ""
 msgid "Remove Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr "Verwijder afbeelding"
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
 msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
@@ -4417,6 +4594,15 @@ msgstr ""
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
 msgstr ""
 
 #. Option in a Select field in the tickets Web Form
@@ -4456,16 +4642,13 @@ msgstr ""
 msgid "Reply on a ticket"
 msgstr ""
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr "Sleutel aanvragen"
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
 msgstr ""
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
@@ -4486,6 +4669,7 @@ msgid "Reset to Default"
 msgstr "Terug naar standaardwaarde"
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr "Oplossing"
@@ -4539,18 +4723,6 @@ msgstr "Antwoord"
 msgid "Response By"
 msgstr "Reactie van"
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr "Antwoordopties"
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr "Antwoordresultaat Sleutelpad"
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr "Reactietijd voor {0} prioriteit in rij {1} kan niet groter zijn dan Oplossingstijd."
@@ -4593,37 +4765,33 @@ msgstr ""
 msgid "Restrict visibility to these teams"
 msgstr ""
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr "Resultaatvoorbeeldveld"
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr "Resultaat Routeveld"
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr "Resultaattitelveld"
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
 msgstr "Recensies"
 
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:215
 msgid "Ringing"
 msgstr "rinkelen"
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "Rol"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr "Rol succesvol bijgewerkt"
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4722,9 +4890,9 @@ msgstr "Zaterdag"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4800,17 +4968,19 @@ msgstr ""
 msgid "Search Score"
 msgstr ""
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr "Zoekterm Parameternaam"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "Zoekvelden..."
 
@@ -4850,6 +5020,7 @@ msgstr "Zoeken..."
 msgid "Searched for:"
 msgstr ""
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr "Zoeken..."
@@ -4868,6 +5039,10 @@ msgstr "Kiezen"
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
 msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
@@ -4890,6 +5065,10 @@ msgstr "Selecteer een standaardprioriteit."
 msgid "Select a rating"
 msgstr ""
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr ""
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4901,6 +5080,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
+msgstr ""
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
@@ -4927,6 +5110,10 @@ msgstr ""
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
 msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
@@ -4967,13 +5154,17 @@ msgstr "Serviceniveaunaam"
 msgid "Service not supported"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "Instellen"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:4
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
@@ -4984,12 +5175,21 @@ msgstr ""
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr "Stel de reactietijd in voor prioriteit {0} in rij {1}."
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr ""
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr ""
 
@@ -5001,7 +5201,7 @@ msgstr ""
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr ""
 
@@ -5135,23 +5335,6 @@ msgstr ""
 msgid "Sort"
 msgstr "Sorteren"
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr "Bron DocType"
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "Bronnaam"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr "Brontype"
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr ""
@@ -5196,6 +5379,8 @@ msgstr ""
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5262,6 +5447,7 @@ msgstr ""
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5373,21 +5559,16 @@ msgstr "Systeem"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5426,8 +5607,6 @@ msgstr ""
 msgid "Teal"
 msgstr "Groenblauw"
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5438,7 +5617,6 @@ msgstr "Groenblauw"
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5544,6 +5722,10 @@ msgstr ""
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr ""
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr ""
@@ -5554,6 +5736,10 @@ msgstr "De vakantie op {0} is niet tussen Van Datum en To Date"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
@@ -5576,6 +5762,14 @@ msgstr ""
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr ""
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr ""
@@ -5583,6 +5777,10 @@ msgstr ""
 #: desk/src/components/ticket/TicketMergeModal.vue:79
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
 msgstr ""
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
@@ -5652,7 +5850,7 @@ msgstr "Donderdag"
 msgid "Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr ""
 
@@ -5666,6 +5864,10 @@ msgstr ""
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
+msgstr ""
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
 msgstr ""
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
@@ -5725,7 +5927,7 @@ msgstr ""
 msgid "Ticket Summary"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr ""
 
@@ -5758,7 +5960,7 @@ msgstr ""
 msgid "Ticket merged successfully."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr ""
 
@@ -5793,12 +5995,6 @@ msgstr ""
 msgid "Ticket to merged with is required"
 msgstr ""
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr ""
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr ""
@@ -5810,12 +6006,15 @@ msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr ""
 
@@ -5827,19 +6026,19 @@ msgstr ""
 msgid "Tickets assigned to you in the last 7 days"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr ""
 
@@ -5856,6 +6055,7 @@ msgid "Tickets that are awaiting your response"
 msgstr ""
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr "Tijdzone"
 
@@ -5945,19 +6145,19 @@ msgstr "Totaal aantal vakantiedagen"
 msgid "Total Ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr ""
 
@@ -5989,6 +6189,10 @@ msgstr "Type"
 msgid "Type a message"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr ""
@@ -5998,7 +6202,7 @@ msgstr ""
 msgid "URL/Method"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr ""
 
@@ -6032,6 +6236,8 @@ msgid "Unpublish"
 msgstr "De-publiceren"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr "Niet opgeslagen"
 
@@ -6049,6 +6255,10 @@ msgstr "Niet opgeslagen"
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
 msgstr "Niet-opgeslagen wijzigingen"
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
 msgid "Untitled"
@@ -6076,10 +6286,13 @@ msgstr "Uploaden"
 msgid "Upload Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
 msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
+msgstr "Afbeelding uploaden"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
 msgid "Uploading {0}%"
@@ -6088,17 +6301,13 @@ msgstr "{0}% uploaden"
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6110,6 +6319,10 @@ msgstr "Gebruiker"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
 msgstr "Oplossingstijd voor de gebruiker"
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
+msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
 msgid "User Signup"
@@ -6128,7 +6341,7 @@ msgstr "Gebruikers"
 msgid "Valid From"
 msgstr "Geldig vanaf"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "Waarde"
 
@@ -6257,19 +6470,23 @@ msgstr "Jaarlijks"
 msgid "Yellow"
 msgstr "Geel"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr ""
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr ""
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr "U hebt geen toegang tot deze bron."
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr ""
 
@@ -6297,6 +6514,14 @@ msgstr ""
 msgid "You do not have permission to access Assignment Rules"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr ""
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr ""
@@ -6319,6 +6544,14 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:46
@@ -6349,7 +6582,7 @@ msgstr ""
 msgid "customize {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr "dagen"
 
@@ -6400,7 +6633,7 @@ msgstr "Hier"
 msgid "here."
 msgstr ""
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr ""
 
@@ -6408,7 +6641,7 @@ msgstr ""
 msgid "in"
 msgstr "in"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "net nu"
 
@@ -6441,7 +6674,11 @@ msgstr ""
 msgid "purple"
 msgstr "paars"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr ""
 
@@ -6458,7 +6695,7 @@ msgstr ""
 msgid "to enable this integration."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr ""
 
@@ -6466,12 +6703,32 @@ msgstr ""
 msgid "views"
 msgstr "keer bekeken"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr ""
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
 msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:307
@@ -6498,7 +6755,7 @@ msgstr ""
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr ""
 

--- a/helpdesk/locale/pl.po
+++ b/helpdesk/locale/pl.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-15 18:50\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-29 21:57\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Polish\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr ""
@@ -108,14 +108,6 @@ msgstr ""
 msgid "A workday with this name already exists"
 msgstr ""
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr ""
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr ""
@@ -132,7 +124,7 @@ msgstr ""
 msgid "Account"
 msgstr "Konto"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr ""
 
@@ -152,11 +144,9 @@ msgstr "Akcja"
 msgid "Action Required"
 msgstr ""
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr ""
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "Akcje"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr ""
 msgid "Active"
 msgstr "Aktywny"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr ""
 
@@ -175,7 +165,7 @@ msgid "Active: The agent is available and working.<br>\n"
 "Unavailable: The agent is off and unavailable."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "Aktywność"
@@ -193,10 +183,11 @@ msgid "Add Column"
 msgstr "Dodaj kolumnę"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "Dodaj filtr..."
 
@@ -206,6 +197,10 @@ msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
 msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:148
@@ -244,7 +239,7 @@ msgstr "Dodaj warunek"
 msgid "Add condition group"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "Dodaj filtr"
 
@@ -278,6 +273,12 @@ msgstr ""
 msgid "Add to Holidays"
 msgstr ""
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr ""
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr ""
@@ -295,17 +296,14 @@ msgid "Administrator"
 msgstr "Administrator"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -316,6 +314,7 @@ msgstr "Administrator"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -335,6 +334,7 @@ msgstr ""
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -342,6 +342,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -376,18 +377,9 @@ msgstr ""
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "Wszystko"
 
@@ -508,6 +500,14 @@ msgstr ""
 msgid "Are you sure you want to delete these articles?"
 msgstr ""
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr ""
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr ""
@@ -543,6 +543,10 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
 msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
@@ -595,16 +599,11 @@ msgstr ""
 msgid "Assign ticket"
 msgstr ""
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr ""
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -618,7 +617,7 @@ msgstr "Przypisany"
 msgid "Assignee Rules"
 msgstr "Reguły przypisania"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr ""
 
@@ -626,14 +625,14 @@ msgstr ""
 msgid "Assignees"
 msgstr "Osoby przypisane"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "Assignment"
-msgstr "Przypisanie"
+msgstr "Zadanie"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:122
 msgid "Assignment Condition"
@@ -692,10 +691,6 @@ msgstr ""
 msgid "Assignment rule {0} updated successfully."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -711,10 +706,6 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
-msgstr ""
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
 msgstr ""
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
@@ -766,7 +757,7 @@ msgid "Automation"
 msgstr "Automatyzacja"
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr ""
@@ -802,7 +793,7 @@ msgstr "Średni czas odpowiedzi"
 msgid "Average Time Metrics"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr ""
 
@@ -810,24 +801,36 @@ msgstr ""
 msgid "Average response and resolution metrics not available"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
 msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
@@ -840,11 +843,11 @@ msgstr ""
 msgid "Avg. resolution time"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr ""
 
@@ -867,11 +870,6 @@ msgstr ""
 msgid "Base Support Rotation"
 msgstr ""
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "Bazowy URL"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -885,11 +883,11 @@ msgstr ""
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr ""
 
@@ -944,11 +942,6 @@ msgstr ""
 msgid "Busy"
 msgstr ""
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "Przycisk"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr ""
@@ -973,19 +966,31 @@ msgstr ""
 msgid "Caller"
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr ""
 
@@ -1025,7 +1030,7 @@ msgstr ""
 msgid "Cannot merge General category"
 msgstr ""
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr ""
 
@@ -1073,11 +1078,11 @@ msgstr ""
 msgid "Category updated successfully."
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr ""
 
@@ -1085,7 +1090,7 @@ msgstr ""
 msgid "Change"
 msgstr "Monety"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "Zmień Hasło"
@@ -1098,9 +1103,8 @@ msgstr ""
 msgid "Change language of the application."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
@@ -1123,7 +1127,7 @@ msgstr ""
 msgid "Change timezone of the application."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr ""
 
@@ -1136,7 +1140,7 @@ msgstr ""
 msgid "Child field"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr ""
 
@@ -1189,7 +1193,7 @@ msgstr ""
 msgid "Clear Table"
 msgstr "Wyczyść tabelę"
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr ""
 
@@ -1203,6 +1207,10 @@ msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
@@ -1223,7 +1231,7 @@ msgstr ""
 msgid "Closed"
 msgstr "Zamknięte"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr ""
 
@@ -1250,7 +1258,7 @@ msgstr "Kolumny"
 msgid "Comma separated emails to invite."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr ""
 
@@ -1283,7 +1291,7 @@ msgstr ""
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "Komentarze"
@@ -1294,6 +1302,11 @@ msgstr "Komunikacja"
 
 #: desk/src/components/ticket/TicketSplitModal.vue:76
 msgid "Communication ID is required"
+msgstr ""
+
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:209
@@ -1307,7 +1320,7 @@ msgstr "Zakończono"
 msgid "Condition"
 msgstr "Stan"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr ""
 
@@ -1331,6 +1344,10 @@ msgstr ""
 msgid "Configure your telephony settings."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1356,10 +1373,11 @@ msgstr ""
 msgid "Connect your support email"
 msgstr ""
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1373,25 +1391,29 @@ msgstr "Kontakt"
 msgid "Contact HTML"
 msgstr "HTML kontaktu"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
 msgstr ""
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
 msgstr ""
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
@@ -1415,7 +1437,7 @@ msgstr ""
 msgid "Copy ticket id"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr ""
 
@@ -1423,7 +1445,11 @@ msgstr ""
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr ""
 
@@ -1431,11 +1457,20 @@ msgstr ""
 msgid "Could not send feedback email,due to: {0}"
 msgstr ""
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "Kraj"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1446,9 +1481,13 @@ msgstr "Utwórz"
 msgid "Create & invite a contact"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
 msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
+msgstr "Utwórz klienta"
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
 msgid "Create View"
@@ -1482,12 +1521,6 @@ msgstr ""
 msgid "Creating a ticket"
 msgstr ""
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr ""
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr ""
@@ -1512,11 +1545,20 @@ msgid "Custom Views"
 msgstr ""
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
 msgstr ""
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
@@ -1528,16 +1570,32 @@ msgstr ""
 msgid "Customer Portal"
 msgstr ""
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
-msgstr "Klient został utworzony poprawnie."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
 msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:595
@@ -1565,6 +1623,8 @@ msgstr "Cyjan"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "Niebezpieczeństwo"
@@ -1622,7 +1682,7 @@ msgstr "Domyślne wysyłanie i skrzynka odbiorcza"
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Default Ticket Status"
-msgstr ""
+msgstr "Domyślny status zgłoszenia"
 
 #: desk/src/pages/ticket/Tickets.vue:354 desk/src/pages/ticket/Tickets.vue:447
 msgid "Default Views"
@@ -1665,18 +1725,26 @@ msgstr ""
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr "Zdefiniuj, kto otrzyma zgłoszenia i w jaki sposób będą one rozdzielane pomiędzy agentów."
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "Usuń"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1692,6 +1760,10 @@ msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
+msgstr ""
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
 msgstr ""
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
@@ -1740,7 +1812,7 @@ msgstr ""
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1826,7 +1898,12 @@ msgstr ""
 msgid "Document Type"
 msgstr "Typ dokumentu"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr ""
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "Domena"
@@ -1867,6 +1944,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
@@ -1917,7 +1998,8 @@ msgstr ""
 msgid "Easily invite new agents, managers, or admins."
 msgstr ""
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1925,6 +2007,14 @@ msgstr "Edytuj"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
 msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:70
@@ -1944,10 +2034,10 @@ msgstr ""
 msgid "Edit your email account"
 msgstr ""
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "E-mail"
 
@@ -1975,8 +2065,9 @@ msgstr ""
 msgid "Email Content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
 msgstr "ID e-mail"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
@@ -2002,22 +2093,22 @@ msgstr ""
 msgid "Email account updated successfully"
 msgstr ""
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr ""
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr ""
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "E-maile"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr ""
 
@@ -2055,8 +2146,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr ""
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2081,8 +2170,6 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2105,20 +2192,24 @@ msgstr "Godzina zakończenia"
 msgid "Enter a name for this HD Service Holiday List."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr ""
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr ""
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
 msgstr ""
 
 #: helpdesk/api/knowledge_base.py:86
@@ -2129,21 +2220,17 @@ msgstr ""
 msgid "Error processing email at index {0}, message: {1}"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr ""
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "Wystąpił błąd podczas łączenia się z kontem e-mail {0}"
 
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr ""
-
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
 msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
@@ -2172,11 +2259,6 @@ msgstr ""
 msgid "Export Type"
 msgstr "Typ eksportu"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr ""
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2184,6 +2266,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "Niepowodzenie"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2218,11 +2304,11 @@ msgstr ""
 msgid "Failed to save Twilio settings"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr ""
 
@@ -2251,6 +2337,7 @@ msgstr ""
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2288,12 +2375,16 @@ msgstr ""
 msgid "Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
+msgstr ""
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
 msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
@@ -2338,13 +2429,14 @@ msgid "Field dependency updated successfully."
 msgstr ""
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "Pola"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "Filtry"
@@ -2354,7 +2446,8 @@ msgstr "Filtry"
 msgid "Find out all of the variables that can be used in the content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "Imię"
 
@@ -2362,6 +2455,10 @@ msgstr "Imię"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
 msgstr "Data pierwszej odpowiedzi"
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
+msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -2385,10 +2482,6 @@ msgstr ""
 #. Name of a report
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -2480,6 +2573,10 @@ msgstr ""
 msgid "Go to Ticket #{0}"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr ""
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2509,19 +2606,12 @@ msgid "Group By Field"
 msgstr ""
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
 msgstr ""
 
 #. Name of a DocType
@@ -2554,24 +2644,36 @@ msgstr ""
 msgid "HD Comment Reaction"
 msgstr ""
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr ""
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr ""
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
 msgstr ""
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
 msgstr ""
 
 #. Name of a DocType
@@ -2592,21 +2694,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
 msgstr ""
 
 #. Name of a DocType
@@ -2648,11 +2735,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
 msgstr ""
 
 #. Name of a DocType
@@ -2750,12 +2832,6 @@ msgstr ""
 msgid "Helpdesk"
 msgstr ""
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr ""
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2772,11 +2848,6 @@ msgstr ""
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
 msgstr "Ukryj "
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr ""
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
@@ -2846,15 +2917,8 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "Adres IP"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2941,6 +3005,11 @@ msgstr "W pudełku"
 msgid "Incoming"
 msgstr "Przychodzące"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr ""
@@ -2954,7 +3023,7 @@ msgstr ""
 msgid "Instantly send e-mail"
 msgstr ""
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "Niewystarczająca zgoda na {0}"
 
@@ -2968,12 +3037,12 @@ msgstr ""
 msgid "Introduction"
 msgstr "Wprowadzenie"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
@@ -2982,22 +3051,42 @@ msgstr ""
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr ""
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr ""
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
 msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
@@ -3008,12 +3097,29 @@ msgstr ""
 msgid "Invite agents"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
-msgstr ""
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
+msgstr "Zaproś jako użytkownika"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
 msgstr ""
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
@@ -3030,6 +3136,11 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "Domyślny"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr ""
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3057,6 +3168,10 @@ msgstr ""
 #. Label of the setup_complete (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
 msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:114
@@ -3093,11 +3208,9 @@ msgstr "Skróty klawiszowe"
 msgid "Knowledge Base"
 msgstr "Baza wiedzy"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3131,9 +3244,9 @@ msgstr ""
 msgid "Last 3 Months"
 msgstr "Ostatnie 3 miesiące"
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr ""
 
@@ -3174,7 +3287,8 @@ msgstr ""
 msgid "Last Month"
 msgstr "Ostatni miesiąc"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "Nazwisko"
 
@@ -3183,23 +3297,32 @@ msgstr "Nazwisko"
 msgid "Last Week"
 msgstr "Ostatni tydzień"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr ""
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
 msgstr ""
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
@@ -3216,26 +3339,6 @@ msgstr ""
 #. 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
-msgstr ""
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "Połączyć"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr "Opcje linku"
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -3264,6 +3367,8 @@ msgstr ""
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "Załaduj więcej"
 
@@ -3286,6 +3391,8 @@ msgstr ""
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr ""
@@ -3324,7 +3431,7 @@ msgstr ""
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr ""
 
@@ -3343,6 +3450,10 @@ msgstr ""
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
+msgstr "Menager"
 
 #: desk/src/pages/MobileNotifications.vue:11
 #: desk/src/pages/MobileNotifications.vue:14
@@ -3396,6 +3507,20 @@ msgstr ""
 msgid "Mobile App Installation"
 msgstr ""
 
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr ""
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr ""
+
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
 #. List'
@@ -3436,7 +3561,7 @@ msgid "My Tickets"
 msgstr ""
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3447,8 +3572,9 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3457,6 +3583,10 @@ msgstr "Nazwa"
 #. Label of the name_weight (Int) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
 msgstr ""
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
@@ -3469,10 +3599,18 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "Nigdy"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3581,11 +3719,11 @@ msgstr ""
 msgid "No Data Found"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr ""
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr ""
 
@@ -3597,8 +3735,14 @@ msgstr ""
 msgid "No SLA found"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
 msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
@@ -3633,19 +3777,27 @@ msgstr ""
 msgid "No changes made"
 msgstr "Nie dokonano zmian"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr ""
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr ""
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr ""
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
@@ -3657,7 +3809,11 @@ msgstr ""
 msgid "No feedback"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr ""
 
@@ -3697,12 +3853,17 @@ msgstr ""
 msgid "No recently assigned tickets"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr ""
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
 msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
@@ -3710,6 +3871,7 @@ msgstr ""
 msgid "No saved replies found"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr ""
@@ -3730,7 +3892,11 @@ msgstr ""
 msgid "No tickets selected"
 msgstr ""
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr ""
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "Niedozwolone"
 
@@ -3742,7 +3908,7 @@ msgstr ""
 msgid "Not Saved"
 msgstr "Nie zapisano"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "Nie ustawiono"
 
@@ -3781,11 +3947,6 @@ msgstr ""
 msgid "On Hold Since"
 msgstr ""
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr ""
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr ""
@@ -3815,6 +3976,10 @@ msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
@@ -3904,7 +4069,12 @@ msgstr ""
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr ""
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "Hasło"
 
@@ -3942,6 +4112,7 @@ msgid "Pending"
 msgstr "Oczekujące"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr ""
 
@@ -3951,19 +4122,19 @@ msgstr ""
 msgid "Pending Tickets"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr ""
 
@@ -3984,13 +4155,14 @@ msgstr "Osobisty"
 msgid "Personal mobile no"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "Telefon"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
 msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
@@ -4047,7 +4219,7 @@ msgstr ""
 msgid "Please enter a valid phone number"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr ""
 
@@ -4090,33 +4262,14 @@ msgstr ""
 msgid "Policy name"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
-msgstr ""
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr "Klucz opisu postu"
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr "Opublikuj listę kluczy"
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr "Wpisz ciąg trasy"
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
 msgstr ""
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
@@ -4151,14 +4304,32 @@ msgstr "Podgląd"
 msgid "Previous ticket"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "główny"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "Główna osoba kontaktowa"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr ""
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr ""
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4166,9 +4337,10 @@ msgstr ""
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4248,17 +4420,6 @@ msgstr ""
 msgid "Quarterly"
 msgstr "Kwartalnie"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "Opcje zapytania"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr ""
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "W kolejce"
@@ -4281,14 +4442,14 @@ msgstr ""
 msgid "Rate this ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr ""
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4384,8 +4545,15 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "Usunąć"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4395,9 +4563,18 @@ msgstr ""
 msgid "Remove Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr ""
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
 msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
@@ -4417,6 +4594,15 @@ msgstr ""
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
 msgstr ""
 
 #. Option in a Select field in the tickets Web Form
@@ -4456,16 +4642,13 @@ msgstr ""
 msgid "Reply on a ticket"
 msgstr ""
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr ""
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
 msgstr ""
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
@@ -4486,6 +4669,7 @@ msgid "Reset to Default"
 msgstr ""
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr "Rozstrzygnięcie"
@@ -4539,18 +4723,6 @@ msgstr "Odpowiedź"
 msgid "Response By"
 msgstr "Odpowiedź wg"
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr ""
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr "Kluczowa ścieżka odpowiedzi"
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr ""
@@ -4593,37 +4765,33 @@ msgstr ""
 msgid "Restrict visibility to these teams"
 msgstr ""
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr "Pole podglądu wyników"
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr "Wynik Pole trasy"
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr "Pole wyniku wyniku"
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
 msgstr "Recenzje"
 
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:215
 msgid "Ringing"
 msgstr "Dzwonienie"
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "Rola"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr ""
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4722,9 +4890,9 @@ msgstr "Sobota"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4800,17 +4968,19 @@ msgstr ""
 msgid "Search Score"
 msgstr ""
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr "Szukane słowo Nazwa Param"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "Pola wyszukiwania..."
 
@@ -4850,6 +5020,7 @@ msgstr "Szukaj..."
 msgid "Searched for:"
 msgstr ""
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr "Szukanie..."
@@ -4868,6 +5039,10 @@ msgstr "Wybierz"
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
 msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
@@ -4890,6 +5065,10 @@ msgstr ""
 msgid "Select a rating"
 msgstr ""
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr ""
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4901,6 +5080,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
+msgstr ""
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
@@ -4927,6 +5110,10 @@ msgstr ""
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
 msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
@@ -4967,13 +5154,17 @@ msgstr ""
 msgid "Service not supported"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "Ustawione"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:4
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
@@ -4984,12 +5175,21 @@ msgstr ""
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr ""
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr ""
 
@@ -5001,7 +5201,7 @@ msgstr ""
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr ""
 
@@ -5135,23 +5335,6 @@ msgstr ""
 msgid "Sort"
 msgstr ""
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr "Źródło DocType"
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "Nazwa źródła"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr ""
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr ""
@@ -5196,6 +5379,8 @@ msgstr ""
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5262,6 +5447,7 @@ msgstr ""
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5373,21 +5559,16 @@ msgstr ""
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5426,8 +5607,6 @@ msgstr ""
 msgid "Teal"
 msgstr ""
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5438,7 +5617,6 @@ msgstr ""
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5544,6 +5722,10 @@ msgstr ""
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr ""
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr ""
@@ -5554,6 +5736,10 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
@@ -5576,6 +5762,14 @@ msgstr ""
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr ""
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr ""
@@ -5583,6 +5777,10 @@ msgstr ""
 #: desk/src/components/ticket/TicketMergeModal.vue:79
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
 msgstr ""
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
@@ -5652,7 +5850,7 @@ msgstr "Czwartek"
 msgid "Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr ""
 
@@ -5666,6 +5864,10 @@ msgstr ""
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
+msgstr ""
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
 msgstr ""
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
@@ -5725,7 +5927,7 @@ msgstr ""
 msgid "Ticket Summary"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr ""
 
@@ -5758,7 +5960,7 @@ msgstr ""
 msgid "Ticket merged successfully."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr ""
 
@@ -5793,12 +5995,6 @@ msgstr ""
 msgid "Ticket to merged with is required"
 msgstr ""
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr ""
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr ""
@@ -5810,12 +6006,15 @@ msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr ""
 
@@ -5827,19 +6026,19 @@ msgstr ""
 msgid "Tickets assigned to you in the last 7 days"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr ""
 
@@ -5856,6 +6055,7 @@ msgid "Tickets that are awaiting your response"
 msgstr ""
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr ""
 
@@ -5945,19 +6145,19 @@ msgstr "Suma dni świątecznych"
 msgid "Total Ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr ""
 
@@ -5989,6 +6189,10 @@ msgstr "Typ"
 msgid "Type a message"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr ""
@@ -5998,7 +6202,7 @@ msgstr ""
 msgid "URL/Method"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr ""
 
@@ -6032,6 +6236,8 @@ msgid "Unpublish"
 msgstr "Cofnij publikację"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr ""
 
@@ -6048,6 +6254,10 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:214
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
+msgstr ""
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
@@ -6076,10 +6286,13 @@ msgstr "Prześlij"
 msgid "Upload Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
 msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
+msgstr "Prześlij obraz"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
 msgid "Uploading {0}%"
@@ -6088,17 +6301,13 @@ msgstr ""
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6110,6 +6319,10 @@ msgstr "Użytkownik"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
 msgstr "Czas rozwiązania użytkownika"
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
+msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
 msgid "User Signup"
@@ -6128,7 +6341,7 @@ msgstr "Użytkownicy"
 msgid "Valid From"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "Wartość"
 
@@ -6257,19 +6470,23 @@ msgstr "Rocznie"
 msgid "Yellow"
 msgstr "Żółty"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr ""
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr ""
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr ""
 
@@ -6297,6 +6514,14 @@ msgstr ""
 msgid "You do not have permission to access Assignment Rules"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr ""
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr ""
@@ -6319,6 +6544,14 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:46
@@ -6349,7 +6582,7 @@ msgstr ""
 msgid "customize {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr "dni  "
 
@@ -6400,7 +6633,7 @@ msgstr ""
 msgid "here."
 msgstr ""
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr "godziny"
 
@@ -6408,7 +6641,7 @@ msgstr "godziny"
 msgid "in"
 msgstr "jest w"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "właśnie teraz"
 
@@ -6441,7 +6674,11 @@ msgstr ""
 msgid "purple"
 msgstr "fioletowy"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr ""
 
@@ -6458,7 +6695,7 @@ msgstr ""
 msgid "to enable this integration."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr ""
 
@@ -6466,12 +6703,32 @@ msgstr ""
 msgid "views"
 msgstr "widoki"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr ""
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
 msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:307
@@ -6498,7 +6755,7 @@ msgstr ""
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr ""
 

--- a/helpdesk/locale/pt.po
+++ b/helpdesk/locale/pt.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-21 20:28\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-29 21:57\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Portuguese\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr ""
@@ -108,14 +108,6 @@ msgstr ""
 msgid "A workday with this name already exists"
 msgstr ""
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr "API"
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr ""
@@ -132,7 +124,7 @@ msgstr ""
 msgid "Account"
 msgstr "Conta"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr ""
 
@@ -152,11 +144,9 @@ msgstr "Ação"
 msgid "Action Required"
 msgstr ""
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr ""
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "Ações"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr ""
 msgid "Active"
 msgstr "Ativo"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr ""
 
@@ -175,7 +165,7 @@ msgid "Active: The agent is available and working.<br>\n"
 "Unavailable: The agent is off and unavailable."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "Atividade"
@@ -193,10 +183,11 @@ msgid "Add Column"
 msgstr "Adicionar Coluna"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "Adicionar Filtro..."
 
@@ -206,6 +197,10 @@ msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
 msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:148
@@ -244,7 +239,7 @@ msgstr ""
 msgid "Add condition group"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "Adicionar filtro"
 
@@ -278,6 +273,12 @@ msgstr ""
 msgid "Add to Holidays"
 msgstr "Adicionar às Férias"
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr ""
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr ""
@@ -295,17 +296,14 @@ msgid "Administrator"
 msgstr "Administrador"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -316,6 +314,7 @@ msgstr "Administrador"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -335,6 +334,7 @@ msgstr ""
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -342,6 +342,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -376,18 +377,9 @@ msgstr ""
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "Todos"
 
@@ -508,6 +500,14 @@ msgstr ""
 msgid "Are you sure you want to delete these articles?"
 msgstr ""
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr ""
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr ""
@@ -543,6 +543,10 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
 msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
@@ -595,16 +599,11 @@ msgstr ""
 msgid "Assign ticket"
 msgstr ""
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr "Atribuir a"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -618,7 +617,7 @@ msgstr "Cessionário"
 msgid "Assignee Rules"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr ""
 
@@ -626,7 +625,7 @@ msgstr ""
 msgid "Assignees"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr ""
 
@@ -692,10 +691,6 @@ msgstr ""
 msgid "Assignment rule {0} updated successfully."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -711,10 +706,6 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
-msgstr ""
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
 msgstr ""
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
@@ -766,7 +757,7 @@ msgid "Automation"
 msgstr ""
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr ""
@@ -802,7 +793,7 @@ msgstr ""
 msgid "Average Time Metrics"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr ""
 
@@ -810,24 +801,36 @@ msgstr ""
 msgid "Average response and resolution metrics not available"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
 msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
@@ -840,11 +843,11 @@ msgstr ""
 msgid "Avg. resolution time"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr ""
 
@@ -867,11 +870,6 @@ msgstr ""
 msgid "Base Support Rotation"
 msgstr ""
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "URL base"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -885,11 +883,11 @@ msgstr ""
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr ""
 
@@ -944,11 +942,6 @@ msgstr ""
 msgid "Busy"
 msgstr ""
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "Botão"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr ""
@@ -973,19 +966,31 @@ msgstr ""
 msgid "Caller"
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr "Chamadas"
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr ""
 
@@ -1025,7 +1030,7 @@ msgstr ""
 msgid "Cannot merge General category"
 msgstr ""
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr ""
 
@@ -1073,11 +1078,11 @@ msgstr ""
 msgid "Category updated successfully."
 msgstr "Categoria atualizada com sucesso."
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr ""
 
@@ -1085,7 +1090,7 @@ msgstr ""
 msgid "Change"
 msgstr "Moedas"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "Alterar Palavra-passe"
@@ -1098,9 +1103,8 @@ msgstr ""
 msgid "Change language of the application."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
@@ -1123,7 +1127,7 @@ msgstr ""
 msgid "Change timezone of the application."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr ""
 
@@ -1136,7 +1140,7 @@ msgstr ""
 msgid "Child field"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr ""
 
@@ -1189,7 +1193,7 @@ msgstr ""
 msgid "Clear Table"
 msgstr "Limpar tabela"
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr ""
 
@@ -1203,6 +1207,10 @@ msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
@@ -1223,7 +1231,7 @@ msgstr ""
 msgid "Closed"
 msgstr "Fechado"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr ""
 
@@ -1250,7 +1258,7 @@ msgstr "Colunas"
 msgid "Comma separated emails to invite."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr ""
 
@@ -1283,7 +1291,7 @@ msgstr ""
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "Comentários"
@@ -1294,6 +1302,11 @@ msgstr "Comunicação"
 
 #: desk/src/components/ticket/TicketSplitModal.vue:76
 msgid "Communication ID is required"
+msgstr ""
+
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:209
@@ -1307,7 +1320,7 @@ msgstr "Concluído"
 msgid "Condition"
 msgstr "Condição"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr ""
 
@@ -1331,6 +1344,10 @@ msgstr ""
 msgid "Configure your telephony settings."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1356,10 +1373,11 @@ msgstr ""
 msgid "Connect your support email"
 msgstr ""
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1373,26 +1391,30 @@ msgstr "Contacto"
 msgid "Contact HTML"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
 msgstr ""
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
 msgstr "Contactos"
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
+msgstr ""
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
 #. Label of the content (Text Editor) field in DocType 'HD Article'
@@ -1415,7 +1437,7 @@ msgstr ""
 msgid "Copy ticket id"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr ""
 
@@ -1423,7 +1445,11 @@ msgstr ""
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr ""
 
@@ -1431,11 +1457,20 @@ msgstr ""
 msgid "Could not send feedback email,due to: {0}"
 msgstr ""
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "País"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1446,8 +1481,12 @@ msgstr "Criar"
 msgid "Create & invite a contact"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
 msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
@@ -1482,12 +1521,6 @@ msgstr ""
 msgid "Creating a ticket"
 msgstr ""
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr ""
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr ""
@@ -1512,11 +1545,20 @@ msgid "Custom Views"
 msgstr ""
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
 msgstr ""
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
@@ -1528,16 +1570,32 @@ msgstr ""
 msgid "Customer Portal"
 msgstr ""
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
-msgstr "Cliente criado com sucesso."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
 msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:595
@@ -1565,6 +1623,8 @@ msgstr "Ciano"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "Perigo"
@@ -1665,18 +1725,26 @@ msgstr ""
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr ""
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "Eliminar"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1692,6 +1760,10 @@ msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
+msgstr ""
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
 msgstr ""
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
@@ -1740,7 +1812,7 @@ msgstr ""
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1826,7 +1898,12 @@ msgstr ""
 msgid "Document Type"
 msgstr "Tipo de Documento"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr ""
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "Domínio"
@@ -1867,6 +1944,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
@@ -1917,7 +1998,8 @@ msgstr ""
 msgid "Easily invite new agents, managers, or admins."
 msgstr ""
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1925,6 +2007,14 @@ msgstr "Editar"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
 msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:70
@@ -1944,10 +2034,10 @@ msgstr ""
 msgid "Edit your email account"
 msgstr ""
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "E-mail"
 
@@ -1975,8 +2065,9 @@ msgstr ""
 msgid "Email Content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
 msgstr "ID de e-mail"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
@@ -2002,22 +2093,22 @@ msgstr ""
 msgid "Email account updated successfully"
 msgstr ""
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr ""
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr ""
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "E-mails"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr ""
 
@@ -2055,8 +2146,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr ""
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2081,8 +2170,6 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2105,20 +2192,24 @@ msgstr "Hora Fim"
 msgid "Enter a name for this HD Service Holiday List."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr ""
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr ""
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
 msgstr ""
 
 #: helpdesk/api/knowledge_base.py:86
@@ -2129,21 +2220,17 @@ msgstr ""
 msgid "Error processing email at index {0}, message: {1}"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr ""
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "Erro ao conectar à conta de e-mail {0}"
 
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr ""
-
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
 msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
@@ -2172,11 +2259,6 @@ msgstr ""
 msgid "Export Type"
 msgstr "Tipo de exportação"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr ""
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2184,6 +2266,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "Falhou"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2218,11 +2304,11 @@ msgstr ""
 msgid "Failed to save Twilio settings"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr ""
 
@@ -2251,6 +2337,7 @@ msgstr ""
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2288,12 +2375,16 @@ msgstr ""
 msgid "Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
+msgstr ""
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
 msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
@@ -2338,13 +2429,14 @@ msgid "Field dependency updated successfully."
 msgstr ""
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "Campos"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "Filtros"
@@ -2354,13 +2446,18 @@ msgstr "Filtros"
 msgid "Find out all of the variables that can be used in the content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "Primeiro nome"
 
 #. Label of the first_responded_on (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
+msgstr ""
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
 msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
@@ -2385,10 +2482,6 @@ msgstr ""
 #. Name of a report
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -2480,6 +2573,10 @@ msgstr ""
 msgid "Go to Ticket #{0}"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr ""
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2509,19 +2606,12 @@ msgid "Group By Field"
 msgstr ""
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
 msgstr ""
 
 #. Name of a DocType
@@ -2554,24 +2644,36 @@ msgstr ""
 msgid "HD Comment Reaction"
 msgstr ""
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr ""
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr ""
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
 msgstr ""
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
 msgstr ""
 
 #. Name of a DocType
@@ -2592,21 +2694,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
 msgstr ""
 
 #. Name of a DocType
@@ -2648,11 +2735,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
 msgstr ""
 
 #. Name of a DocType
@@ -2750,12 +2832,6 @@ msgstr ""
 msgid "Helpdesk"
 msgstr ""
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr ""
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2772,11 +2848,6 @@ msgstr "Olá"
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
 msgstr "Ocultar "
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr ""
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
@@ -2846,15 +2917,8 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "Endereço IP"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2941,6 +3005,11 @@ msgstr "Caixa de Entrada"
 msgid "Incoming"
 msgstr "Recebida"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr "Iniciado"
@@ -2954,7 +3023,7 @@ msgstr ""
 msgid "Instantly send e-mail"
 msgstr ""
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "Permissão insuficiente para {0}"
 
@@ -2968,12 +3037,12 @@ msgstr ""
 msgid "Introduction"
 msgstr "Introdução"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
@@ -2982,22 +3051,42 @@ msgstr ""
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr ""
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr ""
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
 msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
@@ -3008,13 +3097,30 @@ msgstr ""
 msgid "Invite agents"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
-msgstr ""
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
+msgstr "Convidar como Utilizador"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
 msgstr "Convidar por e-mail"
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
+msgstr ""
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -3030,6 +3136,11 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "É Padrão"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr ""
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3057,6 +3168,10 @@ msgstr ""
 #. Label of the setup_complete (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
 msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:114
@@ -3093,11 +3208,9 @@ msgstr "Atalhos de teclado"
 msgid "Knowledge Base"
 msgstr "Base de Conhecimento"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3131,9 +3244,9 @@ msgstr ""
 msgid "Last 3 Months"
 msgstr "Últimos 3 meses"
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr ""
 
@@ -3174,7 +3287,8 @@ msgstr ""
 msgid "Last Month"
 msgstr "Mês passado"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "Sobrenome"
 
@@ -3183,23 +3297,32 @@ msgstr "Sobrenome"
 msgid "Last Week"
 msgstr "Última Semana"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr ""
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
 msgstr ""
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
@@ -3216,26 +3339,6 @@ msgstr ""
 #. 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
-msgstr ""
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "Link"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -3264,6 +3367,8 @@ msgstr ""
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "Carregue mais"
 
@@ -3286,6 +3391,8 @@ msgstr "Iniciar sessão no Frappe Cloud"
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr "Logótipo"
@@ -3324,7 +3431,7 @@ msgstr ""
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr ""
 
@@ -3342,6 +3449,10 @@ msgstr ""
 
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:11
@@ -3396,6 +3507,20 @@ msgstr ""
 msgid "Mobile App Installation"
 msgstr ""
 
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr "Nr. de Telemóvel"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr "Número de telemóvel"
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr ""
+
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
 #. List'
@@ -3436,7 +3561,7 @@ msgid "My Tickets"
 msgstr ""
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3447,8 +3572,9 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3457,6 +3583,10 @@ msgstr "Nome"
 #. Label of the name_weight (Int) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
 msgstr ""
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
@@ -3469,10 +3599,18 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "Nunca"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3581,11 +3719,11 @@ msgstr ""
 msgid "No Data Found"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr ""
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr ""
 
@@ -3597,8 +3735,14 @@ msgstr ""
 msgid "No SLA found"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
 msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
@@ -3633,19 +3777,27 @@ msgstr ""
 msgid "No changes made"
 msgstr "Nenhuma alteração efetuada"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr ""
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr ""
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr ""
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
@@ -3657,7 +3809,11 @@ msgstr ""
 msgid "No feedback"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr ""
 
@@ -3697,12 +3853,17 @@ msgstr ""
 msgid "No recently assigned tickets"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr ""
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
 msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
@@ -3710,6 +3871,7 @@ msgstr ""
 msgid "No saved replies found"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr ""
@@ -3730,7 +3892,11 @@ msgstr ""
 msgid "No tickets selected"
 msgstr ""
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr ""
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "Não Permitido"
 
@@ -3742,7 +3908,7 @@ msgstr ""
 msgid "Not Saved"
 msgstr "Não Guardado"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "Não Definido"
 
@@ -3781,11 +3947,6 @@ msgstr ""
 msgid "On Hold Since"
 msgstr ""
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr ""
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr ""
@@ -3815,6 +3976,10 @@ msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
@@ -3904,7 +4069,12 @@ msgstr ""
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr ""
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "Senha"
 
@@ -3942,6 +4112,7 @@ msgid "Pending"
 msgstr "Pendente"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr ""
 
@@ -3951,19 +4122,19 @@ msgstr ""
 msgid "Pending Tickets"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr ""
 
@@ -3984,13 +4155,14 @@ msgstr "Pessoal"
 msgid "Personal mobile no"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "Telefone"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
 msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
@@ -4047,7 +4219,7 @@ msgstr ""
 msgid "Please enter a valid phone number"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr ""
 
@@ -4090,33 +4262,14 @@ msgstr ""
 msgid "Policy name"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
-msgstr ""
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr ""
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr ""
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr ""
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
 msgstr ""
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
@@ -4151,14 +4304,32 @@ msgstr "Pré-visualização"
 msgid "Previous ticket"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "primário"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "Contacto primário"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr ""
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr "Prioridades"
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4166,9 +4337,10 @@ msgstr "Prioridades"
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4248,17 +4420,6 @@ msgstr ""
 msgid "Quarterly"
 msgstr "Trimestral"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "Opções de consulta"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr ""
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "Em Fila"
@@ -4281,14 +4442,14 @@ msgstr ""
 msgid "Rate this ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr ""
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4384,8 +4545,15 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "Remover"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4395,9 +4563,18 @@ msgstr ""
 msgid "Remove Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr "Remover imagem"
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
 msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
@@ -4417,6 +4594,15 @@ msgstr ""
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
 msgstr ""
 
 #. Option in a Select field in the tickets Web Form
@@ -4456,16 +4642,13 @@ msgstr ""
 msgid "Reply on a ticket"
 msgstr ""
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr ""
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
 msgstr ""
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
@@ -4486,6 +4669,7 @@ msgid "Reset to Default"
 msgstr ""
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr ""
@@ -4539,18 +4723,6 @@ msgstr "Resposta"
 msgid "Response By"
 msgstr "Resposta de"
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr ""
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr ""
@@ -4593,28 +4765,18 @@ msgstr ""
 msgid "Restrict visibility to these teams"
 msgstr ""
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr ""
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr ""
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
+msgstr ""
+
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:215
@@ -4622,8 +4784,14 @@ msgid "Ringing"
 msgstr "A Tocar"
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "Função"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr ""
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4722,9 +4890,9 @@ msgstr "Sábado"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4800,17 +4968,19 @@ msgstr ""
 msgid "Search Score"
 msgstr ""
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr ""
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "Campos de pesquisa..."
 
@@ -4850,6 +5020,7 @@ msgstr "Pesquisar..."
 msgid "Searched for:"
 msgstr ""
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr "Procurando..."
@@ -4868,6 +5039,10 @@ msgstr "Selecione"
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
 msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
@@ -4890,6 +5065,10 @@ msgstr ""
 msgid "Select a rating"
 msgstr ""
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr ""
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4901,6 +5080,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
+msgstr ""
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
@@ -4927,6 +5110,10 @@ msgstr ""
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
 msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
@@ -4967,13 +5154,17 @@ msgstr ""
 msgid "Service not supported"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "Definido"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:4
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
@@ -4984,12 +5175,21 @@ msgstr ""
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr ""
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr ""
 
@@ -5001,7 +5201,7 @@ msgstr ""
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr ""
 
@@ -5135,23 +5335,6 @@ msgstr ""
 msgid "Sort"
 msgstr "Ordenar"
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr ""
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "Nome da Fonte"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr ""
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr ""
@@ -5196,6 +5379,8 @@ msgstr ""
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5262,6 +5447,7 @@ msgstr ""
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5373,21 +5559,16 @@ msgstr "Sistema"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5426,8 +5607,6 @@ msgstr ""
 msgid "Teal"
 msgstr ""
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5438,7 +5617,6 @@ msgstr ""
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5544,6 +5722,10 @@ msgstr ""
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr ""
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr ""
@@ -5554,6 +5736,10 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
@@ -5576,6 +5762,14 @@ msgstr ""
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr ""
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr ""
@@ -5583,6 +5777,10 @@ msgstr ""
 #: desk/src/components/ticket/TicketMergeModal.vue:79
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
 msgstr ""
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
@@ -5652,7 +5850,7 @@ msgstr "Quinta-feira"
 msgid "Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr ""
 
@@ -5666,6 +5864,10 @@ msgstr ""
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
+msgstr ""
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
 msgstr ""
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
@@ -5725,7 +5927,7 @@ msgstr ""
 msgid "Ticket Summary"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr ""
 
@@ -5758,7 +5960,7 @@ msgstr ""
 msgid "Ticket merged successfully."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr ""
 
@@ -5793,12 +5995,6 @@ msgstr ""
 msgid "Ticket to merged with is required"
 msgstr ""
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr ""
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr ""
@@ -5810,12 +6006,15 @@ msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr ""
 
@@ -5827,19 +6026,19 @@ msgstr ""
 msgid "Tickets assigned to you in the last 7 days"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr ""
 
@@ -5856,6 +6055,7 @@ msgid "Tickets that are awaiting your response"
 msgstr ""
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr ""
 
@@ -5945,19 +6145,19 @@ msgstr ""
 msgid "Total Ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr ""
 
@@ -5989,6 +6189,10 @@ msgstr "Tipo"
 msgid "Type a message"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr ""
@@ -5998,7 +6202,7 @@ msgstr ""
 msgid "URL/Method"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr ""
 
@@ -6032,6 +6236,8 @@ msgid "Unpublish"
 msgstr "Cancelar publicação"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr ""
 
@@ -6048,6 +6254,10 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:214
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
+msgstr ""
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
@@ -6076,10 +6286,13 @@ msgstr "Carregar"
 msgid "Upload Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
 msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
+msgstr "Carregar imagem"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
 msgid "Uploading {0}%"
@@ -6088,17 +6301,13 @@ msgstr ""
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6109,6 +6318,10 @@ msgstr "Utilizador"
 #. Label of the user_resolution_time (Duration) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
 msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
@@ -6128,7 +6341,7 @@ msgstr "Utilizadores"
 msgid "Valid From"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "Valor"
 
@@ -6257,19 +6470,23 @@ msgstr "Anual"
 msgid "Yellow"
 msgstr "Amarelo"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr ""
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr ""
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr ""
 
@@ -6297,6 +6514,14 @@ msgstr ""
 msgid "You do not have permission to access Assignment Rules"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr ""
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr ""
@@ -6319,6 +6544,14 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:46
@@ -6349,7 +6582,7 @@ msgstr ""
 msgid "customize {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr "dias"
 
@@ -6400,7 +6633,7 @@ msgstr ""
 msgid "here."
 msgstr ""
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr "horas"
 
@@ -6408,7 +6641,7 @@ msgstr "horas"
 msgid "in"
 msgstr "em"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "agora mesmo"
 
@@ -6441,7 +6674,11 @@ msgstr ""
 msgid "purple"
 msgstr "roxo"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr ""
 
@@ -6458,7 +6695,7 @@ msgstr "ticket"
 msgid "to enable this integration."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr ""
 
@@ -6466,12 +6703,32 @@ msgstr ""
 msgid "views"
 msgstr "vistas"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr ""
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
 msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:307
@@ -6498,7 +6755,7 @@ msgstr ""
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr ""
 

--- a/helpdesk/locale/pt_BR.po
+++ b/helpdesk/locale/pt_BR.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-15 18:51\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-29 21:58\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Portuguese, Brazilian\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr ""
@@ -108,14 +108,6 @@ msgstr ""
 msgid "A workday with this name already exists"
 msgstr ""
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr "API"
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr ""
@@ -132,7 +124,7 @@ msgstr ""
 msgid "Account"
 msgstr "Conta"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr ""
 
@@ -152,11 +144,9 @@ msgstr "Ação"
 msgid "Action Required"
 msgstr ""
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr ""
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "Ações"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr ""
 msgid "Active"
 msgstr "Ativo"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr ""
 
@@ -175,7 +165,7 @@ msgid "Active: The agent is available and working.<br>\n"
 "Unavailable: The agent is off and unavailable."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "Atividade"
@@ -193,10 +183,11 @@ msgid "Add Column"
 msgstr "Adicionar coluna"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "Adicionar filtro..."
 
@@ -206,6 +197,10 @@ msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
 msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:148
@@ -244,7 +239,7 @@ msgstr "Adicionar condição"
 msgid "Add condition group"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "Adicionar filtro"
 
@@ -278,6 +273,12 @@ msgstr ""
 msgid "Add to Holidays"
 msgstr "Adicionar aos feriados"
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr ""
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr ""
@@ -295,17 +296,14 @@ msgid "Administrator"
 msgstr "Administrador"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -316,6 +314,7 @@ msgstr "Administrador"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -335,6 +334,7 @@ msgstr ""
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -342,6 +342,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -376,18 +377,9 @@ msgstr ""
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "Todos"
 
@@ -508,6 +500,14 @@ msgstr ""
 msgid "Are you sure you want to delete these articles?"
 msgstr ""
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr ""
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr ""
@@ -543,6 +543,10 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
 msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
@@ -595,16 +599,11 @@ msgstr ""
 msgid "Assign ticket"
 msgstr ""
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr ""
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -618,7 +617,7 @@ msgstr "Responsável"
 msgid "Assignee Rules"
 msgstr "Regras de Atribuição"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr ""
 
@@ -626,7 +625,7 @@ msgstr ""
 msgid "Assignees"
 msgstr "Responsáveis"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr ""
 
@@ -692,10 +691,6 @@ msgstr ""
 msgid "Assignment rule {0} updated successfully."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -711,10 +706,6 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
-msgstr ""
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
 msgstr ""
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
@@ -766,7 +757,7 @@ msgid "Automation"
 msgstr "Automação"
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr ""
@@ -802,7 +793,7 @@ msgstr ""
 msgid "Average Time Metrics"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr ""
 
@@ -810,24 +801,36 @@ msgstr ""
 msgid "Average response and resolution metrics not available"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
 msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
@@ -840,11 +843,11 @@ msgstr ""
 msgid "Avg. resolution time"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr ""
 
@@ -867,11 +870,6 @@ msgstr ""
 msgid "Base Support Rotation"
 msgstr ""
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "URL base"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -885,11 +883,11 @@ msgstr ""
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr ""
 
@@ -944,11 +942,6 @@ msgstr ""
 msgid "Busy"
 msgstr ""
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "Botão"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr ""
@@ -973,19 +966,31 @@ msgstr ""
 msgid "Caller"
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr ""
 
@@ -1025,7 +1030,7 @@ msgstr ""
 msgid "Cannot merge General category"
 msgstr ""
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr ""
 
@@ -1073,11 +1078,11 @@ msgstr ""
 msgid "Category updated successfully."
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr ""
 
@@ -1085,7 +1090,7 @@ msgstr ""
 msgid "Change"
 msgstr "Moedas"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "Alterar Senha"
@@ -1098,9 +1103,8 @@ msgstr ""
 msgid "Change language of the application."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
@@ -1123,7 +1127,7 @@ msgstr ""
 msgid "Change timezone of the application."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr ""
 
@@ -1136,7 +1140,7 @@ msgstr ""
 msgid "Child field"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr ""
 
@@ -1189,7 +1193,7 @@ msgstr ""
 msgid "Clear Table"
 msgstr "Limpar tabela"
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr ""
 
@@ -1203,6 +1207,10 @@ msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
@@ -1223,7 +1231,7 @@ msgstr ""
 msgid "Closed"
 msgstr "Fechado"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr ""
 
@@ -1250,7 +1258,7 @@ msgstr "Colunas"
 msgid "Comma separated emails to invite."
 msgstr "E-mails separados por vírgula para convidar."
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr ""
 
@@ -1283,7 +1291,7 @@ msgstr ""
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "Comentários"
@@ -1296,6 +1304,11 @@ msgstr "Comunicação"
 msgid "Communication ID is required"
 msgstr ""
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
+msgstr "Empresa"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
 msgstr "Concluído"
@@ -1307,7 +1320,7 @@ msgstr "Concluído"
 msgid "Condition"
 msgstr "Condição"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr ""
 
@@ -1331,6 +1344,10 @@ msgstr ""
 msgid "Configure your telephony settings."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1356,10 +1373,11 @@ msgstr ""
 msgid "Connect your support email"
 msgstr ""
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1373,26 +1391,30 @@ msgstr "Contato"
 msgid "Contact HTML"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
 msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
-msgstr "Contato convidado com sucesso."
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
 msgstr ""
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
 msgstr "Contatos"
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
+msgstr ""
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
 #. Label of the content (Text Editor) field in DocType 'HD Article'
@@ -1415,7 +1437,7 @@ msgstr ""
 msgid "Copy ticket id"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr ""
 
@@ -1423,7 +1445,11 @@ msgstr ""
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr ""
 
@@ -1431,11 +1457,20 @@ msgstr ""
 msgid "Could not send feedback email,due to: {0}"
 msgstr ""
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "País"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1446,9 +1481,13 @@ msgstr "Criar"
 msgid "Create & invite a contact"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
 msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
+msgstr "Criar Cliente"
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
 msgid "Create View"
@@ -1482,12 +1521,6 @@ msgstr ""
 msgid "Creating a ticket"
 msgstr ""
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr ""
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr ""
@@ -1512,12 +1545,21 @@ msgid "Custom Views"
 msgstr ""
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
 msgstr "Cliente"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
+msgstr ""
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1528,16 +1570,32 @@ msgstr "Nome do Cliente"
 msgid "Customer Portal"
 msgstr ""
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
-msgstr "Cliente criado com sucesso."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
 msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:595
@@ -1565,6 +1623,8 @@ msgstr "Ciano"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "Perigo"
@@ -1665,18 +1725,26 @@ msgstr ""
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr ""
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "Excluir"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1692,6 +1760,10 @@ msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
+msgstr ""
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
 msgstr ""
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
@@ -1740,7 +1812,7 @@ msgstr ""
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1826,7 +1898,12 @@ msgstr ""
 msgid "Document Type"
 msgstr "Tipo de Documento"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr ""
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "Domínio"
@@ -1867,6 +1944,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
@@ -1917,7 +1998,8 @@ msgstr ""
 msgid "Easily invite new agents, managers, or admins."
 msgstr ""
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1925,6 +2007,14 @@ msgstr "Editar"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
 msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:70
@@ -1944,10 +2034,10 @@ msgstr ""
 msgid "Edit your email account"
 msgstr ""
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "E-Mail"
 
@@ -1975,8 +2065,9 @@ msgstr ""
 msgid "Email Content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
 msgstr "ID de e-mail"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
@@ -2002,22 +2093,22 @@ msgstr ""
 msgid "Email account updated successfully"
 msgstr ""
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr ""
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr ""
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "E-mails"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr ""
 
@@ -2055,8 +2146,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr ""
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2081,8 +2170,6 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2105,20 +2192,24 @@ msgstr "Hora de término"
 msgid "Enter a name for this HD Service Holiday List."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr ""
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr ""
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
 msgstr ""
 
 #: helpdesk/api/knowledge_base.py:86
@@ -2129,21 +2220,17 @@ msgstr ""
 msgid "Error processing email at index {0}, message: {1}"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr ""
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "Erro ao conectar à conta de e-mail {0}"
 
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr ""
-
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
 msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
@@ -2172,11 +2259,6 @@ msgstr ""
 msgid "Export Type"
 msgstr "Tipo de exportação"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr ""
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2184,6 +2266,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "Falhou"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2218,11 +2304,11 @@ msgstr ""
 msgid "Failed to save Twilio settings"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr ""
 
@@ -2251,6 +2337,7 @@ msgstr ""
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2288,12 +2375,16 @@ msgstr ""
 msgid "Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
+msgstr ""
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
 msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
@@ -2338,13 +2429,14 @@ msgid "Field dependency updated successfully."
 msgstr ""
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "Campos"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "Filtros"
@@ -2354,7 +2446,8 @@ msgstr "Filtros"
 msgid "Find out all of the variables that can be used in the content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "Nome"
 
@@ -2362,6 +2455,10 @@ msgstr "Nome"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
 msgstr "Primeira resposta em"
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
+msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -2385,10 +2482,6 @@ msgstr "Tempo de Primeira Resposta"
 #. Name of a report
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -2480,6 +2573,10 @@ msgstr ""
 msgid "Go to Ticket #{0}"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr ""
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2509,19 +2606,12 @@ msgid "Group By Field"
 msgstr ""
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr "Convidado"
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
 msgstr ""
 
 #. Name of a DocType
@@ -2554,24 +2644,36 @@ msgstr ""
 msgid "HD Comment Reaction"
 msgstr ""
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr ""
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr ""
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
 msgstr ""
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
 msgstr ""
 
 #. Name of a DocType
@@ -2592,21 +2694,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
 msgstr ""
 
 #. Name of a DocType
@@ -2648,11 +2735,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
 msgstr ""
 
 #. Name of a DocType
@@ -2750,12 +2832,6 @@ msgstr ""
 msgid "Helpdesk"
 msgstr "Central de Ajuda"
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr ""
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2772,11 +2848,6 @@ msgstr ""
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
 msgstr "Ocultar "
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr ""
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
@@ -2846,15 +2917,8 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "Endereço IP"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2941,6 +3005,11 @@ msgstr "Caixa de Entrada"
 msgid "Incoming"
 msgstr "Recebida"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr "Pessoa Física"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr "Iniciada"
@@ -2954,7 +3023,7 @@ msgstr ""
 msgid "Instantly send e-mail"
 msgstr ""
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "Permissão insuficiente para {0}"
 
@@ -2968,12 +3037,12 @@ msgstr ""
 msgid "Introduction"
 msgstr "Introdução"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
@@ -2982,22 +3051,42 @@ msgstr ""
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr ""
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr ""
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
 msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
@@ -3008,13 +3097,30 @@ msgstr "Convidar agente"
 msgid "Invite agents"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
-msgstr ""
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
+msgstr "Convidar como Usuário"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
 msgstr "Convidar por e-mail"
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
+msgstr ""
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -3030,6 +3136,11 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "É Padrão"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr ""
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3057,6 +3168,10 @@ msgstr ""
 #. Label of the setup_complete (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
 msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:114
@@ -3093,11 +3208,9 @@ msgstr "Atalhos de teclado"
 msgid "Knowledge Base"
 msgstr "Base de Conhecimento"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3131,9 +3244,9 @@ msgstr "Último"
 msgid "Last 3 Months"
 msgstr "Últimos 3 Meses"
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr ""
 
@@ -3174,7 +3287,8 @@ msgstr ""
 msgid "Last Month"
 msgstr "Mês passado"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "Sobrenome"
 
@@ -3183,24 +3297,33 @@ msgstr "Sobrenome"
 msgid "Last Week"
 msgstr "Última Semana"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr "Último usuário atribuído por esta regra"
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
 msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
+msgstr "Mais Recentes"
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -3216,26 +3339,6 @@ msgstr "Saiba mais sobre as condições"
 #. 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
-msgstr ""
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "Link"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -3264,6 +3367,8 @@ msgstr ""
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "Carregar mais"
 
@@ -3286,6 +3391,8 @@ msgstr "Fazer login no Frappe Cloud"
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr "Logotipo"
@@ -3324,7 +3431,7 @@ msgstr ""
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr ""
 
@@ -3342,6 +3449,10 @@ msgstr ""
 
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:11
@@ -3396,6 +3507,20 @@ msgstr ""
 msgid "Mobile App Installation"
 msgstr ""
 
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr "Celular"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr "Número de Celular"
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr ""
+
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
 #. List'
@@ -3436,7 +3561,7 @@ msgid "My Tickets"
 msgstr ""
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3447,8 +3572,9 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3457,6 +3583,10 @@ msgstr "Nome"
 #. Label of the name_weight (Int) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
 msgstr ""
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
@@ -3469,10 +3599,18 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "Nunca"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3581,11 +3719,11 @@ msgstr ""
 msgid "No Data Found"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr ""
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr ""
 
@@ -3597,8 +3735,14 @@ msgstr ""
 msgid "No SLA found"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
 msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
@@ -3633,19 +3777,27 @@ msgstr ""
 msgid "No changes made"
 msgstr "Nenhuma alteração realizada"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr ""
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr ""
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr ""
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
@@ -3657,7 +3809,11 @@ msgstr "Nenhuma conta de e-mail encontrada"
 msgid "No feedback"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr ""
 
@@ -3697,12 +3853,17 @@ msgstr ""
 msgid "No recently assigned tickets"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr ""
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
 msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
@@ -3710,6 +3871,7 @@ msgstr ""
 msgid "No saved replies found"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr ""
@@ -3730,7 +3892,11 @@ msgstr ""
 msgid "No tickets selected"
 msgstr ""
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr ""
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "Não Permitido"
 
@@ -3742,7 +3908,7 @@ msgstr ""
 msgid "Not Saved"
 msgstr "Não Salvo"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "Não Definido"
 
@@ -3781,11 +3947,6 @@ msgstr ""
 msgid "On Hold Since"
 msgstr ""
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr ""
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr ""
@@ -3815,6 +3976,10 @@ msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
@@ -3904,7 +4069,12 @@ msgstr ""
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr ""
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "Senha"
 
@@ -3942,6 +4112,7 @@ msgid "Pending"
 msgstr "Pendente"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr ""
 
@@ -3951,19 +4122,19 @@ msgstr ""
 msgid "Pending Tickets"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr ""
 
@@ -3984,13 +4155,14 @@ msgstr "Pessoal"
 msgid "Personal mobile no"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "Telefone"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
 msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
@@ -4047,7 +4219,7 @@ msgstr ""
 msgid "Please enter a valid phone number"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr ""
 
@@ -4090,33 +4262,14 @@ msgstr ""
 msgid "Policy name"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
-msgstr ""
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr ""
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr ""
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr ""
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
 msgstr ""
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
@@ -4151,14 +4304,32 @@ msgstr "Pré-visualização"
 msgid "Previous ticket"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "Primário"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "Contato Principal"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr ""
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr "Prioridades"
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4166,9 +4337,10 @@ msgstr "Prioridades"
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4248,17 +4420,6 @@ msgstr ""
 msgid "Quarterly"
 msgstr "Trimestral"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "Opções de consulta"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr ""
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "Na fila"
@@ -4281,14 +4442,14 @@ msgstr ""
 msgid "Rate this ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr ""
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4384,8 +4545,15 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "Remover"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4395,9 +4563,18 @@ msgstr ""
 msgid "Remove Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr "Remover imagem"
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
 msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
@@ -4417,6 +4594,15 @@ msgstr ""
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
 msgstr ""
 
 #. Option in a Select field in the tickets Web Form
@@ -4456,16 +4642,13 @@ msgstr ""
 msgid "Reply on a ticket"
 msgstr ""
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr ""
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
 msgstr ""
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
@@ -4486,6 +4669,7 @@ msgid "Reset to Default"
 msgstr ""
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr ""
@@ -4539,18 +4723,6 @@ msgstr "Resposta"
 msgid "Response By"
 msgstr "Resposta por"
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr ""
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr "O tempo de resposta para {0} prioridade na linha {1} não pode ser maior que o tempo de resolução."
@@ -4593,37 +4765,33 @@ msgstr ""
 msgid "Restrict visibility to these teams"
 msgstr ""
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr ""
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr ""
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
 msgstr "Rever"
 
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:215
 msgid "Ringing"
 msgstr "Toque"
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "Função"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr ""
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4722,9 +4890,9 @@ msgstr "Sábado"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4800,17 +4968,19 @@ msgstr ""
 msgid "Search Score"
 msgstr ""
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr ""
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "Pesquisar campos..."
 
@@ -4850,6 +5020,7 @@ msgstr "Pesquisar..."
 msgid "Searched for:"
 msgstr ""
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr "Procurando..."
@@ -4868,6 +5039,10 @@ msgstr "Selecione"
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
 msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
@@ -4890,6 +5065,10 @@ msgstr "Selecione Uma Prioridade Padrão."
 msgid "Select a rating"
 msgstr ""
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr ""
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4901,6 +5080,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
+msgstr ""
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
@@ -4927,6 +5110,10 @@ msgstr ""
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
 msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
@@ -4967,13 +5154,17 @@ msgstr ""
 msgid "Service not supported"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "Definido"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:4
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
@@ -4984,12 +5175,21 @@ msgstr ""
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr ""
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr ""
 
@@ -5001,7 +5201,7 @@ msgstr ""
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr "Defina dias úteis, horas e feriados selecionando uma agenda predefinida ou criando uma nova."
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr ""
 
@@ -5135,23 +5335,6 @@ msgstr ""
 msgid "Sort"
 msgstr ""
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr ""
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "Nome da Fonte"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr ""
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr ""
@@ -5196,6 +5379,8 @@ msgstr ""
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5262,6 +5447,7 @@ msgstr ""
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5373,21 +5559,16 @@ msgstr "Sistema"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5426,8 +5607,6 @@ msgstr ""
 msgid "Teal"
 msgstr "Azul-petróleo"
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5438,7 +5617,6 @@ msgstr "Azul-petróleo"
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5544,6 +5722,10 @@ msgstr ""
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr ""
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr ""
@@ -5554,6 +5736,10 @@ msgstr "O feriado em {0} não é entre de Data e To Date"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
@@ -5576,6 +5762,14 @@ msgstr ""
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr ""
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr ""
@@ -5583,6 +5777,10 @@ msgstr ""
 #: desk/src/components/ticket/TicketMergeModal.vue:79
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
 msgstr ""
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
@@ -5652,7 +5850,7 @@ msgstr "Quinta"
 msgid "Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr ""
 
@@ -5666,6 +5864,10 @@ msgstr ""
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
+msgstr ""
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
 msgstr ""
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
@@ -5725,7 +5927,7 @@ msgstr ""
 msgid "Ticket Summary"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr ""
 
@@ -5758,7 +5960,7 @@ msgstr ""
 msgid "Ticket merged successfully."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr ""
 
@@ -5793,12 +5995,6 @@ msgstr ""
 msgid "Ticket to merged with is required"
 msgstr ""
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr ""
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr ""
@@ -5810,12 +6006,15 @@ msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr ""
 
@@ -5827,19 +6026,19 @@ msgstr ""
 msgid "Tickets assigned to you in the last 7 days"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr ""
 
@@ -5856,6 +6055,7 @@ msgid "Tickets that are awaiting your response"
 msgstr ""
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr ""
 
@@ -5945,19 +6145,19 @@ msgstr "Total de feriados"
 msgid "Total Ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr ""
 
@@ -5989,6 +6189,10 @@ msgstr "Tipo"
 msgid "Type a message"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr ""
@@ -5998,7 +6202,7 @@ msgstr ""
 msgid "URL/Method"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr ""
 
@@ -6032,6 +6236,8 @@ msgid "Unpublish"
 msgstr "Cancelar publicação"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr ""
 
@@ -6048,6 +6254,10 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:214
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
+msgstr ""
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
@@ -6076,10 +6286,13 @@ msgstr "Carregar"
 msgid "Upload Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
 msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
+msgstr "Carregar imagem"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
 msgid "Uploading {0}%"
@@ -6088,17 +6301,13 @@ msgstr ""
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6109,6 +6318,10 @@ msgstr "Usuário"
 #. Label of the user_resolution_time (Duration) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
 msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
@@ -6128,7 +6341,7 @@ msgstr "Usuários"
 msgid "Valid From"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "Valor"
 
@@ -6257,19 +6470,23 @@ msgstr "Anual"
 msgid "Yellow"
 msgstr "Amarelo"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr ""
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr ""
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr ""
 
@@ -6297,6 +6514,14 @@ msgstr ""
 msgid "You do not have permission to access Assignment Rules"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr ""
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr ""
@@ -6319,6 +6544,14 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:46
@@ -6349,7 +6582,7 @@ msgstr ""
 msgid "customize {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr "dias"
 
@@ -6400,7 +6633,7 @@ msgstr ""
 msgid "here."
 msgstr ""
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr "hrs"
 
@@ -6408,7 +6641,7 @@ msgstr "hrs"
 msgid "in"
 msgstr "em"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "agora mesmo"
 
@@ -6441,7 +6674,11 @@ msgstr ""
 msgid "purple"
 msgstr "roxo"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr ""
 
@@ -6458,7 +6695,7 @@ msgstr "tíquete"
 msgid "to enable this integration."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr ""
 
@@ -6466,12 +6703,32 @@ msgstr ""
 msgid "views"
 msgstr "visualizações"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr ""
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
 msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:307
@@ -6498,7 +6755,7 @@ msgstr ""
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr ""
 

--- a/helpdesk/locale/ru.po
+++ b/helpdesk/locale/ru.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-15 18:50\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-29 21:58\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Russian\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr "% Выполнение SLA"
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr "% созданных билетов, которые были решены в рамках SLA"
@@ -108,14 +108,6 @@ msgstr "Краткое описание"
 msgid "A workday with this name already exists"
 msgstr "Рабочий день с таким названием уже существует"
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr "API"
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr "Доступ ко всем билетам команды"
@@ -132,7 +124,7 @@ msgstr "Доступ только к билетам этой команды"
 msgid "Account"
 msgstr "Аккаунт"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr ""
 
@@ -152,11 +144,9 @@ msgstr "Действие"
 msgid "Action Required"
 msgstr "Требуется Действие"
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr "Действие, которое нужно выполнить при нажатии кнопки. Документ будет доступен как `this`"
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "Действия"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr "Действие, которое нужно выполнить при н
 msgid "Active"
 msgstr "Активен"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr ""
 
@@ -175,7 +165,7 @@ msgid "Active: The agent is available and working.<br>\n"
 "Unavailable: The agent is off and unavailable."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "Активность"
@@ -193,10 +183,11 @@ msgid "Add Column"
 msgstr "Добавить колонку"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "Добавить фильтр..."
 
@@ -207,6 +198,10 @@ msgstr "Добавить праздник"
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
 msgstr "Добавить новую статью"
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
+msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:148
 msgid "Add Sort"
@@ -244,7 +239,7 @@ msgstr "Добавить условие"
 msgid "Add condition group"
 msgstr "Добавить группу условий"
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "Добавить фильтр"
 
@@ -278,6 +273,12 @@ msgstr "Добавьте временные ориентиры для контр
 msgid "Add to Holidays"
 msgstr "Добавить в Праздники"
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr ""
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr "Добавляйте, управляйте агентами и назначайте им роли."
@@ -295,17 +296,14 @@ msgid "Administrator"
 msgstr "Администратор"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -316,6 +314,7 @@ msgstr "Администратор"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -335,6 +334,7 @@ msgstr "Панель управления агента"
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -342,6 +342,7 @@ msgstr "Панель управления агента"
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -376,18 +377,9 @@ msgstr "Агенты больше не смогут просматривать �
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "Все"
 
@@ -508,6 +500,14 @@ msgstr "Вы действительно хотите закрыть этот т�
 msgid "Are you sure you want to delete these articles?"
 msgstr "Вы уверены, что хотите удалить эти статьи?"
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr ""
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr "Вы уверены, что хотите удалить этот тикет? Это необратимое действие, и его нельзя отменить."
@@ -544,6 +544,10 @@ msgstr "Вы уверены, что хотите выйти? Несохранё�
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
 msgstr "Вы уверены, что хотите удалить логотип?"
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
+msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
 msgid "Are you sure you want to reset the content? Current content will be overridden."
@@ -595,16 +599,11 @@ msgstr "Назначьте заявку агенту"
 msgid "Assign ticket"
 msgstr "Назначить заявку"
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr "Назначить"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -618,7 +617,7 @@ msgstr "Правопреемник"
 msgid "Assignee Rules"
 msgstr "Правила назначения исполнителей"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr "Информация об исполнителе успешно обновлена."
 
@@ -626,7 +625,7 @@ msgstr "Информация об исполнителе успешно обно
 msgid "Assignees"
 msgstr "Исполнители"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr ""
 
@@ -692,10 +691,6 @@ msgstr "Правило назначения успешно обновлено."
 msgid "Assignment rule {0} updated successfully."
 msgstr "Правило назначения {0} успешно обновлено."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr "Требуется как минимум один адрес электронной почты"
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -712,10 +707,6 @@ msgstr "Для оценки {0} должна быть включена хотя 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
 msgstr "Требуется как минимум одна команда"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
-msgstr "Требуется указать как минимум один из параметров: приоритет, команда или тип тикета"
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
@@ -766,7 +757,7 @@ msgid "Automation"
 msgstr "Автоматизация"
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr ""
@@ -802,7 +793,7 @@ msgstr "Среднее время ответа"
 msgid "Average Time Metrics"
 msgstr "Показатели среднего времени"
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr "Средняя оценка отзывов в день составляет около {0} звезд"
 
@@ -810,25 +801,37 @@ msgstr "Средняя оценка отзывов в день составля�
 msgid "Average response and resolution metrics not available"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr "Среднее количество заявок в день около {0}"
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr "Средний рейтинг обратной связи"
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr "Средний первый ответ"
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr "Среднее разрешение"
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
-msgstr "Средний рейтинг отзыва для решенных заявок"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
+msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:290
@@ -840,11 +843,11 @@ msgstr "Среднее время первого ответа"
 msgid "Avg. resolution time"
 msgstr "Среднее время разрешения"
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr "Среднее время, затраченное на первый ответ на заявку"
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr "Среднее время на решение заявки"
 
@@ -867,11 +870,6 @@ msgstr "Вернуться к билетам"
 msgid "Base Support Rotation"
 msgstr "Базовая ротация поддержки"
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "Базовый URL"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -885,11 +883,11 @@ msgstr "В соответствии с вашей кадровой полити�
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr "В соответствии с вашей кадровой политикой выберите дату начала периода предоставления отпусков"
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr ""
 
@@ -944,11 +942,6 @@ msgstr "Деловые праздники"
 msgid "Busy"
 msgstr "Занят"
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "Кнопка"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr "CSV"
@@ -973,19 +966,31 @@ msgstr "Продолжительность звонка в секундах"
 msgid "Caller"
 msgstr "Звонящий"
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr "Звонки"
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr "Может приглашать новых агентов, управлять тикетами, создавать пользовательские представления и управлять публичными представлениями."
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr "Может управлять всеми аспектами работы службы поддержки."
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr "Может работать с тикетами, создавать пользовательские представления и управлять частными представлениями."
 
@@ -1025,7 +1030,7 @@ msgstr "Невозможно включить правило без добавл
 msgid "Cannot merge General category"
 msgstr "Нельзя объединить общую категорию"
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr ""
 
@@ -1073,11 +1078,11 @@ msgstr "Категория должна содержать хотя бы одн�
 msgid "Category updated successfully."
 msgstr "Категория успешно обновлена."
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr ""
 
@@ -1085,7 +1090,7 @@ msgstr ""
 msgid "Change"
 msgstr "Изменить"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "Изменить пароль"
@@ -1098,10 +1103,9 @@ msgstr ""
 msgid "Change language of the application."
 msgstr "Изменить язык приложения."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
-msgstr "Изменить фото"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
+msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
 msgid "Change priority"
@@ -1123,7 +1127,7 @@ msgstr "Изменить тип билета"
 msgid "Change timezone of the application."
 msgstr "Изменить часовой пояс приложения."
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr "В целях безопасности измените пароль своей учетной записи."
 
@@ -1136,7 +1140,7 @@ msgstr "Каналы"
 msgid "Child field"
 msgstr "Дочернее поле"
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr ""
 
@@ -1189,7 +1193,7 @@ msgstr "Очистить сортировку"
 msgid "Clear Table"
 msgstr "Очистить таблицу"
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr ""
 
@@ -1204,6 +1208,10 @@ msgstr "Очистить все фильтры"
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
 msgstr "Нажмите \"Добавить в праздники\". Это заполнит таблицу праздников всеми датами, которые приходятся на выбранный выходной. Повторите процесс для заполнения дат всех ваших еженедельных выходных"
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:47
@@ -1223,7 +1231,7 @@ msgstr "Закрыть тикет"
 msgid "Closed"
 msgstr "Закрыт"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr "Закрытые или оцененные тикеты не могут обновляться не агентами"
 
@@ -1250,7 +1258,7 @@ msgstr "Колонны"
 msgid "Comma separated emails to invite."
 msgstr "Разделенные запятыми электронные письма для приглашения."
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr ""
 
@@ -1283,7 +1291,7 @@ msgstr "Прокомментировал"
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "Комментарии"
@@ -1296,6 +1304,11 @@ msgstr "Коммуникация"
 msgid "Communication ID is required"
 msgstr "Требуется идентификатор связи"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
+msgstr "Организация"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
 msgstr "Завершенно"
@@ -1307,7 +1320,7 @@ msgstr "Завершенно"
 msgid "Condition"
 msgstr "Условия"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr ""
 
@@ -1331,6 +1344,10 @@ msgstr "Здесь вы можете настроить параметры ин�
 msgid "Configure your telephony settings."
 msgstr "Настройте параметры телефонии."
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1356,10 +1373,11 @@ msgstr "Подтвердите замену"
 msgid "Connect your support email"
 msgstr "Укажите свой адрес электронной почты службы поддержки"
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1373,26 +1391,30 @@ msgstr "Контакт"
 msgid "Contact HTML"
 msgstr "Контактный HTML"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
-msgstr "Контакт успешно создан."
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
-msgstr "Контактное лицо успешно приглашено."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
+msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr "Контактная информация успешно обновлена."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
-msgstr "Контакт по электронной почте уже существует"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
+msgstr ""
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
 msgstr "Контакты"
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
+msgstr ""
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
 #. Label of the content (Text Editor) field in DocType 'HD Article'
@@ -1415,7 +1437,7 @@ msgstr "Скопировать URL-адрес билета"
 msgid "Copy ticket id"
 msgstr "Скопируйте идентификатор билета"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr "Не удалось отправить email из-за: {0}"
 
@@ -1423,7 +1445,11 @@ msgstr "Не удалось отправить email из-за: {0}"
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr "Не удалось отправить подтверждающее письмо из-за: {0}"
 
@@ -1431,11 +1457,20 @@ msgstr "Не удалось отправить подтверждающее пи
 msgid "Could not send feedback email,due to: {0}"
 msgstr "Не удалось отправить email обратной связи из-за: {0}"
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "Страна"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1446,9 +1481,13 @@ msgstr "Создать"
 msgid "Create & invite a contact"
 msgstr "Создайте и пригласите контакт"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
-msgstr "Создать новый контакт"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
+msgstr "Создать клиента"
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
 msgid "Create View"
@@ -1482,12 +1521,6 @@ msgstr "Создано"
 msgid "Creating a ticket"
 msgstr ""
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr "Критерий"
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr ""
@@ -1512,12 +1545,21 @@ msgid "Custom Views"
 msgstr ""
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
 msgstr "Клиент"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
+msgstr ""
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1528,17 +1570,33 @@ msgstr "Имя клиента"
 msgid "Customer Portal"
 msgstr ""
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
-msgstr "Клиент успешно создан."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr "Тип клиента"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr "Клиентский портал"
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
-msgstr "Обновление данных клиента прошло успешно."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
+msgstr "Клиенты"
 
 #: desk/src/components/layouts/Sidebar.vue:595
 msgid "Customers & Contacts"
@@ -1565,6 +1623,8 @@ msgstr "Циан"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "Опасность"
@@ -1665,18 +1725,26 @@ msgstr "Тип тикета по умолчанию"
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr "Определите, кто получает тикеты и как они распределяются между агентами."
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "Удалить"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1693,6 +1761,10 @@ msgstr "Удалить категорию?"
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
 msgstr "Удалить {0}"
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
+msgstr ""
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
 #. Label of the description (Text Editor) field in DocType 'HD Holiday'
@@ -1740,7 +1812,7 @@ msgstr "Подробное объяснение"
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1826,7 +1898,12 @@ msgstr "Документы"
 msgid "Document Type"
 msgstr "Тип документа"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr ""
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "Домен"
@@ -1868,6 +1945,10 @@ msgstr "Дублирующая политика SLA"
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
 msgstr "Дубликат сохраненного ответа"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
 #: desk/src/pages/call-logs/CallLogModal.vue:68
@@ -1917,7 +1998,8 @@ msgstr ""
 msgid "Easily invite new agents, managers, or admins."
 msgstr "Легко приглашайте новых агентов, менеджеров или администраторов."
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1926,6 +2008,14 @@ msgstr "Редактировать"
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
 msgstr "Редактировать журнал вызовов"
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
+msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:70
 #: desk/src/components/Settings/EmailEdit.vue:63
@@ -1944,10 +2034,10 @@ msgstr "Изменить заголовок"
 msgid "Edit your email account"
 msgstr "Редактировать свой адрес электронной почты"
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "Email"
 
@@ -1975,9 +2065,10 @@ msgstr "Учетные записи Email"
 msgid "Email Content"
 msgstr "Содержимое письма"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
-msgstr "Email Id"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
+msgstr "Email ID"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
 #. Settings'
@@ -2002,22 +2093,22 @@ msgstr "Имя пользователя электронной почты"
 msgid "Email account updated successfully"
 msgstr "Учетная запись Email успешно обновлена"
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr ""
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr "Настройки Exotel успешно обновлены."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr "Адрес электронной почты не должен быть пустым"
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "Электронные письма"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr ""
 
@@ -2055,8 +2146,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr "Включить обратную связь для портала клиента"
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2081,8 +2170,6 @@ msgstr "Включить обратную связь для портала кл�
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2105,21 +2192,25 @@ msgstr "Время окончания"
 msgid "Enter a name for this HD Service Holiday List."
 msgstr "Введите название для этого списка праздников HD Service."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr "Введите действительный адрес электронной почты"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr "Введите действительный номер телефона"
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr "Введите название бренда"
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr ""
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
 msgstr "Введите новое название команды"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
+msgstr ""
 
 #: helpdesk/api/knowledge_base.py:86
 msgid "Error moving article to category"
@@ -2129,22 +2220,18 @@ msgstr "Ошибка перемещения статьи в категорию"
 msgid "Error processing email at index {0}, message: {1}"
 msgstr "Ошибка при обработке письма с индексом {0}, сообщение: {1}"
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr "Ошибка при обновлении данных клиента"
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "Ошибка при подключении к учетной записи электронной почты {0}"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr "Правило эскалации для данного критерия уже существует"
 
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
 msgstr "Excel"
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
+msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
 #: desk/src/components/Settings/Telephony/Telephony.vue:96
@@ -2172,11 +2259,6 @@ msgstr "Экспортировать все {0} записи"
 msgid "Export Type"
 msgstr "Тип экспорта"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr "Внешняя ссылка"
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2184,6 +2266,10 @@ msgstr "Внешняя ссылка"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "Не выполнено"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2218,11 +2304,11 @@ msgstr "Не удалось сохранить настройки Exotel"
 msgid "Failed to save Twilio settings"
 msgstr "Не удалось сохранить настройки Twilio"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr "Не удалось обновить данные о правообладателе."
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr ""
 
@@ -2251,6 +2337,7 @@ msgstr "Favicon"
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2288,13 +2375,17 @@ msgstr "Обратная связь уже существует"
 msgid "Feedback Rating"
 msgstr "Оценка обратной связи"
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr "Тенденция обратной связи"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
 msgstr "Email обратной связи отправлен клиенту"
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
+msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
 msgid "Feedback submitted successfully."
@@ -2338,13 +2429,14 @@ msgid "Field dependency updated successfully."
 msgstr "Зависимость поля успешно обновлена."
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "Поля"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "Фильтры"
@@ -2354,7 +2446,8 @@ msgstr "Фильтры"
 msgid "Find out all of the variables that can be used in the content"
 msgstr "Узнайте все переменные, которые можно использовать в содержимом"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "Имя"
 
@@ -2362,6 +2455,10 @@ msgstr "Имя"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
 msgstr "Первый ответ дан"
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
+msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -2386,10 +2483,6 @@ msgstr "Время первого отклика"
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
 msgstr "Время первого отклика по тикетам"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
-msgstr "Имя не должно быть пустым"
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
@@ -2480,6 +2573,10 @@ msgstr "Глобальный"
 msgid "Go to Ticket #{0}"
 msgstr "Перейти к билету #{0}"
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr ""
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2509,8 +2606,6 @@ msgid "Group By Field"
 msgstr "Группировать по полю"
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr "Гость"
@@ -2518,11 +2613,6 @@ msgstr "Гость"
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
 msgstr "Направляйте пользователей к статьям до тикетов."
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
-msgstr "Действие HD"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -2554,25 +2644,37 @@ msgstr "Обратная связь по статье HD"
 msgid "HD Comment Reaction"
 msgstr "Реакция на комментарий HD"
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr "Клиент HD"
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr ""
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
-msgstr "Запрос аккаунта HD Desk"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
+msgstr ""
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
 msgstr "Email обратная связь HD"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
-msgstr "Правило эскалации HD"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -2593,21 +2695,6 @@ msgstr "Праздник HD"
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
 msgstr "Уведомление HD"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr "Организация HD"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr "Контактный элемент организации HD"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
-msgstr "Запрос регистрации на портале HD"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -2649,11 +2736,6 @@ msgstr "Настройки HD"
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
 msgstr "Стоп-слово HD"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
-msgstr "Источник поиска поддержки HD"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_synonym/hd_synonym.json
@@ -2750,12 +2832,6 @@ msgstr "Служба поддержки"
 msgid "Helpdesk"
 msgstr "Служба поддержки"
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr "Контакт службы поддержки"
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2772,11 +2848,6 @@ msgstr "Привет"
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
 msgstr "Скрыть "
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr "Условие скрытия"
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
@@ -2846,15 +2917,8 @@ msgstr "Я понимаю, добавить условия"
 msgid "ID"
 msgstr "ID"
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "IP-адрес"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2941,6 +3005,11 @@ msgstr "Входящие"
 msgid "Incoming"
 msgstr "Входящий"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr "Частное лицо"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr "По инициативе"
@@ -2954,7 +3023,7 @@ msgstr ""
 msgid "Instantly send e-mail"
 msgstr "Отправить email мгновенно"
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "Недостаточное разрешение для {0}"
 
@@ -2968,13 +3037,13 @@ msgstr "Целочисленное значение"
 msgid "Introduction"
 msgstr "Введение"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
-msgstr "Неверный адрес электронной почты"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
 #: desk/src/components/Settings/Holiday/HolidayView.vue:325
@@ -2982,23 +3051,43 @@ msgstr "Неверный адрес электронной почты"
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr "Некорректные данные, проверьте правильность заполнения полей."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr "Недопустимый тип файла, разрешены только изображения в форматах PNG и JPG"
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr "Недопустимое уведомление"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
 msgstr "Неверный номер телефона"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr ""
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
+msgstr "Пригласить"
 
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
 msgstr "Пригласить агентов"
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
 msgid "Invite agent"
@@ -3008,13 +3097,30 @@ msgstr "Пригласить агента"
 msgid "Invite agents"
 msgstr "Пригласить агентов"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
-msgstr "Пригласить в качестве пользователя"
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
+msgstr "Пригласить как пользователя"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
 msgstr "Пригласить по электронной почте"
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr "Приглашен"
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
+msgstr ""
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -3030,6 +3136,11 @@ msgstr "Является порталом клиента"
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "По умолчанию"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr ""
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3058,6 +3169,10 @@ msgstr "Закреплен"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
 msgstr "Настройка завершена"
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
+msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:114
 msgid "Jump to"
@@ -3093,11 +3208,9 @@ msgstr "Горячие клавиши"
 msgid "Knowledge Base"
 msgstr "База знаний"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3131,9 +3244,9 @@ msgstr "Последний"
 msgid "Last 3 Months"
 msgstr "За 3 месяцев"
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr "Последние 3 месяца"
 
@@ -3174,7 +3287,8 @@ msgstr "Последний ответ клиента"
 msgid "Last Month"
 msgstr "Последний месяц"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "Фамилия"
 
@@ -3183,24 +3297,33 @@ msgstr "Фамилия"
 msgid "Last Week"
 msgstr "Последняя неделя"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
 msgstr "В прошлом месяце"
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr "Последний пользователь, назначенный этим правилом"
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
 msgstr "На прошлой неделе"
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
+msgstr "Последние"
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -3217,26 +3340,6 @@ msgstr "Узнать об условиях"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
 msgstr "Сообщите клиентам, что они создают заявку вне рабочего времени, и когда они могут ожидать ответа."
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "Ссылка"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr "Параметры ссылки"
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr "Ссылка на клиента"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
-msgstr "Ссылка на запись о клиенте"
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #. Label of the list_tab (Tab Break) field in DocType 'HD View'
@@ -3264,6 +3367,8 @@ msgstr "Загрузить столбцы по умолчанию"
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "Загрузить ещё"
 
@@ -3286,6 +3391,8 @@ msgstr "Войти в Frappe Cloud"
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr "Логотип"
@@ -3324,7 +3431,7 @@ msgstr "Управление общими настройками вашего п
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr "Настройте быстрые ответы, которые можно использовать для обработки запросов клиентов."
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr ""
 
@@ -3343,6 +3450,10 @@ msgstr ""
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
 msgstr "Управление информацией своего профиля."
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
+msgstr "Менеджер"
 
 #: desk/src/pages/MobileNotifications.vue:11
 #: desk/src/pages/MobileNotifications.vue:14
@@ -3396,6 +3507,20 @@ msgstr "Разное"
 msgid "Mobile App Installation"
 msgstr ""
 
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr "Номер мобильного телефона"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr "Мобильный номер"
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr ""
+
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
 #. List'
@@ -3436,7 +3561,7 @@ msgid "My Tickets"
 msgstr "Мои билеты"
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3447,8 +3572,9 @@ msgstr "Мои билеты"
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3458,6 +3584,10 @@ msgstr "Имя"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
 msgstr "Вес имени"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
+msgstr "Имя обязательно"
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
 #. Ticket Status'
@@ -3469,10 +3599,18 @@ msgstr "Имя, отображаемое на клиентском портал�
 msgid "Navigation"
 msgstr "Навигация"
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr "Сначала отрицательный"
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "Никогда"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3581,11 +3719,11 @@ msgstr "Нет ответа"
 msgid "No Data Found"
 msgstr "Данные не найдены"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr ""
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr ""
 
@@ -3597,9 +3735,15 @@ msgstr "Список праздников не найден"
 msgid "No SLA found"
 msgstr "Соглашение об уровне обслуживания не найдено"
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
 msgstr "Без команды"
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
+msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
 msgid "No additional comments"
@@ -3633,19 +3777,27 @@ msgstr "Категории отсутствуют"
 msgid "No changes made"
 msgstr "Никаких изменений не было сделано"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr "Изменений для сохранения нет"
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr "Диаграммы не добавлены"
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr ""
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr "Контакты для примененных фильтров не найдены. Попробуйте отрегулировать или очистить фильтры."
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr ""
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr "Для примененных фильтров не найдено ни одного клиента. Попробуйте изменить или очистить фильтры."
 
@@ -3657,7 +3809,11 @@ msgstr "Учетная запись электронной почты не на�
 msgid "No feedback"
 msgstr "Нет обратной связи"
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr ""
 
@@ -3697,19 +3853,25 @@ msgstr "Нет причин"
 msgid "No recently assigned tickets"
 msgstr "Недавно назначенных тикетов нет"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr ""
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
 msgstr "Результаты не найдены"
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
+msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:91
 msgid "No saved replies found"
 msgstr "Сохранённые ответы не найдены"
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr "Билеты не найдены"
@@ -3730,7 +3892,11 @@ msgstr "Билеты на предварительный просмотр не �
 msgid "No tickets selected"
 msgstr ""
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr ""
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "Не разрешено"
 
@@ -3742,7 +3908,7 @@ msgstr "Не назначено"
 msgid "Not Saved"
 msgstr "Не сохранено"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "Не установлено"
 
@@ -3781,11 +3947,6 @@ msgstr "Старые условия"
 msgid "On Hold Since"
 msgstr "На удержании с"
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr "При клике (Javascript)"
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr "Статус заявки"
@@ -3816,6 +3977,10 @@ msgstr "Открыть палитру команд"
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
 msgstr "Открыть поле для комментариев"
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
+msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
 msgid "Open help"
@@ -3906,7 +4071,12 @@ msgstr "Родительское поле"
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr "Требуются родительское поле, дочернее поле и сопоставление родитель-потомок."
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr "Сотрудничество"
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "Пароль"
 
@@ -3944,6 +4114,7 @@ msgid "Pending"
 msgstr "В ожидании"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr "Ожидающие приглашения"
 
@@ -3953,19 +4124,19 @@ msgstr "Ожидающие приглашения"
 msgid "Pending Tickets"
 msgstr "Ожидающие билеты"
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr "Процент от общего числа билетов по каналам"
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr "Процент от общего числа билетов по приоритету"
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr "Процент от общего количества билетов по командам"
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr "Процент от общего числа билетов по типам"
 
@@ -3986,14 +4157,15 @@ msgstr "Личный"
 msgid "Personal mobile no"
 msgstr "Личный мобильный номер"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "Телефон"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
-msgstr "Номера телефонов"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
+msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
 msgid "Pick an option"
@@ -4049,7 +4221,7 @@ msgstr "Пожалуйста, введите тему, чтобы продолж
 msgid "Please enter a valid phone number"
 msgstr "Пожалуйста, введите действительный номер телефона"
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr ""
 
@@ -4092,34 +4264,15 @@ msgstr "Пожалуйста, выберите в неделю выходной"
 msgid "Policy name"
 msgstr "Название полиса"
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
 msgstr "Сначала положительные"
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr "Ключ описания записи"
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr "Список ключей маршрута доставки"
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr "Строка маршрута доставки"
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
-msgstr "Ключ заголовка сообщения"
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:10
@@ -4153,14 +4306,32 @@ msgstr "Просмотр"
 msgid "Previous ticket"
 msgstr "Предыдущий билет"
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "Главная"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "Основной контакт"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr ""
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr "Очередность"
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4168,9 +4339,10 @@ msgstr "Очередность"
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4250,17 +4422,6 @@ msgstr "Извлечение писем может занять нескольк
 msgid "Quarterly"
 msgstr "Ежеквартально"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "Параметры запроса"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr "Строка маршрута запроса"
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "В очереди"
@@ -4283,14 +4444,14 @@ msgstr "Оцените качество поддержки"
 msgid "Rate this ticket"
 msgstr "Оцените этот билет"
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr "Рейтинг Заявок"
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4386,8 +4547,15 @@ msgstr "Пересоздать поисковый индекс"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "Удалить"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4397,10 +4565,19 @@ msgstr "Удалить логотип"
 msgid "Remove Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
-msgstr "Удалить фото"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr "Удалить изображение"
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
+msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
 #: desk/src/components/Settings/Teams/TeamsList.vue:161
@@ -4420,6 +4597,15 @@ msgstr "Переименовать (⌘ + ⏎)"
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
 msgstr "Переименовать команду"
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
+msgstr ""
 
 #. Option in a Select field in the tickets Web Form
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
@@ -4458,17 +4644,14 @@ msgstr "Ответ от контакта"
 msgid "Reply on a ticket"
 msgstr "Ответить на заявку"
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr "Ключ запроса"
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
 msgstr "Обязательно"
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
+msgstr ""
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
 msgid "Reset"
@@ -4488,6 +4671,7 @@ msgid "Reset to Default"
 msgstr "Сброс по умолчанию"
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr "Решение"
@@ -4541,18 +4725,6 @@ msgstr "Ответ"
 msgid "Response By"
 msgstr "Ответ от"
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr "Варианты ответа"
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr "Путь ключей результата ответа"
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr "Время отклика для приоритета {0} в строке {1} не может быть больше времени разрешения."
@@ -4595,37 +4767,33 @@ msgstr "Ограничить просмотр и управление тикет
 msgid "Restrict visibility to these teams"
 msgstr "Ограничить доступ к информации для этих команд"
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr "Поле предварительного просмотра результата"
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr "Поле маршрута результата"
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr "Поле заголовка результата"
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
 msgstr "Отзывы"
 
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:215
 msgid "Ringing"
 msgstr "Идет вызов"
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "Роль"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr "Роль успешно обновлена"
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4724,9 +4892,9 @@ msgstr "Суббота"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4802,17 +4970,19 @@ msgstr "Поисковый индекс пересоздан"
 msgid "Search Score"
 msgstr "Поисковый балл"
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr "Название параметра поискового запроса"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "Поля поиска..."
 
@@ -4852,6 +5022,7 @@ msgstr "Поиск..."
 msgid "Searched for:"
 msgstr "Искалось:"
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr "Идет поиск..."
@@ -4871,6 +5042,10 @@ msgstr "Выбрать"
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
 msgstr "Выберите категорию"
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
+msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
 msgid "Select Range"
@@ -4892,6 +5067,10 @@ msgstr "Выберите приоритет по умолчанию."
 msgid "Select a rating"
 msgstr "Выберите оценку"
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr ""
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4904,6 +5083,10 @@ msgstr "Избранные команды"
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
 msgstr "Выберите билет для предварительного просмотра"
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
 msgid "Select what type all tickets get by default."
@@ -4930,6 +5113,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
 msgstr "Отправить обратную связь когда"
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
+msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
 msgid "Send to {0} tickets"
@@ -4969,7 +5156,7 @@ msgstr "Название уровня обслуживания"
 msgid "Service not supported"
 msgstr "Сервис не поддерживается"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "Установить"
 
@@ -4977,6 +5164,10 @@ msgstr "Установить"
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
 msgstr "Установить номер телефона"
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
 msgid "Set Resolution Time for Priority {0} in row {1}."
@@ -4986,12 +5177,21 @@ msgstr "Установить время решения для приоритет
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr "Установить время отклика для приоритета {0} в строке {1}."
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr "Установить как SLA по умолчанию"
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr ""
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr ""
 
@@ -5003,7 +5203,7 @@ msgstr "Задайте статус по умолчанию, назначаем�
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr "Установите рабочие дни, часы и праздники, выбрав предопределенное расписание или создав новое."
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr ""
 
@@ -5137,23 +5337,6 @@ msgstr "Произошла ошибка при обновлении списка
 msgid "Sort"
 msgstr "Сортировать"
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr "Исходный тип документа"
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "Имя источника"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr "Исходный тип"
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr "Исходная и целевая категория не могут быть одинаковыми"
@@ -5198,6 +5381,8 @@ msgstr "Время начала не может быть больше или р�
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5266,6 +5451,7 @@ msgstr "Статус тикета, когда он создан в систем�
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5377,21 +5563,16 @@ msgstr "Система"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5430,8 +5611,6 @@ msgstr "Целевой тикет не существует"
 msgid "Teal"
 msgstr "Бирюзовый"
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5442,7 +5621,6 @@ msgstr "Бирюзовый"
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5548,6 +5726,10 @@ msgstr "Назначение условия Json '{0}' недействител�
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr "Назначение условия Json '{0}' недействительно: {1}"
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr ""
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr "Диалоговое окно обратной связи будет показано, когда пользователь попытается закрыть тикет из клиентского портала."
@@ -5559,6 +5741,10 @@ msgstr "Праздник на {0} не между From Date и To Date"
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
 msgstr "Количество дней должно быть 1 или более"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
 msgid "The status for sending feedback must be of <u>Resolved</u> category."
@@ -5580,6 +5766,14 @@ msgstr "В настоящий момент категории не опубли�
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr ""
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr ""
@@ -5588,6 +5782,10 @@ msgstr ""
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
 msgstr "Это действие необратимо."
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
+msgstr ""
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
 msgid "This date is calculated based on configured SLAs, working hours, and holidays."
@@ -5656,7 +5854,7 @@ msgstr "Четверг"
 msgid "Ticket"
 msgstr "Заявка"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr "Заявка #{0}: Мы получили ваш запрос"
 
@@ -5671,6 +5869,10 @@ msgstr "Аналитика тикетов"
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
 msgstr "Конфигурация тикетов"
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
+msgstr ""
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
 msgid "Ticket Info"
@@ -5729,7 +5931,7 @@ msgstr ""
 msgid "Ticket Summary"
 msgstr "Сводка по тикетам"
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr "Тренд заявки"
 
@@ -5762,7 +5964,7 @@ msgstr "Тикет не существует."
 msgid "Ticket merged successfully."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr "Тикет должен быть решен с обратной связью"
 
@@ -5797,12 +5999,6 @@ msgstr "Статус билета"
 msgid "Ticket to merged with is required"
 msgstr ""
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr "Тип тикета"
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr ""
@@ -5814,12 +6010,15 @@ msgstr "Анализ поиска тикетов"
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr "Заявки"
 
@@ -5831,19 +6030,19 @@ msgstr "Тикеты, приближающиеся к SLA или нарушаю�
 msgid "Tickets assigned to you in the last 7 days"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr "Заявки по каналам"
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr "Заявки по приоритету"
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr "Заявки по команде"
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr "Заявки по типу"
 
@@ -5860,6 +6059,7 @@ msgid "Tickets that are awaiting your response"
 msgstr "Тикеты, ожидающие вашего ответа"
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr "Часовой пояс"
 
@@ -5949,19 +6149,19 @@ msgstr "Всего праздников"
 msgid "Total Ticket"
 msgstr "Всего тикетов"
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr "Общее количество созданных заявок"
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr "Общее количество билетов по приоритету"
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr "Общее количество билетов по командам"
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr "Общее количество билетов по типу"
 
@@ -5993,6 +6193,10 @@ msgstr "Тип"
 msgid "Type a message"
 msgstr "Введите сообщение"
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr "Требуется ввести текст"
@@ -6002,7 +6206,7 @@ msgstr "Требуется ввести текст"
 msgid "URL/Method"
 msgstr "URL/Метод"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr "Не удаётся отправить электронное письмо. Пожалуйста, настройте учётную запись для исходящей почты по умолчанию."
 
@@ -6036,6 +6240,8 @@ msgid "Unpublish"
 msgstr "Отменить публикацию"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr "Не сохранено"
 
@@ -6053,6 +6259,10 @@ msgstr "Не сохранено"
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
 msgstr "Несохранённые изменения"
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
 msgid "Untitled"
@@ -6080,10 +6290,13 @@ msgstr "Загрузить"
 msgid "Upload Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
-msgstr "Загрузить фото"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
+msgstr "Загрузить изображение"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
 msgid "Uploading {0}%"
@@ -6092,17 +6305,13 @@ msgstr "Загрузка {0}%"
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6114,6 +6323,10 @@ msgstr "Пользователь"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
 msgstr "Время решения задачи пользователем"
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
+msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
 msgid "User Signup"
@@ -6132,7 +6345,7 @@ msgstr "Пользователи"
 msgid "Valid From"
 msgstr "Действительно с"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "Значение"
 
@@ -6261,19 +6474,23 @@ msgstr "Ежегодно"
 msgid "Yellow"
 msgstr "Желтый"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr ""
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr "Вам не разрешено просматривать данные этой панели."
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr "Вы не имеете права доступа к этому ресурсу."
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr "Вам не разрешено добавлять комментарий"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr ""
 
@@ -6301,6 +6518,14 @@ msgstr "Вы не можете установить более одного пр
 msgid "You do not have permission to access Assignment Rules"
 msgstr "У вас нет разрешения на доступ к Правилам назначения заданий"
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr ""
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr "У вас нет доступа к этому билету, или он больше не существует."
@@ -6324,6 +6549,14 @@ msgstr "Ваше старое условие будет перезаписано
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
 msgstr "Ваша производительность"
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
+msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:46
 msgid "assigned you a ticket"
@@ -6353,7 +6586,7 @@ msgstr "созданный"
 msgid "customize {0}"
 msgstr "настроить {0}"
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr "дни"
 
@@ -6404,7 +6637,7 @@ msgstr "здесь"
 msgid "here."
 msgstr "здесь."
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr "часов"
 
@@ -6412,7 +6645,7 @@ msgstr "часов"
 msgid "in"
 msgstr "входит в"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "только что"
 
@@ -6445,7 +6678,11 @@ msgstr ""
 msgid "purple"
 msgstr "фиолетовый"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr "обзоры"
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr "звезды"
 
@@ -6462,7 +6699,7 @@ msgstr "заявка"
 msgid "to enable this integration."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr "просмотрели это"
 
@@ -6470,12 +6707,32 @@ msgstr "просмотрели это"
 msgid "views"
 msgstr "панели и представления"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr ""
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
 msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:307
@@ -6502,7 +6759,7 @@ msgstr "{0} В данный момент представление общедо
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr "{0} В настоящее время вид виден на боковой панели. Скрыв его, Вы уберете его из боковой панели."
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr ""
 

--- a/helpdesk/locale/sl.po
+++ b/helpdesk/locale/sl.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-15 18:50\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-29 21:58\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Slovenian\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr "% izpolnjen Sporazum o Ravni Storitev"
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr "% ustvarjenih zahtevkov, ki so bili rešeni v okviru Sporazuma o Ravni Storitev"
@@ -108,14 +108,6 @@ msgstr ""
 msgid "A workday with this name already exists"
 msgstr ""
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr "API"
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr ""
@@ -132,7 +124,7 @@ msgstr ""
 msgid "Account"
 msgstr "Račun"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr ""
 
@@ -152,11 +144,9 @@ msgstr "Dejanje"
 msgid "Action Required"
 msgstr "Zahtevano Dejanje"
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr "Dejanje, ki se izvede ob kliku na gumb. Dokument bo na voljo kot `this`"
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "Dejanja"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr "Dejanje, ki se izvede ob kliku na gumb. Dokument bo na voljo kot `this`"
 msgid "Active"
 msgstr "Aktivno"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr ""
 
@@ -175,7 +165,7 @@ msgid "Active: The agent is available and working.<br>\n"
 "Unavailable: The agent is off and unavailable."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "Dejavnost"
@@ -193,10 +183,11 @@ msgid "Add Column"
 msgstr "Dodaj Stolpec"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "Dodaj Filter..."
 
@@ -206,6 +197,10 @@ msgstr "Dodaj Praznik"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
 msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:148
@@ -244,7 +239,7 @@ msgstr "Dodaj pogoj"
 msgid "Add condition group"
 msgstr "Dodaj skupino pogojev"
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "Dodaj filter"
 
@@ -278,6 +273,12 @@ msgstr "Dodajte časovne cilje glede mejnikov podpore, kot so časi prvega odgov
 msgid "Add to Holidays"
 msgstr "Dodaj v Praznike"
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr ""
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr "Dodajte, upravljajte agente in jim dodelite vloge."
@@ -295,17 +296,14 @@ msgid "Administrator"
 msgstr "Administrator"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -316,6 +314,7 @@ msgstr "Administrator"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -335,6 +334,7 @@ msgstr ""
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -342,6 +342,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -376,18 +377,9 @@ msgstr ""
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "Vsi"
 
@@ -508,6 +500,14 @@ msgstr ""
 msgid "Are you sure you want to delete these articles?"
 msgstr ""
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr ""
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr ""
@@ -543,6 +543,10 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
 msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
@@ -595,16 +599,11 @@ msgstr ""
 msgid "Assign ticket"
 msgstr ""
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr "Dodeli"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -618,7 +617,7 @@ msgstr "Prejemnik"
 msgid "Assignee Rules"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr ""
 
@@ -626,7 +625,7 @@ msgstr ""
 msgid "Assignees"
 msgstr "Prejemniki"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr ""
 
@@ -692,10 +691,6 @@ msgstr ""
 msgid "Assignment rule {0} updated successfully."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -711,10 +706,6 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
-msgstr ""
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
 msgstr ""
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
@@ -766,7 +757,7 @@ msgid "Automation"
 msgstr "Avtomatizacija"
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr ""
@@ -802,7 +793,7 @@ msgstr ""
 msgid "Average Time Metrics"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr ""
 
@@ -810,24 +801,36 @@ msgstr ""
 msgid "Average response and resolution metrics not available"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
 msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
@@ -840,11 +843,11 @@ msgstr ""
 msgid "Avg. resolution time"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr ""
 
@@ -867,11 +870,6 @@ msgstr ""
 msgid "Base Support Rotation"
 msgstr ""
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "Osnovni URL"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -885,11 +883,11 @@ msgstr ""
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr ""
 
@@ -944,11 +942,6 @@ msgstr ""
 msgid "Busy"
 msgstr "Zasedeno"
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "Gumb"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr "CSV"
@@ -973,19 +966,31 @@ msgstr "Trajanje klica v sekundah"
 msgid "Caller"
 msgstr "Klicatelj"
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr "Klici"
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr ""
 
@@ -1025,7 +1030,7 @@ msgstr ""
 msgid "Cannot merge General category"
 msgstr ""
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr ""
 
@@ -1073,11 +1078,11 @@ msgstr ""
 msgid "Category updated successfully."
 msgstr "Kategorija je uspešno posodobljena."
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr ""
 
@@ -1085,7 +1090,7 @@ msgstr ""
 msgid "Change"
 msgstr "Spremeni"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "Spremeni Geslo"
@@ -1098,9 +1103,8 @@ msgstr ""
 msgid "Change language of the application."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
@@ -1123,7 +1127,7 @@ msgstr ""
 msgid "Change timezone of the application."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr ""
 
@@ -1136,7 +1140,7 @@ msgstr ""
 msgid "Child field"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr ""
 
@@ -1189,7 +1193,7 @@ msgstr ""
 msgid "Clear Table"
 msgstr "Počisti Tabelo"
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr ""
 
@@ -1203,6 +1207,10 @@ msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
@@ -1223,7 +1231,7 @@ msgstr ""
 msgid "Closed"
 msgstr "Zaprto"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr ""
 
@@ -1250,7 +1258,7 @@ msgstr "Stolpci"
 msgid "Comma separated emails to invite."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr ""
 
@@ -1283,7 +1291,7 @@ msgstr "Komentiral"
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "Komentarji"
@@ -1296,6 +1304,11 @@ msgstr "Komunikacija"
 msgid "Communication ID is required"
 msgstr ""
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
+msgstr "Podjetje"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
 msgstr "Dokončano"
@@ -1307,7 +1320,7 @@ msgstr "Dokončano"
 msgid "Condition"
 msgstr "Stanje"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr ""
 
@@ -1331,6 +1344,10 @@ msgstr ""
 msgid "Configure your telephony settings."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1356,10 +1373,11 @@ msgstr "Potrdi prepis"
 msgid "Connect your support email"
 msgstr ""
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1373,26 +1391,30 @@ msgstr "Kontakt"
 msgid "Contact HTML"
 msgstr "Kontakt HTML"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
 msgstr ""
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
 msgstr "Kontakti"
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
+msgstr ""
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
 #. Label of the content (Text Editor) field in DocType 'HD Article'
@@ -1415,7 +1437,7 @@ msgstr ""
 msgid "Copy ticket id"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr ""
 
@@ -1423,7 +1445,11 @@ msgstr ""
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr ""
 
@@ -1431,11 +1457,20 @@ msgstr ""
 msgid "Could not send feedback email,due to: {0}"
 msgstr ""
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "Država"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1446,8 +1481,12 @@ msgstr "Ustvari"
 msgid "Create & invite a contact"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
 msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
@@ -1482,12 +1521,6 @@ msgstr ""
 msgid "Creating a ticket"
 msgstr ""
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr ""
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr ""
@@ -1512,12 +1545,21 @@ msgid "Custom Views"
 msgstr ""
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
 msgstr "Stranka"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
+msgstr ""
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1528,16 +1570,32 @@ msgstr "Ime Stranke"
 msgid "Customer Portal"
 msgstr ""
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
 msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
 msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:595
@@ -1565,6 +1623,8 @@ msgstr "Cian"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "Nevarnost"
@@ -1665,18 +1725,26 @@ msgstr ""
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr ""
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "Izbriši"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1693,6 +1761,10 @@ msgstr ""
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
 msgstr "Izbriši {0}"
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
+msgstr ""
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
 #. Label of the description (Text Editor) field in DocType 'HD Holiday'
@@ -1740,7 +1812,7 @@ msgstr ""
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1826,7 +1898,12 @@ msgstr ""
 msgid "Document Type"
 msgstr "Tip Dokumenta"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr ""
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "Domena"
@@ -1867,6 +1944,10 @@ msgstr "Podvoji pravilo Sporazuma o Ravni Storitev"
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
@@ -1917,7 +1998,8 @@ msgstr ""
 msgid "Easily invite new agents, managers, or admins."
 msgstr ""
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1925,6 +2007,14 @@ msgstr "Uredi"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
 msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:70
@@ -1944,10 +2034,10 @@ msgstr ""
 msgid "Edit your email account"
 msgstr ""
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "E-pošta"
 
@@ -1975,8 +2065,9 @@ msgstr ""
 msgid "Email Content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
 msgstr "E-pošta"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
@@ -2002,22 +2093,22 @@ msgstr ""
 msgid "Email account updated successfully"
 msgstr ""
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr ""
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr ""
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "E-poštna sporočila"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr ""
 
@@ -2055,8 +2146,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr ""
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2081,8 +2170,6 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2105,20 +2192,24 @@ msgstr ""
 msgid "Enter a name for this HD Service Holiday List."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr ""
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr ""
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
 msgstr ""
 
 #: helpdesk/api/knowledge_base.py:86
@@ -2129,21 +2220,17 @@ msgstr ""
 msgid "Error processing email at index {0}, message: {1}"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr ""
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "Napaka pri povezovanju z e-poštnim računom {0}"
 
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr ""
-
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
 msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
@@ -2172,11 +2259,6 @@ msgstr ""
 msgid "Export Type"
 msgstr "Vrsta izvoza"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr ""
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2184,6 +2266,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "Neuspešno"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2218,11 +2304,11 @@ msgstr ""
 msgid "Failed to save Twilio settings"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr ""
 
@@ -2251,6 +2337,7 @@ msgstr ""
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2288,12 +2375,16 @@ msgstr ""
 msgid "Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
+msgstr ""
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
 msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
@@ -2338,13 +2429,14 @@ msgid "Field dependency updated successfully."
 msgstr ""
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "Polja"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "Filtri"
@@ -2354,13 +2446,18 @@ msgstr "Filtri"
 msgid "Find out all of the variables that can be used in the content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "Ime"
 
 #. Label of the first_responded_on (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
+msgstr ""
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
 msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
@@ -2385,10 +2482,6 @@ msgstr ""
 #. Name of a report
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -2480,6 +2573,10 @@ msgstr ""
 msgid "Go to Ticket #{0}"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr ""
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2509,8 +2606,6 @@ msgid "Group By Field"
 msgstr ""
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr "Gost"
@@ -2518,11 +2613,6 @@ msgstr "Gost"
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
 msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
-msgstr "Akcija"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -2554,24 +2644,36 @@ msgstr "Povratne informacije o Članku"
 msgid "HD Comment Reaction"
 msgstr ""
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr "Stranka"
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr ""
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
 msgstr ""
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
 msgstr ""
 
 #. Name of a DocType
@@ -2593,21 +2695,6 @@ msgstr "Prazniki"
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
 msgstr "Obvestilo"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr "Organizacija"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
-msgstr ""
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -2648,11 +2735,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
 msgstr ""
 
 #. Name of a DocType
@@ -2750,12 +2832,6 @@ msgstr "Helpdesk"
 msgid "Helpdesk"
 msgstr "Helpdesk"
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr "Kontakt"
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2772,11 +2848,6 @@ msgstr "Živjo"
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
 msgstr "Skrij "
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr "Skrij stanje"
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
@@ -2846,15 +2917,8 @@ msgstr "Razumem, dodaj pogoje"
 msgid "ID"
 msgstr ""
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "IP naslov"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2941,6 +3005,11 @@ msgstr "Prejeto"
 msgid "Incoming"
 msgstr "Dohodno"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr ""
@@ -2954,7 +3023,7 @@ msgstr ""
 msgid "Instantly send e-mail"
 msgstr ""
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "Nezadostno dovoljenje za {0}"
 
@@ -2968,12 +3037,12 @@ msgstr ""
 msgid "Introduction"
 msgstr "Uvod"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
@@ -2982,22 +3051,42 @@ msgstr ""
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr "Neveljavna polja, preverite, ali so vsa izpolnjena in ali so vrednosti pravilne."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr ""
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr ""
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
+msgstr "Povabi"
+
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
@@ -3008,12 +3097,29 @@ msgstr ""
 msgid "Invite agents"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
-msgstr ""
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
+msgstr "Povabi kot uporabnika"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr "Povabljeni"
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
 msgstr ""
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
@@ -3030,6 +3136,11 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "Je Privzeto"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr ""
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3057,6 +3168,10 @@ msgstr ""
 #. Label of the setup_complete (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
 msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:114
@@ -3093,11 +3208,9 @@ msgstr "Bližnjice na tipkovnici"
 msgid "Knowledge Base"
 msgstr "Baza Znanja"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3131,9 +3244,9 @@ msgstr "Zadnji"
 msgid "Last 3 Months"
 msgstr "Zadnjih 3 Mesecev"
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr ""
 
@@ -3174,7 +3287,8 @@ msgstr ""
 msgid "Last Month"
 msgstr "Prejšnji mesec"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "Priimek"
 
@@ -3183,23 +3297,32 @@ msgstr "Priimek"
 msgid "Last Week"
 msgstr "Prejšnji teden"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr ""
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
 msgstr ""
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
@@ -3216,26 +3339,6 @@ msgstr ""
 #. 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
-msgstr ""
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "Povezava"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -3264,6 +3367,8 @@ msgstr ""
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "Naloži več"
 
@@ -3286,6 +3391,8 @@ msgstr ""
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr "Logotip"
@@ -3324,7 +3431,7 @@ msgstr ""
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr ""
 
@@ -3342,6 +3449,10 @@ msgstr ""
 
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:11
@@ -3396,6 +3507,20 @@ msgstr "Razno"
 msgid "Mobile App Installation"
 msgstr ""
 
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr ""
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr ""
+
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
 #. List'
@@ -3436,7 +3561,7 @@ msgid "My Tickets"
 msgstr ""
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3447,8 +3572,9 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3457,6 +3583,10 @@ msgstr "Ime"
 #. Label of the name_weight (Int) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
 msgstr ""
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
@@ -3469,10 +3599,18 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "Nikoli"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3581,11 +3719,11 @@ msgstr ""
 msgid "No Data Found"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr ""
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr ""
 
@@ -3597,9 +3735,15 @@ msgstr ""
 msgid "No SLA found"
 msgstr "Sporazum o Ravni Storitev ni bil najden"
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
 msgstr "Brez Ekipe"
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
+msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
 msgid "No additional comments"
@@ -3633,19 +3777,27 @@ msgstr ""
 msgid "No changes made"
 msgstr "Nobene spremembe niso bile narejene"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr ""
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr ""
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr ""
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
@@ -3657,7 +3809,11 @@ msgstr ""
 msgid "No feedback"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr ""
 
@@ -3697,12 +3853,17 @@ msgstr ""
 msgid "No recently assigned tickets"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr ""
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
 msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
@@ -3710,6 +3871,7 @@ msgstr ""
 msgid "No saved replies found"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr ""
@@ -3730,7 +3892,11 @@ msgstr ""
 msgid "No tickets selected"
 msgstr ""
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr ""
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "Ni dovoljeno"
 
@@ -3742,7 +3908,7 @@ msgstr ""
 msgid "Not Saved"
 msgstr "Ni shranjeno"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "Ni nastavljeno"
 
@@ -3781,11 +3947,6 @@ msgstr "Stari pogoji"
 msgid "On Hold Since"
 msgstr "Na čakanju od"
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr ""
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr ""
@@ -3815,6 +3976,10 @@ msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
@@ -3906,7 +4071,12 @@ msgstr ""
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr ""
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "Geslo"
 
@@ -3944,6 +4114,7 @@ msgid "Pending"
 msgstr "V teku"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr ""
 
@@ -3953,19 +4124,19 @@ msgstr ""
 msgid "Pending Tickets"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr ""
 
@@ -3986,13 +4157,14 @@ msgstr "Osebno"
 msgid "Personal mobile no"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "Telefon"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
 msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
@@ -4049,7 +4221,7 @@ msgstr ""
 msgid "Please enter a valid phone number"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr ""
 
@@ -4092,33 +4264,14 @@ msgstr ""
 msgid "Policy name"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
-msgstr ""
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr ""
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr ""
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr ""
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
 msgstr ""
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
@@ -4153,14 +4306,32 @@ msgstr "Predogled"
 msgid "Previous ticket"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "Primarno"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "Primarni kontakt"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr ""
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr ""
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4168,9 +4339,10 @@ msgstr ""
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4250,17 +4422,6 @@ msgstr ""
 msgid "Quarterly"
 msgstr "Četrtletno"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "Možnosti poizvedbe"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr ""
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "V čakalni vrsti"
@@ -4283,14 +4444,14 @@ msgstr ""
 msgid "Rate this ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr ""
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4386,8 +4547,15 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "Odstrani"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4397,9 +4565,18 @@ msgstr ""
 msgid "Remove Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr ""
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
 msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
@@ -4419,6 +4596,15 @@ msgstr ""
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
 msgstr ""
 
 #. Option in a Select field in the tickets Web Form
@@ -4458,16 +4644,13 @@ msgstr ""
 msgid "Reply on a ticket"
 msgstr ""
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr "Ključ Zahteva"
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
 msgstr ""
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
@@ -4488,6 +4671,7 @@ msgid "Reset to Default"
 msgstr ""
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr ""
@@ -4541,18 +4725,6 @@ msgstr "Odgovor"
 msgid "Response By"
 msgstr ""
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr ""
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr ""
@@ -4595,28 +4767,18 @@ msgstr ""
 msgid "Restrict visibility to these teams"
 msgstr ""
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr ""
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr ""
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
+msgstr ""
+
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:215
@@ -4624,8 +4786,14 @@ msgid "Ringing"
 msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "Vloga"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr ""
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4724,9 +4892,9 @@ msgstr "Sobota"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4802,17 +4970,19 @@ msgstr ""
 msgid "Search Score"
 msgstr ""
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr ""
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "Iskanje polj..."
 
@@ -4852,6 +5022,7 @@ msgstr "Iskanje..."
 msgid "Searched for:"
 msgstr ""
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr "Iskanje..."
@@ -4870,6 +5041,10 @@ msgstr "Izberite"
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
 msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
@@ -4892,6 +5067,10 @@ msgstr "Izberite Privzeto Prioriteto."
 msgid "Select a rating"
 msgstr ""
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr ""
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4903,6 +5082,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
+msgstr ""
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
@@ -4929,6 +5112,10 @@ msgstr ""
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
 msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
@@ -4969,13 +5156,17 @@ msgstr "Ime Ravni Storitve"
 msgid "Service not supported"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "Nastavljeno"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:4
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
@@ -4986,12 +5177,21 @@ msgstr ""
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr ""
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr ""
 
@@ -5003,7 +5203,7 @@ msgstr ""
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr ""
 
@@ -5137,23 +5337,6 @@ msgstr ""
 msgid "Sort"
 msgstr ""
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr ""
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "Ime vira"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr ""
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr ""
@@ -5198,6 +5381,8 @@ msgstr ""
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5264,6 +5449,7 @@ msgstr ""
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5375,21 +5561,16 @@ msgstr "Sistem"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5428,8 +5609,6 @@ msgstr "Ciljna Zadeva ne obstaja"
 msgid "Teal"
 msgstr "Modrozelena"
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5440,7 +5619,6 @@ msgstr "Modrozelena"
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5546,6 +5724,10 @@ msgstr ""
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr ""
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr ""
@@ -5556,6 +5738,10 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
@@ -5578,6 +5764,14 @@ msgstr ""
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr ""
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr ""
@@ -5585,6 +5779,10 @@ msgstr ""
 #: desk/src/components/ticket/TicketMergeModal.vue:79
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
 msgstr ""
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
@@ -5654,7 +5852,7 @@ msgstr "Četrtek"
 msgid "Ticket"
 msgstr "Zadeva"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr ""
 
@@ -5669,6 +5867,10 @@ msgstr "Analitika Zadeve"
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
 msgstr "Konfiguracija Zadeve"
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
+msgstr ""
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
 msgid "Ticket Info"
@@ -5727,7 +5929,7 @@ msgstr ""
 msgid "Ticket Summary"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr ""
 
@@ -5760,7 +5962,7 @@ msgstr ""
 msgid "Ticket merged successfully."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr ""
 
@@ -5795,12 +5997,6 @@ msgstr ""
 msgid "Ticket to merged with is required"
 msgstr ""
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr ""
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr ""
@@ -5812,12 +6008,15 @@ msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr ""
 
@@ -5829,19 +6028,19 @@ msgstr ""
 msgid "Tickets assigned to you in the last 7 days"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr ""
 
@@ -5858,6 +6057,7 @@ msgid "Tickets that are awaiting your response"
 msgstr ""
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr ""
 
@@ -5947,19 +6147,19 @@ msgstr ""
 msgid "Total Ticket"
 msgstr "Skupno Zadeva"
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr "Skupno ustvarjenih Zadeva"
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr ""
 
@@ -5991,6 +6191,10 @@ msgstr "Vrsta"
 msgid "Type a message"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr ""
@@ -6000,7 +6204,7 @@ msgstr ""
 msgid "URL/Method"
 msgstr "URL/Metoda"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr ""
 
@@ -6034,6 +6238,8 @@ msgid "Unpublish"
 msgstr "Razveljavi objavo"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr ""
 
@@ -6050,6 +6256,10 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:214
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
+msgstr ""
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
@@ -6078,9 +6288,12 @@ msgstr "Naloži"
 msgid "Upload Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
@@ -6090,17 +6303,13 @@ msgstr ""
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6111,6 +6320,10 @@ msgstr "Uporabnik"
 #. Label of the user_resolution_time (Duration) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
 msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
@@ -6130,7 +6343,7 @@ msgstr "Uporabniki"
 msgid "Valid From"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "Vrednost"
 
@@ -6259,19 +6472,23 @@ msgstr "Letno"
 msgid "Yellow"
 msgstr "Rumena"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr ""
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr ""
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr ""
 
@@ -6299,6 +6516,14 @@ msgstr ""
 msgid "You do not have permission to access Assignment Rules"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr ""
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr ""
@@ -6321,6 +6546,14 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:46
@@ -6351,7 +6584,7 @@ msgstr ""
 msgid "customize {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr ""
 
@@ -6402,7 +6635,7 @@ msgstr ""
 msgid "here."
 msgstr ""
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr ""
 
@@ -6410,7 +6643,7 @@ msgstr ""
 msgid "in"
 msgstr "v"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "pravkar"
 
@@ -6443,7 +6676,11 @@ msgstr ""
 msgid "purple"
 msgstr "vijolična"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr ""
 
@@ -6460,7 +6697,7 @@ msgstr "zadeva"
 msgid "to enable this integration."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr ""
 
@@ -6468,12 +6705,32 @@ msgstr ""
 msgid "views"
 msgstr "pogledi"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr ""
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
 msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:307
@@ -6500,7 +6757,7 @@ msgstr ""
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr ""
 

--- a/helpdesk/locale/sr.po
+++ b/helpdesk/locale/sr.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-15 18:50\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-29 21:58\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Serbian (Cyrillic)\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr "% испуњености споразума о нивоу услуге"
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr "% решених креираних тикета у оквиру рокова из споразума о нивоу услуге"
@@ -108,14 +108,6 @@ msgstr "Кратак опис"
 msgid "A workday with this name already exists"
 msgstr "Радни дан са овим називом већ постоји"
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr "API"
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr "Приступ свим тикетима тима"
@@ -132,7 +124,7 @@ msgstr "Приступ само тикетима овог тима"
 msgid "Account"
 msgstr "Налог"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr "Информације о налогу и безбедности"
 
@@ -152,11 +144,9 @@ msgstr "Радња"
 msgid "Action Required"
 msgstr "Неопходна радња"
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr "Радња која се извршава кликом на дугме. Документ ће бити доступан као `this`"
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "Радње"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr "Радња која се извршава кликом на дугме. 
 msgid "Active"
 msgstr "Активан"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr ""
 
@@ -175,7 +165,7 @@ msgid "Active: The agent is available and working.<br>\n"
 "Unavailable: The agent is off and unavailable."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "Активност"
@@ -193,10 +183,11 @@ msgid "Add Column"
 msgstr "Додај колону"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr "Додај имејл"
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "Додај филтер..."
 
@@ -207,6 +198,10 @@ msgstr "Додај празник"
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
 msgstr "Додај нови чланак"
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
+msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:148
 msgid "Add Sort"
@@ -244,7 +239,7 @@ msgstr "Додај услов"
 msgid "Add condition group"
 msgstr "Додај групу услова"
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "Додај филтер"
 
@@ -278,6 +273,12 @@ msgstr "Додајте временске циљеве око кључних т�
 msgid "Add to Holidays"
 msgstr "Додај у празнике"
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr ""
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr "Додајте и управљајте агентима и додељујте им улоге."
@@ -295,17 +296,14 @@ msgid "Administrator"
 msgstr "Администратор"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -316,6 +314,7 @@ msgstr "Администратор"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -335,6 +334,7 @@ msgstr "Контролна табла агента"
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -342,6 +342,7 @@ msgstr "Контролна табла агента"
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -376,18 +377,9 @@ msgstr "Агенти више неће моћи да прегледају и к�
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "Све"
 
@@ -508,6 +500,14 @@ msgstr "Да ли сте сигурни да желите да затворит�
 msgid "Are you sure you want to delete these articles?"
 msgstr "Да ли сте сигурни да желите да обришете ове чланке?"
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr ""
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr "Да ли сте сигурни да желите да обришете овај тикет? Ова радња је неповратна и не може се поништити."
@@ -544,6 +544,10 @@ msgstr "Да ли сте сигурни да желите да напустит�
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
 msgstr "Да ли сте сигурни да желите да уклоните лого?"
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
+msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
 msgid "Are you sure you want to reset the content? Current content will be overridden."
@@ -595,16 +599,11 @@ msgstr "Додели тикет агенту"
 msgid "Assign ticket"
 msgstr "Додели тикет"
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr "Додели"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -618,7 +617,7 @@ msgstr "Додељени корисник"
 msgid "Assignee Rules"
 msgstr "Правило извршиоца"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr "Извршиоци су успешно ажурирани."
 
@@ -626,7 +625,7 @@ msgstr "Извршиоци су успешно ажурирани."
 msgid "Assignees"
 msgstr "Извршиоци"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr ""
 
@@ -692,10 +691,6 @@ msgstr "Правило додељивања је успешно ажуриран
 msgid "Assignment rule {0} updated successfully."
 msgstr "Правило додељивања {0} је успешно ажурирано."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr "Неопходан је барем један имејл"
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -712,10 +707,6 @@ msgstr "Барем једна опција повратне информациј
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
 msgstr "Неопходан је барем један тим"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
-msgstr "Барем један од приоритета, тима и врсте тикета је обавезан"
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
@@ -766,7 +757,7 @@ msgid "Automation"
 msgstr "Аутоматизација"
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr ""
@@ -802,7 +793,7 @@ msgstr "Просечно време одговора"
 msgid "Average Time Metrics"
 msgstr "Просечне временске метрике"
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr "Просечна оцена повратних информација по дану је око {0} звезда"
 
@@ -810,25 +801,37 @@ msgstr "Просечна оцена повратних информација п
 msgid "Average response and resolution metrics not available"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr "Просечан број тикета по дану је око {0}"
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr "Просечна оцена повратних информација"
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr "Просечно време првог одговора"
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr "Просечно време решавања"
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
-msgstr "Просечна оцена повратних информација за решене тикете"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
+msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:290
@@ -840,11 +843,11 @@ msgstr "Просечно време првог одговора"
 msgid "Avg. resolution time"
 msgstr "Просечно време решавања"
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr "Просечно време потребно за први одговор на тикет"
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr "Просечно време потребно за решавање тикета"
 
@@ -867,11 +870,6 @@ msgstr "Назад на тикете"
 msgid "Base Support Rotation"
 msgstr "Основна ротација подршке"
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "Основни URL"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -885,11 +883,11 @@ msgstr "На основу политике људских ресурса, иза
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr "На основу политике људских ресурса, изаберите датум почетка периода расподеле одмора"
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr ""
 
@@ -944,11 +942,6 @@ msgstr "Пословни празници"
 msgid "Busy"
 msgstr "Заузет"
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "Дугме"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr "CSV"
@@ -973,19 +966,31 @@ msgstr "Трајање позива у секундама"
 msgid "Caller"
 msgstr "Позивалац"
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr "Позиви"
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr "Можете позивати нове агенте, управљати тикетима, креирати прилагођене приказе и управљати јавним приказима."
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr "Можете управљати свим аспектима Helpdesk-a."
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr "Можете радити на тикетима, креирати прилагођене приказе и управљати приватним приказима."
 
@@ -1025,7 +1030,7 @@ msgstr "Правило се не може омогућити без додава
 msgid "Cannot merge General category"
 msgstr "Није могуће спојити општу категорију"
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr ""
 
@@ -1073,11 +1078,11 @@ msgstr "Категорија мора имати барем један члан�
 msgid "Category updated successfully."
 msgstr "Категорија је успешно ажурирана."
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr ""
 
@@ -1085,7 +1090,7 @@ msgstr ""
 msgid "Change"
 msgstr "Промена"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "Промени лозинку"
@@ -1098,10 +1103,9 @@ msgstr "Промени фотографију"
 msgid "Change language of the application."
 msgstr "Промените језик апликације."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
-msgstr "Промените фотографију"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
+msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
 msgid "Change priority"
@@ -1123,7 +1127,7 @@ msgstr "Промените врсту тикета"
 msgid "Change timezone of the application."
 msgstr "Промените временску зону апликације."
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr "Промените лозинку налога ради безбедности."
 
@@ -1136,7 +1140,7 @@ msgstr "Канали"
 msgid "Child field"
 msgstr "Зависно поље"
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr ""
 
@@ -1189,7 +1193,7 @@ msgstr "Очисти сортирање"
 msgid "Clear Table"
 msgstr "Очисти табелу"
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr ""
 
@@ -1204,6 +1208,10 @@ msgstr "Очисти све филтере"
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
 msgstr "Кликните на Додај у празнике. Ово ће попунити табелу празника са свим датумима који падају на изабране недељне слободне дане. Поновите процес за попуњавање датума свих недељних празника"
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:47
@@ -1223,7 +1231,7 @@ msgstr "Затвори тикет"
 msgid "Closed"
 msgstr "Затворено"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr "Затворени или оцењени тикети не могу бити ажурирани од стране особа које нису агенти"
 
@@ -1250,7 +1258,7 @@ msgstr "Колоне"
 msgid "Comma separated emails to invite."
 msgstr "Имејлови за позив, одвојени зарезом."
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr ""
 
@@ -1283,7 +1291,7 @@ msgstr "Коментарисано од стране"
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "Коментари"
@@ -1296,6 +1304,11 @@ msgstr "Комуникација"
 msgid "Communication ID is required"
 msgstr "ИД комуникације је обавезан"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
+msgstr "Компанија"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
 msgstr "Завршено"
@@ -1307,7 +1320,7 @@ msgstr "Завршено"
 msgid "Condition"
 msgstr "Услов"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr "Конфигуриши"
 
@@ -1331,6 +1344,10 @@ msgstr "Овде конфигуришите Twilio интеграцију тел
 msgid "Configure your telephony settings."
 msgstr "Конфигуришите подешавања телефоније."
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1356,10 +1373,11 @@ msgstr "Потврди измену"
 msgid "Connect your support email"
 msgstr "Повежите свој имејл за подршку"
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1373,26 +1391,30 @@ msgstr "Контакт"
 msgid "Contact HTML"
 msgstr "HTML контакт"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
-msgstr "Контакт је успешно креиран."
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
-msgstr "Контакт је успешно позван."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
+msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr "Контакт је успешно ажуриран."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
-msgstr "Контакт са овим имејлом већ постоји"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
+msgstr ""
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
 msgstr "Контакти"
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
+msgstr ""
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
 #. Label of the content (Text Editor) field in DocType 'HD Article'
@@ -1415,7 +1437,7 @@ msgstr "Копирај URL тикета"
 msgid "Copy ticket id"
 msgstr "Копирај ИД тикета"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr "Није могуће послати имејл због: {0}"
 
@@ -1423,7 +1445,11 @@ msgstr "Није могуће послати имејл због: {0}"
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr "Није могуће послати имејл потврду пријема због: {0}"
 
@@ -1431,11 +1457,20 @@ msgstr "Није могуће послати имејл потврду приј�
 msgid "Could not send feedback email,due to: {0}"
 msgstr "Неуспешно слање имејла са повратном информацијом због: {0}"
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "Држава"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1446,9 +1481,13 @@ msgstr "Креирај"
 msgid "Create & invite a contact"
 msgstr "Креирај и позови контакт"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
-msgstr "Креирај нови контакт"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
+msgstr "Креирај купца"
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
 msgid "Create View"
@@ -1482,12 +1521,6 @@ msgstr "Креирано од стране"
 msgid "Creating a ticket"
 msgstr ""
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr "Критеријум"
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr "Прилагођене радње"
@@ -1512,12 +1545,21 @@ msgid "Custom Views"
 msgstr ""
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
 msgstr "Клијент"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
+msgstr ""
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1528,17 +1570,33 @@ msgstr "Назив клијента"
 msgid "Customer Portal"
 msgstr ""
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
-msgstr "Клијент је успешно креиран."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr "Врста купца"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr "Портал за клијенте"
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
-msgstr "Клијент је успешно ажуриран."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
+msgstr "Купци"
 
 #: desk/src/components/layouts/Sidebar.vue:595
 msgid "Customers & Contacts"
@@ -1565,6 +1623,8 @@ msgstr "Цијан"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "Опасно"
@@ -1665,18 +1725,26 @@ msgstr "Подразумевана врста тикета"
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr "Дефинишите ко прима тикете и како се они распоређују између агената."
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "Обриши"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr "Обриши контакт"
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1693,6 +1761,10 @@ msgstr "Обриши категорију?"
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
 msgstr "Обриши {0}"
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
+msgstr ""
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
 #. Label of the description (Text Editor) field in DocType 'HD Holiday'
@@ -1740,7 +1812,7 @@ msgstr "Детаљно објашњење"
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1826,7 +1898,12 @@ msgstr "Документа"
 msgid "Document Type"
 msgstr "Врста документа"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr ""
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "Домен"
@@ -1868,6 +1945,10 @@ msgstr "Дупликат политике споразума о нивоу ус�
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
 msgstr "Дупликат сачуваног одговора"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
 #: desk/src/pages/call-logs/CallLogModal.vue:68
@@ -1917,7 +1998,8 @@ msgstr ""
 msgid "Easily invite new agents, managers, or admins."
 msgstr "Једноставно позовите нове агенте, менаџере или администраторе."
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1926,6 +2008,14 @@ msgstr "Уреди"
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
 msgstr "Уреди евиденцију позива"
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
+msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:70
 #: desk/src/components/Settings/EmailEdit.vue:63
@@ -1944,10 +2034,10 @@ msgstr "Уреди наслов"
 msgid "Edit your email account"
 msgstr "Уреди свој имејл налог"
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "Имејл"
 
@@ -1975,8 +2065,9 @@ msgstr "Имејл налози"
 msgid "Email Content"
 msgstr "Имејл садржај"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
 msgstr "Имејл ИД"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
@@ -2002,22 +2093,22 @@ msgstr "Назив имејл налога"
 msgid "Email account updated successfully"
 msgstr "Имејл налог је успешно ажуриран"
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr ""
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr "Подешавања имејла су успешно ажурирана."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr "Имејл не сме бити празан"
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "Имејлови"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr "Имејлови и потписи"
 
@@ -2055,8 +2146,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr "Омогући повратну информацију за тикете путем портала за клијенте"
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2081,8 +2170,6 @@ msgstr "Омогући повратну информацију за тикете
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2105,21 +2192,25 @@ msgstr "Време завршетка"
 msgid "Enter a name for this HD Service Holiday List."
 msgstr "Унесите назив за ову HD листу празника за пружање услуга."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr "Унесите важећи имејл"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr "Унесите важећи број телефона"
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr "Унесите назив бренда"
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr ""
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
 msgstr "Унесите нови назив тима"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
+msgstr ""
 
 #: helpdesk/api/knowledge_base.py:86
 msgid "Error moving article to category"
@@ -2129,22 +2220,18 @@ msgstr "Грешка при премештању чланка у категор�
 msgid "Error processing email at index {0}, message: {1}"
 msgstr "Грешка при обради имејла на индексу {0}, порука: {1}"
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr "Грешка приликом ажурирања клијента"
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "Грешка при повезивању са имејл налогом {0}"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr "Правило ескалације већ постоји за овај критеријум"
 
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
 msgstr "Excel"
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
+msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
 #: desk/src/components/Settings/Telephony/Telephony.vue:96
@@ -2172,11 +2259,6 @@ msgstr "Извоз свих {0} записа"
 msgid "Export Type"
 msgstr "Врста извоза"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr "Спољашњи линк"
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2184,6 +2266,10 @@ msgstr "Спољашњи линк"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "Неуспешно"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2218,11 +2304,11 @@ msgstr "Неуспешно учитавање Exotel подешавања"
 msgid "Failed to save Twilio settings"
 msgstr "Неуспешно учитавање Twilio подешавања"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr "Ажурирање извршилаца није успело."
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr ""
 
@@ -2251,6 +2337,7 @@ msgstr "Favicon"
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2288,13 +2375,17 @@ msgstr "Повратна информација већ постоји"
 msgid "Feedback Rating"
 msgstr "Оцена повратне информације"
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr "Тренд повратних информација"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
 msgstr "Имејл са повратном информацијом је послат клијенту"
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
+msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
 msgid "Feedback submitted successfully."
@@ -2338,13 +2429,14 @@ msgid "Field dependency updated successfully."
 msgstr "Зависност поља је успешно ажурирана."
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "Поља"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "Филтери"
@@ -2354,7 +2446,8 @@ msgstr "Филтери"
 msgid "Find out all of the variables that can be used in the content"
 msgstr "Пронађите све променљиве које се могу користити у садржају"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "Име"
 
@@ -2362,6 +2455,10 @@ msgstr "Име"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
 msgstr "Први одговор дат на"
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
+msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -2386,10 +2483,6 @@ msgstr "Време за први одговор"
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
 msgstr "Време првог одговора за тикете"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
-msgstr "Име не сме бити празно"
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
@@ -2480,6 +2573,10 @@ msgstr "Глобално"
 msgid "Go to Ticket #{0}"
 msgstr "Иди на тикет #{0}"
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr ""
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2509,8 +2606,6 @@ msgid "Group By Field"
 msgstr "Груписано по пољу"
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr "Гост"
@@ -2518,11 +2613,6 @@ msgstr "Гост"
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
 msgstr "Усмерите кориснике на чланке пре креирања тикета."
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
-msgstr "HD радња"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -2554,25 +2644,37 @@ msgstr "HD повратна информација о чланку"
 msgid "HD Comment Reaction"
 msgstr "HD реакција на коментар"
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr "HD клијент"
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr ""
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
-msgstr "HD захтев за налог на радној површини"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
+msgstr ""
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
 msgstr "HD повратна информација путем имејла"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
-msgstr "HD правило ескалације"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -2593,21 +2695,6 @@ msgstr "HD празник"
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
 msgstr "HD обавештење"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr "HD организација"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr "HD ставка контакта организације"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
-msgstr "HD захтев за регистрацију на порталу"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -2649,11 +2736,6 @@ msgstr "HD подешавања"
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
 msgstr "HD Stopword"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
-msgstr "HD извор претраге подршке"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_synonym/hd_synonym.json
@@ -2750,12 +2832,6 @@ msgstr "HelpDesk"
 msgid "Helpdesk"
 msgstr "Helpdesk"
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr "Helpdesk контакт"
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2772,11 +2848,6 @@ msgstr "Здраво"
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
 msgstr "Сакриј "
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr "Сакриј услов"
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
@@ -2846,15 +2917,8 @@ msgstr "Разумем, додај услове"
 msgid "ID"
 msgstr "ИД"
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "IP адреса"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2941,6 +3005,11 @@ msgstr "Пријемна пошта"
 msgid "Incoming"
 msgstr "Улазни"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr "Индивидуални"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr "Иницирано"
@@ -2954,7 +3023,7 @@ msgstr ""
 msgid "Instantly send e-mail"
 msgstr "Слање имејла тренутно"
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "Недовољна овлашћења за {0}"
 
@@ -2968,12 +3037,12 @@ msgstr "Бројчана вредност"
 msgid "Introduction"
 msgstr "Увод"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
 msgstr "Неважећи имејл"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
@@ -2982,23 +3051,43 @@ msgstr "Неважећи имејл"
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr "Неважећа поља, проверите да ли су сва поља попуњена и вредности тачне."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr "Неважећа врста фајла, дозвољене су искључиво PNG и JPG слике"
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr "Неважеће обавештење"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
 msgstr "Неважећи број телефона"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr "Позивница је истекла"
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr ""
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
+msgstr "Позови"
 
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
 msgstr "Позови агенте"
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
 msgid "Invite agent"
@@ -3008,13 +3097,30 @@ msgstr "Позови агента"
 msgid "Invite agents"
 msgstr "Позови агенте"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
 msgstr "Позови као корисника"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
 msgstr "Позовите путем имејла"
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr "Позван"
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
+msgstr ""
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -3030,6 +3136,11 @@ msgstr "Портал за клијенте"
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "Подразумевано"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr ""
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3058,6 +3169,10 @@ msgstr "Фиксирано"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
 msgstr "Поставке завршене"
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
+msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:114
 msgid "Jump to"
@@ -3093,11 +3208,9 @@ msgstr "Пречице на тастатури"
 msgid "Knowledge Base"
 msgstr "База знања"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3131,9 +3244,9 @@ msgstr "Последње"
 msgid "Last 3 Months"
 msgstr "Последњих 3 месеци"
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr "Претходна 3 месеца"
 
@@ -3174,7 +3287,8 @@ msgstr "Последњи одговор клијента"
 msgid "Last Month"
 msgstr "Прошли месец"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "Презиме"
 
@@ -3183,24 +3297,33 @@ msgstr "Презиме"
 msgid "Last Week"
 msgstr "Прошла недеља"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
 msgstr "Претходни месец"
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr "Последњи корисник којем је тикет додељен по овом правилу"
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
 msgstr "Претходна недеља"
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
+msgstr "Најновије"
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -3217,26 +3340,6 @@ msgstr "Сазнајте више о условима"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
 msgstr "Обавестите клијенте да подносе тикет ван радног времена и када могу очекивати одговор."
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "Линк"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr "Опције повезивања"
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr "Линк ка клијенту"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
-msgstr "Линк ка запису клијента"
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #. Label of the list_tab (Tab Break) field in DocType 'HD View'
@@ -3264,6 +3367,8 @@ msgstr "Учитај подразумеване колоне"
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "Учитај више"
 
@@ -3286,6 +3391,8 @@ msgstr "Пријављивање на Frappe Cloud"
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr "Логотип"
@@ -3324,7 +3431,7 @@ msgstr "Управљајте општим подешавањима аплика�
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr "Управљајте унапред дефинисаним одговорима који се могу користити за одговарање на упите клијената."
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr "Управљајте имејловима налога и имејл потписом за комуникацију."
 
@@ -3343,6 +3450,10 @@ msgstr ""
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
 msgstr "Управљајте информацијама свог профила."
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
+msgstr "Менаџер"
 
 #: desk/src/pages/MobileNotifications.vue:11
 #: desk/src/pages/MobileNotifications.vue:14
@@ -3396,6 +3507,20 @@ msgstr "Разно"
 msgid "Mobile App Installation"
 msgstr "Инсталација мобилне апликације"
 
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr "Број мобилног телефона"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr "Број мобилног телефона"
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr ""
+
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
 #. List'
@@ -3436,7 +3561,7 @@ msgid "My Tickets"
 msgstr "Моји тикети"
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3447,8 +3572,9 @@ msgstr "Моји тикети"
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3458,6 +3584,10 @@ msgstr "Назив"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
 msgstr "Пондер назива"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
+msgstr "Назив је обавезан"
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
 #. Ticket Status'
@@ -3469,10 +3599,18 @@ msgstr "Назив приказан на порталу за клијента<br
 msgid "Navigation"
 msgstr "Навигација"
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr "Прво негативно"
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "Никада"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3581,11 +3719,11 @@ msgstr "Нема одговора"
 msgid "No Data Found"
 msgstr "Нема пронађених података"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr ""
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr ""
 
@@ -3597,9 +3735,15 @@ msgstr "Није пронађена листа празника"
 msgid "No SLA found"
 msgstr "Није пронађен споразум о нивоу услуге"
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
 msgstr "Без тима"
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
+msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
 msgid "No additional comments"
@@ -3633,19 +3777,27 @@ msgstr "Нема доступних категорија"
 msgid "No changes made"
 msgstr "Није извршена ниједна промена"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr "Нема измена за чување"
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr "Нема додатих графикона"
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr ""
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr "Ниједан контакт није пронађен за примењене филтере. Покушајте да их измените или обришете."
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr ""
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr "Ниједан клијент није пронађен за примењене филтере. Покушајте да их измените или обришете."
 
@@ -3657,7 +3809,11 @@ msgstr "Није пронађен имејл налог"
 msgid "No feedback"
 msgstr "Нема повратних информација"
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr ""
 
@@ -3697,19 +3853,25 @@ msgstr "Нема разлога"
 msgid "No recently assigned tickets"
 msgstr "Нема недавно додељених тикета"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr ""
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
 msgstr "Нема резултата"
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
+msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:91
 msgid "No saved replies found"
 msgstr "Нема пронађених сачуваних одговора"
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr "Нема пронађених тикета"
@@ -3730,7 +3892,11 @@ msgstr "Нема пронађених тикета за приказ."
 msgid "No tickets selected"
 msgstr ""
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr ""
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "Није дозвољено"
 
@@ -3742,7 +3908,7 @@ msgstr "Није додељено"
 msgid "Not Saved"
 msgstr "Није сачувано"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "Није постављено"
 
@@ -3781,11 +3947,6 @@ msgstr "Стари услови"
 msgid "On Hold Since"
 msgstr "На чекању од"
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr "On click (Javascript)"
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr "На основу статуса тикета"
@@ -3816,6 +3977,10 @@ msgstr "Отвори палету команди"
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
 msgstr "Отвори поље за коментар"
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
+msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
 msgid "Open help"
@@ -3906,7 +4071,12 @@ msgstr "Матично поље"
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr "Матично поље, зависно поље и мапирање матичног и зависног поља су обавезни."
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr "Партнерство"
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "Лозинка"
 
@@ -3944,6 +4114,7 @@ msgid "Pending"
 msgstr "На чекању"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr "Позиви на чекању"
 
@@ -3953,19 +4124,19 @@ msgstr "Позиви на чекању"
 msgid "Pending Tickets"
 msgstr "Тикети на чекању"
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr "Проценат укупних тикета по каналу"
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr "Проценат укупних тикета по приоритету"
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr "Проценат укупних тикета по тиму"
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr "Проценат укупних тикета по врсти"
 
@@ -3986,14 +4157,15 @@ msgstr "Лична"
 msgid "Personal mobile no"
 msgstr "Број личног мобилног телефона"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "Телефон"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
-msgstr "Бројеви телефона"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
+msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
 msgid "Pick an option"
@@ -4049,7 +4221,7 @@ msgstr "Молимо Вас да унесете наслов да бисте н�
 msgid "Please enter a valid phone number"
 msgstr "Молимо Вас да унесете важећи број телефона"
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr ""
 
@@ -4092,34 +4264,15 @@ msgstr "Молимо Вас да изаберете недељни дан одм
 msgid "Policy name"
 msgstr "Назив политике"
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
 msgstr "Прво позитивно"
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr "Кључ описа пошиљке"
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr "Листа кључева путање уноса"
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr "Низ путање уноса"
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
-msgstr "Кључ назива путање уноса"
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:10
@@ -4153,14 +4306,32 @@ msgstr "Преглед"
 msgid "Previous ticket"
 msgstr "Претходни тикет"
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "Примарна"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "Примарни контакт"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr ""
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr "Приоритети"
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4168,9 +4339,10 @@ msgstr "Приоритети"
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4250,17 +4422,6 @@ msgstr "Преузимање имејлова, ово може потрајат�
 msgid "Quarterly"
 msgstr "Квартално"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "Опције упита"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr "Query Route String"
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "У реду"
@@ -4283,14 +4444,14 @@ msgstr "Оцените своје искуство подршке"
 msgid "Rate this ticket"
 msgstr "Оцените овај тикет"
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr "Оцењени тикети"
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4386,8 +4547,15 @@ msgstr "Поново генериши индекс претраге"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "Уклони"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4397,10 +4565,19 @@ msgstr "Уклони лого"
 msgid "Remove Photo"
 msgstr "Уклони фотографију"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
-msgstr "Уклоните фотографију"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr "Уклони слику"
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
+msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
 #: desk/src/components/Settings/Teams/TeamsList.vue:161
@@ -4420,6 +4597,15 @@ msgstr "Преименуј (⌘ + ⏎)"
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
 msgstr "Преименуј тим"
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
+msgstr ""
 
 #. Option in a Select field in the tickets Web Form
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
@@ -4458,17 +4644,14 @@ msgstr "Одговор контакта"
 msgid "Reply on a ticket"
 msgstr "Одговорите на тикет"
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr "Захтев за кључ"
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
 msgstr "Обавезно"
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
+msgstr ""
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
 msgid "Reset"
@@ -4488,6 +4671,7 @@ msgid "Reset to Default"
 msgstr "Ресетуј на подразумевано"
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr "Резолуција"
@@ -4541,18 +4725,6 @@ msgstr "Одговор"
 msgid "Response By"
 msgstr "Одговорио"
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr "Опције одговора"
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr "Кључни пут резултата одговора"
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr "Време одговора за приоритет {0} у реду {1} не може бити веће од времена решавања."
@@ -4595,37 +4767,33 @@ msgstr "Ограничи тикете да их могу прегледати и
 msgid "Restrict visibility to these teams"
 msgstr "Ограничите видљивост на ове тимове"
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr "Поље за преглед резултата"
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr "Поље за путању резултата"
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr "Поље за наслов резултата"
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
 msgstr "Прегледи"
 
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:215
 msgid "Ringing"
 msgstr "Звоњење"
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "Улога"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr "Улога је успешно ажурирана"
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4724,9 +4892,9 @@ msgstr "Субота"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4802,17 +4970,19 @@ msgstr "Индекс претраге је поновно генерисан"
 msgid "Search Score"
 msgstr "Оцена претраге"
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr "Назив параметара за претрагу"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "Поља за претрагу..."
 
@@ -4852,6 +5022,7 @@ msgstr "Претрага..."
 msgid "Searched for:"
 msgstr "Претражено:"
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr "Претраживање..."
@@ -4871,6 +5042,10 @@ msgstr "Изабери"
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
 msgstr "Изаберите категорију"
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
+msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
 msgid "Select Range"
@@ -4892,6 +5067,10 @@ msgstr "Изаберите подразумевани приоритет."
 msgid "Select a rating"
 msgstr "Изаберите оцену"
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr ""
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4904,6 +5083,10 @@ msgstr "Изаберите тимове"
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
 msgstr "Изаберите тикет за приказ"
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
 msgid "Select what type all tickets get by default."
@@ -4930,6 +5113,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
 msgstr "Пошаљи повратну информацију када"
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
+msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
 msgid "Send to {0} tickets"
@@ -4969,7 +5156,7 @@ msgstr "Назив нивоа услуге"
 msgid "Service not supported"
 msgstr "Услуга није подржана"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "Постави"
 
@@ -4977,6 +5164,10 @@ msgstr "Постави"
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
 msgstr "Поставите број телефона"
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
 msgid "Set Resolution Time for Priority {0} in row {1}."
@@ -4986,12 +5177,21 @@ msgstr "Поставите време решавања за приоритет {
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr "Постави време одговора за приоритет {0} у реду {1}."
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr "Постави као подразумевани споразум о нивоу услуге"
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr ""
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr ""
 
@@ -5003,7 +5203,7 @@ msgstr "Поставите подразумевани статус који се
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr "Поставите радне дане, радно време и празнике избором унапред дефинисаног распореда или креирањем новог."
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr ""
 
@@ -5137,23 +5337,6 @@ msgstr "Дошло је до грешке приликом ажурирања л
 msgid "Sort"
 msgstr "Сортирај"
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr "Изворни DocType"
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "Назив извора"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr "Врста извора"
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr "Изворна и циљана категорија не могу бити исте"
@@ -5198,6 +5381,8 @@ msgstr "Време почетка не може бити веће или јед�
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5265,6 +5450,7 @@ msgstr "Статус тикета када се креира у систему."
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5376,21 +5562,16 @@ msgstr "Систем"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5429,8 +5610,6 @@ msgstr "Циљани тикет не постоји"
 msgid "Teal"
 msgstr "Тиркизна"
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5441,7 +5620,6 @@ msgstr "Тиркизна"
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5547,6 +5725,10 @@ msgstr "Услов доделе '{0}' је неважећи: {1}"
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr "JSON услов доделе '{0}' је неважећи: {1}"
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr ""
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr "Дијалог за повратне информације ће се приказати када корисник покуша да затвори тикет са портала за клијенте."
@@ -5558,6 +5740,10 @@ msgstr "Празник који пада на {0} није између дату
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
 msgstr "Број дана мора бити 1 или више"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
 msgid "The status for sending feedback must be of <u>Resolved</u> category."
@@ -5579,6 +5765,14 @@ msgstr "Тренутно нема објављених категорија."
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr ""
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr ""
@@ -5587,6 +5781,10 @@ msgstr ""
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
 msgstr "Ова радња је неповратна."
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
+msgstr ""
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
 msgid "This date is calculated based on configured SLAs, working hours, and holidays."
@@ -5655,7 +5853,7 @@ msgstr "Четвртак"
 msgid "Ticket"
 msgstr "Тикет"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr "Тикет #{0}: Примили смо Ваш захтев"
 
@@ -5670,6 +5868,10 @@ msgstr "Аналитика тикета"
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
 msgstr "Конфигурација тикета"
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
+msgstr ""
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
 msgid "Ticket Info"
@@ -5728,7 +5930,7 @@ msgstr ""
 msgid "Ticket Summary"
 msgstr "Резиме тикета"
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr "Тренд тикета"
 
@@ -5761,7 +5963,7 @@ msgstr "Тикет не постоји."
 msgid "Ticket merged successfully."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr "Тикет мора бити решен са повратном информацијом"
 
@@ -5796,12 +5998,6 @@ msgstr "Статус тикета"
 msgid "Ticket to merged with is required"
 msgstr ""
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr "Врста тикета"
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr ""
@@ -5813,12 +6009,15 @@ msgstr "Анализа претраге тикета"
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr "Тикети"
 
@@ -5830,19 +6029,19 @@ msgstr "Тикети који се приближавају или су прек
 msgid "Tickets assigned to you in the last 7 days"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr "Тикети по каналу"
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr "Тикети по приоритету"
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr "Тикети по тиму"
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr "Тикети по врсти"
 
@@ -5859,6 +6058,7 @@ msgid "Tickets that are awaiting your response"
 msgstr "Тикети који чекају Ваш одговор"
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr "Временска зона"
 
@@ -5948,19 +6148,19 @@ msgstr "Укупно празника"
 msgid "Total Ticket"
 msgstr "Укупан број тикета"
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr "Укупан број креираних тикета"
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr "Укупан број тикета по приоритету"
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr "Укупан број тикета по тиму"
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr "Укупан број тикета по врсти"
 
@@ -5992,6 +6192,10 @@ msgstr "Врста"
 msgid "Type a message"
 msgstr "Унесите поруку"
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr "Врста је обавезна"
@@ -6001,7 +6205,7 @@ msgstr "Врста је обавезна"
 msgid "URL/Method"
 msgstr "URL/Метод"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr "Није могуће послати имејл. Подесите подразумевани излазни имејл налог."
 
@@ -6035,6 +6239,8 @@ msgid "Unpublish"
 msgstr "Повуци са објаве"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr "Несачувано"
 
@@ -6052,6 +6258,10 @@ msgstr "Несачувано"
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
 msgstr "Несачуване измене"
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
 msgid "Untitled"
@@ -6079,10 +6289,13 @@ msgstr "Отпреми"
 msgid "Upload Photo"
 msgstr "Отпреми фотографију"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
-msgstr "Отпремите фотографију"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
+msgstr "Отпреми слику"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
 msgid "Uploading {0}%"
@@ -6091,17 +6304,13 @@ msgstr "Отпремање {0}%"
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6113,6 +6322,10 @@ msgstr "Корисник"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
 msgstr "Време решавања за корисника"
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
+msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
 msgid "User Signup"
@@ -6131,7 +6344,7 @@ msgstr "Корисници"
 msgid "Valid From"
 msgstr "Важи од"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "Вредност"
 
@@ -6260,19 +6473,23 @@ msgstr "Годишње"
 msgid "Yellow"
 msgstr "Жута"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr ""
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr "Није Вам дозвољено да видите податке са ове контролне табле."
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr "Немате дозволу да приступите овом ресурсу."
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr "Није Вам дозвољено да додате коментар"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr ""
 
@@ -6300,6 +6517,14 @@ msgstr "Не можете поставити више од једног подр
 msgid "You do not have permission to access Assignment Rules"
 msgstr "Немате дозволу за приступ правилима доделе"
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr "Немате дозволу за приступ овом ресурсу"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr ""
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr "Немате приступ овом тикету или он више не постоји."
@@ -6323,6 +6548,14 @@ msgstr "Ваши стари услови ће бити преписани. Да 
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
 msgstr "Ваш учинак је"
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
+msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:46
 msgid "assigned you a ticket"
@@ -6352,7 +6585,7 @@ msgstr "креирано"
 msgid "customize {0}"
 msgstr "прилагоди {0}"
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr "дани"
 
@@ -6403,7 +6636,7 @@ msgstr "овде"
 msgid "here."
 msgstr "овде."
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr "часови"
 
@@ -6411,7 +6644,7 @@ msgstr "часови"
 msgid "in"
 msgstr "у"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "управо сада"
 
@@ -6444,7 +6677,11 @@ msgstr ""
 msgid "purple"
 msgstr "љубичаста"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr "прегледи"
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr "звезде"
 
@@ -6461,7 +6698,7 @@ msgstr "тикет"
 msgid "to enable this integration."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr "прегледао је ово"
 
@@ -6469,12 +6706,32 @@ msgstr "прегледао је ово"
 msgid "views"
 msgstr "прикази"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr ""
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
 msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:307
@@ -6501,7 +6758,7 @@ msgstr "Приказ {0} је тренутно јаван. Променом у �
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr "Приказ {0} је тренутно видљив у бочној траци. Сакривањем ће бити уклоњен из бочне траке."
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr ""
 

--- a/helpdesk/locale/sr_CS.po
+++ b/helpdesk/locale/sr_CS.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-15 18:51\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-29 21:58\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Serbian (Latin)\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr "% ispunjenosti sporazuma o nivou usluge"
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr "% rešenih kreiranih tiketa u okviru rokova iz sporazuma o nivou usluge"
@@ -108,14 +108,6 @@ msgstr "Kratak opis"
 msgid "A workday with this name already exists"
 msgstr "Radni dan sa ovim nazivom već postoji"
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr "API"
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr "Pristup svim tiketima tima"
@@ -132,7 +124,7 @@ msgstr "Pristup samo tiketima ovog tima"
 msgid "Account"
 msgstr "Nalog"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr "Informacija o nalogu i bezbednost"
 
@@ -152,11 +144,9 @@ msgstr "Radnja"
 msgid "Action Required"
 msgstr "Neophodna radnja"
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr "Radnja koja se izvršava klikom na dugme. Dokument će biti dostupan kao `this`"
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "Radnje"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr "Radnja koja se izvršava klikom na dugme. Dokument će biti dostupan kao
 msgid "Active"
 msgstr "Aktivan"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr ""
 
@@ -175,7 +165,7 @@ msgid "Active: The agent is available and working.<br>\n"
 "Unavailable: The agent is off and unavailable."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "Aktivnost"
@@ -193,10 +183,11 @@ msgid "Add Column"
 msgstr "Dodaj kolonu"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr "Dodaj imejl"
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "Dodaj filter..."
 
@@ -207,6 +198,10 @@ msgstr "Dodaj praznik"
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
 msgstr "Dodaj novi članak"
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
+msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:148
 msgid "Add Sort"
@@ -244,7 +239,7 @@ msgstr "Dodaj uslov"
 msgid "Add condition group"
 msgstr "Dodaj grupu uslova"
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "Dodaj filter"
 
@@ -278,6 +273,12 @@ msgstr "Dodajte vremenske ciljeve oko ključnih tačaka podrške, kao što su vr
 msgid "Add to Holidays"
 msgstr "Dodaj u praznike"
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr ""
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr "Dodajte i upravljajte agentima i dodeljujte im uloge."
@@ -295,17 +296,14 @@ msgid "Administrator"
 msgstr "Administrator"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -316,6 +314,7 @@ msgstr "Administrator"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -335,6 +334,7 @@ msgstr "Kontrolna tabla agenta"
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -342,6 +342,7 @@ msgstr "Kontrolna tabla agenta"
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -376,18 +377,9 @@ msgstr "Agenti više neće moći da pregledaju i kreiraju sačuvane odgovore sa 
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "Sve"
 
@@ -508,6 +500,14 @@ msgstr "Da li ste sigurni da želite da zatvorite ovaj tiket?"
 msgid "Are you sure you want to delete these articles?"
 msgstr "Da li ste sigurni da želite da obrišete ove članke?"
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr ""
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr "Da li ste sigurni da želite da obrišete ovaj tiket? Ova radnja je nepovratna i ne može se poništiti."
@@ -544,6 +544,10 @@ msgstr "Da li ste sigurni da želite da napustite? Nesačuvane izmene će biti i
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
 msgstr "Da li ste sigurni da želite da uklonite logo?"
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
+msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
 msgid "Are you sure you want to reset the content? Current content will be overridden."
@@ -595,16 +599,11 @@ msgstr "Dodeli tiket agentu"
 msgid "Assign ticket"
 msgstr "Dodeli tiket"
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr "Dodeli"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -618,7 +617,7 @@ msgstr "Dodeljeni korisnik"
 msgid "Assignee Rules"
 msgstr "Pravilo izvršioca"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr "Izvršioci su uspešno ažurirani."
 
@@ -626,7 +625,7 @@ msgstr "Izvršioci su uspešno ažurirani."
 msgid "Assignees"
 msgstr "Izvršioci"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr ""
 
@@ -692,10 +691,6 @@ msgstr "Pravilo dodeljivanja je uspešno ažurirano."
 msgid "Assignment rule {0} updated successfully."
 msgstr "Pravilo dodeljivanja {0} je uspešno ažurirano."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr "Neophodan je barem jedan imejl"
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -712,10 +707,6 @@ msgstr "Barem jedna opcija povratne informacije mora biti omogućena za ocenjiva
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
 msgstr "Neophodan je barem jedan tim"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
-msgstr "Barem jedan od prioriteta, tima i vrste tiketa je obavezan"
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
@@ -766,7 +757,7 @@ msgid "Automation"
 msgstr "Automatizacija"
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr ""
@@ -802,7 +793,7 @@ msgstr "Prosečno vreme odgovora"
 msgid "Average Time Metrics"
 msgstr "Prosečne vremenske metrike"
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr "Prosečna ocena povratnih informacija po danu je oko {0} zvezda"
 
@@ -810,25 +801,37 @@ msgstr "Prosečna ocena povratnih informacija po danu je oko {0} zvezda"
 msgid "Average response and resolution metrics not available"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr "Prosečan broj tiketa po danu je oko {0}"
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr "Prosečna ocena povratnih informacija"
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr "Prosečno vreme prvog odgovora"
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr "Prosečno vreme rešavanja"
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
-msgstr "Prosečna ocena povratnih informacija za rešene tikete"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
+msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:290
@@ -840,11 +843,11 @@ msgstr "Prosečno vreme prvog odgovora"
 msgid "Avg. resolution time"
 msgstr "Prosečno vreme rešavanja"
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr "Prosečno vreme potrebno za prvi odgovor na tiket"
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr "Prosečno vreme potrebno za rešavanje tiketa"
 
@@ -867,11 +870,6 @@ msgstr "Nazad na tikete"
 msgid "Base Support Rotation"
 msgstr "Osnovna rotacija podrške"
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "Osnovni URL"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -885,11 +883,11 @@ msgstr "Na osnovu politike ljudskih resursa, izaberite datum završetka perioda 
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr "Na osnovu politike ljudskih resursa, izaberite datum početka perioda raspodele odmora"
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr ""
 
@@ -944,11 +942,6 @@ msgstr "Poslovni praznici"
 msgid "Busy"
 msgstr "Zauzet"
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "Dugme"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr "CSV"
@@ -973,19 +966,31 @@ msgstr "Trajanje poziva u sekundama"
 msgid "Caller"
 msgstr "Pozivalac"
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr "Pozivi"
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr "Možete pozivati nove agente, upravljati tiketima, kreirati prilagođene prikaze i upravljati javnim prikazima."
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr "Možete upravljati svim aspektima Helpdesk-a."
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr "Možete raditi na tiketima, kreirati prilagođene prikaze i upravljati privatnim prikazima."
 
@@ -1025,7 +1030,7 @@ msgstr "Pravilo se ne može omogućiti bez dodavanja korisnika"
 msgid "Cannot merge General category"
 msgstr "Nije moguće spojiti opštu kategoriju"
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr ""
 
@@ -1073,11 +1078,11 @@ msgstr "Kategorija mora imati barem jedan članak"
 msgid "Category updated successfully."
 msgstr "Kategorija je uspešno ažurirana."
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr ""
 
@@ -1085,7 +1090,7 @@ msgstr ""
 msgid "Change"
 msgstr "Promena"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "Promeni lozinku"
@@ -1098,10 +1103,9 @@ msgstr "Promeni fotografiju"
 msgid "Change language of the application."
 msgstr "Promenite jezik aplikacije."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
-msgstr "Promenite fotografiju"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
+msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
 msgid "Change priority"
@@ -1123,7 +1127,7 @@ msgstr "Promenite vrstu tiketa"
 msgid "Change timezone of the application."
 msgstr "Promenite vremensku zonu aplikacije."
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr "Promenite lozinku naloga radi bezbednosti."
 
@@ -1136,7 +1140,7 @@ msgstr "Kanali"
 msgid "Child field"
 msgstr "Zavisno polje"
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr ""
 
@@ -1189,7 +1193,7 @@ msgstr "Očisti sortiranje"
 msgid "Clear Table"
 msgstr "Očisti tabelu"
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr ""
 
@@ -1204,6 +1208,10 @@ msgstr "Očisti sve filtere"
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
 msgstr "Kliknite na Dodaj u praznike. Ovo će popuniti tabelu praznika sa svim datumima koji padaju na izabrane nedeljne slobodne dane. Ponovite proces za popunjavanje datuma svih nedeljnih praznika"
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:47
@@ -1223,7 +1231,7 @@ msgstr "Zatvori tiket"
 msgid "Closed"
 msgstr "Zatvoreno"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr "Zatvoreni ili ocenjeni tiketi ne mogu biti ažurirani od strane osoba koje nisu agenti"
 
@@ -1250,7 +1258,7 @@ msgstr "Kolone"
 msgid "Comma separated emails to invite."
 msgstr "Imejlovi za poziv, odvojeni zarezom."
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr ""
 
@@ -1283,7 +1291,7 @@ msgstr "Komentarisano od strane"
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "Komentari"
@@ -1296,6 +1304,11 @@ msgstr "Komunikacija"
 msgid "Communication ID is required"
 msgstr "ID komunikacije je obavezan"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
+msgstr "Kompanija"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
 msgstr "Završeno"
@@ -1307,7 +1320,7 @@ msgstr "Završeno"
 msgid "Condition"
 msgstr "Uslov"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr "Konfiguriši"
 
@@ -1331,6 +1344,10 @@ msgstr "Ovde konfigurišite Twilio integraciju telefonije"
 msgid "Configure your telephony settings."
 msgstr "Konfigurišite podešavanja telefonije."
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1356,10 +1373,11 @@ msgstr "Potvrdi izmenu"
 msgid "Connect your support email"
 msgstr "Povežite svoj imejl za podršku"
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1373,26 +1391,30 @@ msgstr "Kontakt"
 msgid "Contact HTML"
 msgstr "HTML kontakt"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
-msgstr "Kontakt je uspešno kreiran."
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
-msgstr "Kontakt je uspešno pozvan."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
+msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr "Kontakt je uspešno ažuriran."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
-msgstr "Kontakt sa ovim imejlom već postoji"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
+msgstr ""
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
 msgstr "Kontakti"
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
+msgstr ""
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
 #. Label of the content (Text Editor) field in DocType 'HD Article'
@@ -1415,7 +1437,7 @@ msgstr "Kopiraj URL tiketa"
 msgid "Copy ticket id"
 msgstr "Kopiraj ID tiketa"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr "Nije moguće poslati imejl zbog: {0}"
 
@@ -1423,7 +1445,11 @@ msgstr "Nije moguće poslati imejl zbog: {0}"
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr "Nije moguće poslati imejl potvrdu prijema zbog: {0}"
 
@@ -1431,11 +1457,20 @@ msgstr "Nije moguće poslati imejl potvrdu prijema zbog: {0}"
 msgid "Could not send feedback email,due to: {0}"
 msgstr "Neuspešno slanje imejla sa povratnom informacijom zbog: {0}"
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "Država"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1446,9 +1481,13 @@ msgstr "Kreiraj"
 msgid "Create & invite a contact"
 msgstr "Kreiraj i pozovi kontakt"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
-msgstr "Kreiraj novi kontakt"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
+msgstr "Kreiraj kupca"
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
 msgid "Create View"
@@ -1482,12 +1521,6 @@ msgstr "Kreirano od strane"
 msgid "Creating a ticket"
 msgstr ""
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr "Kriterijum"
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr "Prilagođene radnje"
@@ -1512,12 +1545,21 @@ msgid "Custom Views"
 msgstr ""
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
 msgstr "Klijent"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
+msgstr ""
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1528,17 +1570,33 @@ msgstr "Naziv klijenta"
 msgid "Customer Portal"
 msgstr ""
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
-msgstr "Klijent je uspešno kreiran."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr "Vrsta kupca"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr "Portal za klijente"
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
-msgstr "Klijent je uspešno ažuriran."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
+msgstr "Kupci"
 
 #: desk/src/components/layouts/Sidebar.vue:595
 msgid "Customers & Contacts"
@@ -1565,6 +1623,8 @@ msgstr "Cijan"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "Opasno"
@@ -1665,18 +1725,26 @@ msgstr "Podrazumevana vrsta tiketa"
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr "Definišite ko prima tikete i kako se oni raspoređuju između agenata."
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "Obriši"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr "Obriši kontakt"
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1693,6 +1761,10 @@ msgstr "Obriši kategoriju?"
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
 msgstr "Obriši {0}"
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
+msgstr ""
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
 #. Label of the description (Text Editor) field in DocType 'HD Holiday'
@@ -1740,7 +1812,7 @@ msgstr "Detaljno objašnjenje"
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1826,7 +1898,12 @@ msgstr "Dokumenta"
 msgid "Document Type"
 msgstr "Vrsta dokumenta"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr ""
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "Domen"
@@ -1868,6 +1945,10 @@ msgstr "Duplikat politike sporazuma o nivou usluge"
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
 msgstr "Duplikat sačuvanog odgovora"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
 #: desk/src/pages/call-logs/CallLogModal.vue:68
@@ -1917,7 +1998,8 @@ msgstr ""
 msgid "Easily invite new agents, managers, or admins."
 msgstr "Jednostavno pozovite nove agente, menadžere ili administratore."
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1926,6 +2008,14 @@ msgstr "Uredi"
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
 msgstr "Uredi evidenciju poziva"
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
+msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:70
 #: desk/src/components/Settings/EmailEdit.vue:63
@@ -1944,10 +2034,10 @@ msgstr "Uredi naslov"
 msgid "Edit your email account"
 msgstr "Uredi svoj imejl nalog"
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "Imejl"
 
@@ -1975,8 +2065,9 @@ msgstr "Imejl nalozi"
 msgid "Email Content"
 msgstr "Imejl sadržaj"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
 msgstr "Imejl ID"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
@@ -2002,22 +2093,22 @@ msgstr "Naziv imejl naloga"
 msgid "Email account updated successfully"
 msgstr "Imejl nalog je uspešno ažuriran"
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr ""
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr "Podešavanja imejla su uspešno ažurirana."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr "Imejl ne sme biti prazan"
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "Imejlovi"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr "Imejlovi i potpisi"
 
@@ -2055,8 +2146,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr "Omogući povratnu informaciju za tikete putem portala za klijente"
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2081,8 +2170,6 @@ msgstr "Omogući povratnu informaciju za tikete putem portala za klijente"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2105,21 +2192,25 @@ msgstr "Vreme završetka"
 msgid "Enter a name for this HD Service Holiday List."
 msgstr "Unesite naziv za ovu HD listu praznika za pružanje usluge."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr "Unesite važeći imejl"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr "Unesite važeći broj telefona"
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr "Unesite naziv brenda"
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr ""
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
 msgstr "Unesite novi naziv tima"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
+msgstr ""
 
 #: helpdesk/api/knowledge_base.py:86
 msgid "Error moving article to category"
@@ -2129,22 +2220,18 @@ msgstr "Greška pri premeštanju članka u kategoriju"
 msgid "Error processing email at index {0}, message: {1}"
 msgstr "Greška pri obradi imejla na indeksu {0}, poruka: {1}"
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr "Greška prilikom ažuriranja klijenta"
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "Greška pri povezivanju sa imejl nalogom {0}"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr "Pravilo eskalacije već postoji za ovaj kriterijum"
 
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
 msgstr "Excel"
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
+msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
 #: desk/src/components/Settings/Telephony/Telephony.vue:96
@@ -2172,11 +2259,6 @@ msgstr "Izvoz svih {0} zapisa"
 msgid "Export Type"
 msgstr "Vrsta izvoza"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr "Spoljašnji link"
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2184,6 +2266,10 @@ msgstr "Spoljašnji link"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "Neuspešno"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2218,11 +2304,11 @@ msgstr "Neuspešno čuvanje Exotel podešavanja"
 msgid "Failed to save Twilio settings"
 msgstr "Neuspešno čuvanje Twilio podešavanja"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr "Ažuriranje izvršilaca nije uspelo."
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr ""
 
@@ -2251,6 +2337,7 @@ msgstr "Favicon"
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2288,13 +2375,17 @@ msgstr "Povratna informacija već postoji"
 msgid "Feedback Rating"
 msgstr "Ocena povratne informacije"
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr "Trend povratnih informacija"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
 msgstr "Imejl sa povratnom informacijom je poslat klijentu"
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
+msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
 msgid "Feedback submitted successfully."
@@ -2338,13 +2429,14 @@ msgid "Field dependency updated successfully."
 msgstr "Zavisnost polja je uspešno ažurirana."
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "Polja"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "Filteri"
@@ -2354,7 +2446,8 @@ msgstr "Filteri"
 msgid "Find out all of the variables that can be used in the content"
 msgstr "Pronađite sve promenljive koje se mogu koristiti u sadržaju"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "Ime"
 
@@ -2362,6 +2455,10 @@ msgstr "Ime"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
 msgstr "Prvi odgovor dat na"
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
+msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -2386,10 +2483,6 @@ msgstr "Vreme za prvi odgovor"
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
 msgstr "Vreme prvog odgovora za tikete"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
-msgstr "Ime ne sme biti prazno"
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
@@ -2480,6 +2573,10 @@ msgstr "Globalno"
 msgid "Go to Ticket #{0}"
 msgstr "Idi na tiket #{0}"
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr ""
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2509,8 +2606,6 @@ msgid "Group By Field"
 msgstr "Grupisano po polju"
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr "Gost"
@@ -2518,11 +2613,6 @@ msgstr "Gost"
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
 msgstr "Usmerite korisnike na članke pre kreiranja tiketa."
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
-msgstr "HD radnja"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -2554,25 +2644,37 @@ msgstr "HD povratna informacija o članku"
 msgid "HD Comment Reaction"
 msgstr "HD reakcija na komentar"
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr "HD klijent"
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr ""
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
-msgstr "HD zahtev za nalog na radnoj površini"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
+msgstr ""
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
 msgstr "HD povratna informacija putem imejla"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
-msgstr "HD pravilo eskalacije"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -2593,21 +2695,6 @@ msgstr "HD praznik"
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
 msgstr "HD obaveštenje"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr "HD organizacija"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr "HD stavka kontakta organizacije"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
-msgstr "HD zahtev za registraciju na portalu"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -2649,11 +2736,6 @@ msgstr "HD podešavanja"
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
 msgstr "HD Stopword"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
-msgstr "HD izvor pretrage podrške"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_synonym/hd_synonym.json
@@ -2750,12 +2832,6 @@ msgstr "HelpDesk"
 msgid "Helpdesk"
 msgstr "Helpdesk"
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr "Helpdesk kontakt"
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2772,11 +2848,6 @@ msgstr "Zdravo"
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
 msgstr "Sakrij "
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr "Sakrij uslov"
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
@@ -2846,15 +2917,8 @@ msgstr "Razumem, dodaj uslove"
 msgid "ID"
 msgstr "ID"
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "IP adresa"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2941,6 +3005,11 @@ msgstr "Prijemna pošta"
 msgid "Incoming"
 msgstr "Ulazni"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr "Individualni"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr "Inicirano"
@@ -2954,7 +3023,7 @@ msgstr ""
 msgid "Instantly send e-mail"
 msgstr "Slanje imejla trenutno"
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "Nedovoljna ovlašćenja za {0}"
 
@@ -2968,12 +3037,12 @@ msgstr "Brojčana vrednost"
 msgid "Introduction"
 msgstr "Uvod"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
 msgstr "Nevažeći imejl"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
@@ -2982,23 +3051,43 @@ msgstr "Nevažeći imejl"
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr "Nevažeća polja, proverite da li su sva polja popunjena i vrednosti tačne."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr "Nevažeća vrsta fajla, dozvoljene su isključivo PNG i JPG slike"
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr "Nevažeće obaveštenje"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
 msgstr "Nevažeći broj telefona"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr "Pozivnica je istekla"
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr ""
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
+msgstr "Pozovi"
 
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
 msgstr "Pozovi agente"
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
 msgid "Invite agent"
@@ -3008,13 +3097,30 @@ msgstr "Pozovi agenta"
 msgid "Invite agents"
 msgstr "Pozovi agente"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
 msgstr "Pozovi kao korisnika"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
 msgstr "Pozovite putem imejla"
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr "Pozvan"
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
+msgstr ""
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -3030,6 +3136,11 @@ msgstr "Portal za klijente"
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "Podrazumevano"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr ""
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3058,6 +3169,10 @@ msgstr "Fiksirano"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
 msgstr "Postavke završene"
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
+msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:114
 msgid "Jump to"
@@ -3093,11 +3208,9 @@ msgstr "Prečice na tastaturi"
 msgid "Knowledge Base"
 msgstr "Baza znanja"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3131,9 +3244,9 @@ msgstr "Poslednje"
 msgid "Last 3 Months"
 msgstr "Poslednjih 3 meseci"
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr "Prethodna 3 meseca"
 
@@ -3174,7 +3287,8 @@ msgstr "Poslednji odgovor klijenta"
 msgid "Last Month"
 msgstr "Prošli mesec"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "Prezime"
 
@@ -3183,24 +3297,33 @@ msgstr "Prezime"
 msgid "Last Week"
 msgstr "Prošla nedelja"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
 msgstr "Prethodni mesec"
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr "Poslednji korisnik kojem je tiket dodeljen po ovom pravilu"
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
 msgstr "Prethodna nedelja"
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
+msgstr "Najnovije"
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -3217,26 +3340,6 @@ msgstr "Saznajte više o uslovima"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
 msgstr "Obavestite klijente da podnose tiket van radnog vremena i kada mogu očekivati odgovor."
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "Link"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr "Opcije povezivanja"
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr "Link ka klijentu"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
-msgstr "Link ka zapisu klijenta"
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #. Label of the list_tab (Tab Break) field in DocType 'HD View'
@@ -3264,6 +3367,8 @@ msgstr "Učitaj podrazumevane kolone"
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "Učitaj više"
 
@@ -3286,6 +3391,8 @@ msgstr "Prijava na Frappe Cloud"
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr "Logotip"
@@ -3324,7 +3431,7 @@ msgstr "Upravljajte opštim podešavanjima aplikacije."
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr "Upravljajte unapred definisanim odgovorima koji se mogu koristiti za odgovaranje na upite klijenata."
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr "Upravljajte imejlovima naloga i imejl potpisom za komunikaciju."
 
@@ -3343,6 +3450,10 @@ msgstr ""
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
 msgstr "Upravljajte informacijama svog profila."
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
+msgstr "Menadžer"
 
 #: desk/src/pages/MobileNotifications.vue:11
 #: desk/src/pages/MobileNotifications.vue:14
@@ -3396,6 +3507,20 @@ msgstr "Razno"
 msgid "Mobile App Installation"
 msgstr "Instalacija mobilne aplikacije"
 
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr "Broj mobilnog telefona"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr "Broj mobilnog telefona"
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr ""
+
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
 #. List'
@@ -3436,7 +3561,7 @@ msgid "My Tickets"
 msgstr "Moji tiketi"
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3447,8 +3572,9 @@ msgstr "Moji tiketi"
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3458,6 +3584,10 @@ msgstr "Naziv"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
 msgstr "Ponder naziva"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
+msgstr "Naziv je obavezan"
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
 #. Ticket Status'
@@ -3469,10 +3599,18 @@ msgstr "Naziv prikazan na portalu za klijente<br>(npr. Odgovoreno → Čeka na o
 msgid "Navigation"
 msgstr "Navigacija"
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr "Prvo negativno"
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "Nikada"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3581,11 +3719,11 @@ msgstr "Nema odgovora"
 msgid "No Data Found"
 msgstr "Nema pronađenih podataka"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr ""
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr ""
 
@@ -3597,9 +3735,15 @@ msgstr "Nije pronađena lista praznika"
 msgid "No SLA found"
 msgstr "Nije pronađen sporazum o nivou usluge"
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
 msgstr "Bez tima"
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
+msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
 msgid "No additional comments"
@@ -3633,19 +3777,27 @@ msgstr "Nema dostupnih kategorija"
 msgid "No changes made"
 msgstr "Nije izvršena nijedna promena"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr "Nema izmena za čuvanje"
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr "Nema dodatih grafikona"
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr ""
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr "Nijedan kontakt nije pronađen za primenjene filtere. Pokušajte da ih izmenite ili obrišete."
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr ""
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr "Nijedan klijent nije pronađen za primenjene filtere. Pokušajte da ih izmenite ili obrišete."
 
@@ -3657,7 +3809,11 @@ msgstr "Nije pronađen imejl nalog"
 msgid "No feedback"
 msgstr "Nema povratnih informacija"
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr ""
 
@@ -3697,19 +3853,25 @@ msgstr "Nema razloga"
 msgid "No recently assigned tickets"
 msgstr "Nema nedavno dodeljenih tiketa"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr ""
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
 msgstr "Nema rezultata"
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
+msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:91
 msgid "No saved replies found"
 msgstr "Nema pronađenih sačuvanih odgovora"
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr "Nema pronađenih tiketa"
@@ -3730,7 +3892,11 @@ msgstr "Nema pronađenih tiketa za prikaz."
 msgid "No tickets selected"
 msgstr ""
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr ""
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "Nije dozvoljeno"
 
@@ -3742,7 +3908,7 @@ msgstr "Nije dodeljeno"
 msgid "Not Saved"
 msgstr "Nije sačuvano"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "Nije postavljeno"
 
@@ -3781,11 +3947,6 @@ msgstr "Stari uslovi"
 msgid "On Hold Since"
 msgstr "Na čekanju od"
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr "On click (Javascript)"
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr "Na osnovu statusa tiketa"
@@ -3816,6 +3977,10 @@ msgstr "Otvori paletu komandi"
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
 msgstr "Otvori polje za komentar"
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
+msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
 msgid "Open help"
@@ -3906,7 +4071,12 @@ msgstr "Matično polje"
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr "Matično polje, zavisno polje i mapiranje matičnog i zavisnog polja su obavezni."
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr "Partnerstvo"
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "Lozinka"
 
@@ -3944,6 +4114,7 @@ msgid "Pending"
 msgstr "Na čekanju"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr "Pozivi na čekanju"
 
@@ -3953,19 +4124,19 @@ msgstr "Pozivi na čekanju"
 msgid "Pending Tickets"
 msgstr "Tiketi na čekanju"
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr "Procenat ukupnih tiketa po kanalu"
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr "Procenat ukupnih tiketa po prioritetu"
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr "Procenat ukupnih tiketa po timu"
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr "Procenat ukupnih tiketa po vrsti"
 
@@ -3986,14 +4157,15 @@ msgstr "Lična"
 msgid "Personal mobile no"
 msgstr "Broj ličnog mobilnog telefona"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "Telefon"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
-msgstr "Brojevi telefona"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
+msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
 msgid "Pick an option"
@@ -4049,7 +4221,7 @@ msgstr "Molimo Vas da unesete naslov da biste nastavili"
 msgid "Please enter a valid phone number"
 msgstr "Molimo Vas da unesete važeći broj telefona"
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr ""
 
@@ -4092,34 +4264,15 @@ msgstr "Molimo Vas da izaberete nedeljni dan odmora"
 msgid "Policy name"
 msgstr "Naziv politike"
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
 msgstr "Prvo pozitivno"
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr "Ključ opisa pošiljke"
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr "Lista ključeva putanje unosa"
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr "Niz putanje unosa"
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
-msgstr "Ključ naziva putanje unosa"
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:10
@@ -4153,14 +4306,32 @@ msgstr "Pregled"
 msgid "Previous ticket"
 msgstr "Prethodni tiket"
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "Primarna"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "Primarni kontakt"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr ""
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr "Prioriteti"
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4168,9 +4339,10 @@ msgstr "Prioriteti"
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4250,17 +4422,6 @@ msgstr "Preuzimanje imejlova, ovo može potrajati nekoliko minuta."
 msgid "Quarterly"
 msgstr "Kvartalno"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "Opcije upita"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr "Query Route String"
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "U redu"
@@ -4283,14 +4444,14 @@ msgstr "Ocenite svoje iskustvo podrške"
 msgid "Rate this ticket"
 msgstr "Ocenite ovaj tiket"
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr "Ocenjeni tiketi"
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4386,8 +4547,15 @@ msgstr "Ponovo generiši indeks pretrage"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "Ukloni"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4397,10 +4565,19 @@ msgstr "Ukloni logo"
 msgid "Remove Photo"
 msgstr "Ukloni fotografiju"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
-msgstr "Uklonite fotografiju"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr "Ukloni sliku"
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
+msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
 #: desk/src/components/Settings/Teams/TeamsList.vue:161
@@ -4420,6 +4597,15 @@ msgstr "Preimenuj (⌘ + ⏎)"
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
 msgstr "Preimenuj tim"
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
+msgstr ""
 
 #. Option in a Select field in the tickets Web Form
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
@@ -4458,17 +4644,14 @@ msgstr "Odgovor kontakta"
 msgid "Reply on a ticket"
 msgstr "Odgovorite na tiket"
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr "Zahtev za ključ"
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
 msgstr "Obavezno"
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
+msgstr ""
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
 msgid "Reset"
@@ -4488,6 +4671,7 @@ msgid "Reset to Default"
 msgstr "Resetuj na podrazumevano"
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr "Rezolucija"
@@ -4541,18 +4725,6 @@ msgstr "Odgovor"
 msgid "Response By"
 msgstr "Odgovorio"
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr "Opcije odgovora"
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr "Ključni put rezultata odgovora"
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr "Vreme odgovora za prioritet {0} u redu {1} ne može biti veće od vremena rešavanja."
@@ -4595,37 +4767,33 @@ msgstr "Ograniči tikete da ih mogu pregledati i upravljati njima samo članovi 
 msgid "Restrict visibility to these teams"
 msgstr "Ograničite vidljivost na ove timove"
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr "Polje za pregled rezultata"
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr "Polje za putanju rezultata"
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr "Polje za naslov rezultata"
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
 msgstr "Recenzije"
 
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:215
 msgid "Ringing"
 msgstr "Zvonjenje"
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "Uloga"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr "Uloga je uspešno ažurirana"
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4724,9 +4892,9 @@ msgstr "Subota"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4802,17 +4970,19 @@ msgstr "Indeks pretrage je ponovno generisan"
 msgid "Search Score"
 msgstr "Ocena pretrage"
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr "Naziv parametara za pretragu"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "Polja za pretragu..."
 
@@ -4852,6 +5022,7 @@ msgstr "Pretraga..."
 msgid "Searched for:"
 msgstr "Pretraženo:"
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr "Pretraživanje..."
@@ -4871,6 +5042,10 @@ msgstr "Izaberi"
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
 msgstr "Izaberite kategoriju"
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
+msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
 msgid "Select Range"
@@ -4892,6 +5067,10 @@ msgstr "Izaberite podrazumevani prioritet."
 msgid "Select a rating"
 msgstr "Izaberite ocenu"
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr ""
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4904,6 +5083,10 @@ msgstr "Izaberite timove"
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
 msgstr "Izaberite tiket za prikaz"
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
 msgid "Select what type all tickets get by default."
@@ -4930,6 +5113,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
 msgstr "Pošalji povratnu informaciju kada"
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
+msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
 msgid "Send to {0} tickets"
@@ -4969,7 +5156,7 @@ msgstr "Naziv nivoa usluge"
 msgid "Service not supported"
 msgstr "Usluga nije podržana"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "Postavi"
 
@@ -4977,6 +5164,10 @@ msgstr "Postavi"
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
 msgstr "Postavite broj telefona"
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
 msgid "Set Resolution Time for Priority {0} in row {1}."
@@ -4986,12 +5177,21 @@ msgstr "Postavite vreme rešavanja za prioritet {0} u redu {1}."
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr "Postavi vreme odgovora za prioritet {0} u redu {1}."
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr "Postavi kao podrazumevani sporazum o nivou usluge"
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr ""
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr ""
 
@@ -5003,7 +5203,7 @@ msgstr "Postavite podrazumevani status koji se dodeljuje kada se tiket kreira i 
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr "Postavite radne dane, radno vreme i praznike izborom unapred definisanog rasporeda ili kreiranjem novog."
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr ""
 
@@ -5137,23 +5337,6 @@ msgstr "Došlo je do greške prilikom ažuriranja liste praznika"
 msgid "Sort"
 msgstr "Sortiraj"
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr "Izvorni DocType"
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "Naziv izvora"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr "Vrsta izvora"
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr "Izvorna i ciljana kategorija ne mogu biti iste"
@@ -5198,6 +5381,8 @@ msgstr "Vreme početka ne može biti veće ili jednako vremenu završetka u redu
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5265,6 +5450,7 @@ msgstr "Status tiketa kada se kreira u sistemu."
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5376,21 +5562,16 @@ msgstr "Sistem"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5429,8 +5610,6 @@ msgstr "Ciljani tiket ne postoji"
 msgid "Teal"
 msgstr "Tirkizna"
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5441,7 +5620,6 @@ msgstr "Tirkizna"
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5547,6 +5725,10 @@ msgstr "Uslov dodele '{0}' je nevažeći: {1}"
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr "JSON uslov dodele '{0}' je nevažeći: {1}"
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr ""
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr "Dijalog za povratne informacije će se prikazati kada korisnik pokuša da zatvori tiket sa portala za klijente."
@@ -5558,6 +5740,10 @@ msgstr "Praznik koji pada na {0} nije između datum početka i datuma završetka
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
 msgstr "Broj dana mora biti 1 ili više"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
 msgid "The status for sending feedback must be of <u>Resolved</u> category."
@@ -5579,6 +5765,14 @@ msgstr "Trenutno nema objavljenih kategorija."
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr ""
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr ""
@@ -5587,6 +5781,10 @@ msgstr ""
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
 msgstr "Ova radnja je nepovratna."
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
+msgstr ""
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
 msgid "This date is calculated based on configured SLAs, working hours, and holidays."
@@ -5655,7 +5853,7 @@ msgstr "Četvrtak"
 msgid "Ticket"
 msgstr "Tiket"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr "Tiket #{0}: Primili smo Vaš zahtev"
 
@@ -5670,6 +5868,10 @@ msgstr "Analitika tiketa"
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
 msgstr "Konfiguracija tiketa"
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
+msgstr ""
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
 msgid "Ticket Info"
@@ -5728,7 +5930,7 @@ msgstr ""
 msgid "Ticket Summary"
 msgstr "Rezime tiketa"
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr "Trend tiketa"
 
@@ -5761,7 +5963,7 @@ msgstr "Tiket ne postoji."
 msgid "Ticket merged successfully."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr "Tiket mora biti rešen sa povratnom informacijom"
 
@@ -5796,12 +5998,6 @@ msgstr "Status tiketa"
 msgid "Ticket to merged with is required"
 msgstr ""
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr "Vrsta tiketa"
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr ""
@@ -5813,12 +6009,15 @@ msgstr "Analiza pretrage tiketa"
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr "Tiketi"
 
@@ -5830,19 +6029,19 @@ msgstr "Tiketi koji se približavaju ili su prekršili sporazum o nivou usluge"
 msgid "Tickets assigned to you in the last 7 days"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr "Tiketi po kanalu"
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr "Tiketi po prioritetu"
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr "Tiketi po timu"
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr "Tiketi po vrsti"
 
@@ -5859,6 +6058,7 @@ msgid "Tickets that are awaiting your response"
 msgstr "Tiketi koji čekaju Vaš odgovor"
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr "Vremenska zona"
 
@@ -5948,19 +6148,19 @@ msgstr "Ukupno praznika"
 msgid "Total Ticket"
 msgstr "Ukupan broj tiketa"
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr "Ukupan broj kreiranih tiketa"
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr "Ukupan broj tiketa po prioritetu"
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr "Ukupan broj tiketa po timu"
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr "Ukupan broj tiketa po vrsti"
 
@@ -5992,6 +6192,10 @@ msgstr "Vrsta"
 msgid "Type a message"
 msgstr "Unesite poruku"
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr "Vrsta je obavezna"
@@ -6001,7 +6205,7 @@ msgstr "Vrsta je obavezna"
 msgid "URL/Method"
 msgstr "URL/Metod"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr "Nije moguće poslati imejl. Podesite podrazumevani izlazni imejl nalog."
 
@@ -6035,6 +6239,8 @@ msgid "Unpublish"
 msgstr "Povuci sa objave"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr "Nesačuvano"
 
@@ -6052,6 +6258,10 @@ msgstr "Nesačuvano"
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
 msgstr "Nesačuvane izmene"
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
 msgid "Untitled"
@@ -6079,10 +6289,13 @@ msgstr "Otpremi"
 msgid "Upload Photo"
 msgstr "Otpremi fotografiju"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
-msgstr "Otpremite fotografiju"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
+msgstr "Otpremi sliku"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
 msgid "Uploading {0}%"
@@ -6091,17 +6304,13 @@ msgstr "Otpremanje {0}%"
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6113,6 +6322,10 @@ msgstr "Korisnik"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
 msgstr "Vreme rešavanja za korisnika"
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
+msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
 msgid "User Signup"
@@ -6131,7 +6344,7 @@ msgstr "Korisnici"
 msgid "Valid From"
 msgstr "Važi od"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "Vrednost"
 
@@ -6260,19 +6473,23 @@ msgstr "Godišnje"
 msgid "Yellow"
 msgstr "Žuta"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr ""
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr "Nije Vam dozvoljeno da vidite podatke sa ove kontrolne table."
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr "Nemate dozvolu da pristupite ovom resursu."
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr "Nije Vam dozvoljeno da dodate komentar"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr ""
 
@@ -6300,6 +6517,14 @@ msgstr "Ne možete postaviti više od jednog podrazumevanog prioriteta."
 msgid "You do not have permission to access Assignment Rules"
 msgstr "Nemate dozvolu za pristup pravilima dodele"
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr "Nemate dozvolu za pristup ovom resursu"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr ""
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr "Nemate pristup ovom tiketu ili on više ne postoji."
@@ -6323,6 +6548,14 @@ msgstr "Vaši stari uslovi će biti prepisani. Da li ste sigurni da želite da s
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
 msgstr "Vaš učinak je"
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
+msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:46
 msgid "assigned you a ticket"
@@ -6352,7 +6585,7 @@ msgstr "kreirano"
 msgid "customize {0}"
 msgstr "prilagodi {0}"
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr "dani"
 
@@ -6403,7 +6636,7 @@ msgstr "ovde"
 msgid "here."
 msgstr "ovde."
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr "časovi"
 
@@ -6411,7 +6644,7 @@ msgstr "časovi"
 msgid "in"
 msgstr "u"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "upravo sada"
 
@@ -6444,7 +6677,11 @@ msgstr ""
 msgid "purple"
 msgstr "ljubičasta"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr "pregledi"
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr "zvezde"
 
@@ -6461,7 +6698,7 @@ msgstr "tiket"
 msgid "to enable this integration."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr "pregledao je ovo"
 
@@ -6469,12 +6706,32 @@ msgstr "pregledao je ovo"
 msgid "views"
 msgstr "pregledi"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr ""
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
 msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:307
@@ -6501,7 +6758,7 @@ msgstr "Prikaz {0} je trenutno javan. Promenom u privatni prikaz biće sakriven 
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr "Prikaz {0} je trenutno vidljiv u bočnoj traci. Sakrivanjem će biti uklonjen iz bočne trake."
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr ""
 

--- a/helpdesk/locale/sv.po
+++ b/helpdesk/locale/sv.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-20 20:30\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-29 21:58\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Swedish\n"
 "MIME-Version: 1.0\n"
@@ -22,14 +22,14 @@ msgstr ""
 msgid " commented"
 msgstr " kommenterade"
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr "% Uppfylld Service Nivå Avtal"
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
-msgstr "% av skapade ärenden som löstes inom Service Nivå Avtal"
+msgstr "% av skapade ärende som löstes inom Service Nivå Avtal"
 
 #: desk/src/pages/SearchAgent.vue:120
 msgid "({0}s)"
@@ -108,17 +108,9 @@ msgstr "Kort beskrivning"
 msgid "A workday with this name already exists"
 msgstr "Arbetsdag med detta namn finns redan"
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr "API"
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
-msgstr "Tillgång till alla Team Ärenden"
+msgstr "Tillgång till alla Team Ärende"
 
 #: helpdesk/api/knowledge_base.py:15
 msgid "Access denied"
@@ -126,13 +118,13 @@ msgstr "Åtkomst nekad"
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:262
 msgid "Access only this team's tickets"
-msgstr "Endast åtkomst till detta team ärenden"
+msgstr "Endast åtkomst till detta team ärende"
 
 #: desk/src/components/Settings/SettingsModal.vue:19
 msgid "Account"
 msgstr "Konto"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr "Konto Information & Säkerhet"
 
@@ -152,11 +144,9 @@ msgstr "Åtgärd"
 msgid "Action Required"
 msgstr "Åtgärd erfordras"
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr "Åtgärd som ska utföras när det klickar på knapp. Dokument kommer att vara tillgängligt som `this`"
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "Åtgärder"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr "Åtgärd som ska utföras när det klickar på knapp. Dokument kommer at
 msgid "Active"
 msgstr "Aktiv"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr "Aktiv nu"
 
@@ -177,7 +167,7 @@ msgstr "Aktiv: Handläggare är tillgänglig och igång.<br>\n"
 "Borta: Handläggare är tillfälligt oåtkomlig.<br>\n"
 "Otillgänglig: Handläggare är avstängd och inte tillgänglig."
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "Aktivitet"
@@ -195,10 +185,11 @@ msgid "Add Column"
 msgstr "Lägg till Kolumn"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr "Lägg till E-post"
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "Lägg till Filter..."
 
@@ -209,6 +200,10 @@ msgstr "Lägg till Helgdag"
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
 msgstr "Lägg till ny Artikel"
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
+msgstr "Lägg till Telefon nummer"
 
 #: desk/src/components/view-controls/SortBy.vue:148
 msgid "Add Sort"
@@ -246,7 +241,7 @@ msgstr "Lägg till villkor"
 msgid "Add condition group"
 msgstr "Lägg till villkorsgrupp"
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "Lägg till filter"
 
@@ -280,6 +275,12 @@ msgstr "Lägg till tidsmål kring supportmilstolpar som första svar och lösnin
 msgid "Add to Holidays"
 msgstr "Lägg till Helger"
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr "Lägg till i mottagare"
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr "Lägg till, hantera handläggare och tilldela roller till dem."
@@ -297,17 +298,14 @@ msgid "Administrator"
 msgstr "Administratör"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -318,6 +316,7 @@ msgstr "Administratör"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -337,6 +336,7 @@ msgstr "Handläggare Översikt Panel"
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -344,6 +344,7 @@ msgstr "Handläggare Översikt Panel"
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -378,18 +379,9 @@ msgstr "Handläggare kommer inte längre att kunna visa och skapa sparade svar m
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "Alla"
 
@@ -413,18 +405,18 @@ msgstr "Alla artiklar från denna kategori kommer att flyttas till Allmän kateg
 
 #: desk/src/components/ticket/TicketMergeModal.vue:7
 msgid "All comments and emails from both tickets will be merged into the selected ticket"
-msgstr "Alla kommentarer och e-postmeddelanden från båda ärendena kommer att slås samman med det valda ärendet"
+msgstr "Alla kommentarer och e-post meddelande från båda ärende kommer att slås samman med valda ärende"
 
 #: desk/src/pages/home/components/PendingTickets.vue:262
 msgid "All your assigned tickets have been responded to"
-msgstr "Alla dina tilldelade ärenden är besvarade"
+msgstr "Alla dina tilldelade ärende är besvarade"
 
 #. Label of the allow_anyone_to_create_tickets (Check) field in DocType 'HD
 #. Settings'
 #: desk/src/components/Settings/General/components/TicketSettings.vue:109
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Allow anyone to create tickets"
-msgstr "Tillåt alla att skapa ärenden"
+msgstr "Tillåt alla att skapa ärende"
 
 #. Description of the 'Enable comment reactions' (Check) field in DocType 'HD
 #. Settings'
@@ -445,7 +437,7 @@ msgstr "Bärnsten"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:113
 msgid "Anyone will be able to create tickets without any permission. e.g. from webform."
-msgstr "Vem som helst kommer att kunna skapa ärenden utan tillstånd, t.ex. från webbformulär."
+msgstr "Vem som helst kommer att kunna skapa ärende utan tillstånd, t.ex. från webbformulär."
 
 #: desk/src/components/Settings/Preferences/Preferences.vue:26
 msgid "Appearance"
@@ -510,6 +502,14 @@ msgstr "Är du säker på att du vill stänga detta ärende?"
 msgid "Are you sure you want to delete these articles?"
 msgstr "Är du säker på att du vill ta bort dessa artiklar?"
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr "Är du säker på att du vill ta bort den här kontakt? Den kommer att tas bort permanent och länk från alla kopplade kunder och ärende tas bort."
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr "Är du säker på att du vill ta bort den här kund? Referens till denna kund kommer att tas bort från alla relaterade ärende."
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr "Är du säker på att du vill ta bort detta ärende? Detta är oåterkallelig åtgärd och kan inte ångras."
@@ -546,6 +546,10 @@ msgstr "Är du säker på att du vill lämna? Ej sparade ändringar kommer att g
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
 msgstr "Är du säker på att du vill ta bort logotyp?"
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
+msgstr "Är du säker på att du vill ta bort denna kontakt från kund?"
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
 msgid "Are you sure you want to reset the content? Current content will be overridden."
@@ -597,16 +601,11 @@ msgstr "Tilldela ärende till handläggare"
 msgid "Assign ticket"
 msgstr "Tilldela ärende"
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr "Tilldela till"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr "Tilldela dig själv"
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -620,7 +619,7 @@ msgstr "Tilldelad"
 msgid "Assignee Rules"
 msgstr "Tilldelning Regler"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr "Tilldelade uppdaterade."
 
@@ -628,7 +627,7 @@ msgstr "Tilldelade uppdaterade."
 msgid "Assignees"
 msgstr "Tilldelade"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr "Tilldelade uppdaterade."
 
@@ -664,7 +663,7 @@ msgstr "Tilldelning Regler"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:11
 msgid "Assignment Rules automatically route tickets to the right team members based on predefined conditions."
-msgstr "Tilldelningsregler styr automatiskt ärenden till rätt team medlemmar baserat på fördefinierade villkor."
+msgstr "Tilldelning regler styr automatiskt ärende till rätt team medlemmar baserat på fördefinierade villkor."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:276
 msgid "Assignment Schedule"
@@ -694,10 +693,6 @@ msgstr "Tilldelning regel uppdaterad."
 msgid "Assignment rule {0} updated successfully."
 msgstr "Tilldelning regel {0} uppdaterad."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr "Åtminstone en e-post erfordras"
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -714,10 +709,6 @@ msgstr "Åtminstone en återkoppling alternativ måste vara aktiverad för betyg
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
 msgstr "Åtminstone ett team erfordras"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
-msgstr "Minst en av prioritet, team och ärendetyp erfordras"
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
@@ -745,7 +736,7 @@ msgstr "Automatisk stängning efter (dagar)"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:148
 msgid "Auto-close tickets that remain in a status for the specified number of days."
-msgstr "Stäng automatiskt ärenden som förblir i status under angiven antal dagar."
+msgstr "Stäng automatiskt ärende som förblir i status under angiven antal dagar."
 
 #. Description of the 'Condition' (Code) field in DocType 'HD Service Level
 #. Agreement'
@@ -756,7 +747,7 @@ msgstr "Automatiskt genererad från portalvyn — redigera inte direkt om du int
 #. Label of the auto_close_tickets (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Automatically Close Tickets when"
-msgstr "Stäng Ärenden Automatiskt när"
+msgstr "Stäng Ärende Automatiskt när"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:145
 msgid "Automatically close stale tickets"
@@ -768,7 +759,7 @@ msgid "Automation"
 msgstr "Automatisering"
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr "Tillgänglighet"
@@ -804,7 +795,7 @@ msgstr "Svarstid Medelvärde"
 msgid "Average Time Metrics"
 msgstr "Medeltid Mätvärde"
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr "Återkoppling Bedömning Medelvärde per dag är runt {0} stjärnor"
 
@@ -812,25 +803,37 @@ msgstr "Återkoppling Bedömning Medelvärde per dag är runt {0} stjärnor"
 msgid "Average response and resolution metrics not available"
 msgstr "Svar och Upplösning Medelvärde  är inte tillgänglig"
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
-msgstr "Antal Ärende Medelvärde per dag ligger på cirka {0}"
+msgstr "Medelvärde på Antal Ärende per dag ligger på runt {0}"
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr "Genomsnittlig Återkoppling Betyg"
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr "Mottagen Återkoppling Medelvärde"
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr "Genomsnittlig Första Svar"
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr "Första Svarstid Medelvärde"
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr "Genomsnittlig Upplösning"
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
-msgstr "Genomsnittlig återkoppling betyg för lösta ärenden"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr "Upplösning Tid Medelvärde"
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
+msgstr "Medelvärde för återkoppling betyg för ärende som lösts under denna period"
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:290
@@ -842,11 +845,11 @@ msgstr "Genomsnittlig Första Svar Tid"
 msgid "Avg. resolution time"
 msgstr "Genomsnittlig upplösning tid"
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr "Genomsnittlig tid det tar för först svar på ärende"
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr "Genomsnittlig tid det tar att lösa ärende"
 
@@ -869,11 +872,6 @@ msgstr "Tillbaka till Ärende"
 msgid "Base Support Rotation"
 msgstr "Bas Support Rotation"
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "Bas URL"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -887,11 +885,11 @@ msgstr "Baserat på din Personal Regel välj slutdatum för din frånvaro tillde
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr "Baserat på din Personal Regel välj startdatum för frånvaro period"
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr "Hemlig kopia"
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr "Hemlig kopia:"
 
@@ -946,11 +944,6 @@ msgstr "Helgdagar"
 msgid "Busy"
 msgstr "Upptagen"
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "Knapp"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr "CSV"
@@ -975,21 +968,33 @@ msgstr "Samtalslängd i sekunder"
 msgid "Caller"
 msgstr "Uppringare"
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr "Samtal"
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
-msgstr "Kan bjuda in nya handläggare, hantera ärenden, skapa anpassade vyer och hantera offentliga vyer."
+msgstr "Kan bjuda in nya handläggare, hantera ärende, skapa anpassade vyer och hantera offentliga vyer."
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr "Kan hantera alla aspekter av Support."
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr "Kan skapa ärende för bolag och hantera de ärende som de har skapat."
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr "Kan visa alla ärende som skapats och utse andra medlemmar till ansvariga."
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr "Kan visa ärende som har skapats av alla kundens kontakter."
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
-msgstr "Kan arbeta med ärenden, skapa anpassade vyer och hantera privata vyer."
+msgstr "Kan arbeta med ärende, skapa anpassade vyer och hantera privata vyer."
 
 #: desk/src/components/ListViewBuilder.vue:714 desk/src/pages/home/Home.vue:44
 msgid "Cancel"
@@ -1027,7 +1032,7 @@ msgstr "Kan inte aktivera regel utan att lägga till användare i den"
 msgid "Cannot merge General category"
 msgstr "Kan inte slå samman Allmän kategori"
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr "Kan inte ändra namn: ett orelaterat {0} '{1}' finns redan på andra sidan. Lös konflikt manuellt först."
 
@@ -1075,11 +1080,11 @@ msgstr "Kategorin måste ha minst en artikel"
 msgid "Category updated successfully."
 msgstr "Kategori uppdaterad."
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr "Kopia"
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr "Kopia:"
 
@@ -1087,7 +1092,7 @@ msgstr "Kopia:"
 msgid "Change"
 msgstr "Ändra"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "Ändra Lösenord"
@@ -1100,10 +1105,9 @@ msgstr "Ändra Bild"
 msgid "Change language of the application."
 msgstr "Ändra språk för ansökan."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
-msgstr "Ändra bild"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
+msgstr "Ändra operator ({0})"
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
 msgid "Change priority"
@@ -1125,7 +1129,7 @@ msgstr "Ändra ärende typ"
 msgid "Change timezone of the application."
 msgstr "Ändra språk för ansökan."
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr "Ändra lösenord för ditt konto för säkerhets skull."
 
@@ -1138,7 +1142,7 @@ msgstr "Kanaler"
 msgid "Child field"
 msgstr "Underordnad fält"
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr "Välj ett fält"
 
@@ -1148,7 +1152,7 @@ msgstr "Välj hur länge denna Service Nivå Avtal princip ska vara aktiv."
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:22
 msgid "Choose how tickets are distributed among selected assignees."
-msgstr "Välj hur ärenden ska fördelas mellan utvalda handläggare."
+msgstr "Välj hur ärende ska fördelas mellan valda handläggare."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:280
 msgid "Choose the days of the week when this rule should be active."
@@ -1164,7 +1168,7 @@ msgstr "Välj e-post tjänst leverantör som ska konfigureras."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:127
 msgid "Choose which tickets are affected by this assignment rule."
-msgstr "Välj vilka ärenden som påverkas av denna tilldelningsregel."
+msgstr "Välj vilka ärende som påverkas av denna tilldelning regel."
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:69
 msgid "Choose which tickets are affected by this policy."
@@ -1172,7 +1176,7 @@ msgstr "Välj vilka ärende som påverkas av denna princip."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:204
 msgid "Choose which tickets are affected by this un-assignment rule."
-msgstr "Välj vilka ärenden som påverkas av denna regel för återkallelse av tilldelning."
+msgstr "Välj vilka ärende som påverkas av denna regel för återkallelse av tilldelning."
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:69
 msgid "Choose who can view and use this response."
@@ -1180,7 +1184,7 @@ msgstr "Välj vem som kan se och använda detta svar."
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:78
 msgid "Choose who receives the tickets."
-msgstr "Välj vem som får ärenden."
+msgstr "Välj vem som får ärende."
 
 #: desk/src/components/view-controls/SortBy.vue:160
 msgid "Clear Sort"
@@ -1191,7 +1195,7 @@ msgstr "Rensa Sortering"
 msgid "Clear Table"
 msgstr "Rensa Tabell"
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr "Rensa allt"
 
@@ -1206,6 +1210,10 @@ msgstr "Rensa alla filter"
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
 msgstr "Klicka på 'Lägg till Helger'. Detta kommer att fylla helg tabell med alla datum som infaller på valda veckovis frånvaro. Upprepa processen för att fylla i datum för alla helger"
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
+msgstr "Klicka för att kopiera"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:47
@@ -1225,9 +1233,9 @@ msgstr "Stäng ärende"
 msgid "Closed"
 msgstr "Stängd"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
-msgstr "Stängda eller betygsatta ärenden kan bara uppdateras av handläggare"
+msgstr "Stängda eller betygsatta ärende kan bara uppdateras av handläggare"
 
 #: desk/src/components/layouts/Sidebar.vue:143
 msgid "Collapse"
@@ -1250,9 +1258,9 @@ msgstr "Kolumner"
 
 #: desk/src/components/Settings/InviteAgents.vue:15
 msgid "Comma separated emails to invite."
-msgstr "Kommaseparerade e-postmeddelanden att bjuda in."
+msgstr "Lägg till komma separerade e-post adresser."
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr "Komma avgränsade värden"
 
@@ -1285,7 +1293,7 @@ msgstr "Kommenterades av"
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "Kommentarer"
@@ -1298,6 +1306,11 @@ msgstr "Kommunikation"
 msgid "Communication ID is required"
 msgstr "Kommunikation ID erfordras"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
+msgstr "Bolag"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
 msgstr "Klar"
@@ -1309,7 +1322,7 @@ msgstr "Klar"
 msgid "Condition"
 msgstr "Villkor"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr "Konfigurera"
 
@@ -1333,6 +1346,10 @@ msgstr "Konfigurera Twilio telefoni integration inställningar här"
 msgid "Configure your telephony settings."
 msgstr "Konfigurera dina telefoni inställningar."
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1358,10 +1375,11 @@ msgstr "Bekräfta överskrivning"
 msgid "Connect your support email"
 msgstr "Koppla support e-postadress"
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1375,26 +1393,30 @@ msgstr "Kontakt"
 msgid "Contact HTML"
 msgstr "Kontakt HTML"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
-msgstr "Kontakt skapad."
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
-msgstr "Kontakt inbjuden."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
+msgstr "Kontakt borttagen"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr "Kontakt uppdaterad."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
-msgstr "Kontakt med e-postadress finns redan"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
+msgstr "Kontakt {0} har ingen e-post adress"
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
 msgstr "Kontakter"
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
+msgstr "Kontakter lades till"
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
 #. Label of the content (Text Editor) field in DocType 'HD Article'
@@ -1417,7 +1439,7 @@ msgstr "Kopiera ärende URL"
 msgid "Copy ticket id"
 msgstr "Kopiera ärende ID"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr "Kunde inte skicka e-post på grund av: {0}"
 
@@ -1425,7 +1447,11 @@ msgstr "Kunde inte skicka e-post på grund av: {0}"
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr "Kunde inte hitta kolumn `name` i tabHD Ärende"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr "Kunde inte migrera kontakter för {0} kunder(er): {1}. Fixa underliggande data och kör om patch."
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr "Kunde inte skicka bekräftelse e-post på grund av: {0}"
 
@@ -1433,11 +1459,20 @@ msgstr "Kunde inte skicka bekräftelse e-post på grund av: {0}"
 msgid "Could not send feedback email,due to: {0}"
 msgstr "Kunde inte skicka återkoppling e-post, på grund av: {0}"
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "Land"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1446,11 +1481,15 @@ msgstr "Skapa"
 #: desk/src/components/layouts/Sidebar.vue:537
 #: desk/src/components/layouts/Sidebar.vue:543
 msgid "Create & invite a contact"
-msgstr "Skapa och bjud in kontakt"
+msgstr "Skapa och Lägg till Kontakt"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
-msgstr "Skapa Ny Kontakt"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr "Skapa Kontakt"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
+msgstr "Skapa Kund"
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
 msgid "Create View"
@@ -1484,12 +1523,6 @@ msgstr "Skapad av"
 msgid "Creating a ticket"
 msgstr "Skapar ärende"
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr "Kriterier"
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr "Anpassade Åtgärder"
@@ -1514,12 +1547,21 @@ msgid "Custom Views"
 msgstr "Anpassade Vyer"
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
 msgstr "Kund"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
+msgstr "Kund Ansvarig"
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1530,17 +1572,33 @@ msgstr "Kund Namn"
 msgid "Customer Portal"
 msgstr "Kundportal"
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
-msgstr "Kund skapad."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr "Kund Typ"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr "Kund skapad"
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
+msgstr "Kund namn kan inte vara tomt"
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr "Kundportal"
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
-msgstr "Kund uppdaterad."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
+msgstr "Kund uppdaterad"
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
+msgstr "Kunder"
 
 #: desk/src/components/layouts/Sidebar.vue:595
 msgid "Customers & Contacts"
@@ -1567,6 +1625,8 @@ msgstr "Cyan"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "Fara"
@@ -1665,20 +1725,28 @@ msgstr "Standard ärende typ"
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:9
 msgid "Define who receives the tickets and how they’re distributed among agents."
-msgstr "Definiera vem som får ärendena och hur de fördelas mellan handläggare."
+msgstr "Definiera vem som får ärende och hur de fördelas mellan handläggare."
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "Ta bort"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr "Ta bort Kontakt"
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1695,6 +1763,10 @@ msgstr "Ta bort kategori?"
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
 msgstr "Ta bort {0}"
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
+msgstr "Ta bort {0} ärende(n)"
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
 #. Label of the description (Text Editor) field in DocType 'HD Holiday'
@@ -1742,7 +1814,7 @@ msgstr "Detaljerad förklaring"
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1795,7 +1867,7 @@ msgstr "Förkasta ändringar?"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:203
 msgid "Display a customizable banner message when customers raise tickets outside your working hours."
-msgstr "Visa anpassningsbart banner meddelande när kunder skapar ärenden utanför arbetstid."
+msgstr "Visa anpassningsbart banner meddelande när kund skapar ärende utanför arbetstid."
 
 #. Description of the 'Ignore Restrictions' (Check) field in DocType 'HD Team'
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
@@ -1806,11 +1878,11 @@ msgstr "Tillämpa inte filter och begränsningar på handläggare i detta team"
 #. DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Do not restrict tickets without a Team"
-msgstr "Begränsa inte ärenden utan Team"
+msgstr "Begränsa inte ärende utan Team"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:52
 msgid "Do not restrict tickets without a team"
-msgstr "Begränsa inte ärenden utan Team"
+msgstr "Begränsa inte ärende utan Team"
 
 #. Label of the dt (Link) field in DocType 'HD Form Script'
 #. Label of the dt (Link) field in DocType 'HD View'
@@ -1828,7 +1900,12 @@ msgstr "Dokument"
 msgid "Document Type"
 msgstr "DocType"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr "Doe"
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "Domän"
@@ -1870,6 +1947,10 @@ msgstr "Duplicera Service Nivå Avtal princip"
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
 msgstr "Duplicera Fördefinierad Svar"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
+msgstr "Duplicerade kontakter är inte tillåtna"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
 #: desk/src/pages/call-logs/CallLogModal.vue:68
@@ -1917,9 +1998,10 @@ msgstr "Affärssystem är inte installerat på webbplats. Installera Affärssyst
 
 #: desk/src/components/Settings/InviteAgents.vue:4
 msgid "Easily invite new agents, managers, or admins."
-msgstr "Bjud enkelt in nya handläggare, ansvariga eller administratörer."
+msgstr "Lägg till nya handläggare, ansvariga eller administratörer."
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1928,6 +2010,14 @@ msgstr "Redigera"
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
 msgstr "Redigera Samtalslogg"
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr "Redigera Kontakt"
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
+msgstr "Redigera Kund"
 
 #: desk/src/components/Settings/EmailAdd.vue:70
 #: desk/src/components/Settings/EmailEdit.vue:63
@@ -1944,12 +2034,12 @@ msgstr "Redigera Titel"
 
 #: desk/src/components/Settings/EmailEdit.vue:4
 msgid "Edit your email account"
-msgstr "Redigera ditt e-postkonto"
+msgstr "Redigera e-post konto"
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "E-post"
 
@@ -1963,7 +2053,7 @@ msgstr "E-post Konto"
 
 #: desk/src/components/Settings/EmailAccountList.vue:3
 msgid "Email Accounts"
-msgstr "E-post Konton"
+msgstr "E-post Konto"
 
 #. Label of the feedback_email_content (Text) field in DocType 'HD Settings'
 #. Label of the acknowledgement_email_content (Text) field in DocType 'HD
@@ -1977,8 +2067,9 @@ msgstr "E-post Konton"
 msgid "Email Content"
 msgstr "E-post Innehåll"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
 msgstr "E-post"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
@@ -1994,7 +2085,7 @@ msgstr "E-post Inställningar"
 
 #: desk/src/components/Settings/EmailAdd.vue:309
 msgid "Email account created"
-msgstr "E-postkonto Skapad"
+msgstr "E-post konto skapad"
 
 #: desk/src/components/Settings/EmailAccountList.vue:27
 msgid "Email account name"
@@ -2004,22 +2095,22 @@ msgstr "E-post konto namn"
 msgid "Email account updated successfully"
 msgstr "E-post konto uppdaterad"
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr "E-post adress till primära kontakt"
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr "E-post inställningar uppdaterade."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr "E-post adress får inte vara tom"
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "E-post "
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr "E-post & Signatur"
 
@@ -2057,8 +2148,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr "Aktivera återkoppling för Kund Portal"
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2083,8 +2172,6 @@ msgstr "Aktivera återkoppling för Kund Portal"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2107,21 +2194,25 @@ msgstr "Slut Tid "
 msgid "Enter a name for this HD Service Holiday List."
 msgstr "Ange namn för Tjänstgöring Helg Lista."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr "Ange giltig e-postadress"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr "Ange giltigt telefonnummer"
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr "Ange varumärke namn"
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr "Ange e-post adress"
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
 msgstr "Ange ny namn för team"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr "Ange primära kontakt e-post adress"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
+msgstr "Ange primär kontakt förnamn"
 
 #: helpdesk/api/knowledge_base.py:86
 msgid "Error moving article to category"
@@ -2131,22 +2222,18 @@ msgstr "Fel vid flytt av artikel till kategori"
 msgid "Error processing email at index {0}, message: {1}"
 msgstr "Fel vid bearbetning av e-post vid index {0}, meddelande: {1}"
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr "Fel vid uppdatering av kund"
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "Fel vid anslutning till E-post Konto {0}"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr "Eskaleringsregel finns redan för dessa kriterier"
 
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
 msgstr "Excel"
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
+msgstr "Befintliga användare kan ansluta direkt. Övriga får inbjudan."
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
 #: desk/src/components/Settings/Telephony/Telephony.vue:96
@@ -2174,11 +2261,6 @@ msgstr "Exportera Alla {0} Post(er)"
 msgid "Export Type"
 msgstr "Export Typ"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr "Extern länk"
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2186,6 +2268,10 @@ msgstr "Extern länk"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "Misslyckad"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr "Misslyckade Service Nivå Avtal"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2220,11 +2306,11 @@ msgstr "Misslyckades med att spara Exotel Inställningar"
 msgid "Failed to save Twilio settings"
 msgstr "Misslyckades med att spara Twilio Inställningar"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr "Misslyckades med att uppdatera Tilldelade."
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr "Misslyckades med att uppdatera Tilldelade."
 
@@ -2253,6 +2339,7 @@ msgstr "Favicon"
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2290,13 +2377,17 @@ msgstr "Återkoppling finns redan"
 msgid "Feedback Rating"
 msgstr "Återkoppling Betyg"
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr "Återkoppling Statistik"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
 msgstr "Återkoppling e-post skickad till kund"
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
+msgstr "Återkoppling från denna kontakt kommer att visas här när den är tillgänglig."
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
 msgid "Feedback submitted successfully."
@@ -2340,13 +2431,14 @@ msgid "Field dependency updated successfully."
 msgstr "Fältberoende uppdaterad."
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "Fält"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "Filter"
@@ -2356,13 +2448,18 @@ msgstr "Filter"
 msgid "Find out all of the variables that can be used in the content"
 msgstr "Ta reda på alla variabler som kan användas i innehållet"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "Förnamn"
 
 #. Label of the first_responded_on (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
+msgstr "Första Svar"
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
 msgstr "Första Svar"
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
@@ -2387,11 +2484,7 @@ msgstr "Första Svarstid"
 #. Name of a report
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
-msgstr "Första svarstid för Ärenden"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
-msgstr "Förnamn får inte vara tomt"
+msgstr "Första Svarstid för Ärenden"
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
@@ -2482,6 +2575,10 @@ msgstr "Globalt"
 msgid "Go to Ticket #{0}"
 msgstr "Gå till Ärende #{0}"
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr "Tilldela Ansvarig Åtkomst"
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2491,7 +2588,7 @@ msgstr "grå"
 
 #: desk/src/pages/home/components/PendingTickets.vue:254
 msgid "Great! All your tickets are within SLA"
-msgstr "Jättebra! Alla dina ärenden är inom Service Nivå Avtal ram"
+msgstr "Jättebra! Alla dina ärende är inom Service Nivå Avtal"
 
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
@@ -2511,20 +2608,13 @@ msgid "Group By Field"
 msgstr "Gruppera efter Fält"
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr "Gäst"
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
-msgstr "Vägled användarna till artiklar innan de skickar ärenden."
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
-msgstr "Åtgärd"
+msgstr "Vägled användare till artiklar innan de skickar ärende."
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -2556,15 +2646,32 @@ msgstr "Artikel Återkoppling"
 msgid "HD Comment Reaction"
 msgstr "Kommentar Reaktion"
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr "Kund"
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr "Kund Ansvarig"
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
-msgstr "Skrivbord Konto Begäran"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
+msgstr "Kund Medlem"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
@@ -2572,14 +2679,9 @@ msgid "HD Email Feedback"
 msgstr "E-post Återkoppling"
 
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
-msgstr "Eskalering Regel"
-
-#. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 msgid "HD Field Layout"
-msgstr "Fält Utseende"
+msgstr "Fält Uppsättning"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
@@ -2595,21 +2697,6 @@ msgstr "Helgdag"
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
 msgstr "Avisering"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr "Organisation"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr "Organisation Kontakt"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
-msgstr "Portal Registrering Begäran"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -2651,11 +2738,6 @@ msgstr "Inställningar"
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
 msgstr "Stoppord"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
-msgstr "Support Sök Källa"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_synonym/hd_synonym.json
@@ -2752,12 +2834,6 @@ msgstr "Support"
 msgid "Helpdesk"
 msgstr "Support"
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr "Support Kontakt"
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2774,11 +2850,6 @@ msgstr "Hej"
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
 msgstr "Dölj "
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr "Dölj villkor"
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
@@ -2848,15 +2919,8 @@ msgstr "Jag förstår, lägg till villkor"
 msgid "ID"
 msgstr "ID"
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "IP Adress"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2881,7 +2945,7 @@ msgstr "Om aktiverad, kommer e-post att skickas till alla tilldelade handläggar
 #. 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "If enabled, anyone will be able to create tickets (without any permission). "
-msgstr "Om aktiverad, kommer alla kunna skapa ärenden (utan någon behörighet). "
+msgstr "Om aktiverad, kommer alla kunna skapa ärende (utan någon behörighet). "
 
 #. Description of the 'Enabled' (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2943,6 +3007,11 @@ msgstr "Inkorg"
 msgid "Incoming"
 msgstr "Inkommande"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr "Privat"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr "Initierad"
@@ -2956,7 +3025,7 @@ msgstr "Installera"
 msgid "Instantly send e-mail"
 msgstr "Skicka e-post direkt"
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "Otillräckliga Behörigheter för ändring av {0}"
 
@@ -2970,13 +3039,13 @@ msgstr "Heltal Värde"
 msgid "Introduction"
 msgstr "Introduktion"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr "Ogiltig tillgänglighet"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
-msgstr "Ogiltig e-postadress"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
+msgstr "Ogiltig e-post adress"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
 #: desk/src/components/Settings/Holiday/HolidayView.vue:325
@@ -2984,39 +3053,76 @@ msgstr "Ogiltig e-postadress"
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr "Ogiltiga fält, kontrollera att alla är ifyllda och att värdena är korrekta."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr "Ogiltig filtyp, endast PNG och JPG bilder tillåts"
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr "Ogiltig avisering"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
 msgstr "Ogiltigt telefonnummer"
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr "Ogiltig roll {0}"
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr "Inbjudan Utgången"
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr "Inbjudan avbruten"
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr "Inbjudan har gått ut. Skicka den på nytt för att bjuda in igen."
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
+msgstr "Inbjudan"
+
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
-msgstr "Bjud in handläggare"
+msgstr "Lägg till Handläggare"
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
+msgstr "Bjud in Kontakt"
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
 msgid "Invite agent"
-msgstr "Bjud in handläggare"
+msgstr "Lägg till Handläggare"
 
 #: desk/src/components/layouts/Sidebar.vue:450
 msgid "Invite agents"
-msgstr "Bjud in handläggare"
+msgstr "Lägg till Handläggare"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
-msgstr "Bjud in som användare"
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
+msgstr "Skapa Användare"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
+msgstr "Lägg till via E-post"
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr "Inbjudan skickad. Väntar på att användare ska acceptera."
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
 msgstr "Bjud in via e-post"
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr "Inbjuden"
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
+msgstr "Inbjuden av"
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -3032,6 +3138,11 @@ msgstr "Är Kund Portal"
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "Är Standard"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr "Är Ansvarig"
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3060,6 +3171,10 @@ msgstr "Är fäst"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
 msgstr "Är installationen klar"
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
+msgstr "John"
 
 #: desk/src/components/command-palette/CP.vue:114
 msgid "Jump to"
@@ -3095,11 +3210,9 @@ msgstr "Kort Kommando"
 msgid "Knowledge Base"
 msgstr "Kunskap Bas"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3133,9 +3246,9 @@ msgstr "Sista"
 msgid "Last 3 Months"
 msgstr "Senaste 3 Månader"
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr "Senaste 3 månader"
 
@@ -3176,7 +3289,8 @@ msgstr "Senaste Kund Svar"
 msgid "Last Month"
 msgstr "Förra Månad"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "Efternamn"
 
@@ -3185,29 +3299,38 @@ msgstr "Efternamn"
 msgid "Last Week"
 msgstr "Förra Vecka"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
 msgstr "Förra månaden"
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
+msgstr "Senast sedd"
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr "Senaste användare tilldelad av denna regel"
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
 msgstr "Förra veckan"
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
+msgstr "Senaste"
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 msgid "Layout"
-msgstr "Utseende"
+msgstr "Uppsättning"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:135
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:212
@@ -3219,26 +3342,6 @@ msgstr "Lär dig om villkoren"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
 msgstr "Informera kunderna om att de skapar ärende utanför arbetstid och när de kan förvänta sig svar."
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "Länk"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr "Länk Alternativ"
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr "Länk till kund"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
-msgstr "Länk till kund post"
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #. Label of the list_tab (Tab Break) field in DocType 'HD View'
@@ -3266,6 +3369,8 @@ msgstr "Ladda Standard Kolumner"
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "Ladda Mer"
 
@@ -3288,6 +3393,8 @@ msgstr "Logga in på Frappe Cloud"
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr "Logotyp"
@@ -3326,13 +3433,13 @@ msgstr "Hantera allmänna inställningar för din app."
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr "Hantera fördefinierade svar som kan användas för att svara på kundfrågor."
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr "Hantera e-post konto meddelanden och e-post signatur för kommunikation."
 
 #: desk/src/components/Settings/EmailAccountList.vue:5
 msgid "Manage your email accounts and configure incoming and outgoing settings."
-msgstr "Hantera dina e-postkonton och konfigurera inställningar för inkommande och utgående e-post."
+msgstr "Hantera e-post konto och konfigurera inställningar för inkommande och utgående e-post."
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:25
 msgid "Manage your email signature."
@@ -3345,6 +3452,10 @@ msgstr "Hantera dina personliga preferenser."
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
 msgstr "Hantera din profil information."
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
+msgstr "Ansvarig"
 
 #: desk/src/pages/MobileNotifications.vue:11
 #: desk/src/pages/MobileNotifications.vue:14
@@ -3398,6 +3509,20 @@ msgstr "Övrigt"
 msgid "Mobile App Installation"
 msgstr "Mobil App Installation"
 
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr "Mobil Nummer"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr "Mobilnummer"
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr "Mobil nummer till primära kontakt"
+
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
 #. List'
@@ -3438,7 +3563,7 @@ msgid "My Tickets"
 msgstr "Mina Ärende"
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3449,8 +3574,9 @@ msgstr "Mina Ärende"
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3460,6 +3586,10 @@ msgstr "Namn"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
 msgstr "Namn Vikt"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
+msgstr "Namn erfordras"
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
 #. Ticket Status'
@@ -3471,10 +3601,18 @@ msgstr "Namn som visas på kundportalen<br> (t.ex., Svarade → Väntar på svar
 msgid "Navigation"
 msgstr "Navigering"
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr "Negativ"
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr "Negativt först"
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "Aldrig"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3583,11 +3721,11 @@ msgstr "Ingen Svar"
 msgid "No Data Found"
 msgstr "Ingen data hittades"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
-msgstr "Inget e-postkonto hittades för {0}"
+msgstr "Inget e-post konto hittades för {0}"
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr "Ingen Handläggare post för aktuell användare"
 
@@ -3599,9 +3737,15 @@ msgstr "Ingen Helgdagslista hittades"
 msgid "No SLA found"
 msgstr "Inget Service Nivå Avtal hittades"
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
 msgstr "Inget Team"
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
+msgstr "Inga aktiva ärende"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
 msgid "No additional comments"
@@ -3635,31 +3779,43 @@ msgstr "Inga kategorier tillgängliga"
 msgid "No changes made"
 msgstr "Inga ändringar gjorda"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr "Inga ändringar att spara"
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr "Inga diagram tillagda"
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr "Inga kontakter hittades"
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr "Inga kontakter hittades för tillämpade filter. Försök att justera eller rensa dina filter."
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr "Inga kontakter att lägga till"
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr "Inget land hittades"
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr "Inga kunder hittades för tillämpade filter. Försök att justera eller rensa dina filter."
 
 #: desk/src/components/Settings/EmailAccountList.vue:46
 msgid "No email account found"
-msgstr "Inget e-postkonto hittades"
+msgstr "Inget e-post konto hittades"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:283
 msgid "No feedback"
 msgstr "Ingen återkoppling"
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr "Ingen återkoppling än"
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr "Inga fält hittades"
 
@@ -3673,7 +3829,7 @@ msgstr "Inga nya aviseringar"
 
 #: desk/src/pages/home/components/PendingTickets.vue:258
 msgid "No new tickets assigned to you in the last 7 days"
-msgstr "Inga nya ärenden har tilldelats dig under de senaste 7 dagarna"
+msgstr "Inga nya ärende har tilldelats dig under de senaste 7 dagarna"
 
 #: desk/src/components/ticket-agent/TicketNavigation.vue:25
 msgid "No next ticket"
@@ -3685,7 +3841,7 @@ msgstr "Ingen"
 
 #: desk/src/pages/home/components/PendingTickets.vue:261
 msgid "No pending tickets"
-msgstr "Inga pågående ärenden"
+msgstr "Inga pågående ärende"
 
 #: desk/src/components/ticket-agent/TicketNavigation.vue:10
 msgid "No previous ticket"
@@ -3699,40 +3855,50 @@ msgstr "Ingen anledning"
 msgid "No recently assigned tickets"
 msgstr "Inga nyligen tilldelade ärenden"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr "Inga resultat"
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
 msgstr "Inga resultat hittades"
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
+msgstr "Inga recensioner hittades"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:91
 msgid "No saved replies found"
 msgstr "Inga sparade svar hittades"
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
-msgstr "Inga ärenden hittades"
+msgstr "Inga ärende hittades"
 
 #: desk/src/pages/ticket/Tickets.vue:202
 msgid "No tickets found for the applied filters. Try adjusting or clearing your filters."
-msgstr "Inga ärenden hittades för tillämpade filter. Försök att justera eller rensa dina filter."
+msgstr "Inga ärende hittades för tillämpade filter. Försök att justera eller rensa dina filter."
 
 #: desk/src/pages/ticket/Tickets.vue:198
 msgid "No tickets found for this view. Try adjusting your filters or creating a new view."
-msgstr "Inga ärenden hittades för denna vy. Försök att justera dina filter eller skapa ny vy."
+msgstr "Inga ärende hittades för denna vy. Försök att justera dina filter eller skapa ny vy."
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:99
 msgid "No tickets found to preview."
-msgstr "Inga ärenden hittades att förhandsgranska."
+msgstr "Inga ärende hittades att förhandsgranska."
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:84
 msgid "No tickets selected"
 msgstr "Inga ärende valda"
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr "Ingen användare länkad till kontakt {0}"
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "Ej Tillåtet"
 
@@ -3744,7 +3910,7 @@ msgstr "Ej Tilldelad"
 msgid "Not Saved"
 msgstr "Ej Sparad"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "Ej Angiven"
 
@@ -3783,18 +3949,13 @@ msgstr "Gamla Villkor"
 msgid "On Hold Since"
 msgstr "Spärrad Sedan"
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr "Vid klick (Javascript)"
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr "På Ärende Status"
 
 #: helpdesk/api/ticket.py:75
 msgid "Only administrators can delete tickets."
-msgstr "Endast administratörer kan ta bort ärenden."
+msgstr "Endast administratörer kan ta bort ärende."
 
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.py:29
 msgid "Only one default view is allowed per user for {0}"
@@ -3818,6 +3979,10 @@ msgstr "Öppna kommandopalett"
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
 msgstr "Öppna kommentarsfält"
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
+msgstr "Öppna kund"
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
 msgid "Open help"
@@ -3908,7 +4073,12 @@ msgstr "Överordnad Fält"
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr "Överordnad fält, underordnad fält och överordnad-underordnad mappning erfordras."
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr "Partner"
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "Lösenord"
 
@@ -3946,30 +4116,31 @@ msgid "Pending"
 msgstr "Pågående"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
-msgstr "Väntande Inbjudningar"
+msgstr "Väntande"
 
 #: desk/src/pages/home/Home.vue:353
 #: desk/src/pages/home/components/PendingTickets.vue:234
 #: desk/src/pages/home/components/PendingTickets.vue:238
 msgid "Pending Tickets"
-msgstr "Väntande ärenden"
+msgstr "Väntande Ärende"
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
-msgstr "Procentandel av Totala Ärenden per Kanal"
+msgstr "Procentandel av Totala Ärende per Kanal"
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
-msgstr "Procentandel av Totala Ärenden per Prioritet"
+msgstr "Procentandel av Totala Ärende per Prioritet"
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
-msgstr "Procentandel av Totala Ärenden per Team"
+msgstr "Procentandel av Totala Ärende per Team"
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
-msgstr "Procentandel av Totala Ärenden per Typ"
+msgstr "Procentandel av Totala Ärende per Typ"
 
 #: desk/src/pages/dashboard/Dashboard.vue:46
 msgid "Period"
@@ -3988,14 +4159,15 @@ msgstr "Personlig"
 msgid "Personal mobile no"
 msgstr "Personlig mobilnummer"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "Telefon"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
-msgstr "Telefonnummer"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
+msgstr "Bild"
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
 msgid "Pick an option"
@@ -4051,9 +4223,9 @@ msgstr "Ange ämne att fortsätta"
 msgid "Please enter a valid phone number"
 msgstr "Ange giltigt telefonnummer"
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
-msgstr "Ange minst en giltig e-post adress för att skicka inbjudan."
+msgstr "Ange minst en giltig e-post adress för att kunna skicka inbjudan."
 
 #: desk/src/components/Settings/Teams/NewTeam.vue:129
 #: desk/src/pages/call-logs/CallLogModal.vue:264
@@ -4094,34 +4266,15 @@ msgstr "Välj Ledig Veckodag"
 msgid "Policy name"
 msgstr "Princip Namn"
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr "Positiv"
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
 msgstr "Positiv först"
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr "Ange Beskrivning Nyckel"
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr "Ange Sökväg Nyckel Lista"
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr "Ange Sökväg Sträng"
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
-msgstr "Ange Benämning Nyckel"
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:10
@@ -4155,14 +4308,32 @@ msgstr "Förhandsgranska"
 msgid "Previous ticket"
 msgstr "Föregående ärende"
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "Primär"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "Primär Kontakt"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr "Primär kontakt måste vara en av de listade kontakter"
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr "Primär kontakt uppdaterad"
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr "Prioriteringar"
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4170,9 +4341,10 @@ msgstr "Prioriteringar"
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4252,17 +4424,6 @@ msgstr "Hämtar e-post, det kan ta några minuter."
 msgid "Quarterly"
 msgstr "Kvartalsvis"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "Dataförfråga Alternativ"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr "Dataförfrågning Sökväg Sträng"
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "I Kö"
@@ -4285,14 +4446,14 @@ msgstr "Betygsätt Din Supportupplevelse"
 msgid "Rate this ticket"
 msgstr "Betygsätt detta ärende"
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr "Betygsatta Ärende"
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4331,7 +4492,7 @@ msgstr "Senaste"
 
 #: desk/src/pages/home/components/PendingTickets.vue:233
 msgid "Recent Tickets"
-msgstr "Senaste ärenden"
+msgstr "Senaste Ärende"
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:30
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:29
@@ -4388,8 +4549,15 @@ msgstr "Återskapa Sökindex"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "Ta bort"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr "Ta bort Kontakt"
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4399,10 +4567,19 @@ msgstr "Ta bort logotyp"
 msgid "Remove Photo"
 msgstr "Ta bort Bild"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr "Ta bort filter"
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
 msgstr "Ta bort bild"
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
+msgstr "Ta bort primär kontakt"
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
 #: desk/src/components/Settings/Teams/TeamsList.vue:161
@@ -4422,6 +4599,15 @@ msgstr "Byt namn (⌘ + ⏎)"
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
 msgstr "Döp om team"
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr "Ändra filter"
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
+msgstr "Ersätt bild"
 
 #. Option in a Select field in the tickets Web Form
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
@@ -4460,17 +4646,14 @@ msgstr "Svar från kontakt"
 msgid "Reply on a ticket"
 msgstr "Svara på ärende"
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr "Begärd Nyckel"
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
 msgstr "Erfordras"
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
+msgstr "Skicka inbjudan igen"
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
 msgid "Reset"
@@ -4490,6 +4673,7 @@ msgid "Reset to Default"
 msgstr "Återställ till Standard"
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr "Beslut"
@@ -4543,18 +4727,6 @@ msgstr "Svar"
 msgid "Response By"
 msgstr "Svar Efter"
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr "Svar Alternativ"
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr "Svar Resultat Nyckel Sökväg"
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr "Svar Tid för {0} prioritet på rad {1} kan inte vara längre än Lösning Tid."
@@ -4583,37 +4755,19 @@ msgstr "Begränsa handläggare tilldelning till valt team"
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Restrict tickets by Team"
-msgstr "Begränsa ärenden per Team"
+msgstr "Begränsa ärende per Team"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:35
 msgid "Restrict tickets by team"
-msgstr "Begränsa ärenden efter team"
+msgstr "Begränsa ärende per Team"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:38
 msgid "Restrict tickets to be viewed and managed by team members only."
-msgstr "Begränsa ärenden till att endast visas och hanteras av team medlemmar."
+msgstr "Begränsa ärende till att endast visas och hanteras av team medlemmar."
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:83
 msgid "Restrict visibility to these teams"
 msgstr "Begränsa synlighet för dessa team"
-
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr "Resultat Förhandsvisning Fält"
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr "Resultat Sökväg Fält"
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr "Resultat Benämning Fält"
 
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
@@ -4621,13 +4775,27 @@ msgstr "Resultat Benämning Fält"
 msgid "Reviews"
 msgstr "Recensioner"
 
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr "Återkalla Inbjudan"
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
+msgstr "Återkalla Ansvarig Åtkomst"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:215
 msgid "Ringing"
 msgstr "Ringer"
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "Roll"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr "Roll uppdaterad"
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4726,9 +4894,9 @@ msgstr "Lördag"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4804,17 +4972,19 @@ msgstr "Sökindex Återskapad"
 msgid "Search Score"
 msgstr "Sökresultat"
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr "Sökterm Parameter Namn"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr "Sök handläggare..."
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr "Sök efter ID eller Ämne"
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr "Sök land"
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "Sökfält..."
 
@@ -4840,11 +5010,11 @@ msgstr "Sök ärende"
 
 #: desk/src/pages/SearchAgent.vue:16
 msgid "Search tickets, comments, and communications..."
-msgstr "Sök efter ärenden, kommentarer och kommunikation..."
+msgstr "Sök efter ärende, kommentarer och kommunikation..."
 
 #: desk/src/components/command-palette/CP.vue:12
 msgid "Search tickets, emails, comments, or #234 to navigate to ticket"
-msgstr "Sök efter ärenden, e-postmeddelanden, kommentarer eller #234 för att navigera till ärende"
+msgstr "Sök efter ärende, e-post meddelande, kommentarer eller #234 för att navigera till ärende"
 
 #: desk/src/components/view-controls/filter/FilterValueEditor.vue:33
 msgid "Search..."
@@ -4854,13 +5024,14 @@ msgstr "Sök..."
 msgid "Searched for:"
 msgstr "Sökte efter:"
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr "Söker..."
 
 #: desk/src/pages/home/components/PendingTickets.vue:147
 msgid "See all {0} tickets"
-msgstr "Se alla {0} ärenden"
+msgstr "Se alla {0} ärende"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:28
 #: desk/src/pages/call-logs/CallLogModal.vue:57
@@ -4873,6 +5044,10 @@ msgstr "Välj"
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
 msgstr "Välj Kategori"
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
+msgstr "Välj Kund"
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
 msgid "Select Range"
@@ -4894,6 +5069,10 @@ msgstr "Välj Standard Prioritet."
 msgid "Select a rating"
 msgstr "Välj betyg"
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr "Välj land"
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4907,9 +5086,13 @@ msgstr "Välj team"
 msgid "Select ticket to preview"
 msgstr "Välj ärende att förhandsgranska"
 
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
+msgstr "Välj tidszon"
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
 msgid "Select what type all tickets get by default."
-msgstr "Välj vilken typ alla ärenden får som standard."
+msgstr "Välj vilken typ alla ärende får som standard."
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:41
 msgid "Select your weekly off day"
@@ -4921,7 +5104,7 @@ msgstr "Skicka"
 
 #: desk/src/components/Settings/InviteAgents.vue:37
 msgid "Send Invites"
-msgstr "Skicka Inbjudningar"
+msgstr "Skicka"
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:32
 msgid "Send Reply"
@@ -4932,6 +5115,10 @@ msgstr "Skicka Svar"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
 msgstr "Skicka återkoppling när"
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
+msgstr "Skicka e-post meddelande för återställning av lösenord"
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
 msgid "Send to {0} tickets"
@@ -4959,7 +5146,7 @@ msgstr "Service Nivå Avtal"
 
 #: desk/src/components/Settings/Sla/SlaPolicies.vue:5
 msgid "Service Level Agreements (SLAs)"
-msgstr "Service Nivå Avtalen"
+msgstr "Service Nivå Avtal"
 
 #. Label of the service_level (Data) field in DocType 'HD Service Level
 #. Agreement'
@@ -4971,7 +5158,7 @@ msgstr "Service Nivå Namn"
 msgid "Service not supported"
 msgstr "Tjänsten stöds inte"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "Ange"
 
@@ -4979,6 +5166,10 @@ msgstr "Ange"
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
 msgstr "Ange Telefonnummer"
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
+msgstr "Ange Primär Kontakt"
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
 msgid "Set Resolution Time for Priority {0} in row {1}."
@@ -4988,12 +5179,21 @@ msgstr "Ange Upplösning Tid för Prioritet {0} på rad {1}."
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr "Ange Svarstid för Prioritet {0} i rad {1}."
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr "Ange som Primär"
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr "Ange som standard Service Nivå Avtal"
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr "Ange som Primär"
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr "Ange status"
 
@@ -5005,7 +5205,7 @@ msgstr "Ange standard status som tilldelas när ett ärende skapas och status so
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr "Ange arbetsdagar, öppettider och helgdagar genom att välja ett fördefinierat schema eller skapa ett nytt."
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr "Ange din tillgänglighet så att ditt team vet när du är tillgänglig."
 
@@ -5139,23 +5339,6 @@ msgstr "Fel uppstod när helg lista uppdaterades"
 msgid "Sort"
 msgstr "Sortera"
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr "Käll DocType"
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "Käll Namn"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr "Käll Typ"
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr "Källa och mål kategori kan inte vara desamma"
@@ -5200,6 +5383,8 @@ msgstr "Starttiden kan inte vara senare än eller lika med sluttid på rad <u>{0
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5268,6 +5453,7 @@ msgstr "Status för ärende när det skapas i system."
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5330,7 +5516,7 @@ msgstr "Växla mellan ljus, mörk eller system tema"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:44
 msgid "Switch between outgoing email accounts when sending emails from your configured accounts."
-msgstr "Växla mellan utgående e-postkonton när du skickar e-post från dina konfigurerade konton."
+msgstr "Växla mellan utgående e-post konto när du skickar e-post från konfigurerade konto."
 
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.js:16
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.js:18
@@ -5379,21 +5565,16 @@ msgstr "System"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5432,8 +5613,6 @@ msgstr "Ärende finns inte"
 msgid "Teal"
 msgstr "Turkos"
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5444,7 +5623,6 @@ msgstr "Turkos"
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5464,7 +5642,7 @@ msgstr "Team Begränsningar"
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:269
 msgid "Team can now access all tickets."
-msgstr "Team kan nu komma åt alla ärenden."
+msgstr "Team kan nu komma åt alla ärende."
 
 #: desk/src/components/Settings/NewTeamModal.vue:52
 msgid "Team created"
@@ -5497,7 +5675,7 @@ msgstr "Team namn ändrad."
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:270
 msgid "Team will only see their own tickets."
-msgstr "Team kommer bara att se sina egna ärenden."
+msgstr "Team kommer bara att se sina egna ärende."
 
 #. Label of the teams (Table MultiSelect) field in DocType 'HD Saved Reply'
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:74
@@ -5550,6 +5728,10 @@ msgstr "Tilldelningsvillkor '{0}' är ogiltig: {1}"
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr "Tilldelningsvillkor JSON '{0}' är ogiltig: {1}"
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr "Kontakt {0} är kopplad till flera kunder. Välj kund manuellt."
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr "Återkoppling dialog ruta visas när användare försöker stänga ärende från kundportal."
@@ -5561,6 +5743,10 @@ msgstr "Helgdag {0} är inte mellan Från Datum och Till Datum"
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
 msgstr "Antal dagar måste vara 1 eller fler"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
+msgstr "Vald kund {0} är inte länkad till kontakt {1}. Välj giltig kund eller uppdatera länkade kunder."
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
 msgid "The status for sending feedback must be of <u>Resolved</u> category."
@@ -5582,6 +5768,14 @@ msgstr "Det finns inga kategorier publicerade för tillfället."
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr "Det ska finnas minst en tilldelning regel för ärende"
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr "De får tillgång till ärende som skapats av alla i organisation."
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr "De kommer bara att se sina egna biljetter framöver."
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr "Denna Tilldelning Regel är länkad till team {0}.</br> Användare {1} har lagts till i tilldelning regel men inte i länkad team. Lägg till användare i {2} för att säkerställa korrekt teamstruktur."
@@ -5590,6 +5784,10 @@ msgstr "Denna Tilldelning Regel är länkad till team {0}.</br> Användare {1} h
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
 msgstr "Denna åtgärd är oåterkallelig."
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
+msgstr "Denna kontakt blir primär kontakt punkt och kan se ärende som skapats av alla andra kontakter i organisation."
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
 msgid "This date is calculated based on configured SLAs, working hours, and holidays."
@@ -5610,7 +5808,7 @@ msgstr "Detta fält används för att skicka ett e-post meddelande direkt utan a
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "This field is used to skip email-related workflows for tickets. If this field is checked, no emails will be sent related to tickets, such as new ticket creation, status updates, or notifications."
-msgstr "Detta fält används för att hoppa över e-post relaterade arbetsflöden för ärenden. Om detta fält är vald skickas inga e-post meddelanden som rör ärenden, t. ex. skapande av nya ärenden, status uppdateringar eller meddelande."
+msgstr "Detta fält används för att hoppa över e-post relaterade arbetsflöde för ärende. Om detta fält är vald skickas inga e-post meddelande som rör ärende, t. ex. skapande av nya ärende, status uppdateringar eller meddelande."
 
 #: helpdesk/www/helpdesk/index.py:26
 msgid "This method is only meant for developer mode"
@@ -5658,7 +5856,7 @@ msgstr "Torsdag"
 msgid "Ticket"
 msgstr "Ärende"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr "Ärende #{0}: Vi har mottagit begäran"
 
@@ -5673,6 +5871,10 @@ msgstr "Ärende Statistik"
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
 msgstr "Ärende Konfiguration"
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
+msgstr "Ärende ID"
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
 msgid "Ticket Info"
@@ -5731,7 +5933,7 @@ msgstr "Ärende Ämne"
 msgid "Ticket Summary"
 msgstr "Ärende Sammanfattning"
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr "Ärende Statistik"
 
@@ -5764,7 +5966,7 @@ msgstr "Ärende finns inte."
 msgid "Ticket merged successfully."
 msgstr "Ärendet har sammanfogats."
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr "Ärende måste lösas med återkoppling"
 
@@ -5799,12 +6001,6 @@ msgstr "Ärende status"
 msgid "Ticket to merged with is required"
 msgstr "Ärende att sammanfoga med erfordras"
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr "Ärende typ"
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr "Ärende uppdaterad."
@@ -5816,12 +6012,15 @@ msgstr "Ärendesökning Statistik"
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr "Ärende"
 
@@ -5831,37 +6030,38 @@ msgstr "Ärenden som närmar sig eller brutit mot Service Nivå Avtal"
 
 #: desk/src/pages/home/components/PendingTickets.vue:243
 msgid "Tickets assigned to you in the last 7 days"
-msgstr "Ärenden som tilldelats dig under de senaste 7 dagarna"
+msgstr "Ärende som tilldelats dig under de senaste 7 dagarna"
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
-msgstr "Ärenden per Kanal"
+msgstr "Ärende per Kanal"
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
-msgstr "Ärenden per Prioritet"
+msgstr "Ärende per Prioritet"
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
-msgstr "Ärenden per Team"
+msgstr "Ärende per Team"
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
-msgstr "Ärenden per Typ"
+msgstr "Ärende per Typ"
 
 #: helpdesk/api/ticket.py:65
 msgid "Tickets can only be assigned to agents"
-msgstr "Ärenden kan endast tilldelas handläggare"
+msgstr "Ärende kan endast tilldelas handläggare"
 
 #: desk/src/components/ticket/TicketMergeModal.vue:29
 msgid "Tickets must meet the following conditions:"
-msgstr "Ärenden måste uppfylla följande villkor:"
+msgstr "Ärende måste uppfylla följande villkor:"
 
 #: desk/src/pages/home/components/PendingTickets.vue:244
 msgid "Tickets that are awaiting your response"
-msgstr "Ärenden som väntar på ditt svar"
+msgstr "Ärende som väntar på ditt svar"
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr "Tidszon"
 
@@ -5918,7 +6118,7 @@ msgstr "Till erfordras"
 
 #: desk/src/components/Settings/EmailEdit.vue:268
 msgid "To know more about setting up email accounts, click"
-msgstr "För att veta mer om hur du konfigurerar e-post konton, klicka här"
+msgstr "För att veta mer om hur du konfigurerar e-post konto, klicka här"
 
 #: desk/src/pages/dashboard/Dashboard.vue:472
 #: desk/src/pages/dashboard/Dashboard.vue:474
@@ -5951,21 +6151,21 @@ msgstr "Totalt Antal Helger"
 msgid "Total Ticket"
 msgstr "Totalt Ärende"
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
-msgstr "Totalt antal skapade ärenden"
+msgstr "Totalt antal skapade ärende"
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
-msgstr "Totala Ärenden per Prioritet"
+msgstr "Total antal Ärende per Prioritet"
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
-msgstr "Totalt antal Ärenden per Team"
+msgstr "Totalt antal Ärende per Team"
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
-msgstr "Totalt antal Ärenden efter Typ"
+msgstr "Totalt antal Ärende efter Typ"
 
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
@@ -5995,6 +6195,10 @@ msgstr "Typ "
 msgid "Type a message"
 msgstr "Skriv meddelande"
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr "Skriv en e-post adress"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr "Typ erfordras"
@@ -6004,7 +6208,7 @@ msgstr "Typ erfordras"
 msgid "URL/Method"
 msgstr "URL/Metod"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr "Kunde inte skicka e-post. Konfigurera standard konto för utgående e-post."
 
@@ -6038,6 +6242,8 @@ msgid "Unpublish"
 msgstr "Avpublicera"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr "Ej Sparad"
 
@@ -6055,6 +6261,10 @@ msgstr "Ej Sparad"
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
 msgstr "Ej sparade ändringar"
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
+msgstr "DocType ”{0}” stöds inte för ärende statistik."
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
 msgid "Untitled"
@@ -6082,10 +6292,13 @@ msgstr "Ladda upp"
 msgid "Upload Photo"
 msgstr "Ladda upp Bild"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
-msgstr "Ladda upp bild"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
+msgstr "Ladda upp bild i PNG eller JPG format"
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
+msgstr "Ladda upp Bild"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
 msgid "Uploading {0}%"
@@ -6094,17 +6307,13 @@ msgstr "Ladda Upp {0}%"
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6116,6 +6325,10 @@ msgstr "Användare"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
 msgstr "Användare Resolution Tid"
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
+msgstr "Användare Recensioner"
 
 #: desk/src/components/Settings/General/General.vue:42
 msgid "User Signup"
@@ -6134,7 +6347,7 @@ msgstr "Användare"
 msgid "Valid From"
 msgstr "Giltig Från"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "Värde"
 
@@ -6263,19 +6476,23 @@ msgstr "Årsvis"
 msgid "Yellow"
 msgstr "Gul"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr "Du har inte tillåtelse att visa annan handläggare statistik."
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr "Du har inte behörighet att visa översikt panel data."
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr "Du har inte behörighet att komma åt denna resurs."
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr "Du har inte behörighet att lägga till kommentar"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr "Du har inte behörighet att svara som handläggare"
 
@@ -6303,6 +6520,14 @@ msgstr "Du kan inte ange mer än standard prioritet."
 msgid "You do not have permission to access Assignment Rules"
 msgstr "Du har inte behörighet att komma åt Tilldelning Regler"
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr "Du har inte behörighet att komma åt denna resurs"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr "Du har inte behörighet att uppdatera kontakter"
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr "Du har inte tillgång till detta ärende, eller så finns den inte längre."
@@ -6326,6 +6551,14 @@ msgstr "Dina gamla villkor kommer att skrivas över. Är du säker på att du vi
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
 msgstr "Din prestation är"
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr "aktiv ärende"
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
+msgstr "aktiva ärenden"
 
 #: desk/src/pages/MobileNotifications.vue:46
 msgid "assigned you a ticket"
@@ -6355,7 +6588,7 @@ msgstr "skapad"
 msgid "customize {0}"
 msgstr "anpassa {0}"
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr "dagar"
 
@@ -6406,7 +6639,7 @@ msgstr "här"
 msgid "here."
 msgstr "här."
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr "tid"
 
@@ -6414,7 +6647,7 @@ msgstr "tid"
 msgid "in"
 msgstr "i"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "just nu"
 
@@ -6447,7 +6680,11 @@ msgstr "publicerad av"
 msgid "purple"
 msgstr "lila"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr "recensioner"
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr "stjärnor"
 
@@ -6464,7 +6701,7 @@ msgstr "ärende"
 msgid "to enable this integration."
 msgstr "för att aktivera denna integration."
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr "visade detta"
 
@@ -6472,13 +6709,33 @@ msgstr "visade detta"
 msgid "views"
 msgstr "vyer"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr "{0} Kunder"
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr "{0} är redan tillagd"
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr "{0} är ogiltig e-post adress"
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr "{0} är för närvarande borta."
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
 msgstr "{0} är för närvarande otillgänglig."
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr "{0} är inte befintlig kontakt"
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
+msgstr "{0} är inte befintlig användare"
 
 #: desk/src/components/ListViewBuilder.vue:307
 msgid "{0} item(s) deleted successfully"
@@ -6504,7 +6761,7 @@ msgstr "{0} vyn är för närvarande publik. Om du ändrar den till privat dölj
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr "{0} vyn är för närvarande synlig i sidofältet. Om du döljer den tas den bort från sidofältet."
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr "{0} · Senast aktiv {1}"
 

--- a/helpdesk/locale/th.po
+++ b/helpdesk/locale/th.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-15 18:51\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-29 21:58\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Thai\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr "% SLA ที่บรรลุแล้ว"
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr "ร้อยละของบัตรที่สร้างขึ้นซึ่งได้รับการแก้ไขภายใน SLA"
@@ -108,14 +108,6 @@ msgstr "คำอธิบายสั้น ๆ"
 msgid "A workday with this name already exists"
 msgstr ""
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr "API"
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr "เข้าถึงตั๋วทีมทั้งหมด"
@@ -132,7 +124,7 @@ msgstr "เข้าถึงได้เฉพาะตั๋วของที
 msgid "Account"
 msgstr "บัญชี"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr ""
 
@@ -152,11 +144,9 @@ msgstr "การดำเนินการ"
 msgid "Action Required"
 msgstr "ต้องดำเนินการ"
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr "การดำเนินการเมื่อคลิกปุ่ม เอกสารจะพร้อมใช้งานใน `this`"
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "การกระทำ"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr "การดำเนินการเมื่อคลิกปุ่
 msgid "Active"
 msgstr "ใช้งาน"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr ""
 
@@ -175,7 +165,7 @@ msgid "Active: The agent is available and working.<br>\n"
 "Unavailable: The agent is off and unavailable."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "กิจกรรม"
@@ -193,10 +183,11 @@ msgid "Add Column"
 msgstr "เพิ่มคอลัมน์"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "เพิ่มตัวกรอง..."
 
@@ -207,6 +198,10 @@ msgstr "เพิ่มวันหยุด"
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
 msgstr "เพิ่มบทความใหม่"
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
+msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:148
 msgid "Add Sort"
@@ -244,7 +239,7 @@ msgstr "เพิ่มเงื่อนไข"
 msgid "Add condition group"
 msgstr "เพิ่มกลุ่มเงื่อนไข"
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "เพิ่มตัวกรอง"
 
@@ -278,6 +273,12 @@ msgstr ""
 msgid "Add to Holidays"
 msgstr "เพิ่มวันหยุด"
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr ""
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr "เพิ่ม, จัดการตัวแทน และมอบบทบาทให้พวกเขา"
@@ -295,17 +296,14 @@ msgid "Administrator"
 msgstr "ผู้ดูแลระบบ"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -316,6 +314,7 @@ msgstr "ผู้ดูแลระบบ"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -335,6 +334,7 @@ msgstr ""
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -342,6 +342,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -376,18 +377,9 @@ msgstr "ตัวแทนจะไม่สามารถดูและสร
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "ทั้งหมด"
 
@@ -508,6 +500,14 @@ msgstr "คุณแน่ใจหรือไม่ว่าต้องกา
 msgid "Are you sure you want to delete these articles?"
 msgstr "คุณแน่ใจหรือไม่ว่าคุณต้องการลบบทความเหล่านี้"
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr ""
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr ""
@@ -544,6 +544,10 @@ msgstr "คุณแน่ใจหรือไม่ว่าต้องกา
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
 msgstr "คุณแน่ใจหรือไม่ว่าต้องการลบโลโก้?"
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
+msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
 msgid "Are you sure you want to reset the content? Current content will be overridden."
@@ -595,16 +599,11 @@ msgstr "มอบหมายตั๋วให้กับตัวแทน"
 msgid "Assign ticket"
 msgstr "มอบหมายตั๋ว"
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr "มอบหมายให้กับ"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -618,7 +617,7 @@ msgstr "ผู้รับมอบหมาย"
 msgid "Assignee Rules"
 msgstr "กฎของผู้รับมอบหมาย"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr ""
 
@@ -626,7 +625,7 @@ msgstr ""
 msgid "Assignees"
 msgstr "ผู้รับมอบหมาย"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr ""
 
@@ -692,10 +691,6 @@ msgstr ""
 msgid "Assignment rule {0} updated successfully."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr "จำเป็นต้องมีอย่างน้อยหนึ่งอีเมล"
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -712,10 +707,6 @@ msgstr "ต้องเปิดใช้งานตัวเลือกข้
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
 msgstr "จำเป็นต้องมีทีมอย่างน้อยหนึ่งทีม"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
-msgstr "อย่างน้อยหนึ่งรายการจากประเภทความสำคัญ, ทีม และประเภทตั๋ว"
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
@@ -766,7 +757,7 @@ msgid "Automation"
 msgstr "ระบบอัตโนมัติ"
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr ""
@@ -802,7 +793,7 @@ msgstr "เวลาตอบสนองเฉลี่ย"
 msgid "Average Time Metrics"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr "คะแนนการให้คะแนนเฉลี่ยต่อวันอยู่ที่ประมาณ {0} ดาว"
 
@@ -810,25 +801,37 @@ msgstr "คะแนนการให้คะแนนเฉลี่ยต่
 msgid "Average response and resolution metrics not available"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr "ตั๋วเฉลี่ยต่อวันอยู่ที่ประมาณ {0}"
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr "คะแนนการให้คะแนนเฉลี่ย"
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr "ค่าเฉลี่ยการตอบกลับครั้งแรก"
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr "ค่าเฉลี่ยของการแก้ไขปัญหา"
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
-msgstr "คะแนนการให้ข้อเสนอแนะเฉลี่ยสำหรับตั๋วที่แก้ไขแล้ว"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
+msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:290
@@ -840,11 +843,11 @@ msgstr ""
 msgid "Avg. resolution time"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr "เวลาเฉลี่ยที่ใช้ในการตอบกลับครั้งแรกต่อตั๋ว"
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr "เวลาเฉลี่ยที่ใช้ในการแก้ไขตั๋ว"
 
@@ -867,11 +870,6 @@ msgstr ""
 msgid "Base Support Rotation"
 msgstr "การหมุนเวียนงานสนับสนุนฐาน"
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "URL พื้นฐาน"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -885,11 +883,11 @@ msgstr "ตามนโยบาย HR ของคุณ, เลือกวั
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr "ตามนโยบาย HR ของคุณ, เลือกวันที่เริ่มต้นของรอบการจัดสรรวันลา"
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr ""
 
@@ -944,11 +942,6 @@ msgstr "วันหยุดทางธุรกิจ"
 msgid "Busy"
 msgstr "ไม่ว่าง"
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "ปุ่ม"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr "CSV"
@@ -973,19 +966,31 @@ msgstr "ระยะเวลาการโทร (วินาที)"
 msgid "Caller"
 msgstr "ผู้โทร"
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr "การโทร"
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr "สามารถเชิญตัวแทนใหม่ จัดการตั๋ว สร้างมุมมองที่กำหนดเอง และจัดการมุมมองสาธารณะ"
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr "สามารถจัดการทุกด้านของศูนย์ช่วยเหลือได้"
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr "สามารถทำงานกับตั๋ว สร้างมุมมองที่กำหนดเอง และจัดการมุมมองส่วนตัวได้"
 
@@ -1025,7 +1030,7 @@ msgstr "ไม่สามารถเปิดใช้งานกฎได้
 msgid "Cannot merge General category"
 msgstr "ไม่สามารถรวมหมวดหมู่ทั่วไปได้"
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr ""
 
@@ -1073,11 +1078,11 @@ msgstr "หมวดหมู่ต้องมีบทความอย่า
 msgid "Category updated successfully."
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr ""
 
@@ -1085,7 +1090,7 @@ msgstr ""
 msgid "Change"
 msgstr "เปลี่ยนแปลง"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "เปลี่ยนรหัสผ่าน"
@@ -1098,10 +1103,9 @@ msgstr ""
 msgid "Change language of the application."
 msgstr "เปลี่ยนภาษาของแอปพลิเคชัน"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
-msgstr "เปลี่ยนรูปภาพ"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
+msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
 msgid "Change priority"
@@ -1123,7 +1127,7 @@ msgstr "เปลี่ยนประเภทตั๋ว"
 msgid "Change timezone of the application."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr "เปลี่ยนรหัสผ่านบัญชีของคุณเพื่อความปลอดภัย"
 
@@ -1136,7 +1140,7 @@ msgstr "ช่องทาง"
 msgid "Child field"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr ""
 
@@ -1189,7 +1193,7 @@ msgstr "เรียงลำดับแบบชัดเจน"
 msgid "Clear Table"
 msgstr "ล้างตาราง"
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr ""
 
@@ -1204,6 +1208,10 @@ msgstr "ล้างตัวกรองทั้งหมด"
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
 msgstr "คลิกที่ 'เพิ่มในวันหยุด' ซึ่งจะเติมตารางวันหยุดด้วยวันที่ทั้งหมดที่ตรงกับวันหยุดประจำสัปดาห์ที่เลือก ทำซ้ำกระบวนการเพื่อเติมวันที่สำหรับวันหยุดประจำสัปดาห์ทั้งหมดของคุณ"
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:47
@@ -1223,7 +1231,7 @@ msgstr "ปิดตั๋ว"
 msgid "Closed"
 msgstr "ปิดแล้ว"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr "ตั๋วที่ถูกปิดหรือได้รับการจัดอันดับแล้วไม่สามารถอัปเดตได้โดยผู้ที่ไม่ใช่ตัวแทน"
 
@@ -1250,7 +1258,7 @@ msgstr "คอลัมน์"
 msgid "Comma separated emails to invite."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr ""
 
@@ -1283,7 +1291,7 @@ msgstr "แสดงความคิดเห็นโดย"
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "ความคิดเห็น"
@@ -1296,6 +1304,11 @@ msgstr "การสื่อสาร"
 msgid "Communication ID is required"
 msgstr ""
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
+msgstr "บริษัท"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
 msgstr "เสร็จสิ้น"
@@ -1307,7 +1320,7 @@ msgstr "เสร็จสิ้น"
 msgid "Condition"
 msgstr "เงื่อนไข"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr ""
 
@@ -1331,6 +1344,10 @@ msgstr ""
 msgid "Configure your telephony settings."
 msgstr "กำหนดค่าการตั้งค่าโทรศัพท์ของคุณ"
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1356,10 +1373,11 @@ msgstr "ยืนยันการเขียนทับ"
 msgid "Connect your support email"
 msgstr "เชื่อมต่ออีเมลสำหรับการสนับสนุนของคุณ"
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1373,26 +1391,30 @@ msgstr "ผู้ติดต่อ"
 msgid "Contact HTML"
 msgstr "HTML ผู้ติดต่อ"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
-msgstr "มีการติดต่อทางอีเมลอยู่แล้ว"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
+msgstr ""
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
 msgstr "ผู้ติดต่อ"
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
+msgstr ""
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
 #. Label of the content (Text Editor) field in DocType 'HD Article'
@@ -1415,7 +1437,7 @@ msgstr "คัดลอก URL ตั๋ว"
 msgid "Copy ticket id"
 msgstr "คัดลอกหมายเลขตั๋ว"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr "ไม่สามารถส่งอีเมลได้เนื่องจาก: {0}"
 
@@ -1423,7 +1445,11 @@ msgstr "ไม่สามารถส่งอีเมลได้เนื่
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr "ไม่สามารถส่งอีเมลยืนยันได้เนื่องจาก: {0}"
 
@@ -1431,11 +1457,20 @@ msgstr "ไม่สามารถส่งอีเมลยืนยันไ
 msgid "Could not send feedback email,due to: {0}"
 msgstr "ไม่สามารถส่งอีเมลตอบกลับได้ เนื่องจาก: {0}"
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "ประเทศ"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1446,9 +1481,13 @@ msgstr "สร้าง"
 msgid "Create & invite a contact"
 msgstr "สร้างและเชิญผู้ติดต่อ"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
-msgstr "สร้างผู้ติดต่อใหม่"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
 msgid "Create View"
@@ -1482,12 +1521,6 @@ msgstr ""
 msgid "Creating a ticket"
 msgstr ""
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr "เกณฑ์"
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr ""
@@ -1512,12 +1545,21 @@ msgid "Custom Views"
 msgstr ""
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
 msgstr "ลูกค้า"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
+msgstr ""
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1528,17 +1570,33 @@ msgstr "ชื่อลูกค้า"
 msgid "Customer Portal"
 msgstr ""
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
-msgstr "ลูกค้าสร้างสำเร็จแล้ว."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr "ประเภทลูกค้า"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr "พอร์ทัลลูกค้า"
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
 msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
+msgstr "ลูกค้า"
 
 #: desk/src/components/layouts/Sidebar.vue:595
 msgid "Customers & Contacts"
@@ -1565,6 +1623,8 @@ msgstr "สีฟ้า"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "อันตราย"
@@ -1665,18 +1725,26 @@ msgstr "ประเภทตั๋วเริ่มต้น"
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr "กำหนดว่าใครจะได้รับตั๋วและวิธีการแจกจ่ายตั๋วให้กับตัวแทน"
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "ลบ"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1693,6 +1761,10 @@ msgstr "ลบหมวดหมู่?"
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
 msgstr "ลบ {0}"
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
+msgstr ""
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
 #. Label of the description (Text Editor) field in DocType 'HD Holiday'
@@ -1740,7 +1812,7 @@ msgstr "คำอธิบายโดยละเอียด"
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1826,7 +1898,12 @@ msgstr "เอกสาร"
 msgid "Document Type"
 msgstr "ประเภทเอกสาร"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr ""
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "โดเมน"
@@ -1868,6 +1945,10 @@ msgstr "นโยบาย SLA ซ้ำซ้อน"
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
 msgstr "ตอบกลับที่บันทึกซ้ำ"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
 #: desk/src/pages/call-logs/CallLogModal.vue:68
@@ -1917,7 +1998,8 @@ msgstr ""
 msgid "Easily invite new agents, managers, or admins."
 msgstr "เชิญตัวแทน ผู้จัดการ หรือผู้ดูแลระบบใหม่ได้อย่างง่ายดาย"
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1926,6 +2008,14 @@ msgstr "แก้ไข"
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
 msgstr "แก้ไขบันทึกการโทร"
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
+msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:70
 #: desk/src/components/Settings/EmailEdit.vue:63
@@ -1944,10 +2034,10 @@ msgstr "แก้ไขชื่อ"
 msgid "Edit your email account"
 msgstr "แก้ไขบัญชีอีเมลของคุณ"
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "อีเมล"
 
@@ -1975,8 +2065,9 @@ msgstr "บัญชีอีเมล"
 msgid "Email Content"
 msgstr "เนื้อหาอีเมล"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
 msgstr "รหัสอีเมล"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
@@ -2002,22 +2093,22 @@ msgstr ""
 msgid "Email account updated successfully"
 msgstr "บัญชีอีเมลได้รับการอัปเดตเรียบร้อยแล้ว"
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr ""
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr "อีเมลไม่ควรว่างเปล่า"
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "อีเมล"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr ""
 
@@ -2055,8 +2146,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr "เปิดใช้งานการให้ข้อเสนอแนะสำหรับพอร์ทัลลูกค้า"
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2081,8 +2170,6 @@ msgstr "เปิดใช้งานการให้ข้อเสนอแ
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2105,21 +2192,25 @@ msgstr "เวลาสิ้นสุด"
 msgid "Enter a name for this HD Service Holiday List."
 msgstr "ป้อนชื่อสำหรับรายการวันหยุดบริการ HD นี้"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr "กรุณาป้อนอีเมลที่ถูกต้อง"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr "กรุณากรอกหมายเลขโทรศัพท์ที่ถูกต้อง"
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr "ป้อนชื่อแบรนด์"
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr ""
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
 msgstr "กรุณากรอกชื่อใหม่สำหรับทีม"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
+msgstr ""
 
 #: helpdesk/api/knowledge_base.py:86
 msgid "Error moving article to category"
@@ -2129,22 +2220,18 @@ msgstr "เกิดข้อผิดพลาดในการย้ายบ
 msgid "Error processing email at index {0}, message: {1}"
 msgstr "เกิดข้อผิดพลาดในการประมวลผลอีเมลที่ดัชนี {0}, ข้อความ: {1}"
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr ""
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "ข้อผิดพลาดขณะเชื่อมต่อกับบัญชีอีเมล {0}"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr "มีกฎการยกระดับอยู่แล้วสำหรับเกณฑ์นี้"
 
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
 msgstr "เอ็กเซล"
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
+msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
 #: desk/src/components/Settings/Telephony/Telephony.vue:96
@@ -2172,11 +2259,6 @@ msgstr "ส่งออกทั้งหมด {0} รายการ"
 msgid "Export Type"
 msgstr "ประเภทการส่งออก"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr "ลิงก์ภายนอก"
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2184,6 +2266,10 @@ msgstr "ลิงก์ภายนอก"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "ล้มเหลว"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2218,11 +2304,11 @@ msgstr "ไม่สามารถบันทึกการตั้งค่
 msgid "Failed to save Twilio settings"
 msgstr "ไม่สามารถบันทึกการตั้งค่า Twilio ได้"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr ""
 
@@ -2251,6 +2337,7 @@ msgstr "ไอคอนเว็บไซต์"
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2288,13 +2375,17 @@ msgstr "มีข้อเสนอแนะอยู่แล้ว"
 msgid "Feedback Rating"
 msgstr "คะแนนการประเมินผล"
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr "แนวโน้มความคิดเห็น"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
 msgstr "อีเมลตอบกลับได้ถูกส่งไปยังลูกค้าแล้ว"
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
+msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
 msgid "Feedback submitted successfully."
@@ -2338,13 +2429,14 @@ msgid "Field dependency updated successfully."
 msgstr "การปรับปรุงการพึ่งพาข้อมูลภาคสนามสำเร็จแล้ว"
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "ฟิลด์"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "ตัวกรอง"
@@ -2354,7 +2446,8 @@ msgstr "ตัวกรอง"
 msgid "Find out all of the variables that can be used in the content"
 msgstr "ค้นหาตัวแปรทั้งหมดที่สามารถใช้ในเนื้อหา"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "ชื่อแรก"
 
@@ -2362,6 +2455,10 @@ msgstr "ชื่อแรก"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
 msgstr "ตอบกลับครั้งแรกเมื่อ"
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
+msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -2386,10 +2483,6 @@ msgstr "เวลาการตอบกลับครั้งแรก"
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
 msgstr "เวลาตอบสนองครั้งแรกสำหรับตั๋ว"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
-msgstr "ชื่อไม่ควรว่างเปล่า"
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
@@ -2480,6 +2573,10 @@ msgstr "ระดับโลก"
 msgid "Go to Ticket #{0}"
 msgstr "ไปที่ตั๋ว #{0}"
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr ""
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2509,8 +2606,6 @@ msgid "Group By Field"
 msgstr "จัดกลุ่มตามฟิลด์"
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr "ผู้เข้าพัก"
@@ -2518,11 +2613,6 @@ msgstr "ผู้เข้าพัก"
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
 msgstr "แนะนำผู้ใช้ไปยังบทความก่อนการเปิดตั๋ว"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
-msgstr "เอชดี แอ็คชั่น"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -2554,25 +2644,37 @@ msgstr "บทความ HD ข้อเสนอแนะ"
 msgid "HD Comment Reaction"
 msgstr "ความคิดเห็นและปฏิกิริยาของ HD"
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr "ลูกค้า HD"
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr ""
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
-msgstr "คำขอเปิดบัญชี HD Desk"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
+msgstr ""
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
 msgstr "อีเมลข้อเสนอแนะ HD"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
-msgstr "กฎการยกระดับความละเอียด HD"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -2593,21 +2695,6 @@ msgstr "วันหยุด HD"
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
 msgstr "การแจ้งเตือน HD"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr "การจัดองค์กรแบบ HD"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr "HD องค์กร ติดต่อ รายการ"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
-msgstr "คำขอลงทะเบียน HD Portal"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -2649,11 +2736,6 @@ msgstr "การตั้งค่า HD"
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
 msgstr "คำที่ไม่ใช้ใน HD"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
-msgstr "การค้นหาแหล่งที่มาที่รองรับ HD"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_synonym/hd_synonym.json
@@ -2750,12 +2832,6 @@ msgstr "ศูนย์ช่วยเหลือ"
 msgid "Helpdesk"
 msgstr "ศูนย์ช่วยเหลือ"
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr "ติดต่อฝ่ายช่วยเหลือ"
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2772,11 +2848,6 @@ msgstr "เฮ้"
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
 msgstr "ซ่อน "
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr "ซ่อนเงื่อนไข"
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
@@ -2846,15 +2917,8 @@ msgstr "ฉันเข้าใจแล้ว เพิ่มเงื่อ�
 msgid "ID"
 msgstr "รหัส"
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "ที่อยู่ IP"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2941,6 +3005,11 @@ msgstr "กล่องจดหมาย"
 msgid "Incoming"
 msgstr "ขาเข้า"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr "บุคคล"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr "เริ่มต้นแล้ว"
@@ -2954,7 +3023,7 @@ msgstr ""
 msgid "Instantly send e-mail"
 msgstr "ส่งอีเมลทันที"
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "สิทธิ์ไม่เพียงพอสำหรับ {0}"
 
@@ -2968,13 +3037,13 @@ msgstr "ค่าจำนวนเต็ม"
 msgid "Introduction"
 msgstr "การแนะนำ"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
-msgstr "อีเมลไม่ถูกต้อง"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
 #: desk/src/components/Settings/Holiday/HolidayView.vue:325
@@ -2982,23 +3051,43 @@ msgstr "อีเมลไม่ถูกต้อง"
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr "ฟิลด์ไม่ถูกต้อง ตรวจสอบว่ากรอกข้อมูลครบถ้วนและค่าถูกต้อง"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr "ไฟล์ไม่ถูกต้อง, อนุญาตให้ใช้ไฟล์ภาพ PNG และ JPG เท่านั้น"
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr "การแจ้งเตือนไม่ถูกต้อง"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
 msgstr "หมายเลขโทรศัพท์ไม่ถูกต้อง"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr ""
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
+msgstr "เชิญ"
 
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
 msgstr "เชิญตัวแทน"
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
 msgid "Invite agent"
@@ -3008,13 +3097,30 @@ msgstr "เชิญตัวแทน"
 msgid "Invite agents"
 msgstr "เชิญตัวแทน"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
-msgstr "เชิญผู้ใช้"
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
+msgstr "เชิญเป็นผู้ใช้"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
 msgstr "เชิญทางอีเมล"
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr "ได้รับเชิญ"
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
+msgstr ""
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -3030,6 +3136,11 @@ msgstr "พอร์ทัลลูกค้า"
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "เป็นค่าเริ่มต้น"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr ""
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3058,6 +3169,10 @@ msgstr "ถูกปักหมุด"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
 msgstr "การตั้งค่าเสร็จสมบูรณ์แล้วหรือไม่"
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
+msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:114
 msgid "Jump to"
@@ -3093,11 +3208,9 @@ msgstr "ทางลัดแป้นพิมพ์"
 msgid "Knowledge Base"
 msgstr "ฐานความรู้"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3131,9 +3244,9 @@ msgstr "ครั้งสุดท้าย"
 msgid "Last 3 Months"
 msgstr "3 เดือนที่ผ่านมา"
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr ""
 
@@ -3174,7 +3287,8 @@ msgstr "การตอบกลับลูกค้าครั้งล่า
 msgid "Last Month"
 msgstr "เดือนที่แล้ว"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "นามสกุล"
 
@@ -3183,24 +3297,33 @@ msgstr "นามสกุล"
 msgid "Last Week"
 msgstr "สัปดาห์ที่แล้ว"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr "ผู้ใช้คนสุดท้ายที่ถูกกำหนดโดยกฎนี้"
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
 msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
+msgstr "ล่าสุด"
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -3217,26 +3340,6 @@ msgstr "เรียนรู้เกี่ยวกับเงื่อนไ
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
 msgstr "แจ้งให้ลูกค้าทราบว่าพวกเขากำลังสร้างตั๋วอยู่นอกเวลาทำการ และเมื่อไหร่ที่พวกเขาสามารถคาดหวังการตอบกลับได้"
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "ลิงก์"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr "ตัวเลือกการลิงก์"
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr "ลิงก์ไปยังลูกค้า"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
-msgstr "ลิงก์ไปยังบันทึกข้อมูลลูกค้า"
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #. Label of the list_tab (Tab Break) field in DocType 'HD View'
@@ -3264,6 +3367,8 @@ msgstr "โหลดคอลัมน์เริ่มต้น"
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "โหลดเพิ่มเติม"
 
@@ -3286,6 +3391,8 @@ msgstr "เข้าสู่ระบบ Frappe Cloud"
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr "โลโก้"
@@ -3324,7 +3431,7 @@ msgstr "จัดการการตั้งค่าทั่วไปขอ
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr "จัดการการตอบกลับที่กำหนดไว้ล่วงหน้าซึ่งสามารถใช้ตอบคำถามของลูกค้าได้"
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr ""
 
@@ -3343,6 +3450,10 @@ msgstr ""
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
 msgstr "จัดการข้อมูลโปรไฟล์ของคุณ"
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
+msgstr "ผู้จัดการ"
 
 #: desk/src/pages/MobileNotifications.vue:11
 #: desk/src/pages/MobileNotifications.vue:14
@@ -3396,6 +3507,20 @@ msgstr "อื่นๆ"
 msgid "Mobile App Installation"
 msgstr ""
 
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr "หมายเลขมือถือ"
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr ""
+
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
 #. List'
@@ -3436,7 +3561,7 @@ msgid "My Tickets"
 msgstr ""
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3447,8 +3572,9 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3458,6 +3584,10 @@ msgstr "ชื่อ"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
 msgstr "ชื่อ น้ำหนัก"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
+msgstr "จำเป็นต้องระบุชื่อ"
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
 #. Ticket Status'
@@ -3469,10 +3599,18 @@ msgstr "ชื่อที่แสดงบนพอร์ทัลลูกค
 msgid "Navigation"
 msgstr "การนำทาง"
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "ไม่เคย"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3581,11 +3719,11 @@ msgstr "ไม่มีคำตอบ"
 msgid "No Data Found"
 msgstr "ไม่พบข้อมูล"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr ""
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr ""
 
@@ -3597,9 +3735,15 @@ msgstr "ไม่พบรายการวันหยุด"
 msgid "No SLA found"
 msgstr "ไม่พบ SLA"
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
 msgstr "ไม่มีทีม"
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
+msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
 msgid "No additional comments"
@@ -3633,19 +3777,27 @@ msgstr ""
 msgid "No changes made"
 msgstr "ไม่มีการเปลี่ยนแปลง"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr "ไม่มีการเปลี่ยนแปลงที่จะบันทึก"
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr ""
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr ""
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr ""
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
@@ -3657,7 +3809,11 @@ msgstr "ไม่พบบัญชีอีเมล"
 msgid "No feedback"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr ""
 
@@ -3697,19 +3853,25 @@ msgstr ""
 msgid "No recently assigned tickets"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr ""
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
 msgstr "ไม่พบผลลัพธ์"
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
+msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:91
 msgid "No saved replies found"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr ""
@@ -3730,7 +3892,11 @@ msgstr "ไม่พบตั๋วสำหรับการชมล่วง
 msgid "No tickets selected"
 msgstr ""
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr ""
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "ไม่อนุญาต"
 
@@ -3742,7 +3908,7 @@ msgstr ""
 msgid "Not Saved"
 msgstr "ไม่ได้บันทึก"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "ไม่ได้ตั้งค่า"
 
@@ -3781,11 +3947,6 @@ msgstr "เงื่อนไขเก่า"
 msgid "On Hold Since"
 msgstr "ค้างอยู่ตั้งแต่"
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr "เมื่อคลิก (Javascript)"
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr ""
@@ -3816,6 +3977,10 @@ msgstr "เปิดพาเลตคำสั่ง"
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
 msgstr "เปิดกล่องความคิดเห็น"
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
+msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
 msgid "Open help"
@@ -3906,7 +4071,12 @@ msgstr ""
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr "จำเป็นต้องมีฟิลด์หลัก ฟิลด์ย่อย และการแมปแบบหลัก-ย่อย"
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr "หุ้นส่วน"
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "รหัสผ่าน"
 
@@ -3944,6 +4114,7 @@ msgid "Pending"
 msgstr "รอดำเนินการ"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr "Pending Invites"
 
@@ -3953,19 +4124,19 @@ msgstr "Pending Invites"
 msgid "Pending Tickets"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr ""
 
@@ -3986,14 +4157,15 @@ msgstr "ส่วนตัว"
 msgid "Personal mobile no"
 msgstr "หมายเลขโทรศัพท์มือถือส่วนตัว"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "โทรศัพท์"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
-msgstr "หมายเลขโทรศัพท์"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
+msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
 msgid "Pick an option"
@@ -4049,7 +4221,7 @@ msgstr "กรุณากรอกหัวข้อเพื่อดำเน
 msgid "Please enter a valid phone number"
 msgstr "กรุณากรอกหมายเลขโทรศัพท์ที่ถูกต้อง"
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr ""
 
@@ -4092,34 +4264,15 @@ msgstr "โปรดเลือกวันหยุดประจำสัป
 msgid "Policy name"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
 msgstr ""
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr "คีย์คำอธิบายโพสต์"
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr "รายการคีย์เส้นทางโพสต์"
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr "สตริงเส้นทางโพสต์"
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
-msgstr "คีย์ชื่อโพสต์"
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:10
@@ -4153,14 +4306,32 @@ msgstr "ดูตัวอย่าง"
 msgid "Previous ticket"
 msgstr "ตั๋วเก่า"
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "หลัก"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "ผู้ติดต่อหลัก"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr ""
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr "ลำดับความสำคัญ"
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4168,9 +4339,10 @@ msgstr "ลำดับความสำคัญ"
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4250,17 +4422,6 @@ msgstr "ดึงอีเมล อาจใช้เวลาสักคร�
 msgid "Quarterly"
 msgstr "รายไตรมาส"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "ตัวเลือกการค้นหา"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr "สตริงเส้นทางการค้นหา"
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "อยู่ในคิว"
@@ -4283,14 +4444,14 @@ msgstr "ให้คะแนนประสบการณ์การสนั
 msgid "Rate this ticket"
 msgstr "ให้คะแนนตั๋วนี้"
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr "บัตรที่จองแล้ว"
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4386,8 +4547,15 @@ msgstr "สร้างดัชนีการค้นหาใหม่"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "ลบ"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4397,10 +4565,19 @@ msgstr "ลบโลโก้"
 msgid "Remove Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
 msgstr "ลบรูปภาพ"
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
+msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
 #: desk/src/components/Settings/Teams/TeamsList.vue:161
@@ -4420,6 +4597,15 @@ msgstr ""
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
 msgstr "เปลี่ยนชื่อทีม"
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
+msgstr ""
 
 #. Option in a Select field in the tickets Web Form
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
@@ -4458,17 +4644,14 @@ msgstr "ตอบกลับจากผู้ติดต่อ"
 msgid "Reply on a ticket"
 msgstr "ตอบกลับในตั๋ว"
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr "คำขอคีย์"
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
 msgstr "จำเป็น"
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
+msgstr ""
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
 msgid "Reset"
@@ -4488,6 +4671,7 @@ msgid "Reset to Default"
 msgstr "รีเซ็ตเป็นค่าเริ่มต้น"
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr "การแก้ไขปัญหา"
@@ -4541,18 +4725,6 @@ msgstr "การตอบกลับ"
 msgid "Response By"
 msgstr "การตอบกลับโดย"
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr "ตัวเลือกการตอบกลับ"
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr "เส้นทางคีย์ผลลัพธ์การตอบกลับ"
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr "เวลาตอบกลับสำหรับลำดับความสำคัญ {0} ในแถว {1} ต้องไม่เกินเวลาแก้ไขปัญหา"
@@ -4595,37 +4767,33 @@ msgstr "จำกัดให้เฉพาะสมาชิกในทีม
 msgid "Restrict visibility to these teams"
 msgstr "จำกัดการมองเห็นสำหรับทีมเหล่านี้"
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr "ฟิลด์ดูตัวอย่างผลลัพธ์"
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr "ฟิลด์เส้นทางผลลัพธ์"
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr "ฟิลด์ชื่อผลลัพธ์"
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
 msgstr "การตรวจสอบ"
 
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:215
 msgid "Ringing"
 msgstr "กำลังโทร"
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "บทบาท"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr "บทบาทได้รับการอัปเดตเรียบร้อยแล้ว"
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4724,9 +4892,9 @@ msgstr "วันเสาร์"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4802,17 +4970,19 @@ msgstr "สร้างดัชนีการค้นหาใหม่"
 msgid "Search Score"
 msgstr "คะแนนการค้นหา"
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr "คำค้นหา ชื่อพารามิเตอร์"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "ช่องค้นหา..."
 
@@ -4852,6 +5022,7 @@ msgstr "ค้นหา..."
 msgid "Searched for:"
 msgstr "ค้นหา:"
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr "กำลังค้นหา..."
@@ -4871,6 +5042,10 @@ msgstr "เลือก"
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
 msgstr "เลือกหมวดหมู่"
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
+msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
 msgid "Select Range"
@@ -4892,6 +5067,10 @@ msgstr "เลือกความสำคัญเริ่มต้น"
 msgid "Select a rating"
 msgstr "เลือกคะแนน"
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr ""
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4904,6 +5083,10 @@ msgstr "ทีมที่เลือก"
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
 msgstr "เลือกตั๋วเพื่อดูตัวอย่าง"
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
 msgid "Select what type all tickets get by default."
@@ -4930,6 +5113,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
 msgstr "ส่งข้อเสนอแนะเมื่อ"
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
+msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
 msgid "Send to {0} tickets"
@@ -4969,7 +5156,7 @@ msgstr "ชื่อระดับการให้บริการ"
 msgid "Service not supported"
 msgstr "บริการไม่รองรับ"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "ตั้งค่า"
 
@@ -4977,6 +5164,10 @@ msgstr "ตั้งค่า"
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
 msgstr "ตั้งค่าหมายเลขโทรศัพท์"
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
 msgid "Set Resolution Time for Priority {0} in row {1}."
@@ -4986,12 +5177,21 @@ msgstr "กำหนดเวลาการแก้ไขสำหรับล
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr "ตั้งค่าเวลาตอบสนองสำหรับลำดับความสำคัญ {0} ในแถว {1}"
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr "ตั้งค่าเป็น SLA เริ่มต้น"
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr ""
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr ""
 
@@ -5003,7 +5203,7 @@ msgstr "ตั้งค่าสถานะเริ่มต้นที่จ
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr ""
 
@@ -5137,23 +5337,6 @@ msgstr "เกิดข้อผิดพลาดขณะอัปเดตร
 msgid "Sort"
 msgstr "จัดเรียง"
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr "ประเภทเอกสารต้นฉบับ"
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "ชื่อต้นทาง"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr "ประเภทต้นทาง"
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr "แหล่งที่มาและหมวดหมู่เป้าหมายไม่สามารถเป็นหมวดหมู่เดียวกันได้"
@@ -5198,6 +5381,8 @@ msgstr "เวลาเริ่มต้นไม่สามารถมาก
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5266,6 +5451,7 @@ msgstr "สถานะของตั๋ว เมื่อตั๋วถู�
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5377,21 +5563,16 @@ msgstr "ระบบ"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5430,8 +5611,6 @@ msgstr "ไม่มีตั๋วเป้าหมาย"
 msgid "Teal"
 msgstr "สีฟ้าอมเขียว"
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5442,7 +5621,6 @@ msgstr "สีฟ้าอมเขียว"
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5548,6 +5726,10 @@ msgstr "เงื่อนไขการมอบหมาย '{0}' ไม่�
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr "เงื่อนไขการมอบหมายงาน json '{0}' ไม่ถูกต้อง: {1}"
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr ""
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr "กล่องข้อความแสดงความคิดเห็นจะปรากฏขึ้นเมื่อผู้ใช้พยายามปิดตั๋วจากพอร์ทัลลูกค้า"
@@ -5559,6 +5741,10 @@ msgstr "วันหยุดใน {0} ไม่อยู่ระหว่า�
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
 msgstr "จำนวนวันต้องเป็น 1 หรือมากกว่า"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
 msgid "The status for sending feedback must be of <u>Resolved</u> category."
@@ -5580,6 +5766,14 @@ msgstr ""
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr ""
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr ""
@@ -5587,6 +5781,10 @@ msgstr ""
 #: desk/src/components/ticket/TicketMergeModal.vue:79
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
 msgstr ""
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
@@ -5656,7 +5854,7 @@ msgstr "วันพฤหัสบดี"
 msgid "Ticket"
 msgstr "บัตร"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr "ตั๋ว #{0}: เราได้รับคำขอของคุณแล้ว"
 
@@ -5671,6 +5869,10 @@ msgstr "การวิเคราะห์ตั๋ว"
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
 msgstr "การกำหนดค่าตั๋ว"
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
+msgstr ""
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
 msgid "Ticket Info"
@@ -5729,7 +5931,7 @@ msgstr ""
 msgid "Ticket Summary"
 msgstr "สรุปตั๋ว"
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr "แนวโน้มตั๋ว"
 
@@ -5762,7 +5964,7 @@ msgstr "ตั๋วไม่มีอยู่"
 msgid "Ticket merged successfully."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr "ตั๋วต้องได้รับการแก้ไขพร้อมคำติชม"
 
@@ -5797,12 +5999,6 @@ msgstr "สถานะบัตร"
 msgid "Ticket to merged with is required"
 msgstr ""
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr "ประเภทตั๋ว"
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr ""
@@ -5814,12 +6010,15 @@ msgstr "การวิเคราะห์การค้นหาตั๋ว
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr "บัตร"
 
@@ -5831,19 +6030,19 @@ msgstr ""
 msgid "Tickets assigned to you in the last 7 days"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr "บัตรเข้าชมตามช่องทาง"
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr "บัตรเข้าชมตามลำดับความสำคัญ"
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr "บัตรเข้าชมตามทีม"
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr "ตั๋วตามประเภท"
 
@@ -5860,6 +6059,7 @@ msgid "Tickets that are awaiting your response"
 msgstr ""
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr "เขตเวลา"
 
@@ -5949,19 +6149,19 @@ msgstr "รวมวันหยุด"
 msgid "Total Ticket"
 msgstr "ตั๋วทั้งหมด"
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr "จำนวนตั๋วทั้งหมดที่สร้างขึ้น"
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr ""
 
@@ -5993,6 +6193,10 @@ msgstr "ประเภท"
 msgid "Type a message"
 msgstr "พิมพ์ข้อความ"
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr "จำเป็นต้องกรอกข้อมูล"
@@ -6002,7 +6206,7 @@ msgstr "จำเป็นต้องกรอกข้อมูล"
 msgid "URL/Method"
 msgstr "URL/วิธีการ"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr "ไม่สามารถส่งอีเมลได้ กรุณาตั้งค่าบัญชีอีเมลขาออกเริ่มต้น"
 
@@ -6036,6 +6240,8 @@ msgid "Unpublish"
 msgstr "ยกเลิกการเผยแพร่"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr "ไม่ได้บันทึก"
 
@@ -6053,6 +6259,10 @@ msgstr "ไม่ได้บันทึก"
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
 msgstr "การเปลี่ยนแปลงที่ยังไม่ได้บันทึก"
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
 msgid "Untitled"
@@ -6080,9 +6290,12 @@ msgstr "อัปโหลด"
 msgid "Upload Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
 msgstr "อัปโหลดรูปภาพ"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
@@ -6092,17 +6305,13 @@ msgstr "กำลังอัปโหลด {0}%"
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6114,6 +6323,10 @@ msgstr "ผู้ใช้"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
 msgstr "เวลาการแก้ไขของผู้ใช้"
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
+msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
 msgid "User Signup"
@@ -6132,7 +6345,7 @@ msgstr "ผู้ใช้"
 msgid "Valid From"
 msgstr "ใช้ได้ตั้งแต่"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "ค่า"
 
@@ -6261,19 +6474,23 @@ msgstr "รายปี"
 msgid "Yellow"
 msgstr "สีเหลือง"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr ""
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr "คุณไม่ได้รับอนุญาตให้ดูข้อมูลแดชบอร์ดนี้"
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr "คุณไม่ได้รับอนุญาตให้เข้าถึงทรัพยากรนี้"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr "คุณไม่ได้รับอนุญาตให้เพิ่มความคิดเห็น"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr ""
 
@@ -6301,6 +6518,14 @@ msgstr "คุณไม่สามารถตั้งลำดับควา
 msgid "You do not have permission to access Assignment Rules"
 msgstr "คุณไม่มีสิทธิ์เข้าถึงกฎการมอบหมายงาน"
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr ""
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr ""
@@ -6323,6 +6548,14 @@ msgstr "เงื่อนไขเก่าของคุณจะถูกแ
 
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:46
@@ -6353,7 +6586,7 @@ msgstr "สร้างแล้ว"
 msgid "customize {0}"
 msgstr "ปรับแต่ง {0}"
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr "วัน"
 
@@ -6404,7 +6637,7 @@ msgstr "ที่นี่"
 msgid "here."
 msgstr ""
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr "ชั่วโมง"
 
@@ -6412,7 +6645,7 @@ msgstr "ชั่วโมง"
 msgid "in"
 msgstr "ใน"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "เมื่อสักครู่"
 
@@ -6445,7 +6678,11 @@ msgstr ""
 msgid "purple"
 msgstr "สีม่วง"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr "การตรวจสอบ"
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr "ดาว"
 
@@ -6462,7 +6699,7 @@ msgstr "บัตร"
 msgid "to enable this integration."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr "ดูสิ่งนี้"
 
@@ -6470,12 +6707,32 @@ msgstr "ดูสิ่งนี้"
 msgid "views"
 msgstr "การดู"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr ""
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
 msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:307
@@ -6502,7 +6759,7 @@ msgstr ""
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr ""
 

--- a/helpdesk/locale/tr.po
+++ b/helpdesk/locale/tr.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-15 18:50\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-29 21:58\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Turkish\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr ""
@@ -108,14 +108,6 @@ msgstr ""
 msgid "A workday with this name already exists"
 msgstr ""
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr ""
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr ""
@@ -132,7 +124,7 @@ msgstr ""
 msgid "Account"
 msgstr "Hesap"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr ""
 
@@ -152,11 +144,9 @@ msgstr "İşlem"
 msgid "Action Required"
 msgstr ""
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr ""
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "İşlemler"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr ""
 msgid "Active"
 msgstr "Aktif"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr ""
 
@@ -175,7 +165,7 @@ msgid "Active: The agent is available and working.<br>\n"
 "Unavailable: The agent is off and unavailable."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "Aktivite"
@@ -193,10 +183,11 @@ msgid "Add Column"
 msgstr "Sütun Ekle"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "Filtre Ekle..."
 
@@ -206,6 +197,10 @@ msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
 msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:148
@@ -244,7 +239,7 @@ msgstr ""
 msgid "Add condition group"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "Filtre Ekle"
 
@@ -278,6 +273,12 @@ msgstr ""
 msgid "Add to Holidays"
 msgstr "Tatillere Ekle"
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr ""
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr ""
@@ -295,17 +296,14 @@ msgid "Administrator"
 msgstr "Yönetici"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -316,6 +314,7 @@ msgstr "Yönetici"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -335,6 +334,7 @@ msgstr ""
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -342,6 +342,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -376,18 +377,9 @@ msgstr ""
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "Tümü"
 
@@ -508,6 +500,14 @@ msgstr ""
 msgid "Are you sure you want to delete these articles?"
 msgstr ""
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr ""
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr ""
@@ -543,6 +543,10 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
 msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
@@ -595,16 +599,11 @@ msgstr ""
 msgid "Assign ticket"
 msgstr ""
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr ""
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -618,7 +617,7 @@ msgstr "Atanan kişi"
 msgid "Assignee Rules"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr ""
 
@@ -626,14 +625,14 @@ msgstr ""
 msgid "Assignees"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "Assignment"
-msgstr "Atama"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:122
 msgid "Assignment Condition"
@@ -692,10 +691,6 @@ msgstr ""
 msgid "Assignment rule {0} updated successfully."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -711,10 +706,6 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
-msgstr ""
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
 msgstr ""
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
@@ -766,7 +757,7 @@ msgid "Automation"
 msgstr "Otomasyon"
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr ""
@@ -802,7 +793,7 @@ msgstr "Ortalama Yanıt Süresi"
 msgid "Average Time Metrics"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr ""
 
@@ -810,24 +801,36 @@ msgstr ""
 msgid "Average response and resolution metrics not available"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
 msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
@@ -840,11 +843,11 @@ msgstr ""
 msgid "Avg. resolution time"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr ""
 
@@ -867,11 +870,6 @@ msgstr ""
 msgid "Base Support Rotation"
 msgstr ""
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "Ana URL"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -885,11 +883,11 @@ msgstr "İnsan Kaynakları Politikanıza göre izin tahsis döneminizin bitiş t
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr "İnsan Kaynakları Politikanıza göre izin tahsis döneminizin bitiş tarihini seçin"
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr ""
 
@@ -944,11 +942,6 @@ msgstr ""
 msgid "Busy"
 msgstr "Meşgul"
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "Düğme"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr "CSV Dosyası"
@@ -973,19 +966,31 @@ msgstr ""
 msgid "Caller"
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr "Aramalar"
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr ""
 
@@ -1025,7 +1030,7 @@ msgstr ""
 msgid "Cannot merge General category"
 msgstr ""
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr ""
 
@@ -1073,11 +1078,11 @@ msgstr ""
 msgid "Category updated successfully."
 msgstr "Kategori başarıyla güncellendi."
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr ""
 
@@ -1085,7 +1090,7 @@ msgstr ""
 msgid "Change"
 msgstr "Değiştir"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "Şifre Değiştir"
@@ -1098,9 +1103,8 @@ msgstr ""
 msgid "Change language of the application."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
@@ -1123,7 +1127,7 @@ msgstr ""
 msgid "Change timezone of the application."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr ""
 
@@ -1136,7 +1140,7 @@ msgstr ""
 msgid "Child field"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr ""
 
@@ -1189,7 +1193,7 @@ msgstr ""
 msgid "Clear Table"
 msgstr "Tabloyu Temizle"
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr ""
 
@@ -1204,6 +1208,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
 msgstr "Tatillere Ekle'ye tıklayın. Bu işlem, tatiller tablosunu seçilen haftalık izin gününe denk gelen tüm tarihlerle dolduracaktır. Tüm haftalık tatillerinizin tarihlerini doldurmak için işlemi tekrarlayın"
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:47
@@ -1223,7 +1231,7 @@ msgstr ""
 msgid "Closed"
 msgstr "Kapatıldı"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr ""
 
@@ -1250,7 +1258,7 @@ msgstr "Sütunlar"
 msgid "Comma separated emails to invite."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr ""
 
@@ -1283,7 +1291,7 @@ msgstr ""
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "Yorumlar"
@@ -1296,6 +1304,11 @@ msgstr "İletişim"
 msgid "Communication ID is required"
 msgstr ""
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
+msgstr "Şirket"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
 msgstr "Tamamlandı"
@@ -1307,7 +1320,7 @@ msgstr "Tamamlandı"
 msgid "Condition"
 msgstr "Koşul"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr ""
 
@@ -1331,6 +1344,10 @@ msgstr ""
 msgid "Configure your telephony settings."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1356,10 +1373,11 @@ msgstr ""
 msgid "Connect your support email"
 msgstr ""
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1373,26 +1391,30 @@ msgstr "Kişi"
 msgid "Contact HTML"
 msgstr "İletişim HTML'si"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
 msgstr ""
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
 msgstr "Kişiler"
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
+msgstr ""
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
 #. Label of the content (Text Editor) field in DocType 'HD Article'
@@ -1415,7 +1437,7 @@ msgstr ""
 msgid "Copy ticket id"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr ""
 
@@ -1423,7 +1445,11 @@ msgstr ""
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr ""
 
@@ -1431,11 +1457,20 @@ msgstr ""
 msgid "Could not send feedback email,due to: {0}"
 msgstr ""
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "Ülke"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1446,9 +1481,13 @@ msgstr "Oluştur"
 msgid "Create & invite a contact"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
-msgstr "Yeni Kişi Oluştur"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
 msgid "Create View"
@@ -1482,12 +1521,6 @@ msgstr ""
 msgid "Creating a ticket"
 msgstr ""
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr ""
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr ""
@@ -1512,12 +1545,21 @@ msgid "Custom Views"
 msgstr ""
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
 msgstr "Müşteri"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
+msgstr ""
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1528,17 +1570,33 @@ msgstr "Müşteri Adı"
 msgid "Customer Portal"
 msgstr ""
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
-msgstr "Müşteri başarıyla oluşturuldu."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr "Müşteri Türü"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
 msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
+msgstr "Müşteriler"
 
 #: desk/src/components/layouts/Sidebar.vue:595
 msgid "Customers & Contacts"
@@ -1565,6 +1623,8 @@ msgstr "Camgöbeği"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "Tehlikeli"
@@ -1665,18 +1725,26 @@ msgstr ""
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr ""
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "Sil"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1693,6 +1761,10 @@ msgstr ""
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
 msgstr "Sil {0}"
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
+msgstr ""
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
 #. Label of the description (Text Editor) field in DocType 'HD Holiday'
@@ -1740,7 +1812,7 @@ msgstr ""
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1826,7 +1898,12 @@ msgstr ""
 msgid "Document Type"
 msgstr "Belge Türü"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr ""
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "Domain"
@@ -1867,6 +1944,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
@@ -1917,7 +1998,8 @@ msgstr ""
 msgid "Easily invite new agents, managers, or admins."
 msgstr ""
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1925,6 +2007,14 @@ msgstr "Düzenle"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
 msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:70
@@ -1944,10 +2034,10 @@ msgstr ""
 msgid "Edit your email account"
 msgstr ""
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "E-posta"
 
@@ -1975,8 +2065,9 @@ msgstr ""
 msgid "Email Content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
 msgstr "E-posta Kimliği"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
@@ -2002,22 +2093,22 @@ msgstr ""
 msgid "Email account updated successfully"
 msgstr ""
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr ""
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr ""
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "E-postalar"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr ""
 
@@ -2055,8 +2146,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr ""
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2081,8 +2170,6 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2105,20 +2192,24 @@ msgstr "Bitiş Zamanı"
 msgid "Enter a name for this HD Service Holiday List."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr ""
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr ""
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
 msgstr ""
 
 #: helpdesk/api/knowledge_base.py:86
@@ -2129,22 +2220,18 @@ msgstr ""
 msgid "Error processing email at index {0}, message: {1}"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr ""
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "E-posta hesabına bağlanırken hata oluştu {0}"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr ""
 
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
 msgstr "Excel"
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
+msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
 #: desk/src/components/Settings/Telephony/Telephony.vue:96
@@ -2172,11 +2259,6 @@ msgstr ""
 msgid "Export Type"
 msgstr "Dışa Aktarma Türü"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr ""
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2184,6 +2266,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "Başarısız"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2218,11 +2304,11 @@ msgstr ""
 msgid "Failed to save Twilio settings"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr ""
 
@@ -2251,6 +2337,7 @@ msgstr ""
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2288,12 +2375,16 @@ msgstr ""
 msgid "Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
+msgstr ""
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
 msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
@@ -2338,13 +2429,14 @@ msgid "Field dependency updated successfully."
 msgstr ""
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "Alanlar"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "Filtreler"
@@ -2354,7 +2446,8 @@ msgstr "Filtreler"
 msgid "Find out all of the variables that can be used in the content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "Adı"
 
@@ -2362,6 +2455,10 @@ msgstr "Adı"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
 msgstr "İlk Yanıt Tarihi"
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
+msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -2385,10 +2482,6 @@ msgstr "İlk Müdahale Süresi"
 #. Name of a report
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -2480,6 +2573,10 @@ msgstr ""
 msgid "Go to Ticket #{0}"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr ""
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2509,19 +2606,12 @@ msgid "Group By Field"
 msgstr ""
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr "Ziyaretçi"
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
 msgstr ""
 
 #. Name of a DocType
@@ -2554,24 +2644,36 @@ msgstr ""
 msgid "HD Comment Reaction"
 msgstr ""
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr ""
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr ""
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
 msgstr ""
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
 msgstr ""
 
 #. Name of a DocType
@@ -2592,21 +2694,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
 msgstr ""
 
 #. Name of a DocType
@@ -2648,11 +2735,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
 msgstr ""
 
 #. Name of a DocType
@@ -2750,12 +2832,6 @@ msgstr ""
 msgid "Helpdesk"
 msgstr ""
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr ""
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2772,11 +2848,6 @@ msgstr "Merhaba"
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
 msgstr "Gizle "
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr ""
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
@@ -2846,15 +2917,8 @@ msgstr ""
 msgid "ID"
 msgstr "ID"
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "IP Adresi"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2941,6 +3005,11 @@ msgstr "Gelen Kutusu"
 msgid "Incoming"
 msgstr "Gelen"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr "Bireysel"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr "Başlatıldı"
@@ -2954,7 +3023,7 @@ msgstr ""
 msgid "Instantly send e-mail"
 msgstr ""
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "{0} için Yetki Verilmemiş"
 
@@ -2968,12 +3037,12 @@ msgstr ""
 msgid "Introduction"
 msgstr "Giriş"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
@@ -2982,22 +3051,42 @@ msgstr ""
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr ""
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr ""
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
 msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
@@ -3008,13 +3097,30 @@ msgstr ""
 msgid "Invite agents"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
-msgstr ""
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
+msgstr "Kullanıcı olarak davet et"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
 msgstr "E-posta ile davet et"
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr "Davet Edildi"
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
+msgstr ""
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -3030,6 +3136,11 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "Varsayılan"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr ""
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3057,6 +3168,10 @@ msgstr ""
 #. Label of the setup_complete (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
 msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:114
@@ -3093,11 +3208,9 @@ msgstr "Klavye Kısayolları"
 msgid "Knowledge Base"
 msgstr "Bilgi Merkezi"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3131,9 +3244,9 @@ msgstr ""
 msgid "Last 3 Months"
 msgstr "Son 3 Ay"
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr ""
 
@@ -3174,7 +3287,8 @@ msgstr ""
 msgid "Last Month"
 msgstr "Geçen Ay"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "Soyadı"
 
@@ -3183,24 +3297,33 @@ msgstr "Soyadı"
 msgid "Last Week"
 msgstr "Geçen Hafta"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr ""
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
 msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
+msgstr "Son"
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -3216,26 +3339,6 @@ msgstr ""
 #. 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
-msgstr ""
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "Bağlantı"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr "Bağlantı Seçenekleri"
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -3264,6 +3367,8 @@ msgstr ""
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "Daha Fazla Yükle"
 
@@ -3286,6 +3391,8 @@ msgstr "Frappe Cloud'a Giriş Yapın"
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr "Logo"
@@ -3324,7 +3431,7 @@ msgstr ""
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr ""
 
@@ -3343,6 +3450,10 @@ msgstr ""
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
+msgstr "Müdür"
 
 #: desk/src/pages/MobileNotifications.vue:11
 #: desk/src/pages/MobileNotifications.vue:14
@@ -3396,6 +3507,20 @@ msgstr ""
 msgid "Mobile App Installation"
 msgstr ""
 
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr "Cep No"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr "Cep Telefonu"
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr ""
+
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
 #. List'
@@ -3436,7 +3561,7 @@ msgid "My Tickets"
 msgstr ""
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3447,8 +3572,9 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3457,6 +3583,10 @@ msgstr "Adı"
 #. Label of the name_weight (Int) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
 msgstr ""
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
@@ -3469,10 +3599,18 @@ msgstr ""
 msgid "Navigation"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "Asla"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3581,11 +3719,11 @@ msgstr "Cevap Yok"
 msgid "No Data Found"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr ""
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr ""
 
@@ -3597,8 +3735,14 @@ msgstr ""
 msgid "No SLA found"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
 msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
@@ -3633,19 +3777,27 @@ msgstr ""
 msgid "No changes made"
 msgstr "Hiçbir değişiklik yapılmadı"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr ""
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr ""
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr ""
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
@@ -3657,7 +3809,11 @@ msgstr "Hiçbir e-posta hesabı bulunamadı"
 msgid "No feedback"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr ""
 
@@ -3697,12 +3853,17 @@ msgstr ""
 msgid "No recently assigned tickets"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr ""
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
+msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
 msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
@@ -3710,6 +3871,7 @@ msgstr ""
 msgid "No saved replies found"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr ""
@@ -3730,7 +3892,11 @@ msgstr ""
 msgid "No tickets selected"
 msgstr ""
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr ""
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "İzin verilmedi"
 
@@ -3742,7 +3908,7 @@ msgstr ""
 msgid "Not Saved"
 msgstr "Kaydedilmedi"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "Ayarlanmamış"
 
@@ -3781,11 +3947,6 @@ msgstr ""
 msgid "On Hold Since"
 msgstr "O zaman beri beklemede"
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr ""
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr ""
@@ -3815,6 +3976,10 @@ msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
@@ -3904,7 +4069,12 @@ msgstr ""
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr "Ortaklık"
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "Şifre"
 
@@ -3942,6 +4112,7 @@ msgid "Pending"
 msgstr "Beklemede"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr ""
 
@@ -3951,19 +4122,19 @@ msgstr ""
 msgid "Pending Tickets"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr ""
 
@@ -3984,13 +4155,14 @@ msgstr "Kişisel"
 msgid "Personal mobile no"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "Telefon"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
 msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
@@ -4047,7 +4219,7 @@ msgstr ""
 msgid "Please enter a valid phone number"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr ""
 
@@ -4090,34 +4262,15 @@ msgstr "Haftalık izin süresini seçin"
 msgid "Policy name"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
 msgstr ""
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr "Mesaj Açıklama Anahtarı"
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr "Rota Rota Listesini Kaydet"
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr "Rota Dizisi Gönder"
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
-msgstr "Yazı Başlığı Anahtarı"
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:10
@@ -4151,14 +4304,32 @@ msgstr "Önizleme"
 msgid "Previous ticket"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "Birincil"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "Birincil İlgili Kişi"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr ""
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr "Öncelikler"
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4166,9 +4337,10 @@ msgstr "Öncelikler"
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4248,17 +4420,6 @@ msgstr ""
 msgid "Quarterly"
 msgstr "3 ayda bir"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "Sorgu Seçenekleri"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr "Sorgu Rota Dizesi"
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "Sıraya alındı"
@@ -4281,14 +4442,14 @@ msgstr ""
 msgid "Rate this ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr ""
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4384,8 +4545,15 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "Kaldır"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4395,9 +4563,18 @@ msgstr ""
 msgid "Remove Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr "Görseli kaldır"
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
 msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
@@ -4417,6 +4594,15 @@ msgstr ""
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
 msgstr ""
 
 #. Option in a Select field in the tickets Web Form
@@ -4456,16 +4642,13 @@ msgstr ""
 msgid "Reply on a ticket"
 msgstr ""
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr ""
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
 msgstr ""
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
@@ -4486,6 +4669,7 @@ msgid "Reset to Default"
 msgstr ""
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr "Çözüm"
@@ -4539,18 +4723,6 @@ msgstr "Yanıt"
 msgid "Response By"
 msgstr "Yanıtlayan"
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr "Yanıt Seçenekleri"
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr "Yanıt Sonuç Anahtar Yolu"
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr "{1} satırındaki {0} önceliği için Yanıt Süresi, Çözüm Süresinden büyük olamaz."
@@ -4593,37 +4765,33 @@ msgstr ""
 msgid "Restrict visibility to these teams"
 msgstr ""
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr "Sonuç Önizleme Alanı"
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr "Sonuç Rota Alanı"
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr "Sonuç Başlık Alanı"
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
 msgstr "Yorumlar"
 
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:215
 msgid "Ringing"
 msgstr "Çalıyor..."
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "Rol"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr ""
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4722,9 +4890,9 @@ msgstr "Cumartesi"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4800,17 +4968,19 @@ msgstr ""
 msgid "Search Score"
 msgstr ""
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr "Arama Dönem Param Adı"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "Alanları Ara..."
 
@@ -4850,6 +5020,7 @@ msgstr "Arama..."
 msgid "Searched for:"
 msgstr ""
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr ""
@@ -4868,6 +5039,10 @@ msgstr "Seçim"
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
 msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
@@ -4890,6 +5065,10 @@ msgstr "Bir Varsayılan Öncelik seçin."
 msgid "Select a rating"
 msgstr ""
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr ""
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4901,6 +5080,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
+msgstr ""
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
@@ -4927,6 +5110,10 @@ msgstr ""
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
 msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
@@ -4967,13 +5154,17 @@ msgstr "Hizmet Seviyesi Adı"
 msgid "Service not supported"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "Ayarla"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:4
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
@@ -4984,12 +5175,21 @@ msgstr ""
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr "{1} satırında {0} Önceliği için Yanıt Süresini ayarlayın."
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr ""
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr ""
 
@@ -5001,7 +5201,7 @@ msgstr ""
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr ""
 
@@ -5135,23 +5335,6 @@ msgstr ""
 msgid "Sort"
 msgstr ""
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr "Kaynak DocType"
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "Kaynak Adı"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr "Kaynak Türü"
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr ""
@@ -5196,6 +5379,8 @@ msgstr ""
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5262,6 +5447,7 @@ msgstr ""
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5373,21 +5559,16 @@ msgstr "Sistem"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5426,8 +5607,6 @@ msgstr ""
 msgid "Teal"
 msgstr ""
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5438,7 +5617,6 @@ msgstr ""
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5544,6 +5722,10 @@ msgstr ""
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr ""
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr ""
@@ -5554,6 +5736,10 @@ msgstr "{0} tarihindeki tatil Başlangıç Tarihi ile Bitiş Tarihi arasında de
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
@@ -5576,6 +5762,14 @@ msgstr ""
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr ""
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr ""
@@ -5583,6 +5777,10 @@ msgstr ""
 #: desk/src/components/ticket/TicketMergeModal.vue:79
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
 msgstr ""
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
@@ -5652,7 +5850,7 @@ msgstr "Perşembe"
 msgid "Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr ""
 
@@ -5666,6 +5864,10 @@ msgstr ""
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
+msgstr ""
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
 msgstr ""
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
@@ -5725,7 +5927,7 @@ msgstr ""
 msgid "Ticket Summary"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr ""
 
@@ -5758,7 +5960,7 @@ msgstr ""
 msgid "Ticket merged successfully."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr ""
 
@@ -5793,12 +5995,6 @@ msgstr ""
 msgid "Ticket to merged with is required"
 msgstr ""
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr ""
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr ""
@@ -5810,12 +6006,15 @@ msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr ""
 
@@ -5827,19 +6026,19 @@ msgstr ""
 msgid "Tickets assigned to you in the last 7 days"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr ""
 
@@ -5856,6 +6055,7 @@ msgid "Tickets that are awaiting your response"
 msgstr ""
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr "Zaman Dilimi"
 
@@ -5945,19 +6145,19 @@ msgstr "Toplam Tatil Günü"
 msgid "Total Ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr ""
 
@@ -5989,6 +6189,10 @@ msgstr "Türü"
 msgid "Type a message"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr ""
@@ -5998,7 +6202,7 @@ msgstr ""
 msgid "URL/Method"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr ""
 
@@ -6032,6 +6236,8 @@ msgid "Unpublish"
 msgstr "Taslağa Çevir"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr ""
 
@@ -6048,6 +6254,10 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:214
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
+msgstr ""
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
@@ -6076,10 +6286,13 @@ msgstr "Yükle"
 msgid "Upload Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
 msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
+msgstr "Resim Yükle"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
 msgid "Uploading {0}%"
@@ -6088,17 +6301,13 @@ msgstr "%{0} Yükleniyor"
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6110,6 +6319,10 @@ msgstr "Kullanıcı"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
 msgstr "Kullanıcı Çözüm Süresi"
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
+msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
 msgid "User Signup"
@@ -6128,7 +6341,7 @@ msgstr "Kullanıcılar"
 msgid "Valid From"
 msgstr "Geçerlilik Başlangıç Tarihi"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "Değer"
 
@@ -6257,19 +6470,23 @@ msgstr "Yıllık"
 msgid "Yellow"
 msgstr "Sarı"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr ""
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr ""
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr ""
 
@@ -6297,6 +6514,14 @@ msgstr ""
 msgid "You do not have permission to access Assignment Rules"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr ""
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr ""
@@ -6319,6 +6544,14 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:46
@@ -6349,7 +6582,7 @@ msgstr "oluşturdu"
 msgid "customize {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr "gün"
 
@@ -6400,7 +6633,7 @@ msgstr ""
 msgid "here."
 msgstr ""
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr "saat"
 
@@ -6408,7 +6641,7 @@ msgstr "saat"
 msgid "in"
 msgstr "i̇çerir"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "Şimdi"
 
@@ -6441,7 +6674,11 @@ msgstr ""
 msgid "purple"
 msgstr "mor"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr "i̇ncelemeler"
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr ""
 
@@ -6458,7 +6695,7 @@ msgstr ""
 msgid "to enable this integration."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr ""
 
@@ -6466,12 +6703,32 @@ msgstr ""
 msgid "views"
 msgstr "görüntüleme"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr ""
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
 msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:307
@@ -6498,7 +6755,7 @@ msgstr ""
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr ""
 

--- a/helpdesk/locale/uz.po
+++ b/helpdesk/locale/uz.po
@@ -3,201 +3,203 @@ msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
 "POT-Creation-Date: 2026-06-28 11:13+0000\n"
-"PO-Revision-Date: 2026-06-29 21:58\n"
+"PO-Revision-Date: 2026-07-02 22:35\n"
 "Last-Translator: hello@frappe.io\n"
-"Language-Team: Hindi\n"
+"Language-Team: Uzbek\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.16.0\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Crowdin-Project: frappe\n"
 "X-Crowdin-Project-ID: 639578\n"
-"X-Crowdin-Language: hi\n"
+"X-Crowdin-Language: uz\n"
 "X-Crowdin-File: /[frappe.helpdesk] develop/helpdesk/locale/main.pot\n"
 "X-Crowdin-File-ID: 118\n"
-"Language: hi_IN\n"
+"Language: uz_UZ\n"
 
 #: desk/src/components/CommentBox.vue:14
 msgid " commented"
-msgstr " टिप्पणी की"
+msgstr " izoh berdi"
 
 #: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
-msgstr ""
+msgstr "SLA bajarilgan foiz"
 
 #: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
-msgstr ""
+msgstr "SLA doirasida hal qilingan chiptalarning % i"
 
 #: desk/src/pages/SearchAgent.vue:120
 msgid "({0}s)"
-msgstr ""
+msgstr "({0}s)"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:114
 msgid "- Default Ticket Status<br>"
-msgstr ""
+msgstr "- Standart chipta holati<br>"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:116
 msgid "- Ticket Reopen Status<br>"
-msgstr "- टिकट पुनः खोलने की स्थिति<br>"
+msgstr "- Chipta qayta ochilish holati<br>"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:92
 msgid "- {0} as Default Status<br>"
-msgstr ""
+msgstr "- {0} standart holat sifatida<br>"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:94
 msgid "- {0} as Reopen Status<br>"
-msgstr "- {0} पुनः खोलने की स्थिति<br> के रूप में"
+msgstr "- {0} qayta ochilish holatida<br>"
 
 #. Description of the 'Feedback' (Select) field in DocType 'HD Article
 #. Feedback'
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 msgid "0 is no feedback, 1 is Like, 2 is Dislike"
-msgstr ""
+msgstr "0 - fikr-mulohaza yo'q, 1 - yoqtirish, 2 - yoqtirmaslik"
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:178
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:196
 msgid "1 Year"
-msgstr "1 वर्ष"
+msgstr "1 yil"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.py:154
 msgid "1 person reacted to your comment"
-msgstr ""
+msgstr "Fikringizga 1 kishi munosabat bildirdi"
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:176
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:188
 msgid "3 Months"
-msgstr "3 महीने"
+msgstr "3 oy"
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:177
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:183
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:192
 msgid "6 Months"
-msgstr "6 महीने"
+msgstr "6 oy"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:117
 msgid "<br>Please update HD Settings to use a different status before disabling this status."
-msgstr ""
+msgstr "<br>Ushbu holatni o'chirishdan oldin boshqa holatdan foydalanish uchun HD sozlamalarini yangilang."
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:95
 msgid "<br>Please update the SLA(s) to use a different status before disabling this status."
-msgstr ""
+msgstr "<br>Ushbu holatni o'chirishdan oldin, iltimos, SLA(lar)ni boshqa holatdan foydalanish uchun yangilang."
 
 #. Introduction text of the email-feedback Web Form
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
 msgid "<div class=\"ql-editor read-mode\"><p>Let us know if we solved your issue well. It’ll help us serve you better next time.</p></div>"
-msgstr ""
+msgstr "<div class=\"ql-editor read-mode\"><p>Muammoingizni yaxshi hal qilgan bo'lsak, bizga xabar bering. Bu keyingi safar sizga yaxshiroq xizmat ko'rsatishimizga yordam beradi.</p></div>"
 
 #. Header text in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "<span class=\"h3\" style=\"\"><a href=\"/helpdesk\">Visit Helpdesk</a></span>"
-msgstr ""
+msgstr "<span class=\"h3\" style=\"\"><a href=\"/helpdesk\">Yordam xizmatiga tashrif buyuring</a></span>"
 
 #. Paragraph text in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "<span class=\"h4\">Helpdesk Configuration<br></span>"
-msgstr ""
+msgstr "<span class=\"h4\">Yordam xizmati konfiguratsiyasi<br></span>"
 
 #: desk/src/pages/ticket/TicketNew.vue:69
 msgid "A short description"
-msgstr "एक संक्षिप्त विवरण"
+msgstr "Qisqacha tavsif"
 
 #: desk/src/components/Settings/Sla/Modals/WorkDayModal.vue:268
 msgid "A workday with this name already exists"
-msgstr ""
+msgstr "Bu nomdagi ish kuni allaqachon mavjud"
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
-msgstr ""
+msgstr "Barcha jamoa chiptalariga kirish"
 
 #: helpdesk/api/knowledge_base.py:15
 msgid "Access denied"
-msgstr ""
+msgstr "Ruxsat berilmadi"
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:262
 msgid "Access only this team's tickets"
-msgstr "केवल इसी टीम के टिकटों तक पहुंच प्राप्त करें"
+msgstr "Faqat shu jamoaning chiptalariga kirish"
 
 #: desk/src/components/Settings/SettingsModal.vue:19
 msgid "Account"
-msgstr "खाता"
+msgstr "Hisob"
 
 #: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
-msgstr "खाता जानकारी और सुरक्षा"
+msgstr "Hisob ma'lumotlari va xavfsizligi"
 
 #. Label of the acknowledgement_section (Section Break) field in DocType 'HD
 #. Settings'
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:72
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Acknowledgement"
-msgstr ""
+msgstr "Tasdiqlash"
 
 #. Label of the action (Small Text) field in DocType 'HD Ticket Activity'
 #: helpdesk/helpdesk/doctype/hd_ticket_activity/hd_ticket_activity.json
 msgid "Action"
-msgstr "कार्रवाई"
+msgstr "Harakat"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.py:24
 msgid "Action Required"
-msgstr "कार्रवाई आवश्यक है"
+msgstr "Harakat talab qilinadi"
 
 #: desk/src/pages/contact/Contact.vue:303
 msgid "Actions"
-msgstr "कार्रवाई"
+msgstr "Harakatlar"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 msgid "Active"
-msgstr "सक्रिय"
+msgstr "Faol"
 
 #: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
-msgstr ""
+msgstr "Hozir faol"
 
 #. Description of the 'Category' (Select) field in DocType 'HD Agent Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 msgid "Active: The agent is available and working.<br>\n"
 "Away: The agent is temporarily unreachable.<br>\n"
 "Unavailable: The agent is off and unavailable."
-msgstr ""
+msgstr "Faol: Agent mavjud va ishlayapti.<br>\n"
+"Mavjud emas: Agent vaqtinchalik foydalanib bo'lmaydi.<br>\n"
+"Mavjud emas: Agent o'chirilgan va mavjud emas."
 
 #: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
-msgstr ""
+msgstr "Faoliyat"
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:9
 msgid "Add Assignee"
-msgstr ""
+msgstr "Topshiriq beruvchini qo'shish"
 
 #: desk/src/pages/knowledge-base/Article.vue:643
 msgid "Add Category"
-msgstr "श्रेणी जोड़ना"
+msgstr "Kategoriya qo'shish"
 
 #: desk/src/components/view-controls/ColumnSettings.vue:69
 msgid "Add Column"
-msgstr ""
+msgstr "Ustun qo'shish"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
 #: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
-msgstr ""
+msgstr "Elektron pochta qo'shish"
 
 #: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
-msgstr ""
+msgstr "Filtr qo'shish..."
 
 #: desk/src/components/Settings/Holiday/HolidayView.vue:163
 msgid "Add Holiday"
-msgstr ""
+msgstr "Bayram qo'shish"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
-msgstr ""
+msgstr "Yangi maqola qo'shish"
 
 #: desk/src/components/contact/EditContactDialog.vue:99
 msgid "Add Phone"
@@ -205,51 +207,51 @@ msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:148
 msgid "Add Sort"
-msgstr ""
+msgstr "Saralash qo'shish"
 
 #. Label of the add_weekly_holidays (Section Break) field in DocType 'HD
 #. Service Holiday List'
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Add Weekly Holidays"
-msgstr ""
+msgstr "Haftalik ta'tillarni qo'shish"
 
 #: desk/src/components/layouts/Sidebar.vue:507
 msgid "Add a comment on a ticket"
-msgstr ""
+msgstr "Chiptaga izoh qo'shing"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesSection.vue:17
 msgid "Add a condition"
-msgstr ""
+msgstr "Shart qo'shish"
 
 #: desk/src/components/Settings/Sla/SlaAssignmentConditions.vue:14
 msgid "Add a custom condition"
-msgstr ""
+msgstr "Maxsus shart qo'shish"
 
 #: desk/src/pages/home/Home.vue:91
 msgid "Add charts to get started"
-msgstr ""
+msgstr "Boshlash uchun jadvallar qo'shing"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesSection.vue:29
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesSection.vue:66
 #: desk/src/components/Settings/Sla/SlaAssignmentConditions.vue:25
 msgid "Add condition"
-msgstr ""
+msgstr "Shart qo'shish"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesSection.vue:72
 msgid "Add condition group"
-msgstr ""
+msgstr "Shart guruhini qo'shish"
 
 #: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
-msgstr ""
+msgstr "Filtr qo'shish"
 
 #: desk/src/components/Settings/Holiday/HolidayView.vue:136
 msgid "Add holidays here to make sure they’re excluded from SLA calculations."
-msgstr ""
+msgstr "SLA hisob-kitoblaridan chiqarib tashlanganligiga ishonch hosil qilish uchun bu yerga bayramlarni qo'shing."
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:97
 msgid "Add members to this team to get started."
-msgstr ""
+msgstr "Boshlash uchun ushbu jamoaga a'zolar qo'shing."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:23
 #: desk/src/components/Settings/EmailAccountList.vue:47
@@ -257,21 +259,21 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:92
 #: desk/src/components/Settings/Sla/SlaPolicyList.vue:23
 msgid "Add one to get started."
-msgstr ""
+msgstr "Boshlash uchun bitta qo'shing."
 
 #: desk/src/components/Settings/Holiday/HolidayView.vue:117
 msgid "Add recurring holidays such as weekends."
-msgstr ""
+msgstr "Dam olish kunlari kabi takroriy bayramlarni qo'shing."
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:183
 msgid "Add time targets around support milestones like first reply and resolution times."
-msgstr ""
+msgstr "Birinchi javob va yechim vaqtlari kabi qo'llab-quvvatlash bosqichlari atrofida vaqt maqsadlarini qo'shing."
 
 #. Label of the get_weekly_off_dates (Button) field in DocType 'HD Service
 #. Holiday List'
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Add to Holidays"
-msgstr ""
+msgstr "Bayramlarga qo'shish"
 
 #: desk/src/components/EmailEditor.vue:43
 #: desk/src/components/EmailEditor.vue:83
@@ -281,19 +283,19 @@ msgstr ""
 
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
-msgstr ""
+msgstr "Agentlarni qo'shing, boshqaring va ularga rollarni tayinlang."
 
 #. Label of the about (Code) field in DocType 'HD Ticket Template'
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Additional Information"
-msgstr "अतिरिक्त जानकारी"
+msgstr "Qo'shimcha ma'lumot"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Administrator"
-msgstr "प्रशासक"
+msgstr "Administrator"
 
 #. Name of a role
 #. Label of a Link in the Helpdesk Workspace
@@ -320,16 +322,16 @@ msgstr "प्रशासक"
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Agent"
-msgstr "प्रतिनिधि"
+msgstr "Agent"
 
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Agent Configuration"
-msgstr ""
+msgstr "Agent konfiguratsiyasi"
 
 #: desk/src/pages/dashboard/Dashboard.vue:248
 msgid "Agent Dashboard"
-msgstr ""
+msgstr "Agent boshqaruv paneli"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
@@ -346,33 +348,33 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
-msgstr "एजेंट प्रबंधक"
+msgstr "Agent menejeri"
 
 #. Label of the agent_name (Data) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Agent Name"
-msgstr "एजेंट का नाम"
+msgstr "Agent nomi"
 
 #. Label of the agent_status (Data) field in DocType 'HD Agent Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 msgid "Agent Status"
-msgstr ""
+msgstr "Agent maqomi"
 
 #: desk/src/components/Settings/Agents.vue:109
 msgid "Agent name"
-msgstr "एजेंट का नाम"
+msgstr "Agent nomi"
 
 #: desk/src/components/Settings/Agents.vue:3
 msgid "Agents"
-msgstr ""
+msgstr "Agentlar"
 
 #: desk/src/components/layouts/Sidebar.vue:591
 msgid "Agents & Teams"
-msgstr ""
+msgstr "Agentlar va jamoalar"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:70
 msgid "Agents will no longer be able to view and create saved replies with global scope."
-msgstr ""
+msgstr "Agentlar endi global miqyosdagi saqlangan javoblarni ko'ra olmaydi va yarata olmaydi."
 
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
@@ -381,124 +383,124 @@ msgstr ""
 #: desk/src/components/ticket/TicketSplitModal.vue:6
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "All"
-msgstr "सभी"
+msgstr "Hammasi"
 
 #: desk/src/pages/home/components/PendingTickets.vue:253
 msgid "All SLAs on track"
-msgstr ""
+msgstr "Barcha SLAlar yo'lda"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:360
 #: desk/src/pages/home/components/RecentFeedback.vue:398
 #: desk/src/pages/home/components/RecentFeedback.vue:406
 msgid "All Time"
-msgstr "पूरे समय"
+msgstr "Hamma vaqt"
 
 #: desk/src/components/layouts/Sidebar.vue:293
 msgid "All Views"
-msgstr "सभी दृश्य"
+msgstr "Barcha ko'rishlar"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:322
 msgid "All articles from this category will move to General category."
-msgstr ""
+msgstr "Ushbu toifadagi barcha maqolalar Umumiy toifaga o'tkaziladi."
 
 #: desk/src/components/ticket/TicketMergeModal.vue:7
 msgid "All comments and emails from both tickets will be merged into the selected ticket"
-msgstr ""
+msgstr "Ikkala chiptadan kelgan barcha izohlar va elektron pochta xabarlari tanlangan chiptaga birlashtiriladi"
 
 #: desk/src/pages/home/components/PendingTickets.vue:262
 msgid "All your assigned tickets have been responded to"
-msgstr ""
+msgstr "Sizga berilgan barcha chiptalarga javob berildi"
 
 #. Label of the allow_anyone_to_create_tickets (Check) field in DocType 'HD
 #. Settings'
 #: desk/src/components/Settings/General/components/TicketSettings.vue:109
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Allow anyone to create tickets"
-msgstr "किसी को भी टिकट बनाने की अनुमति दें"
+msgstr "Har kimga chiptalar yaratishga ruxsat bering"
 
 #. Description of the 'Enable comment reactions' (Check) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Allow users to react to comments with emojis"
-msgstr ""
+msgstr "Foydalanuvchilarga izohlarga emojilar bilan munosabat bildirishga ruxsat berish"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:26
 msgid "Allow users to react to comments with emojis."
-msgstr ""
+msgstr "Foydalanuvchilarga izohlarga emojilar bilan munosabat bildirish imkonini bering."
 
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Amber"
-msgstr ""
+msgstr "Amber"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:113
 msgid "Anyone will be able to create tickets without any permission. e.g. from webform."
-msgstr ""
+msgstr "Har kim hech qanday ruxsatsiz chiptalar yaratishi mumkin, masalan, veb-shakldan."
 
 #: desk/src/components/Settings/Preferences/Preferences.vue:26
 msgid "Appearance"
-msgstr "उपस्थिति"
+msgstr "Tashqi ko'rinish"
 
 #: desk/src/components/Settings/General/components/Branding.vue:17
 msgid "Appears in the left sidebar. Recommended size is minimum 32x32 px in PNG or SVG."
-msgstr ""
+msgstr "Chap yon panelda paydo bo'ladi. Tavsiya etilgan o'lcham PNG yoki SVG formatida kamida 32x32 piksel."
 
 #. Description of the 'Favicon' (Attach Image) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Appears next to the title in your browser tab. Recommended size is minimum 32x32 px in PNG or ICO"
-msgstr ""
+msgstr "Brauzeringiz yorlig'ida sarlavha yonida paydo bo'ladi. Tavsiya etilgan o'lcham PNG yoki ICO formatida kamida 32x32 piksel."
 
 #: desk/src/components/Settings/General/components/Branding.vue:29
 msgid "Appears next to the title in your browser tab. Recommended size is minimum 32x32 px in PNG or ICO."
-msgstr ""
+msgstr "Brauzeringiz yorlig'ida sarlavha yonida paydo bo'ladi. Tavsiya etilgan o'lcham PNG yoki ICO formatida kamida 32x32 piksel."
 
 #. Label of the apply_sla_for_resolution (Check) field in DocType 'HD Service
 #. Level Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Apply SLA for Resolution Time"
-msgstr "समाधान समय के लिए SLA लागू करें"
+msgstr "Qaror vaqti uchun SLA ni qo'llang"
 
 #. Label of the apply_to (Select) field in DocType 'HD Form Script'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 msgid "Apply To"
-msgstr "पर लागू"
+msgstr "Qo'llash"
 
 #. Label of the apply_on_new_page (Check) field in DocType 'HD Form Script'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 msgid "Apply on new page"
-msgstr "नए पेज पर आवेदन करें"
+msgstr "Yangi sahifada qo'llash"
 
 #. Label of the enable_outside_hours_banner (Check) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Apply outside working hours"
-msgstr "कार्य समय के बाहर आवेदन करें"
+msgstr "Ish vaqtidan tashqari qo'llanilishi"
 
 #. Label of the apply_to_customer_portal (Check) field in DocType 'HD Form
 #. Script'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 msgid "Apply to customer portal"
-msgstr "ग्राहक पोर्टल पर आवेदन करें"
+msgstr "Mijozlar portaliga murojaat qiling"
 
 #. Option for the 'Status' (Select) field in DocType 'HD Article'
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:451
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 msgid "Archived"
-msgstr ""
+msgstr "Arxivlangan"
 
 #: desk/src/components/Settings/SettingsModal.vue:74
 msgid "Are you sure you want to change tabs? Unsaved changes will be lost."
-msgstr ""
+msgstr "Haqiqatan ham yorliqlarni o'zgartirmoqchimisiz? Saqlanmagan o'zgarishlar yo'qoladi."
 
 #: desk/src/pages/ticket/TicketCustomer.vue:314
 msgid "Are you sure you want to close this ticket?"
-msgstr "क्या आप वाकई इस टिकट को बंद करना चाहते हैं?"
+msgstr "Haqiqatan ham ushbu chiptani yopmoqchimisiz?"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:205
 msgid "Are you sure you want to delete these articles?"
-msgstr ""
+msgstr "Ushbu maqolalarni o'chirib tashlamoqchimisiz?"
 
 #: desk/src/pages/contact/Contact.vue:102
 msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
@@ -510,19 +512,19 @@ msgstr ""
 
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
-msgstr ""
+msgstr "Ushbu chiptani o'chirib tashlamoqchimisiz? Bu qaytarib bo'lmaydigan amal va uni bekor qilib bo'lmaydi."
 
 #: desk/src/pages/ticket/Tickets.vue:541
 msgid "Are you sure you want to delete this view?"
-msgstr "क्या आप वाकई इस दृश्य को हटाना चाहते हैं?"
+msgstr "Ushbu ko'rinishni o'chirib tashlamoqchimisiz?"
 
 #: desk/src/pages/knowledge-base/Article.vue:147
 msgid "Are you sure you want to discard changes?"
-msgstr "क्या आप वाकई बदलावों को रद्द करना चाहते हैं?"
+msgstr "O'zgarishlarni bekor qilmoqchimisiz?"
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:144
 msgid "Are you sure you want to discard this article?"
-msgstr "क्या आप वाकई इस लेख को हटाना चाहते हैं?"
+msgstr "Ushbu maqolani o'chirib tashlamoqchimisiz?"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:450
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:103
@@ -535,15 +537,15 @@ msgstr "क्या आप वाकई इस लेख को हटाना
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:215
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:184
 msgid "Are you sure you want to go back? Unsaved changes will be lost."
-msgstr ""
+msgstr "Haqiqatan ham orqaga qaytmoqchimisiz? Saqlanmagan o'zgarishlar yo'qoladi."
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:165
 msgid "Are you sure you want to leave? Unsaved changes will be lost."
-msgstr ""
+msgstr "Haqiqatan ham ketmoqchimisiz? Saqlanmagan o'zgarishlar yo'qoladi."
 
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
-msgstr "क्या आप वाकई लोगो हटाना चाहते हैं?"
+msgstr "Logotipni olib tashlashni xohlaysizmi?"
 
 #: desk/src/components/customer/ContactCard.vue:295
 msgid "Are you sure you want to remove this contact from the customer?"
@@ -551,263 +553,263 @@ msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
 msgid "Are you sure you want to reset the content? Current content will be overridden."
-msgstr ""
+msgstr "Haqiqatan ham kontentni asl holatiga qaytarmoqchimisiz? Joriy kontent bekor qilinadi."
 
 #. Label of the article (Link) field in DocType 'HD Article Feedback'
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:114
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 msgid "Article"
-msgstr "लेख"
+msgstr "Maqola"
 
 #: desk/src/pages/knowledge-base/Article.vue:519
 msgid "Article body cannot be set as empty."
-msgstr ""
+msgstr "Maqola asosiy qismini bo'sh qilib belgilash mumkin emas."
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:117
 msgid "Article created successfully."
-msgstr ""
+msgstr "Maqola muvaffaqiyatli yaratildi."
 
 #: desk/src/pages/knowledge-base/Article.vue:558
 msgid "Article deleted successfully."
-msgstr ""
+msgstr "Maqola muvaffaqiyatli o'chirildi."
 
 #: desk/src/pages/knowledge-base/Article.vue:654
 msgid "Article link copied to clipboard"
-msgstr ""
+msgstr "Maqola havolasi buferga nusxalandi"
 
 #: desk/src/pages/knowledge-base/Article.vue:514
 msgid "Article title cannot be set as empty"
-msgstr "लेख का शीर्षक खाली नहीं रखा जा सकता"
+msgstr "Maqola sarlavhasini bo'sh qilib o'rnatib bo'lmaydi"
 
 #: desk/src/pages/knowledge-base/Article.vue:545
 msgid "Article updated successfully."
-msgstr ""
+msgstr "Maqola muvaffaqiyatli yangilandi."
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:359
 msgid "Articles deleted successfully."
-msgstr ""
+msgstr "Maqolalar muvaffaqiyatli o'chirildi."
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:235
 msgid "Articles moved successfully."
-msgstr ""
+msgstr "Maqolalar muvaffaqiyatli ko'chirildi."
 
 #: desk/src/components/layouts/Sidebar.vue:482
 msgid "Assign a ticket to an agent"
-msgstr ""
+msgstr "Agentga chipta tayinlang"
 
 #: desk/src/components/modals/ShortcutsModal.vue:90
 msgid "Assign ticket"
-msgstr ""
+msgstr "Chiptani tayinlash"
 
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
-msgstr "स्वयं को नियुक्त करें"
+msgstr "O'zingizni tayinlang"
 
 #: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
-msgstr "को सौंपना"
+msgstr "Kimga tayinlandi"
 
 #: desk/src/components/ticket-agent/AssignTo.vue:11
 msgid "Assignee"
-msgstr "संपत्ति-भागी"
+msgstr "Topshiruvchi"
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:5
 msgid "Assignee Rules"
-msgstr ""
+msgstr "Topshiriq beruvchi qoidalari"
 
 #: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
-msgstr ""
+msgstr "Topshiruvchi muvaffaqiyatli yangilandi."
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:75
 msgid "Assignees"
-msgstr ""
+msgstr "Topshiriq beruvchilar"
 
 #: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
-msgstr ""
+msgstr "Topshiriq beruvchilar muvaffaqiyatli yangilandi."
 
 #. Option for the 'Type' (Select) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "Assignment"
-msgstr "कार्यभार"
+msgstr "Topshiriq"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:122
 msgid "Assignment Condition"
-msgstr ""
+msgstr "Topshiriq sharti"
 
 #. Label of the filters_section (Section Break) field in DocType 'HD Service
 #. Level Agreement'
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:66
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Assignment Conditions"
-msgstr ""
+msgstr "Topshiriq shartlari"
 
 #. Label of the assignment_rule (Link) field in DocType 'HD Team'
 #. Label of a Link in the Helpdesk Workspace
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Assignment Rule"
-msgstr ""
+msgstr "Topshiriq qoidasi"
 
 #. Label of the assignment_rules_section (Section Break) field in DocType 'HD
 #. Settings'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:5
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Assignment Rules"
-msgstr ""
+msgstr "Topshiriq qoidalari"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:11
 msgid "Assignment Rules automatically route tickets to the right team members based on predefined conditions."
-msgstr ""
+msgstr "Topshiriq qoidalari oldindan belgilangan shartlar asosida chiptalarni avtomatik ravishda to'g'ri jamoa a'zolariga yo'naltiradi."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:276
 msgid "Assignment Schedule"
-msgstr ""
+msgstr "Topshiriqlar jadvali"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:29
 msgid "Assignment rule"
-msgstr ""
+msgstr "Topshiriq qoidasi"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:545
 msgid "Assignment rule created successfully."
-msgstr ""
+msgstr "Topshiriq qoidasi muvaffaqiyatli yaratildi."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:130
 msgid "Assignment rule deleted successfully."
-msgstr ""
+msgstr "Topshiriq qoidasi muvaffaqiyatli o'chirildi."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:173
 msgid "Assignment rule duplicated successfully."
-msgstr ""
+msgstr "Topshiriq qoidasi muvaffaqiyatli nusxalandi."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:632
 msgid "Assignment rule updated successfully."
-msgstr ""
+msgstr "Topshiriq qoidasi muvaffaqiyatli yangilandi."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:226
 msgid "Assignment rule {0} updated successfully."
-msgstr ""
+msgstr "Topshiriq qoidasi {0} muvaffaqiyatli yangilandi."
 
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
-msgstr ""
+msgstr "Kamida bitta yoqilgan Faol holat talab qilinadi."
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:73
 msgid "At least one enabled status for <u>{0}</u> category must be enabled."
-msgstr ""
+msgstr "<u>{0}</u> kategoriyasi uchun kamida bitta yoqilgan holat yoqilgan bo'lishi kerak."
 
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.py:38
 msgid "At least one feedback option must be enabled for rating {0}"
-msgstr ""
+msgstr "{0} reytingini olish uchun kamida bitta fikr-mulohaza opsiyasi yoqilgan bo'lishi kerak"
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
-msgstr "कम से कम एक टीम आवश्यक है"
+msgstr "Kamida bitta jamoa talab qilinadi"
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
 msgid "Attachment"
-msgstr "लगाव"
+msgstr "Ilova"
 
 #. Label of the author (Link) field in DocType 'HD Article'
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 msgid "Author"
-msgstr "लेखक"
+msgstr "Muallif"
 
 #. Label of the auto_update_status (Check) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/TicketSettings.vue:80
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Auto update status"
-msgstr ""
+msgstr "Avtomatik yangilanish holati"
 
 #. Label of the auto_close_after_days (Int) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/TicketSettings.vue:176
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Auto-close after (Days)"
-msgstr ""
+msgstr "(Kunlar) dan keyin avtomatik yopilish"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:148
 msgid "Auto-close tickets that remain in a status for the specified number of days."
-msgstr ""
+msgstr "Belgilangan kunlar soni davomida statusda qoladigan chiptalarni avtomatik yopish."
 
 #. Description of the 'Condition' (Code) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Auto-generated from the portal view — do not edit directly unless you know what you're doing! "
-msgstr ""
+msgstr "Portal ko'rinishidan avtomatik ravishda yaratilgan — nima qilayotganingizni bilmasangiz, to'g'ridan-to'g'ri tahrirlamang! "
 
 #. Label of the auto_close_tickets (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Automatically Close Tickets when"
-msgstr ""
+msgstr "Chiptalarni avtomatik ravishda yoping"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:145
 msgid "Automatically close stale tickets"
-msgstr "पुराने टिकट अपने आप बंद हो जाते हैं"
+msgstr "Eskirgan chiptalarni avtomatik ravishda yopish"
 
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Automation"
-msgstr ""
+msgstr "Avtomatlashtirish"
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
 #: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
-msgstr ""
+msgstr "Mavjudlik"
 
 #. Label of the availability_changed_on (Datetime) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability Changed On"
-msgstr ""
+msgstr "Mavjudlik o'zgartirildi"
 
 #: desk/src/pages/home/components/ChartItem.vue:6
 msgid "Average First Response"
-msgstr "औसत प्रथम प्रतिक्रिया"
+msgstr "O'rtacha birinchi javob"
 
 #: desk/src/pages/home/Home.vue:317
 msgid "Average First Response Time"
-msgstr "औसत प्रथम प्रतिक्रिया समय"
+msgstr "O'rtacha birinchi javob vaqti"
 
 #: desk/src/pages/home/components/ChartItem.vue:16
 msgid "Average Resolution"
-msgstr "औसत संकल्प"
+msgstr "O'rtacha aniqlik"
 
 #: desk/src/pages/home/Home.vue:329
 msgid "Average Resolution Time"
-msgstr "औसत समाधान समय"
+msgstr "O'rtacha aniqlik vaqti"
 
 #. Label of the avg_response_time (Duration) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Average Response Time"
-msgstr "औसत प्रतिक्रिया समय"
+msgstr "O'rtacha javob vaqti"
 
 #: desk/src/pages/home/Home.vue:305
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:5
 msgid "Average Time Metrics"
-msgstr ""
+msgstr "O'rtacha vaqt ko'rsatkichlari"
 
 #: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
-msgstr ""
+msgstr "Kunlik o'rtacha fikr-mulohaza reytingi {0} yulduz atrofida"
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:107
 msgid "Average response and resolution metrics not available"
-msgstr ""
+msgstr "O'rtacha javob va aniqlik ko'rsatkichlari mavjud emas"
 
 #: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
-msgstr "प्रतिदिन टिकटों की औसत संख्या लगभग {0} है"
+msgstr "Kuniga o'rtacha chiptalar taxminan {0}"
 
 #: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
-msgstr "औसत प्रतिक्रिया रेटिंग"
+msgstr "O'rtacha fikr-mulohaza reytingi"
 
 #: desk/src/components/customer/TicketStats.vue:13
 msgid "Avg. Feedback Received"
@@ -815,7 +817,7 @@ msgstr ""
 
 #: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
-msgstr "औसत प्रथम प्रतिक्रिया"
+msgstr "O'rtacha birinchi javob"
 
 #: desk/src/components/customer/TicketStats.vue:49
 msgid "Avg. First Response Time"
@@ -823,7 +825,7 @@ msgstr ""
 
 #: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
-msgstr "औसत संकल्प"
+msgstr "O'rtacha aniqlik"
 
 #: desk/src/components/customer/TicketStats.vue:62
 msgid "Avg. Resolution Time"
@@ -836,147 +838,147 @@ msgstr ""
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:290
 msgid "Avg. first response time"
-msgstr "औसत प्रथम प्रतिक्रिया समय"
+msgstr "O'rtacha birinchi javob vaqti"
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:130
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:298
 msgid "Avg. resolution time"
-msgstr "औसत समाधान समय"
+msgstr "O'rtacha aniqlik vaqti"
 
 #: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
-msgstr "टिकट पर पहली प्रतिक्रिया देने में लगने वाला औसत समय"
+msgstr "Chiptaga birinchi bo'lib javob berish uchun o'rtacha vaqt"
 
 #: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
-msgstr "किसी टिकट को हल करने में लगने वाला औसत समय"
+msgstr "Chiptani hal qilish uchun o'rtacha vaqt"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 msgid "Away"
-msgstr ""
+msgstr "Uzoqda"
 
 #: desk/src/components/Settings/EmailAdd.vue:145
 #: desk/src/components/Settings/EmailEdit.vue:134
 msgid "Back"
-msgstr "पीछे"
+msgstr "Orqaga"
 
 #: desk/src/pages/InvalidPage.vue:25 desk/src/pages/ticket/TicketAgent.vue:44
 msgid "Back to Tickets"
-msgstr "टिकटों पर वापस जाएँ"
+msgstr "Chiptalarga qaytish"
 
 #. Label of the base_support_rotation (Link) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Base Support Rotation"
-msgstr "आधार समर्थन घूर्णन"
+msgstr "Baza tayanchining aylanishi"
 
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
-msgstr "पर आधारित"
+msgstr "Asoslangan"
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:34
 msgid "Based on your HR Policy, select your leave allocation period's end date"
-msgstr ""
+msgstr "Kadrlar siyosatingizga asoslanib, ta'til ajratish davrining tugash sanasini tanlang"
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:27
 msgid "Based on your HR Policy, select your leave allocation period's start date"
-msgstr ""
+msgstr "Kadrlar siyosatingizga asoslanib, ta'til ajratish davri boshlanish sanasini tanlang"
 
 #: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
-msgstr ""
+msgstr "Yashirin nusxa"
 
 #: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
-msgstr ""
+msgstr "Yashirin nusxa:"
 
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Black"
-msgstr "काला"
+msgstr "Qora"
 
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Blue"
-msgstr "नीला"
+msgstr "Moviy"
 
 #: desk/src/components/Settings/General/components/Branding.vue:10
 msgid "Brand name"
-msgstr "ब्रांड का नाम"
+msgstr "Brend nomi"
 
 #. Label of the branding_tab (Tab Break) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:4
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Branding"
-msgstr ""
+msgstr "Brending"
 
 #: desk/src/components/ListViewBuilder.vue:270
 msgid "Bulk Operation Failed"
-msgstr ""
+msgstr "Ommaviy operatsiya bajarilmadi"
 
 #: desk/src/components/ListViewBuilder.vue:273
 msgid "Bulk Operation Successful"
-msgstr ""
+msgstr "Ommaviy operatsiya muvaffaqiyatli"
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:2
 #: desk/src/pages/ticket/Tickets.vue:122
 msgid "Bulk Reply"
-msgstr ""
+msgstr "Ommaviy javob"
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:105
 msgid "Bulk reply sent successfully to 1 ticket."
-msgstr ""
+msgstr "Ommaviy javob 1 ta chiptaga muvaffaqiyatli yuborildi."
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:106
 msgid "Bulk reply sent successfully to {0} tickets."
-msgstr ""
+msgstr "Ommaviy javob {0} chiptalariga muvaffaqiyatli yuborildi."
 
 #: desk/src/components/Settings/Holiday/Holidays.vue:3
 msgid "Business Holidays"
-msgstr "व्यावसायिक अवकाश"
+msgstr "Biznes bayramlari"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:210
 msgid "Busy"
-msgstr "व्यस्त"
+msgstr "Band"
 
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
-msgstr ""
+msgstr "CSV"
 
 #: desk/src/pages/call-logs/CallLogDetailModal.vue:8
 msgid "Call Details"
-msgstr ""
+msgstr "Qo'ng'iroq tafsilotlari"
 
 #: desk/src/components/layouts/Sidebar.vue:288
 msgid "Call Logs"
-msgstr ""
+msgstr "Qo'ng'iroqlar jurnallari"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:81
 msgid "Call Received By"
-msgstr ""
+msgstr "Qo'ng'iroqni qabul qilgan shaxs"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:69
 msgid "Call duration in seconds"
-msgstr ""
+msgstr "Qo'ng'iroq davomiyligi soniyalarda"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:93
 msgid "Caller"
-msgstr ""
+msgstr "Qo'ng'iroq qiluvchi"
 
 #: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
-msgstr ""
+msgstr "Qo'ng'iroqlar"
 
 #: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
-msgstr ""
+msgstr "Yangi agentlarni taklif qilishi, chiptalarni boshqarishi, maxsus ko'rinishlar yaratishi va ommaviy ko'rinishlarni boshqarishi mumkin."
 
 #: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
-msgstr ""
+msgstr "Yordam xizmatining barcha jihatlarini boshqarishi mumkin."
 
 #: desk/src/components/customer/InviteContactDialog.vue:134
 msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
@@ -992,51 +994,51 @@ msgstr ""
 
 #: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
-msgstr ""
+msgstr "Chiptalar ustida ishlashi, maxsus ko'rinishlar yaratishi va shaxsiy ko'rinishlarni boshqarishi mumkin."
 
 #: desk/src/components/ListViewBuilder.vue:714 desk/src/pages/home/Home.vue:44
 msgid "Cancel"
-msgstr "रद्द करना"
+msgstr "Bekor qilish"
 
 #: desk/src/components/Settings/InviteAgents.vue:63
 msgid "Cancel Invitation"
-msgstr ""
+msgstr "Taklifni bekor qilish"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:214
 msgid "Canceled"
-msgstr "रद्द कर दिया गया"
+msgstr "Bekor qilindi"
 
 #: helpdesk/integrations/erpnext/api.py:47
 msgid "Cannot Sync Customers"
-msgstr ""
+msgstr "Mijozlarni sinxronlashtirib bo'lmadi"
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:526
 msgid "Cannot delete the default SLA. At least one SLA must be marked as default."
-msgstr ""
+msgstr "Standart SLA ni o'chirib bo'lmaydi. Kamida bitta SLA standart sifatida belgilanishi kerak."
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:110
 msgid "Cannot disable this status as it is linked in HD Settings:<br><br>"
-msgstr ""
+msgstr "Bu holatni o'chirib bo'lmaydi, chunki u HD sozlamalarida bog'langan:<br><br>"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:88
 msgid "Cannot disable this status as it is linked in the following SLAs:<br><br>"
-msgstr ""
+msgstr "Ushbu holatni o'chirib bo'lmaydi, chunki u quyidagi xizmat ko'rsatish shartnomalarida bog'langan:<br><br>"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:198
 msgid "Cannot enable rule without adding users in it"
-msgstr ""
+msgstr "Foydalanuvchilarni qo'shmasdan qoidani yoqib bo'lmaydi"
 
 #: helpdesk/api/knowledge_base.py:128
 msgid "Cannot merge General category"
-msgstr ""
+msgstr "Umumiy kategoriyani birlashtirib bo'lmadi"
 
 #: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
-msgstr ""
+msgstr "Qayta nomlab bo'lmadi: boshqa tomonda aloqador bo'lmagan {0} '{1}' allaqachon mavjud. Avval nizoni qo'lda hal qiling."
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseCustomer.vue:24
 msgid "Categories"
-msgstr ""
+msgstr "Kategoriyalar"
 
 #. Label of the category (Select) field in DocType 'HD Agent Status'
 #. Label of the category (Link) field in DocType 'HD Article'
@@ -1046,168 +1048,168 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Category"
-msgstr "वर्ग"
+msgstr "Kategoriya"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:175
 msgid "Category '{0}' link copied to clipboard"
-msgstr ""
+msgstr "'{0}' kategoriyasi havolasi buferga nusxalandi"
 
 #: desk/src/pages/knowledge-base/Article.vue:335
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:266
 msgid "Category created successfully."
-msgstr ""
+msgstr "Kategoriya muvaffaqiyatli yaratildi."
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:337
 msgid "Category deleted successfully."
-msgstr ""
+msgstr "Kategoriya muvaffaqiyatli o'chirildi."
 
 #: desk/src/components/ticket/TicketMergeModal.vue:188
 msgid "Category is required"
-msgstr ""
+msgstr "Kategoriya talab qilinadi"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:374
 msgid "Category merged successfully."
-msgstr ""
+msgstr "Kategoriya muvaffaqiyatli birlashtirildi."
 
 #: helpdesk/api/knowledge_base.py:78
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.py:65
 msgid "Category must have atleast one article"
-msgstr "श्रेणी में कम से कम एक लेख होना चाहिए"
+msgstr "Kategoriyada kamida bitta maqola bo'lishi kerak"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:305
 msgid "Category updated successfully."
-msgstr ""
+msgstr "Kategoriya muvaffaqiyatli yangilandi."
 
 #: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
-msgstr ""
+msgstr "Cc"
 
 #: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
-msgstr ""
+msgstr "Nusxa ko'chirish:"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:40
 msgid "Change"
-msgstr "परिवर्तन"
+msgstr "O'zgarish"
 
 #: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
-msgstr ""
+msgstr "Parolni o'zgartirish"
 
 #: desk/src/components/Settings/Profile/Profile.vue:198
 msgid "Change Photo"
-msgstr ""
+msgstr "Suratni o'zgartirish"
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:9
 msgid "Change language of the application."
-msgstr ""
+msgstr "Ilova tilini o'zgartiring."
 
 #: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
 msgid "Change operator ({0})"
-msgstr ""
+msgstr "Operatorni o'zgartirish ({0})"
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
 msgid "Change priority"
-msgstr ""
+msgstr "Ustuvorlikni o'zgartirish"
 
 #: desk/src/components/modals/ShortcutsModal.vue:91
 msgid "Change status"
-msgstr ""
+msgstr "Holatni o'zgartirish"
 
 #: desk/src/components/modals/ShortcutsModal.vue:89
 msgid "Change team"
-msgstr "परिवर्तन टीम"
+msgstr "Jamoani o'zgartirish"
 
 #: desk/src/components/modals/ShortcutsModal.vue:87
 msgid "Change ticket type"
-msgstr ""
+msgstr "Chipta turini o'zgartirish"
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:25
 msgid "Change timezone of the application."
-msgstr ""
+msgstr "Ilovaning vaqt mintaqasini o'zgartiring."
 
 #: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
-msgstr ""
+msgstr "Xavfsizlik uchun hisobingiz parolini o'zgartiring."
 
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Channels"
-msgstr "चैनल"
+msgstr "Kanallar"
 
 #: desk/src/components/Settings/FieldDependency/FieldDependencyFieldsSelection.vue:18
 msgid "Child field"
-msgstr "बाल क्षेत्र"
+msgstr "Bolalar maydoni"
 
 #: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
-msgstr ""
+msgstr "Maydon tanlang"
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:135
 msgid "Choose how long this SLA policy will be active."
-msgstr ""
+msgstr "Ushbu SLA siyosati qancha vaqt davomida faol bo'lishini tanlang."
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:22
 msgid "Choose how tickets are distributed among selected assignees."
-msgstr ""
+msgstr "Tanlangan topshiriq beruvchilar o'rtasida chiptalar qanday taqsimlanishini tanlang."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:280
 msgid "Choose the days of the week when this rule should be active."
-msgstr ""
+msgstr "Ushbu qoida faol bo'lishi kerak bo'lgan hafta kunlarini tanlang."
 
 #: desk/src/components/Settings/Holiday/HolidayView.vue:66
 msgid "Choose the duration of this holiday list."
-msgstr ""
+msgstr "Ushbu ta'til ro'yxatining davomiyligini tanlang."
 
 #: desk/src/components/Settings/EmailAdd.vue:5
 msgid "Choose the email service provider you want to configure."
-msgstr ""
+msgstr "Sozlamoqchi bo'lgan elektron pochta xizmati provayderini tanlang."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:127
 msgid "Choose which tickets are affected by this assignment rule."
-msgstr ""
+msgstr "Ushbu topshiriq qoidasi qaysi chiptalarga ta'sir qilishini tanlang."
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:69
 msgid "Choose which tickets are affected by this policy."
-msgstr ""
+msgstr "Ushbu siyosat qaysi chiptalarga ta'sir qilishini tanlang."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:204
 msgid "Choose which tickets are affected by this un-assignment rule."
-msgstr ""
+msgstr "Ushbu topshiriqni bekor qilish qoidasi qaysi chiptalarga ta'sir qilishini tanlang."
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:69
 msgid "Choose who can view and use this response."
-msgstr ""
+msgstr "Bu javobni kim ko'rishi va undan foydalanishi mumkinligini tanlang."
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:78
 msgid "Choose who receives the tickets."
-msgstr ""
+msgstr "Chiptalarni kim olishini tanlang."
 
 #: desk/src/components/view-controls/SortBy.vue:160
 msgid "Clear Sort"
-msgstr "क्रम साफ़ करें"
+msgstr "Saralashni tozalash"
 
 #. Label of the clear_table (Button) field in DocType 'HD Service Holiday List'
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Clear Table"
-msgstr ""
+msgstr "Toza stol"
 
 #: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
-msgstr ""
+msgstr "Hammasini tozalash"
 
 #: desk/src/components/view-controls/filter/FilterTrigger.vue:17
 msgid "Clear all Filter"
-msgstr ""
+msgstr "Barcha filtrlarni tozalash"
 
 #: desk/src/pages/SearchAgent.vue:86
 msgid "Clear all filters"
-msgstr ""
+msgstr "Barcha filtrlarni tozalash"
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
-msgstr ""
+msgstr "\"Bayramlarga qo'shish\" tugmasini bosing. Bu bayramlar jadvalini tanlangan haftalik dam olish kuniga to'g'ri keladigan barcha sanalar bilan to'ldiradi. Barcha haftalik bayramlaringiz uchun sanalarni to'ldirish jarayonini takrorlang."
 
 #: desk/src/components/EmailMultiSelect.vue:11
 msgid "Click to copy"
@@ -1220,24 +1222,24 @@ msgstr ""
 #: desk/src/pages/ticket/MobileTicketAgent.vue:159
 #: desk/src/pages/ticket/TicketCustomer.vue:14
 msgid "Close"
-msgstr "बंद करना"
+msgstr "Yopish"
 
 #: desk/src/pages/ticket/TicketCustomer.vue:313
 msgid "Close Ticket"
-msgstr "टिकट बंद करें"
+msgstr "Chiptani yopish"
 
 #. Option in a Select field in the tickets Web Form
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
 msgid "Closed"
-msgstr "बंद किया हुआ"
+msgstr "Yopiq"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
-msgstr ""
+msgstr "Yopiq yoki reytinglangan chiptalarni agent bo'lmaganlar yangilay olmaydi"
 
 #: desk/src/components/layouts/Sidebar.vue:143
 msgid "Collapse"
-msgstr "गिर जाना"
+msgstr "Yig'ish"
 
 #. Label of the color (Select) field in DocType 'HD Agent Status'
 #. Label of the color (Color) field in DocType 'HD Service Holiday List'
@@ -1246,103 +1248,103 @@ msgstr "गिर जाना"
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Color"
-msgstr "रंग"
+msgstr "Rang"
 
 #. Label of the columns (Code) field in DocType 'HD View'
 #: desk/src/components/view-controls/ColumnSettings.vue:4
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Columns"
-msgstr "कॉलम"
+msgstr "Ustunlar"
 
 #: desk/src/components/Settings/InviteAgents.vue:15
 msgid "Comma separated emails to invite."
-msgstr ""
+msgstr "Taklifnoma yuborish uchun vergul bilan ajratilgan elektron pochta xabarlari."
 
 #: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
-msgstr ""
+msgstr "Vergul bilan ajratilgan qiymatlar"
 
 #. Label of the reference_comment (Link) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "Comment"
-msgstr "टिप्पणी"
+msgstr "Izoh"
 
 #: desk/src/components/CommentBox.vue:318
 msgid "Comment cannot be empty."
-msgstr ""
+msgstr "Izoh bo'sh bo'lishi mumkin emas."
 
 #: desk/src/components/CommentBox.vue:308
 msgid "Comment deleted successfully."
-msgstr ""
+msgstr "Izoh muvaffaqiyatli o'chirildi."
 
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.py:67
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.py:112
 msgid "Comment not found"
-msgstr "टिप्पणी नहीं मिली"
+msgstr "Izoh topilmadi"
 
 #: desk/src/components/CommentBox.vue:334
 msgid "Comment updated successfully."
-msgstr ""
+msgstr "Izoh muvaffaqiyatli yangilandi."
 
 #. Label of the commented_by (Link) field in DocType 'HD Ticket Comment'
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 msgid "Commented By"
-msgstr "द्वारा टिप्पणी की गई"
+msgstr "Fikr qoldirgan"
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
 #: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
-msgstr "टिप्पणियाँ"
+msgstr "Izohlar"
 
 #: desk/src/components/modals/ShortcutsModal.vue:97
 msgid "Communication"
-msgstr "संचार"
+msgstr "Aloqa"
 
 #: desk/src/components/ticket/TicketSplitModal.vue:76
 msgid "Communication ID is required"
-msgstr ""
+msgstr "Aloqa identifikatori talab qilinadi"
 
 #. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Company"
-msgstr "कंपनी"
+msgstr "Kompaniya"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
-msgstr ""
+msgstr "Tugallandi"
 
 #. Label of the condition (Code) field in DocType 'HD Service Level Agreement'
 #. Label of the condition_json (Code) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Condition"
-msgstr "स्थिति"
+msgstr "Ahvoli"
 
 #: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
-msgstr ""
+msgstr "Sozlash"
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:3
 msgid "Configure your Exotel settings for Helpdesk."
-msgstr ""
+msgstr "Exotel sozlamalarini Yordam xizmati uchun sozlang."
 
 #: desk/src/components/Settings/Telephony/Telephony.vue:100
 msgid "Configure your Exotel telephony integration settings here"
-msgstr ""
+msgstr "Exotel telefoniya integratsiyasi sozlamalarini bu yerda sozlang"
 
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:3
 msgid "Configure your Twilio settings for Helpdesk."
-msgstr ""
+msgstr "Yordam xizmati uchun Twilio sozlamalaringizni sozlang."
 
 #: desk/src/components/Settings/Telephony/Telephony.vue:76
 msgid "Configure your Twilio telephony integration settings here"
-msgstr ""
+msgstr "Twilio telefoniya integratsiyasi sozlamalarini bu yerda sozlang"
 
 #: desk/src/components/Settings/Telephony/Telephony.vue:2
 msgid "Configure your telephony settings."
-msgstr ""
+msgstr "Telefon sozlamalarini sozlang."
 
 #: desk/src/components/customer/ContactCard.vue:233
 #: desk/src/components/customer/ContactCard.vue:271
@@ -1355,23 +1357,23 @@ msgstr ""
 #: desk/src/pages/ticket/Tickets.vue:428 desk/src/pages/ticket/Tickets.vue:550
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.js:27
 msgid "Confirm"
-msgstr "पुष्टि करना"
+msgstr "Tasdiqlash"
 
 #: desk/src/components/ListViewBuilder.vue:698
 msgid "Confirm Changes"
-msgstr "परिवर्तनों की पुष्टि करें"
+msgstr "O'zgarishlarni tasdiqlash"
 
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:19
 msgid "Confirm Password"
-msgstr ""
+msgstr "Parolni tasdiqlang"
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:393
 msgid "Confirm overwrite"
-msgstr ""
+msgstr "Qayta yozishni tasdiqlang"
 
 #: desk/src/components/layouts/Sidebar.vue:439
 msgid "Connect your support email"
-msgstr ""
+msgstr "Qo'llab-quvvatlash elektron pochtangizni ulang"
 
 #. Label of the contact (Link) field in DocType 'HD Ticket'
 #: desk/src/components/contact/EditContactDialog.vue:26
@@ -1384,12 +1386,12 @@ msgstr ""
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:43
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.py:72
 msgid "Contact"
-msgstr "संपर्क"
+msgstr "Aloqa"
 
 #. Label of the contact_html (HTML) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contact HTML"
-msgstr ""
+msgstr "HTML bilan bog'lanish"
 
 #: desk/src/components/customer/ContactCard.vue:313
 msgid "Contact removed successfully"
@@ -1397,7 +1399,7 @@ msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
-msgstr ""
+msgstr "Kontakt muvaffaqiyatli yangilandi."
 
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
 msgid "Contact {0} has no email address"
@@ -1410,7 +1412,7 @@ msgstr ""
 #: desk/src/pages/customer/Customer.vue:151
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
-msgstr "संपर्क"
+msgstr "Kontaktlar"
 
 #: desk/src/components/customer/InviteContactDialog.vue:168
 msgid "Contacts added successfully"
@@ -1422,28 +1424,28 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 msgid "Content"
-msgstr "सामग्री"
+msgstr "Tarkib"
 
 #. Label of the content_type (Data) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Content Type"
-msgstr "सामग्री प्रकार"
+msgstr "Kontent turi"
 
 #: desk/src/components/modals/ShortcutsModal.vue:93
 msgid "Copy ticket URL"
-msgstr ""
+msgstr "Chipta URL manzilini nusxalash"
 
 #: desk/src/components/modals/ShortcutsModal.vue:92
 msgid "Copy ticket id"
-msgstr ""
+msgstr "Chipta identifikatorini nusxalash"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
-msgstr ""
+msgstr "Quyidagi sababga ko'ra elektron pochta xabarini yuborib bo'lmadi: {0}"
 
 #: helpdesk/patches/set_hd_ticket_naming_series.py:37
 msgid "Could not find the `name` column in tabHD Ticket"
-msgstr ""
+msgstr "TabHD chiptasida `nom` ustunini topib bo'lmadi"
 
 #: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
 msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
@@ -1451,17 +1453,17 @@ msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
-msgstr ""
+msgstr "Quyidagi sababga ko'ra tasdiqlovchi elektron pochta xabarini yuborib bo'lmadi: {0}"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:169
 msgid "Could not send feedback email,due to: {0}"
-msgstr ""
+msgstr "Fikr-mulohaza elektron pochtasini yuborib bo'lmadi, sababi: {0}"
 
 #. Label of the country (Link) field in DocType 'HD Customer'
 #: desk/src/components/customer/NewCustomerDialog.vue:36
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Country"
-msgstr "देश"
+msgstr "Mamlakat"
 
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
@@ -1474,12 +1476,12 @@ msgstr "देश"
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
-msgstr ""
+msgstr "Yaratish"
 
 #: desk/src/components/layouts/Sidebar.vue:537
 #: desk/src/components/layouts/Sidebar.vue:543
 msgid "Create & invite a contact"
-msgstr ""
+msgstr "Kontakt yarating va taklif qiling"
 
 #: desk/src/components/contact/NewContactDialog.vue:5
 msgid "Create Contact"
@@ -1487,49 +1489,49 @@ msgstr ""
 
 #: desk/src/components/customer/NewCustomerDialog.vue:4
 msgid "Create Customer"
-msgstr ""
+msgstr "Mijoz yarating"
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
 msgid "Create View"
-msgstr ""
+msgstr "Ko'rinish yaratish"
 
 #: desk/src/components/layouts/Sidebar.vue:472
 msgid "Create a ticket"
-msgstr ""
+msgstr "Chipta yarating"
 
 #: desk/src/components/layouts/Sidebar.vue:520
 msgid "Create an article"
-msgstr ""
+msgstr "Maqola yarating"
 
 #: desk/src/components/Settings/Teams/TeamsList.vue:5
 msgid "Create and manage teams and assign agents to specific teams."
-msgstr ""
+msgstr "Jamoalarni yarating va boshqaring hamda ma'lum jamoalarga agentlarni tayinlang."
 
 #: desk/src/components/Settings/FieldDependency/FieldDependencyList.vue:13
 msgid "Create field dependencies to dynamically update options based on user selections. Learn more about field dependencies"
-msgstr ""
+msgstr "Foydalanuvchi tanlovlari asosida parametrlarni dinamik ravishda yangilash uchun maydon bog'liqliklarini yarating. Maydon bog'liqliklari haqida ko'proq bilib oling"
 
 #: desk/src/components/Settings/Sla/SlaHolidays.vue:57
 msgid "Create new business holiday"
-msgstr ""
+msgstr "Yangi biznes bayramini yarating"
 
 #: desk/src/components/Settings/FieldDependency/FieldDependencyList.vue:69
 msgid "Created by"
-msgstr "के द्वारा बनाई गई"
+msgstr "Yaratgan"
 
 #: desk/src/components/layouts/Sidebar.vue:583
 msgid "Creating a ticket"
-msgstr ""
+msgstr "Chipta yaratish"
 
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
-msgstr ""
+msgstr "Maxsus harakatlar"
 
 #. Label of the outside_working_hours_message (Small Text) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Custom Outside Working Hours Message"
-msgstr ""
+msgstr "Maxsus ish vaqtidan tashqari xabar"
 
 #: desk/src/pages/dashboard/Dashboard.vue:509
 #: desk/src/pages/dashboard/Dashboard.vue:515
@@ -1538,11 +1540,11 @@ msgstr ""
 #: desk/src/pages/home/components/RecentFeedback.vue:376
 #: desk/src/pages/home/components/RecentFeedback.vue:402
 msgid "Custom Range"
-msgstr ""
+msgstr "Maxsus diapazon"
 
 #: desk/src/components/layouts/Sidebar.vue:629
 msgid "Custom Views"
-msgstr ""
+msgstr "Maxsus ko'rinishlar"
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
 #: desk/src/components/contact/EditContactDialog.vue:122
@@ -1554,7 +1556,7 @@ msgstr ""
 #: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
-msgstr "ग्राहक"
+msgstr "Mijoz"
 
 #: desk/src/components/customer/ContactCard.vue:177
 #: desk/src/components/customer/InviteContactDialog.vue:130
@@ -1564,17 +1566,17 @@ msgstr ""
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Customer Name"
-msgstr "ग्राहक का नाम"
+msgstr "Mijoz nomi"
 
 #: desk/src/components/layouts/Sidebar.vue:603
 msgid "Customer Portal"
-msgstr ""
+msgstr "Mijozlar portali"
 
 #. Label of the customer_type (Select) field in DocType 'HD Customer'
 #: desk/src/components/customer/NewCustomerDialog.vue:31
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Customer Type"
-msgstr "ग्राहक प्रकार"
+msgstr "Mijoz turi"
 
 #: desk/src/components/customer/NewCustomerDialog.vue:142
 msgid "Customer created"
@@ -1586,7 +1588,7 @@ msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
-msgstr "ग्राहक पोर्टल"
+msgstr "Mijozlar portali"
 
 #: desk/src/components/customer/EditCustomerDialog.vue:136
 #: desk/src/components/customer/EditCustomerDialog.vue:150
@@ -1596,30 +1598,30 @@ msgstr ""
 #: desk/src/pages/customer/Customer.vue:198
 #: desk/src/pages/customer/Customers.vue:6
 msgid "Customers"
-msgstr "ग्राहकों"
+msgstr "Mijozlar"
 
 #: desk/src/components/layouts/Sidebar.vue:595
 msgid "Customers & Contacts"
-msgstr ""
+msgstr "Mijozlar va kontaktlar"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:82
 msgid "Customers are in sync"
-msgstr ""
+msgstr "Mijozlar sinxronlashmoqda"
 
 #: desk/src/components/layouts/Sidebar.vue:624
 msgid "Customizations"
-msgstr ""
+msgstr "Moslashtirishlar"
 
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:5
 msgid "Customize your email notification preferences to stay informed about important updates and activities."
-msgstr ""
+msgstr "Muhim yangilanishlar va tadbirlar haqida xabardor bo'lib turish uchun elektron pochta xabarnomalari sozlamalarini sozlang."
 
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Cyan"
-msgstr ""
+msgstr "Moviy rang"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
@@ -1627,33 +1629,33 @@ msgstr ""
 #: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
-msgstr ""
+msgstr "Xavfli"
 
 #: desk/src/pages/dashboard/Dashboard.vue:567
 msgid "Dashboard"
-msgstr ""
+msgstr "Boshqaruv paneli"
 
 #: desk/src/pages/home/Home.vue:264 desk/src/pages/home/Home.vue:286
 msgid "Dashboard saved"
-msgstr ""
+msgstr "Boshqaruv paneli saqlandi"
 
 #. Label of the holiday_date (Date) field in DocType 'HD Holiday'
 #: helpdesk/helpdesk/doctype/hd_holiday/hd_holiday.json
 #: helpdesk/helpdesk/report/support_hour_distribution/support_hour_distribution.py:77
 msgid "Date"
-msgstr "तारीख"
+msgstr "Sana"
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:29
 msgid "Day count for auto closing tickets cannot be negative or zero"
-msgstr ""
+msgstr "Avtomatik yopilish chiptalari uchun kunlar soni manfiy yoki nolga teng bo'lmasligi kerak"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:38
 msgid "Days"
-msgstr "दिन"
+msgstr "Kunlar"
 
 #: desk/src/components/Settings/EmailAccountCard.vue:53
 msgid "Default Inbox"
-msgstr ""
+msgstr "Standart pochta qutisi"
 
 #. Label of the default_priority (Link) field in DocType 'HD Service Level
 #. Agreement'
@@ -1662,68 +1664,68 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 msgid "Default Priority"
-msgstr ""
+msgstr "Standart ustuvorlik"
 
 #. Label of the default_sla (Check) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Default SLA"
-msgstr ""
+msgstr "Standart SLA"
 
 #: desk/src/components/Settings/EmailAccountCard.vue:56
 msgid "Default Sending"
-msgstr ""
+msgstr "Standart yuborish"
 
 #: desk/src/components/Settings/EmailAccountCard.vue:50
 msgid "Default Sending and Inbox"
-msgstr ""
+msgstr "Standart yuborish va kirish qutisi"
 
 #. Label of the default_ticket_status (Link) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Default Ticket Status"
-msgstr ""
+msgstr "Standart chipta holati"
 
 #: desk/src/pages/ticket/Tickets.vue:354 desk/src/pages/ticket/Tickets.vue:447
 msgid "Default Views"
-msgstr ""
+msgstr "Standart ko'rinishlar"
 
 #: desk/src/components/ticket-agent/TicketHeader.vue:264
 #: desk/src/components/ticket-agent/TicketHeader.vue:275
 msgid "Default actions"
-msgstr ""
+msgstr "Standart harakatlar"
 
 #: desk/src/components/Settings/Telephony/Telephony.vue:45
 msgid "Default calling medium for logged in user"
-msgstr ""
+msgstr "Tizimga kirgan foydalanuvchi uchun standart qo'ng'iroq vositasi"
 
 #: desk/src/components/Settings/Telephony/Telephony.vue:42
 msgid "Default medium"
-msgstr ""
+msgstr "Standart vosita"
 
 #. Label of the default_priority (Link) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Default priority"
-msgstr ""
+msgstr "Standart ustuvorlik"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.py:63
 msgid "Default template can not be deleted"
-msgstr ""
+msgstr "Standart shablonni o'chirib bo'lmaydi"
 
 #. Label of the default_ticket_status (Link) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Default ticket status"
-msgstr ""
+msgstr "Standart chipta holati"
 
 #. Label of the default_ticket_type (Link) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/TicketSettings.vue:129
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Default ticket type"
-msgstr ""
+msgstr "Standart chipta turi"
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:9
 msgid "Define who receives the tickets and how they’re distributed among agents."
-msgstr ""
+msgstr "Chiptalarni kim olishini va ular agentlar o'rtasida qanday taqsimlanishini aniqlang."
 
 #: desk/src/components/DeleteWithTicketsDialog.vue:20
 #: desk/src/components/DeleteWithTicketsDialog.vue:63
@@ -1740,27 +1742,27 @@ msgstr ""
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
-msgstr ""
+msgstr "O'chirish"
 
 #: desk/src/pages/customer/Customer.vue:92
 msgid "Delete Contact"
-msgstr ""
+msgstr "Kontaktni o'chirish"
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
-msgstr ""
+msgstr "Ko'rinishni o'chirish"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:204
 msgid "Delete articles"
-msgstr ""
+msgstr "Maqolalarni o'chirish"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:321
 msgid "Delete category?"
-msgstr ""
+msgstr "Kategoriya oʻchirilsinmi?"
 
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
-msgstr "{0} को हटाएँ"
+msgstr "{0} ni o'chirish"
 
 #: desk/src/components/DeleteWithTicketsDialog.vue:10
 msgid "Delete {0} ticket(s)"
@@ -1790,23 +1792,23 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
 msgid "Description"
-msgstr "विवरण"
+msgstr "Tavsif"
 
 #. Label of the description_template (Text Editor) field in DocType 'HD Ticket
 #. Template'
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Description Template"
-msgstr ""
+msgstr "Tavsif shabloni"
 
 #. Label of the description_weight (Int) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Description Weight"
-msgstr "विवरण वजन"
+msgstr "Tavsif Og'irligi"
 
 #: desk/src/pages/ticket/TicketNew.vue:90
 #: desk/src/pages/ticket/TicketNew.vue:115
 msgid "Detailed explanation"
-msgstr "विस्तृत व्याख्या"
+msgstr "Batafsil tushuntirish"
 
 #. Label of the details_section (Section Break) field in DocType 'HD
 #. Notification'
@@ -1817,21 +1819,21 @@ msgstr "विस्तृत व्याख्या"
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Details"
-msgstr "विवरण"
+msgstr "Tafsilotlar"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:67
 msgid "Disable global saved replies"
-msgstr ""
+msgstr "Global saqlangan javoblarni o'chirib qo'yish"
 
 #. Label of the disable_saved_replies_global_scope (Check) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Disable saved replies with scope 'Global'"
-msgstr ""
+msgstr "\"Global\" doirasi bilan saqlangan javoblarni o'chirib qo'yish"
 
 #: desk/src/components/Settings/General/General.vue:47
 msgid "Disable signup"
-msgstr "साइन अप अक्षम करें"
+msgstr "Ro'yxatdan o'tishni o'chirib qo'yish"
 
 #. Label of the disabled (Check) field in DocType 'HD Team'
 #. Label of the disabled (Check) field in DocType 'HD Ticket Feedback Option'
@@ -1843,60 +1845,60 @@ msgstr "साइन अप अक्षम करें"
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "Disabled"
-msgstr "अक्षम"
+msgstr "Nogiron"
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:29
 msgid "Disables all email notifications for the ticket - including creation, updates, and alerts."
-msgstr ""
+msgstr "Chipta uchun barcha elektron pochta xabarnomalarini, jumladan, yaratish, yangilash va ogohlantirishlarni o'chirib qo'yadi."
 
 #: desk/src/components/TextEditor.vue:41
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:24
 #: desk/src/pages/knowledge-base/NewArticle.vue:27
 msgid "Discard"
-msgstr "खारिज करना"
+msgstr "Tashlab ketish"
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:143
 msgid "Discard Article"
-msgstr "लेख को त्याग दें"
+msgstr "Maqolani bekor qilish"
 
 #: desk/src/pages/knowledge-base/Article.vue:146
 msgid "Discard changes?"
-msgstr "परिवर्तनों को निरस्त करें?"
+msgstr "O'zgarishlar bekor qilinsinmi?"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:203
 msgid "Display a customizable banner message when customers raise tickets outside your working hours."
-msgstr ""
+msgstr "Mijozlar ish vaqtingizdan tashqarida chiptalarni ko'targanda, moslashtiriladigan banner xabarini ko'rsating."
 
 #. Description of the 'Ignore Restrictions' (Check) field in DocType 'HD Team'
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Do not apply filters and restrictions to agents of this team"
-msgstr ""
+msgstr "Ushbu jamoa agentlariga filtrlar va cheklovlarni qo'llamang"
 
 #. Label of the do_not_restrict_tickets_without_an_agent_group (Check) field in
 #. DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Do not restrict tickets without a Team"
-msgstr ""
+msgstr "Jamoasiz chiptalarni cheklamang"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:52
 msgid "Do not restrict tickets without a team"
-msgstr ""
+msgstr "Jamoasiz chiptalarni cheklamang"
 
 #. Label of the dt (Link) field in DocType 'HD Form Script'
 #. Label of the dt (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "DocType"
-msgstr "दस्तावेज़ प्रकार"
+msgstr "DocType"
 
 #: desk/src/components/layouts/Sidebar.vue:371
 msgid "Docs"
-msgstr ""
+msgstr "Hujjatlar"
 
 #. Label of the document_type (Link) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 msgid "Document Type"
-msgstr "दस्तावेज़ प्रकार"
+msgstr "Hujjat turi"
 
 #: desk/src/components/contact/EditContactDialog.vue:45
 msgid "Doe"
@@ -1906,17 +1908,17 @@ msgstr ""
 #: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
-msgstr ""
+msgstr "Domen"
 
 #: desk/src/components/ticket/ExportModal.vue:32
 msgid "Download"
-msgstr "डाउनलोड करना"
+msgstr "Yuklab olish"
 
 #. Option for the 'Status' (Select) field in DocType 'HD Article'
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:447
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 msgid "Draft"
-msgstr "मसौदा"
+msgstr "Qoralama"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:72
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:138
@@ -1928,23 +1930,23 @@ msgstr "मसौदा"
 #: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:102
 #: desk/src/pages/ticket/Tickets.vue:451
 msgid "Duplicate"
-msgstr ""
+msgstr "Dublikat"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:53
 msgid "Duplicate Assignment Rule"
-msgstr ""
+msgstr "Takroriy topshiriq qoidasi"
 
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:30
 msgid "Duplicate Holiday List"
-msgstr ""
+msgstr "Takroriy bayramlar ro'yxati"
 
 #: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:42
 msgid "Duplicate SLA Policy"
-msgstr ""
+msgstr "Takroriy SLA siyosati"
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
-msgstr ""
+msgstr "Saqlangan javobning nusxasi"
 
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
 msgid "Duplicate contacts are not allowed"
@@ -1953,61 +1955,61 @@ msgstr ""
 #: desk/src/pages/call-logs/CallLogModal.vue:64
 #: desk/src/pages/call-logs/CallLogModal.vue:68
 msgid "Duration"
-msgstr "अवधि"
+msgstr "Davomiyligi"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:388
 msgid "Duration is required"
-msgstr "अवधि आवश्यक है"
+msgstr "Davomiylikni ko'rsatish shart"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:8
 msgid "ERPNext"
-msgstr ""
+msgstr "ERPNext"
 
 #. Label of the erpnext_customer (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "ERPNext Customer"
-msgstr ""
+msgstr "ERPNext mijozi"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 msgid "ERPNext HD Settings"
-msgstr ""
+msgstr "ERPNext HD sozlamalari"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:182
 msgid "ERPNext Integration is disabled"
-msgstr ""
+msgstr "ERPNext integratsiyasi o'chirilgan"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:181
 msgid "ERPNext Integration is enabled"
-msgstr ""
+msgstr "ERPNext integratsiyasi yoqilgan"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:66
 msgid "ERPNext app"
-msgstr ""
+msgstr "ERPNext ilovasi"
 
 #: helpdesk/integrations/erpnext/api.py:47
 msgid "ERPNext integration is not enabled"
-msgstr ""
+msgstr "ERPNext integratsiyasi yoqilmagan"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:203
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.py:19
 msgid "ERPNext is not installed on your site. Please install ERPNext to enable this setting"
-msgstr ""
+msgstr "ERPNext saytingizda o'rnatilmagan. Ushbu sozlamani yoqish uchun ERPNext ni o'rnating"
 
 #: desk/src/components/Settings/InviteAgents.vue:4
 msgid "Easily invite new agents, managers, or admins."
-msgstr ""
+msgstr "Yangi agentlar, menejerlar yoki administratorlarni osongina taklif qiling."
 
 #: desk/src/pages/contact/Contact.vue:31
 #: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
-msgstr "संपादन करना"
+msgstr "Tahrirlash"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
-msgstr ""
+msgstr "Qo'ng'iroqlar jurnalini tahrirlash"
 
 #: desk/src/components/contact/EditContactDialog.vue:8
 msgid "Edit Contact"
@@ -2020,26 +2022,26 @@ msgstr ""
 #: desk/src/components/Settings/EmailAdd.vue:70
 #: desk/src/components/Settings/EmailEdit.vue:63
 msgid "Edit Domain"
-msgstr ""
+msgstr "Domenni tahrirlash"
 
 #: desk/src/components/Settings/EmailEdit.vue:3
 msgid "Edit Email"
-msgstr ""
+msgstr "Elektron pochtani tahrirlash"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:147
 msgid "Edit Title"
-msgstr ""
+msgstr "Sarlavhani tahrirlash"
 
 #: desk/src/components/Settings/EmailEdit.vue:4
 msgid "Edit your email account"
-msgstr ""
+msgstr "Elektron pochta hisobingizni tahrirlang"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
 #: desk/src/components/contact/EditContactDialog.vue:52
 #: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
 msgid "Email"
-msgstr "ईमेल"
+msgstr "Elektron pochta"
 
 #. Label of the email_account (Link) field in DocType 'HD Ticket'
 #. Label of a Link in the Helpdesk Workspace
@@ -2047,11 +2049,11 @@ msgstr "ईमेल"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Email Account"
-msgstr "ईमेल खाता"
+msgstr "Elektron pochta hisobi"
 
 #: desk/src/components/Settings/EmailAccountList.vue:3
 msgid "Email Accounts"
-msgstr ""
+msgstr "Elektron pochta hisoblari"
 
 #. Label of the feedback_email_content (Text) field in DocType 'HD Settings'
 #. Label of the acknowledgement_email_content (Text) field in DocType 'HD
@@ -2063,35 +2065,35 @@ msgstr ""
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:61
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Email Content"
-msgstr "ईमेल सामग्री"
+msgstr "Elektron pochta kontenti"
 
 #. Label of the email_id (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Email ID"
-msgstr ""
+msgstr "Elektron pochta identifikatori"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
 #. Settings'
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:3
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Email Notifications"
-msgstr "ईमेल सूचनाएं"
+msgstr "Elektron pochta bildirishnomalari"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:3
 msgid "Email Settings"
-msgstr ""
+msgstr "Elektron pochta sozlamalari"
 
 #: desk/src/components/Settings/EmailAdd.vue:309
 msgid "Email account created"
-msgstr "ईमेल खाता बनाया गया"
+msgstr "Elektron pochta hisobi yaratildi"
 
 #: desk/src/components/Settings/EmailAccountList.vue:27
 msgid "Email account name"
-msgstr "ईमेल खाते का नाम"
+msgstr "Elektron pochta hisobi nomi"
 
 #: desk/src/components/Settings/EmailEdit.vue:471
 msgid "Email account updated successfully"
-msgstr "ईमेल खाता सफलतापूर्वक अपडेट हो गया"
+msgstr "Elektron pochta hisobi muvaffaqiyatli yangilandi"
 
 #. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -2100,50 +2102,50 @@ msgstr ""
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
-msgstr ""
+msgstr "Elektron pochta sozlamalari muvaffaqiyatli yangilandi."
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
 #: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
-msgstr "ईमेल"
+msgstr "Elektron pochta xabarlari"
 
 #: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
-msgstr "ईमेल और हस्ताक्षर"
+msgstr "Elektron pochta xabarlari va imzo"
 
 #: desk/src/components/Settings/EmailEdit.vue:417
 msgid "Emails pulled successfully"
-msgstr ""
+msgstr "Elektron pochta xabarlari muvaffaqiyatli olindi"
 
 #. Label of the emoji (Data) field in DocType 'HD Comment Reaction'
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
 msgid "Emoji"
-msgstr ""
+msgstr "Emoji"
 
 #: desk/src/components/view-controls/SortBy.vue:134
 msgid "Empty - Choose a field to sort by"
-msgstr ""
+msgstr "Bo'sh - Saralash uchun maydonni tanlang"
 
 #. Label of the enable (Check) field in DocType 'HD Agent Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 msgid "Enable"
-msgstr "सक्षम"
+msgstr "Yoqish"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:36
 msgid "Enable ERPNext Integration"
-msgstr ""
+msgstr "ERPNext integratsiyasini yoqish"
 
 #. Label of the enable_comment_reactions (Check) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/TicketSettings.vue:23
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Enable comment reactions"
-msgstr "टिप्पणियों पर प्रतिक्रियाएँ सक्षम करें"
+msgstr "Fikrlarga munosabat bildirishni yoqish"
 
 #. Label of the is_feedback_mandatory (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Enable feedback for Customer Portal"
-msgstr ""
+msgstr "Mijozlar portali uchun fikr-mulohazalarni yoqish"
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
@@ -2176,25 +2178,25 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Enabled"
-msgstr "सक्रिय"
+msgstr "Yoqilgan"
 
 #. Label of the end_date (Date) field in DocType 'HD Service Level Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "End Date"
-msgstr "अंतिम तिथि"
+msgstr "Tugash sanasi"
 
 #. Label of the end_time (Time) field in DocType 'HD Service Day'
 #: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
 msgid "End Time"
-msgstr "अंत समय"
+msgstr "Tugash vaqti"
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:22
 msgid "Enter a name for this HD Service Holiday List."
-msgstr ""
+msgstr "Ushbu HD xizmati bayramlari ro'yxati uchun nom kiriting."
 
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
-msgstr "ब्रांड का नाम दर्ज करें"
+msgstr "Brend nomini kiriting"
 
 #: desk/src/components/customer/InviteContactDialog.vue:12
 msgid "Enter email address"
@@ -2202,7 +2204,7 @@ msgstr ""
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
-msgstr "टीम के लिए नया नाम दर्ज करें"
+msgstr "Jamoa uchun yangi nom kiriting"
 
 #: desk/src/components/customer/NewCustomerDialog.vue:182
 msgid "Enter the primary contact's email"
@@ -2214,20 +2216,20 @@ msgstr ""
 
 #: helpdesk/api/knowledge_base.py:86
 msgid "Error moving article to category"
-msgstr ""
+msgstr "Maqolani kategoriyaga ko'chirishda xatolik yuz berdi"
 
 #: helpdesk/overrides/email_account.py:93
 msgid "Error processing email at index {0}, message: {1}"
-msgstr ""
+msgstr "{0}indeksida elektron pochtani qayta ishlashda xatolik, xabar: {1}"
 
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
-msgstr ""
+msgstr "Elektron pochta hisobiga ulanishda xatolik {0}"
 
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
-msgstr ""
+msgstr "Excel"
 
 #: desk/src/components/customer/InviteContactDialog.vue:24
 msgid "Existing users join instantly. Others get an invite."
@@ -2236,28 +2238,28 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
 #: desk/src/components/Settings/Telephony/Telephony.vue:96
 msgid "Exotel"
-msgstr ""
+msgstr "Exotel"
 
 #: desk/src/components/layouts/Sidebar.vue:143
 msgid "Expand"
-msgstr "बढ़ाना"
+msgstr "Kengaytirish"
 
 #: desk/src/components/layouts/Sidebar.vue:557
 msgid "Explore customer portal"
-msgstr ""
+msgstr "Mijozlar portalini o'rganing"
 
 #: desk/src/components/ticket/ExportModal.vue:2
 #: desk/src/pages/ticket/Tickets.vue:130
 msgid "Export"
-msgstr "निर्यात"
+msgstr "Eksport qilish"
 
 #: desk/src/components/ticket/ExportModal.vue:26
 msgid "Export All {0} Record(s)"
-msgstr ""
+msgstr "Barcha yozuvlarni eksport qilish {0}"
 
 #: desk/src/components/ticket/ExportModal.vue:7
 msgid "Export Type"
-msgstr "निर्यात प्रकार"
+msgstr "Eksport turi"
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
@@ -2265,7 +2267,7 @@ msgstr "निर्यात प्रकार"
 #: desk/src/pages/ticket/Tickets.vue:263 desk/src/pages/ticket/Tickets.vue:271
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
-msgstr "असफल"
+msgstr "Muvaffaqiyatsiz"
 
 #: desk/src/components/customer/TicketStats.vue:39
 msgid "Failed SLAs"
@@ -2273,66 +2275,66 @@ msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
-msgstr "श्रेणी बनाने में विफल"
+msgstr "Kategoriya yaratilmadi"
 
 #: desk/src/components/Settings/EmailAdd.vue:315
 msgid "Failed to create email account, Invalid credentials"
-msgstr ""
+msgstr "Elektron pochta hisobini yaratib bo'lmadi, hisob ma'lumotlari noto'g'ri"
 
 #: desk/src/components/ticket-agent/TicketHeader.vue:222
 msgid "Failed to delete ticket."
-msgstr ""
+msgstr "Chiptani o'chirib bo'lmadi."
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:194
 #: desk/src/components/Settings/Telephony/Telephony.vue:195
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:172
 msgid "Failed to load telephony agent"
-msgstr ""
+msgstr "Telefoniya agentini yuklashda xatolik yuz berdi"
 
 #: desk/src/components/Settings/EmailEdit.vue:422
 msgid "Failed to pull emails"
-msgstr "ईमेल प्राप्त करने में विफल"
+msgstr "Elektron pochta xabarlarini olishda xatolik yuz berdi"
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:259
 #: desk/src/components/Settings/Telephony/Telephony.vue:238
 msgid "Failed to save Exotel settings"
-msgstr ""
+msgstr "Exotel sozlamalarini saqlashda xatolik yuz berdi"
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:251
 #: desk/src/components/Settings/Telephony/Telephony.vue:230
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:215
 msgid "Failed to save Twilio settings"
-msgstr ""
+msgstr "Twilio sozlamalarini saqlashda xatolik yuz berdi"
 
 #: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
-msgstr ""
+msgstr "Topshiruvchini yangilashda xatolik yuz berdi."
 
 #: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
-msgstr ""
+msgstr "Topshiriq beruvchilarni yangilashda xatolik yuz berdi."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:232
 msgid "Failed to update assignment rule {0}."
-msgstr ""
+msgstr "{0} tayinlash qoidasini yangilashda xatolik yuz berdi."
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:312
 msgid "Failed to update category."
-msgstr ""
+msgstr "Kategoriyani yangilashda xatolik yuz berdi."
 
 #: desk/src/components/Settings/EmailEdit.vue:476
 msgid "Failed to update email account, Invalid credentials"
-msgstr ""
+msgstr "Elektron pochta hisobini yangilashda xatolik yuz berdi, hisob ma'lumotlari noto'g'ri"
 
 #: desk/src/components/Settings/FieldDependency/FieldDependencyList.vue:184
 msgid "Failed to update field dependency."
-msgstr ""
+msgstr "Maydonga bog'liqlikni yangilashda xatolik yuz berdi."
 
 #. Label of the favicon (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:27
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Favicon"
-msgstr ""
+msgstr "Favikon"
 
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
@@ -2344,7 +2346,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Feedback"
-msgstr "प्रतिक्रिया"
+msgstr "Fikr-mulohaza"
 
 #. Label of the feedback_extra (Small Text) field in DocType 'HD Email
 #. Feedback'
@@ -2352,36 +2354,36 @@ msgstr "प्रतिक्रिया"
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
 msgid "Feedback "
-msgstr "प्रतिक्रिया "
+msgstr "Fikr-mulohaza "
 
 #. Label of the feedback_extra (Long Text) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Feedback (Extra)"
-msgstr "प्रतिक्रिया (अतिरिक्त)"
+msgstr "Fikr-mulohaza (Qo'shimcha)"
 
 #. Label of the feedback (Link) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Feedback (Option)"
-msgstr "प्रतिक्रिया (विकल्प)"
+msgstr "Fikr-mulohaza (ixtiyoriy)"
 
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:30
 msgid "Feedback Already Exists"
-msgstr "प्रतिक्रिया पहले से मौजूद है"
+msgstr "Fikr-mulohaza allaqachon mavjud"
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Email Feedback'
 #. Label of a field in the email-feedback Web Form
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
 msgid "Feedback Rating"
-msgstr "प्रतिक्रिया रेटिंग"
+msgstr "Fikr-mulohaza reytingi"
 
 #: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
-msgstr "प्रतिक्रिया प्रवृत्ति"
+msgstr "Fikr-mulohaza trendi"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
-msgstr ""
+msgstr "Mijozga fikr-mulohaza elektron pochtasi yuborildi"
 
 #: desk/src/components/contact/ContactFeedback.vue:20
 msgid "Feedback from this contact will appear here once available."
@@ -2389,72 +2391,72 @@ msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
 msgid "Feedback submitted successfully."
-msgstr ""
+msgstr "Fikr-mulohaza muvaffaqiyatli yuborildi."
 
 #. Label of the fieldname (Data) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Field (fieldname)"
-msgstr ""
+msgstr "Maydon (maydon nomi)"
 
 #: desk/src/components/Settings/FieldDependency/FieldDependencyList.vue:6
 msgid "Field Dependencies"
-msgstr ""
+msgstr "Maydonga bog'liqliklar"
 
 #: desk/src/components/layouts/Sidebar.vue:628
 msgid "Field Dependency"
-msgstr ""
+msgstr "Maydonga bog'liqlik"
 
 #: desk/src/components/Settings/FieldDependency/FieldDependency.vue:303
 msgid "Field Dependency created successfully"
-msgstr ""
+msgstr "Maydonga bog'liqlik muvaffaqiyatli yaratildi"
 
 #: desk/src/components/Settings/FieldDependency/FieldDependency.vue:304
 msgid "Field Dependency updated successfully"
-msgstr ""
+msgstr "Maydonga bog'liqlik muvaffaqiyatli yangilandi"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.py:25
 msgid "Field `{0}` does not exist in Ticket"
-msgstr "टिकट में फ़ील्ड `{0}` मौजूद नहीं है"
+msgstr "Chiptada `{0}` maydoni mavjud emas"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.py:41
 msgid "Field `{0}` is not allowed in Ticket Template"
-msgstr ""
+msgstr "Chipta shablonida \"{0}\" maydoniga ruxsat berilmaydi"
 
 #: desk/src/components/Settings/FieldDependency/FieldDependencyList.vue:160
 msgid "Field dependency deleted successfully."
-msgstr ""
+msgstr "Maydonga bog'liqlik muvaffaqiyatli o'chirildi."
 
 #: desk/src/components/Settings/FieldDependency/FieldDependencyList.vue:180
 msgid "Field dependency updated successfully."
-msgstr ""
+msgstr "Maydonga bog'liqlik muvaffaqiyatli yangilandi."
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
 #: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
-msgstr "क्षेत्र"
+msgstr "Maydonlar"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
 #: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
-msgstr ""
+msgstr "Filtrlar"
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:70
 #: desk/src/components/Settings/General/components/TicketSettings.vue:229
 msgid "Find out all of the variables that can be used in the content"
-msgstr ""
+msgstr "Tarkibda ishlatilishi mumkin bo'lgan barcha o'zgaruvchilarni toping"
 
 #: desk/src/components/contact/EditContactDialog.vue:35
 #: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
-msgstr "पहला नाम"
+msgstr "Ism"
 
 #. Label of the first_responded_on (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
-msgstr "सबसे पहले जवाब दिया"
+msgstr "Birinchi bo'lib javob berilgan sana"
 
 #: desk/src/components/customer/TicketsTab.vue:224
 msgid "First Response"
@@ -2463,13 +2465,13 @@ msgstr ""
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Response Due"
-msgstr ""
+msgstr "Birinchi javob kerak"
 
 #. Label of the first_response_failed_by (Duration) field in DocType 'HD
 #. Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Response Failed By"
-msgstr "पहली प्रतिक्रिया विफल रही"
+msgstr "Birinchi javob muvaffaqiyatsiz tugadi"
 
 #. Label of the response_time (Duration) field in DocType 'HD Service Level
 #. Priority'
@@ -2477,21 +2479,21 @@ msgstr "पहली प्रतिक्रिया विफल रही"
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Response Time"
-msgstr "प्रथम प्रतिक्रिया समय"
+msgstr "Birinchi javob vaqti"
 
 #. Name of a report
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
-msgstr "टिकटों के लिए प्रथम प्रतिक्रिया समय"
+msgstr "Chiptalar uchun birinchi javob vaqti"
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 msgid "Form"
-msgstr "रूप"
+msgstr "Shakl"
 
 #: desk/src/components/layouts/Sidebar.vue:637
 msgid "Frappe Helpdesk Mobile"
-msgstr ""
+msgstr "Frappe yordam xizmati mobil"
 
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
@@ -2499,14 +2501,14 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Friday"
-msgstr "शुक्रवार"
+msgstr "Juma"
 
 #. Label of the user_from (Link) field in DocType 'HD Notification'
 #: desk/src/components/EmailEditor.vue:23
 #: desk/src/pages/call-logs/CallLogModal.vue:44
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "From"
-msgstr "से"
+msgstr "Kimdan"
 
 #. Label of the from_date (Date) field in DocType 'HD Service Holiday List'
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
@@ -2515,50 +2517,50 @@ msgstr "से"
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:17
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:17
 msgid "From Date"
-msgstr "की तिथि से"
+msgstr "Boshlanish sanasi"
 
 #: desk/src/components/Settings/Holiday/HolidayView.vue:71
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:140
 msgid "From date"
-msgstr "की तिथि से"
+msgstr "Boshlang'ich sana"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:374
 msgid "From is required"
-msgstr "से आवश्यक है"
+msgstr "Kimdan talab qilinadi"
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/Tickets.vue:224 desk/src/pages/ticket/Tickets.vue:263
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Fulfilled"
-msgstr "पूरा"
+msgstr "Bajarildi"
 
 #: desk/src/components/Settings/General/General.vue:6
 #: desk/src/components/layouts/Sidebar.vue:528
 #: desk/src/components/modals/ShortcutsModal.vue:76
 msgid "General"
-msgstr "सामान्य"
+msgstr "Umumiy"
 
 #. Label of a Link in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "General Settings"
-msgstr ""
+msgstr "Umumiy sozlamalar"
 
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.py:40
 msgid "General category can't be deleted"
-msgstr "सामान्य श्रेणी को हटाया नहीं जा सकता"
+msgstr "Umumiy kategoriyani o'chirib bo'lmaydi"
 
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.py:36
 msgid "General category name can't be changed"
-msgstr "सामान्य श्रेणी का नाम बदला नहीं जा सकता"
+msgstr "Umumiy kategoriya nomini o'zgartirib bo'lmaydi"
 
 #: helpdesk/api/knowledge_base.py:56
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.py:23
 msgid "General is a reserved category name. Please use a different name to proceed."
-msgstr ""
+msgstr "Umumiy - band qilingan kategoriya nomi. Davom etish uchun boshqa nomdan foydalaning."
 
 #: desk/src/components/layouts/Sidebar.vue:578
 msgid "Getting Started"
-msgstr "शुरू करना"
+msgstr "Ishni boshlash"
 
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #: desk/src/components/SavedRepliesSelectorModal.vue:180
@@ -2567,11 +2569,11 @@ msgstr "शुरू करना"
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:200
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 msgid "Global"
-msgstr ""
+msgstr "Global"
 
 #: desk/src/components/command-palette/CP.vue:89
 msgid "Go to Ticket #{0}"
-msgstr "टिकट पर जाएं #{0}"
+msgstr "Chipta #{0} ga o'ting"
 
 #: desk/src/components/customer/ContactCard.vue:220
 msgid "Grant Manager Access"
@@ -2582,67 +2584,67 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Gray"
-msgstr ""
+msgstr "Kulrang"
 
 #: desk/src/pages/home/components/PendingTickets.vue:254
 msgid "Great! All your tickets are within SLA"
-msgstr ""
+msgstr "Ajoyib! Barcha chiptalaringiz SLA doirasida"
 
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Green"
-msgstr "हरा"
+msgstr "Yashil"
 
 #. Label of the group_by_tab (Tab Break) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Group By"
-msgstr ""
+msgstr "Guruh bo'yicha"
 
 #. Label of the group_by_field (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Group By Field"
-msgstr ""
+msgstr "Maydon bo'yicha guruhlash"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
-msgstr "अतिथि"
+msgstr "Mehmon"
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
-msgstr ""
+msgstr "Foydalanuvchilarni chiptalar oldidan maqolalarga yo'naltiring."
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "HD Agent"
-msgstr ""
+msgstr "HD agenti"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 msgid "HD Agent Status"
-msgstr ""
+msgstr "HD Agent Maqomi"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 msgid "HD Article"
-msgstr ""
+msgstr "HD maqola"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 msgid "HD Article Category"
-msgstr ""
+msgstr "HD maqola toifasi"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 msgid "HD Article Feedback"
-msgstr ""
+msgstr "HD Maqola Fikr-mulohazalari"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
 msgid "HD Comment Reaction"
-msgstr ""
+msgstr "HD sharh reaksiyasi"
 
 #. Name of a role
 #. Name of a DocType
@@ -2658,7 +2660,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
-msgstr ""
+msgstr "HD mijoz"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -2674,88 +2676,88 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
-msgstr ""
+msgstr "HD elektron pochta orqali fikr-mulohaza"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 msgid "HD Field Layout"
-msgstr ""
+msgstr "HD maydon sxemasi"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 msgid "HD Form Script"
-msgstr ""
+msgstr "HD Form Skripti"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_holiday/hd_holiday.json
 msgid "HD Holiday"
-msgstr ""
+msgstr "HD bayram"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
-msgstr ""
+msgstr "HD bildirishnoma"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 msgid "HD Saved Reply"
-msgstr ""
+msgstr "HD saqlangan javob"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 msgid "HD Saved Reply Team"
-msgstr ""
+msgstr "HD saqlangan javoblar jamoasi"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
 msgid "HD Service Day"
-msgstr ""
+msgstr "HD xizmat kuni"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list_calendar.js:20
 msgid "HD Service Holiday List"
-msgstr ""
+msgstr "HD xizmati bayramlari ro'yxati"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "HD Service Level Agreement"
-msgstr ""
+msgstr "HD xizmat ko'rsatish darajasi shartnomasi"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 msgid "HD Service Level Priority"
-msgstr ""
+msgstr "HD xizmat ko'rsatish darajasi ustuvorligi"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "HD Settings"
-msgstr ""
+msgstr "HD sozlamalari"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
-msgstr ""
+msgstr "HD to'xtash so'zi"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_synonym/hd_synonym.json
 msgid "HD Synonym"
-msgstr ""
+msgstr "HD sinonimi"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_synonyms/hd_synonyms.json
 msgid "HD Synonyms"
-msgstr ""
+msgstr "HD sinonimlari"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "HD Team"
-msgstr ""
+msgstr "HD jamoasi"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 msgid "HD Team Member"
-msgstr ""
+msgstr "HD jamoasi a'zosi"
 
 #. Name of a DocType
 #. Label of the ticket (Link) field in DocType 'HD Ticket Activity'
@@ -2763,138 +2765,138 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_activity/hd_ticket_activity.json
 msgid "HD Ticket"
-msgstr ""
+msgstr "HD chipta"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_ticket_activity/hd_ticket_activity.json
 msgid "HD Ticket Activity"
-msgstr ""
+msgstr "HD chipta faoliyati"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 msgid "HD Ticket Comment"
-msgstr ""
+msgstr "HD chipta sharhi"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "HD Ticket Feedback Option"
-msgstr ""
+msgstr "HD chipta fikr-mulohazalari opsiyasi"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 msgid "HD Ticket Priority"
-msgstr ""
+msgstr "HD chipta ustuvorligi"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "HD Ticket Status"
-msgstr ""
+msgstr "HD chipta holati"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "HD Ticket Template"
-msgstr ""
+msgstr "HD chipta shabloni"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "HD Ticket Template Field"
-msgstr ""
+msgstr "HD chipta shabloni maydoni"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Ticket Type"
-msgstr ""
+msgstr "HD chipta turi"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "HD View"
-msgstr ""
+msgstr "HD ko'rinish"
 
 #. Label of the headings_weight (Int) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Headings Weight"
-msgstr ""
+msgstr "Sarlavhalar og'irligi"
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:100
 msgid "Hello {{ contact }}, \\n\\nWe are sorry for the inconvenience, we will get back to you soon. \\n\\nRegards, \\n{{ full_name }}"
-msgstr ""
+msgstr "Salom {{ contact }}, \\n\\nNoqulayliklar uchun uzr so'raymiz, tez orada siz bilan bog'lanamiz. \\n\\nHurmat bilan, \\n{{ full_name }}"
 
 #: desk/src/components/layouts/Sidebar.vue:125
 msgid "Help"
-msgstr "मदद"
+msgstr "Yordam"
 
 #: helpdesk/config/desktop.py:11
 msgid "HelpDesk"
-msgstr "सहायता केंद्र"
+msgstr "Yordam xizmati"
 
 #. Name of a Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk"
-msgstr "सहायता केंद्र"
+msgstr "Yordam xizmati"
 
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
-msgstr ""
+msgstr "Yordam xizmati hisobotlari"
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:53
 msgid "Here, your weekly offs are pre-populated based on the previous selections. You can add more rows to also add public and national holidays individually."
-msgstr ""
+msgstr "Bu yerda sizning haftalik dam olish kunlaringiz avvalgi tanlovlar asosida oldindan to'ldiriladi. Shuningdek, siz alohida-alohida davlat va milliy bayramlarni qo'shish uchun qo'shimcha qatorlar qo'shishingiz mumkin."
 
 #: desk/src/pages/home/Home.vue:79
 msgid "Hey"
-msgstr ""
+msgstr "Salom"
 
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
-msgstr ""
+msgstr "Yashirish "
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Hide from customer"
-msgstr ""
+msgstr "Mijozdan yashirish"
 
 #: desk/src/pages/ticket/Tickets.vue:481
 msgid "Hide from sidebar"
-msgstr ""
+msgstr "Yon paneldan yashirish"
 
 #: desk/src/pages/ticket/Tickets.vue:489
 msgid "Hide view from sidebar"
-msgstr ""
+msgstr "Yon paneldan ko'rinishni yashirish"
 
 #. Option in a Select field in the tickets Web Form
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
 msgid "Hold"
-msgstr "पकड़ना"
+msgstr "Kutib turing"
 
 #. Label of the holiday_list (Link) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Holiday List"
-msgstr ""
+msgstr "Bayramlar ro'yxati"
 
 #. Label of the holiday_list_name (Data) field in DocType 'HD Service Holiday
 #. List'
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Holiday List Name"
-msgstr ""
+msgstr "Bayramlar ro'yxati nomi"
 
 #: desk/src/components/Settings/Holiday/HolidayView.vue:355
 msgid "Holiday list created successfully."
-msgstr ""
+msgstr "Bayramlar ro'yxati muvaffaqiyatli tuzildi."
 
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:153
 msgid "Holiday list deleted successfully."
-msgstr ""
+msgstr "Bayramlar ro'yxati muvaffaqiyatli o'chirildi."
 
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:126
 msgid "Holiday list duplicated successfully."
-msgstr ""
+msgstr "Bayramlar ro'yxati muvaffaqiyatli nusxalandi."
 
 #: desk/src/components/Settings/Holiday/HolidayView.vue:417
 msgid "Holiday list updated successfully."
-msgstr ""
+msgstr "Bayramlar ro'yxati muvaffaqiyatli yangilandi."
 
 #. Label of the holidays_section (Section Break) field in DocType 'HD Service
 #. Holiday List'
@@ -2903,161 +2905,161 @@ msgstr ""
 #: desk/src/components/Settings/Holiday/HolidayView.vue:172
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Holidays"
-msgstr ""
+msgstr "Bayramlar"
 
 #: desk/src/pages/home/Home.vue:5
 msgid "Home"
-msgstr "घर"
+msgstr "Uy"
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:115
 msgid "I understand, add conditions"
-msgstr ""
+msgstr "Tushundim, shartlarni qo'shing"
 
 #: desk/src/pages/home/components/PendingTickets.vue:26
 msgid "ID"
-msgstr "पहचान"
+msgstr "ID"
 
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
-msgstr ""
+msgstr "Belgi"
 
 #. Description of the 'Enabled' (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "If enabled, a ticket creation acknowledgement email will be sent to the user right after creating an email ticket"
-msgstr ""
+msgstr "Agar yoqilgan bo'lsa, elektron pochta chiptasi yaratilgandan so'ng darhol foydalanuvchiga chipta yaratilganligi haqida tasdiqlovchi elektron pochta xabari yuboriladi"
 
 #. Description of the 'Enabled' (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "If enabled, an email is sent to all of the recipients associated with an agent's reply"
-msgstr ""
+msgstr "Agar yoqilgan bo'lsa, agentning javobi bilan bog'liq barcha qabul qiluvchilarga elektron pochta xabari yuboriladi"
 
 #. Description of the 'Enabled' (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "If enabled, an email will be sent to all of the assigned agents after a reply from one of the contacts"
-msgstr ""
+msgstr "Agar yoqilgan bo'lsa, kontaktlardan birining javobidan so'ng barcha tayinlangan agentlarga elektron pochta xabari yuboriladi."
 
 #. Description of the 'Allow anyone to create tickets' (Check) field in DocType
 #. 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "If enabled, anyone will be able to create tickets (without any permission). "
-msgstr ""
+msgstr "Agar yoqilgan bo'lsa, istalgan kishi (hech qanday ruxsatsiz) chiptalar yaratishi mumkin bo'ladi. "
 
 #. Description of the 'Enabled' (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "If enabled, feedback email will be sent to the customer when you mark a ticket as the status selected below.\n"
-msgstr ""
+msgstr "Agar yoqilgan bo'lsa, chiptani quyida tanlangan holat sifatida belgilaganingizda mijozga fikr-mulohaza elektron pochtasi yuboriladi.\n"
 
 #. Description of the 'Enable feedback for Customer Portal' (Check) field in
 #. DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "If enabled, the feedback dialog will be shown, when a user tries to close a ticket. \n"
-msgstr ""
+msgstr "Agar yoqilsa, foydalanuvchi chiptani yopishga harakat qilganda, fikr-mulohaza oynasi ko'rsatiladi. \n"
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:15
 msgid "If your issue isn't resolved, raise a support ticket"
-msgstr ""
+msgstr "Agar muammoingiz hal qilinmasa, qo'llab-quvvatlash uchun ariza to'plang"
 
 #. Label of the ignore_restrictions (Check) field in DocType 'HD Team'
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Ignore Restrictions"
-msgstr ""
+msgstr "Cheklovlarni e'tiborsiz qoldiring"
 
 #. Label of the user_image (Attach Image) field in DocType 'HD Agent'
 #. Label of the image (Attach Image) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Image"
-msgstr "छवि"
+msgstr "Rasm"
 
 #: desk/src/components/Settings/General/components/Branding.vue:80
 msgid "Image removed successfully."
-msgstr ""
+msgstr "Rasm muvaffaqiyatli olib tashlandi."
 
 #. Description of the 'Logo' (Attach Image) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Image to be used in various places, including Login and Signup pages. An image with transparent background and 160 x 32 is preferred"
-msgstr ""
+msgstr "Rasm turli joylarda, jumladan, Kirish va Ro'yxatdan o'tish sahifalarida ishlatiladi. Shaffof fonga ega va 160 x 32 o'lchamdagi rasm afzalroq."
 
 #: desk/src/components/Settings/General/components/Branding.vue:83
 msgid "Image updated successfully."
-msgstr ""
+msgstr "Rasm muvaffaqiyatli yangilandi."
 
 #: desk/src/pages/call-logs/CallLogModal.vue:217
 msgid "In Progress"
-msgstr "प्रगति पर है"
+msgstr "Jarayonda"
 
 #: desk/src/components/Settings/Agents.vue:126
 msgid "Inactive"
-msgstr "निष्क्रिय"
+msgstr "Faol emas"
 
 #: desk/src/components/CallArea.vue:36
 msgid "Inbound Call"
-msgstr ""
+msgstr "Kiruvchi qo'ng'iroq"
 
 #: desk/src/components/Settings/EmailAccountCard.vue:59
 msgid "Inbox"
-msgstr ""
+msgstr "Kiruvchi xabarlar qutisi"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:203
 msgid "Incoming"
-msgstr "आने वाली"
+msgstr "Kiruvchi"
 
 #. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Individual"
-msgstr "व्यक्ति"
+msgstr "Shaxsiy"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
-msgstr "शुरू किया"
+msgstr "Boshlangan"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:59
 msgid "Install the"
-msgstr ""
+msgstr "O'rnating"
 
 #. Label of the instantly_send_email (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Instantly send e-mail"
-msgstr "तुरंत ईमेल भेजें"
+msgstr "Darhol elektron pochta xabarini yuboring"
 
 #: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
-msgstr "{0} के लिए अपर्याप्त अनुमति"
+msgstr "{0} uchun ruxsat yetarli emas"
 
 #. Label of the integer_value (Int) field in DocType 'HD Ticket Priority'
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 msgid "Integer value"
-msgstr ""
+msgstr "Butun son qiymati"
 
 #: desk/src/components/layouts/Sidebar.vue:570
 #: desk/src/components/layouts/Sidebar.vue:573
 msgid "Introduction"
-msgstr "परिचय"
+msgstr "Kirish"
 
 #: helpdesk/api/agent.py:37
 msgid "Invalid availability"
-msgstr ""
+msgstr "Noto'g'ri mavjudlik"
 
 #: desk/src/components/customer/NewCustomerDialog.vue:186
 msgid "Invalid email address"
-msgstr "अमान्य ईमेल पता"
+msgstr "Elektron pochta manzili noto'g'ri"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
 #: desk/src/components/Settings/Holiday/HolidayView.vue:325
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:384
 msgid "Invalid fields, check if all are filled in and values are correct."
-msgstr ""
+msgstr "Maydonlar noto'g'ri, barcha to'ldirilganligini va qiymatlar to'g'ri ekanligini tekshiring."
 
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
-msgstr "अमान्य सूचना"
+msgstr "Noto'g'ri bildirishnoma"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
 msgid "Invalid phone number"
-msgstr "अमान्य फ़ोन नंबर"
+msgstr "Noto'g'ri telefon raqami"
 
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
 msgid "Invalid role {0}"
@@ -3065,7 +3067,7 @@ msgstr ""
 
 #: desk/src/pages/contact/Contact.vue:251
 msgid "Invitation Expired"
-msgstr "निमंत्रण की समय सीमा समाप्त हो गई है"
+msgstr "Taklifnoma muddati tugadi"
 
 #: desk/src/components/Settings/InviteAgents.vue:246
 #: desk/src/components/customer/RevokeInviteButton.vue:40
@@ -3079,11 +3081,11 @@ msgstr ""
 #: desk/src/components/customer/CustomerContactTab.vue:7
 #: desk/src/components/customer/InviteContactDialog.vue:77
 msgid "Invite"
-msgstr ""
+msgstr "Taklif qiling"
 
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
-msgstr ""
+msgstr "Agentlarni taklif qiling"
 
 #: desk/src/components/customer/InviteContactDialog.vue:2
 msgid "Invite Contact"
@@ -3091,20 +3093,20 @@ msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
 msgid "Invite agent"
-msgstr ""
+msgstr "Agentni taklif qiling"
 
 #: desk/src/components/layouts/Sidebar.vue:450
 msgid "Invite agents"
-msgstr ""
+msgstr "Agentlarni taklif qiling"
 
 #: desk/src/components/contact/NewContactDialog.vue:100
 #: desk/src/pages/contact/Contact.vue:269
 msgid "Invite as User"
-msgstr ""
+msgstr "Foydalanuvchi sifatida taklif qilish"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
-msgstr ""
+msgstr "Elektron pochta orqali taklif qilish"
 
 #: desk/src/pages/contact/Contact.vue:259
 msgid "Invite sent. Waiting for the user to accept."
@@ -3116,7 +3118,7 @@ msgstr ""
 
 #: desk/src/pages/contact/Contact.vue:257
 msgid "Invited"
-msgstr ""
+msgstr "Taklif qilingan"
 
 #: desk/src/components/customer/InviteContactDialog.vue:57
 msgid "Invited by"
@@ -3125,17 +3127,17 @@ msgstr ""
 #. Label of the is_active (Check) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Is Active"
-msgstr "सक्रिय है"
+msgstr "Faol"
 
 #. Label of the is_customer_portal (Check) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Customer Portal"
-msgstr "क्या ग्राहक पोर्टल"
+msgstr "Mijozlar portali"
 
 #. Label of the is_default (Check) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
-msgstr ""
+msgstr "Standart"
 
 #. Label of the is_manager (Check) field in DocType 'HD Customer Member'
 #: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
@@ -3147,28 +3149,28 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Standard"
-msgstr "मानक है"
+msgstr "Standartmi?"
 
 #. Label of the apply_to_system (Check) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 msgid "Is applied to system"
-msgstr "सिस्टम पर लागू होता है"
+msgstr "Tizimga qo'llaniladi"
 
 #. Label of the initial_helpdesk_name_setup_skipped (Check) field in DocType
 #. 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is name setup skipped"
-msgstr ""
+msgstr "Nom sozlamalari o'tkazib yuborilganmi?"
 
 #. Label of the is_pinned (Check) field in DocType 'HD Ticket Comment'
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 msgid "Is pinned"
-msgstr ""
+msgstr "Mahkamlangan"
 
 #. Label of the setup_complete (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
-msgstr ""
+msgstr "Sozlash tugallandi"
 
 #: desk/src/components/contact/EditContactDialog.vue:38
 msgid "John"
@@ -3176,11 +3178,11 @@ msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:114
 msgid "Jump to"
-msgstr "करने के लिए कूद"
+msgstr "O'tish"
 
 #: desk/src/pages/knowledge-base/Article.vue:672
 msgid "KB"
-msgstr ""
+msgstr "KB"
 
 #. Label of the key (Data) field in DocType 'HD Email Feedback'
 #. Label of the key (Data) field in DocType 'HD Ticket'
@@ -3189,11 +3191,11 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
 msgid "Key"
-msgstr "चाबी"
+msgstr "Kalit"
 
 #: desk/src/components/modals/ShortcutsModal.vue:2
 msgid "Keyboard Shortcuts"
-msgstr ""
+msgstr "Klaviatura yorliqlari"
 
 #. Label of the knowledge_base_section (Section Break) field in DocType 'HD
 #. Settings'
@@ -3206,7 +3208,7 @@ msgstr ""
 #: desk/src/pages/knowledge-base/NewArticle.vue:169
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Knowledge Base"
-msgstr ""
+msgstr "Bilimlar bazasi"
 
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
@@ -3215,87 +3217,87 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Label"
-msgstr "लेबल"
+msgstr "Yorliq"
 
 #. Label of the label_customer (Data) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Label (customer view)"
-msgstr "लेबल (ग्राहक दृश्य)"
+msgstr "Yorliq (mijoz ko'rinishi)"
 
 #. Option for the 'Type' (Select) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 msgid "Landing Page"
-msgstr "लैंडिंग पृष्ठ"
+msgstr "Qo'nish sahifasi"
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:6
 msgid "Language"
-msgstr "भाषा"
+msgstr "Til"
 
 #: desk/src/components/Settings/Preferences/Preferences.vue:36
 msgid "Language & Time"
-msgstr "भाषा और समय"
+msgstr "Til va vaqt"
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:102
 msgid "Last"
-msgstr "अंतिम"
+msgstr "Oxirgi"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:372
 #: desk/src/pages/home/components/RecentFeedback.vue:401
 msgid "Last 3 Months"
-msgstr "पिछले 3 महीने"
+msgstr "So'nggi 3 oy"
 
 #: desk/src/components/ChartCardBase.vue:169
 #: desk/src/components/ChartCardBase.vue:171
 #: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
-msgstr "पिछले 3 महीने"
+msgstr "So'nggi 3 oy"
 
 #: desk/src/pages/dashboard/Dashboard.vue:453
 #: desk/src/pages/dashboard/Dashboard.vue:486
 #: desk/src/pages/dashboard/Dashboard.vue:488
 #: desk/src/pages/dashboard/Dashboard.vue:524
 msgid "Last 30 Days"
-msgstr "पिछले 30 दिन"
+msgstr "Oxirgi 30 kun"
 
 #: desk/src/pages/dashboard/Dashboard.vue:493
 #: desk/src/pages/dashboard/Dashboard.vue:495
 msgid "Last 60 Days"
-msgstr "पिछले 60 दिन"
+msgstr "Oxirgi 60 kun"
 
 #: desk/src/pages/dashboard/Dashboard.vue:479
 #: desk/src/pages/dashboard/Dashboard.vue:481
 msgid "Last 7 Days"
-msgstr "पिछले 7 दिन"
+msgstr "So'nggi 7 kun"
 
 #: desk/src/pages/dashboard/Dashboard.vue:500
 #: desk/src/pages/dashboard/Dashboard.vue:502
 msgid "Last 90 Days"
-msgstr "पिछले 90 दिन"
+msgstr "Oxirgi 90 kun"
 
 #. Label of the last_agent_response (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Last Agent Response"
-msgstr "अंतिम एजेंट प्रतिक्रिया"
+msgstr "Agentning oxirgi javobi"
 
 #. Label of the last_customer_response (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Last Customer Response"
-msgstr "अंतिम ग्राहक प्रतिक्रिया"
+msgstr "Mijozning oxirgi javobi"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:368
 #: desk/src/pages/home/components/RecentFeedback.vue:400
 msgid "Last Month"
-msgstr ""
+msgstr "O'tgan oy"
 
 #: desk/src/components/contact/EditContactDialog.vue:43
 #: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
-msgstr ""
+msgstr "Familiya"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:364
 #: desk/src/pages/home/components/RecentFeedback.vue:399
 msgid "Last Week"
-msgstr "पिछले सप्ताह"
+msgstr "O'tkan hafta"
 
 #: desk/src/components/BarChartCard.vue:79
 #: desk/src/components/ChartCardBase.vue:135
@@ -3305,7 +3307,7 @@ msgstr "पिछले सप्ताह"
 #: desk/src/components/LineChartCard.vue:74
 #: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
-msgstr ""
+msgstr "O'tgan oy"
 
 #: desk/src/components/customer/ContactCard.vue:134
 msgid "Last seen"
@@ -3313,33 +3315,33 @@ msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
-msgstr ""
+msgstr "Ushbu qoida bo'yicha oxirgi tayinlangan foydalanuvchi"
 
 #: desk/src/components/ChartCardBase.vue:155
 #: desk/src/components/ChartCardBase.vue:157
 #: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
-msgstr "पिछले सप्ताह"
+msgstr "O'tkan hafta"
 
 #: desk/src/components/contact/FeedbackList.vue:122
 msgid "Latest"
-msgstr "नवीनतम"
+msgstr "Eng so'nggi"
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 msgid "Layout"
-msgstr ""
+msgstr "Joylashtirish"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:135
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:212
 msgid "Learn about conditions"
-msgstr "स्थितियों के बारे में जानें"
+msgstr "Shartlar haqida bilib oling"
 
 #. Description of the 'Apply outside working hours' (Check) field in DocType
 #. 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
-msgstr ""
+msgstr "Mijozlarga ish vaqtidan tashqari jarima to'lashlarini va qachon javob kutishlari mumkinligini bildiring."
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #. Label of the list_tab (Tab Break) field in DocType 'HD View'
@@ -3350,44 +3352,44 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "List"
-msgstr "सूची"
+msgstr "Ro'yxat"
 
 #: desk/src/pages/ticket/Tickets.vue:357
 msgid "List View"
-msgstr "लिस्ट व्यू"
+msgstr "Ro'yxat ko'rinishi"
 
 #: desk/src/components/CallArea.vue:72
 msgid "Listen"
-msgstr "सुनना"
+msgstr "Tinglang"
 
 #. Label of the load_default_columns (Check) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Load Default Columns"
-msgstr ""
+msgstr "Standart ustunlarni yuklash"
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
 #: desk/src/components/contact/FeedbackList.vue:84
 #: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
-msgstr "और लोड करें"
+msgstr "Batafsil yuklash"
 
 #: desk/src/components/ticket-agent/AssignTo.vue:93
 msgid "Loading..."
-msgstr "लोड हो रहा है..."
+msgstr "Yuklanmoqda..."
 
 #: desk/src/components/ticket/ActivityHeader.vue:65
 msgid "Log a Call"
-msgstr ""
+msgstr "Qo'ng'iroqni yozib olish"
 
 #: desk/src/components/layouts/Sidebar.vue:344
 #: desk/src/components/layouts/Sidebar.vue:395
 msgid "Log out"
-msgstr "लॉग आउट"
+msgstr "Chiqish"
 
 #: desk/src/components/layouts/Sidebar.vue:375
 msgid "Login to Frappe Cloud"
-msgstr ""
+msgstr "Frappe Cloud’ga kirish"
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
@@ -3395,117 +3397,117 @@ msgstr ""
 #: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
-msgstr "प्रतीक चिन्ह"
+msgstr "Logotip"
 
 #. Description of the 'Integer value' (Int) field in DocType 'HD Ticket
 #. Priority'
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 msgid "Lower the Integer value, higher is the priority of the issue"
-msgstr ""
+msgstr "Butun son qiymati pastroq bo'lsa, muammoning ustuvorligi yuqori bo'ladi"
 
 #: desk/src/pages/ticket/Tickets.vue:501
 msgid "Make Private"
-msgstr ""
+msgstr "Shaxsiylashtiring"
 
 #: desk/src/pages/ticket/Tickets.vue:501
 msgid "Make Public"
-msgstr "सार्वजनिक करें"
+msgstr "Ommaviy qilish"
 
 #: desk/src/components/ticket/ActivityHeader.vue:60
 msgid "Make a Call"
-msgstr "फोन करें"
+msgstr "Qo'ng'iroq qiling"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:10
 msgid "Make feedback mandatory"
-msgstr ""
+msgstr "Fikr-mulohazalarni majburiy qiling"
 
 #: desk/src/pages/ticket/Tickets.vue:509
 msgid "Make view private"
-msgstr ""
+msgstr "Ko'rinishni shaxsiy qilish"
 
 #: desk/src/components/Settings/General/General.vue:2
 msgid "Manage general settings of your app."
-msgstr ""
+msgstr "Ilovangizning umumiy sozlamalarini boshqaring."
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:5
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
-msgstr ""
+msgstr "Mijozlarning so'rovlariga javob berish uchun ishlatilishi mumkin bo'lgan oldindan belgilangan javoblarni boshqaring."
 
 #: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
-msgstr ""
+msgstr "Aloqa uchun hisob qaydnomangiz elektron pochta xabarlarini va elektron pochta imzosini boshqaring."
 
 #: desk/src/components/Settings/EmailAccountList.vue:5
 msgid "Manage your email accounts and configure incoming and outgoing settings."
-msgstr ""
+msgstr "Elektron pochta hisoblaringizni boshqaring va kiruvchi va chiquvchi sozlamalarni sozlang."
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:25
 msgid "Manage your email signature."
-msgstr ""
+msgstr "Elektron pochta imzongizni boshqaring."
 
 #: desk/src/components/Settings/Preferences/Preferences.vue:2
 msgid "Manage your personal preferences."
-msgstr ""
+msgstr "Shaxsiy afzalliklaringizni boshqaring."
 
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
-msgstr ""
+msgstr "Profil ma'lumotlaringizni boshqaring."
 
 #: desk/src/components/customer/ContactCard.vue:25
 msgid "Manager"
-msgstr "प्रबंधक"
+msgstr "Menejer"
 
 #: desk/src/pages/MobileNotifications.vue:11
 #: desk/src/pages/MobileNotifications.vue:14
 msgid "Mark all as read"
-msgstr "सभी को पढ़ा हुआ मार्क करें"
+msgstr "Hammasini o'qilgan deb belgilash"
 
 #: desk/src/components/layouts/Sidebar.vue:608
 msgid "Masters"
-msgstr ""
+msgstr "Magistrlar"
 
 #: desk/src/components/Settings/Teams/NewTeam.vue:38
 msgid "Members"
-msgstr "सदस्यों"
+msgstr "A'zolar"
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:56
 msgid "Members ({0})"
-msgstr "सदस्य ({0})"
+msgstr "A'zolar ({0})"
 
 #. Option for the 'Type' (Select) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "Mention"
-msgstr "उल्लेख"
+msgstr "Eslatib o'tish"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:158
 msgid "Merge"
-msgstr ""
+msgstr "Birlashtirish"
 
 #: desk/src/components/ticket-agent/TicketHeader.vue:255
 #: desk/src/components/ticket/TicketAgentSidebar.vue:18
 msgid "Merge Ticket"
-msgstr ""
+msgstr "Birlashtirish chiptasi"
 
 #. Label of the merged_with (Link) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Merged With"
-msgstr "के साथ विलय हो गया"
+msgstr "Birlashtirilgan"
 
 #. Label of the message (Text) field in DocType 'HD Notification'
 #. Label of the message (Text Editor) field in DocType 'HD Saved Reply'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 msgid "Message"
-msgstr "संदेश"
+msgstr "Xabar"
 
 #. Label of the misc_tab (Tab Break) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Misc"
-msgstr "विविध"
+msgstr "Boshqa"
 
 #: desk/src/components/layouts/Sidebar.vue:640
 msgid "Mobile App Installation"
-msgstr ""
+msgstr "Mobil ilovani o'rnatish"
 
 #. Label of the mobile_no (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -3514,7 +3516,7 @@ msgstr ""
 
 #: desk/src/components/customer/NewCustomerDialog.vue:94
 msgid "Mobile Number"
-msgstr "मोबाइल नंबर"
+msgstr "Mobil raqam"
 
 #. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -3527,38 +3529,38 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Monday"
-msgstr "सोमवार"
+msgstr "Dushanba"
 
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:35
 msgid "Monthly"
-msgstr "महीने के"
+msgstr "Oylik"
 
 #: desk/src/pages/knowledge-base/Article.vue:636
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:191
 msgid "Move To"
-msgstr "करने के लिए कदम"
+msgstr "Ko'chib o'tish"
 
 #: desk/src/pages/dashboard/Dashboard.vue:249
 msgid "My Dashboard"
-msgstr "मेरे यंत्र रखने की जगह"
+msgstr "Mening boshqaruv panelim"
 
 #: desk/src/pages/dashboard/Dashboard.vue:302
 msgid "My Organization"
-msgstr ""
+msgstr "Mening tashkilotim"
 
 #: desk/src/pages/dashboard/Dashboard.vue:307
 msgid "My Stats"
-msgstr ""
+msgstr "Mening statistikam"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:175
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:337
 msgid "My Team"
-msgstr "मेरी टीम"
+msgstr "Mening jamoam"
 
 #: desk/src/pages/home/Home.vue:293
 #: desk/src/pages/home/components/AgentTicketsCard.vue:4
 msgid "My Tickets"
-msgstr "मेरे टिकट"
+msgstr "Mening chiptalarim"
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
 #. Label of the contact_name (Link) field in DocType 'HD Customer Member'
@@ -3578,26 +3580,26 @@ msgstr "मेरे टिकट"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
-msgstr "नाम"
+msgstr "Ism"
 
 #. Label of the name_weight (Int) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
-msgstr "नाम वजन"
+msgstr "Ismning vazni"
 
 #: desk/src/components/customer/NewCustomerDialog.vue:151
 msgid "Name is required"
-msgstr "नाम आवश्यक है"
+msgstr "Ism talab qilinadi"
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
 #. Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Name shown on the customer portal<br> (e.g., Replied → Awaiting Response)."
-msgstr ""
+msgstr "Mijozlar portalida ko'rsatilgan ism<br> (masalan, Javob berildi → Javob kutilmoqda)."
 
 #: desk/src/components/modals/ShortcutsModal.vue:105
 msgid "Navigation"
-msgstr "मार्गदर्शन"
+msgstr "Navigatsiya"
 
 #: desk/src/components/contact/FeedbackList.vue:124
 msgid "Negative"
@@ -3606,11 +3608,11 @@ msgstr ""
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
-msgstr "पहले नकारात्मक"
+msgstr "Avval salbiy"
 
 #: desk/src/components/customer/ContactCard.vue:137
 msgid "Never"
-msgstr "कभी नहीं"
+msgstr "Hech qachon"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3623,121 +3625,121 @@ msgstr "कभी नहीं"
 #: desk/src/components/ticket/ActivityHeader.vue:19
 #: desk/src/pages/home/Home.vue:55
 msgid "New"
-msgstr "नया"
+msgstr "Yangi"
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:174
 #: desk/src/pages/knowledge-base/NewArticle.vue:181
 msgid "New Article"
-msgstr "नया लेख"
+msgstr "Yangi maqola"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:4
 msgid "New Assignment Rule"
-msgstr ""
+msgstr "Yangi topshiriq qoidasi"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:59
 msgid "New Assignment Rule Name"
-msgstr ""
+msgstr "Yangi topshiriq qoidasi nomi"
 
 #: desk/src/components/Settings/Holiday/HolidayView.vue:3
 msgid "New Business Holiday"
-msgstr "नई व्यावसायिक छुट्टी"
+msgstr "Yangi biznes bayrami"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "New Call Log"
-msgstr ""
+msgstr "Yangi qo'ng'iroqlar jurnali"
 
 #: desk/src/components/Settings/FieldDependency/FieldDependency.vue:104
 msgid "New Field Dependency"
-msgstr ""
+msgstr "Yangi maydonga bog'liqlik"
 
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:36
 msgid "New Holiday List Name"
-msgstr ""
+msgstr "Yangi bayramlar ro'yxati nomi"
 
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:8
 msgid "New Password"
-msgstr "नया पासवर्ड"
+msgstr "Yangi parol"
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:3
 msgid "New SLA Policy"
-msgstr ""
+msgstr "Yangi SLA siyosati"
 
 #: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:48
 msgid "New SLA Policy Name"
-msgstr ""
+msgstr "Yangi SLA siyosati nomi"
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:3
 msgid "New Saved Reply"
-msgstr ""
+msgstr "Yangi saqlangan javob"
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:184
 msgid "New Saved reply Name"
-msgstr ""
+msgstr "Yangi saqlangan javob nomi"
 
 #: desk/src/pages/ticket/MobileTicketAgent.vue:141
 msgid "New Subject"
-msgstr "नया विषय"
+msgstr "Yangi mavzu"
 
 #: desk/src/components/Settings/Teams/NewTeam.vue:3
 msgid "New Team"
-msgstr "नई टीम"
+msgstr "Yangi jamoa"
 
 #: desk/src/pages/ticket/TicketNew.vue:302
 #: desk/src/pages/ticket/TicketNew.vue:312
 msgid "New Ticket"
-msgstr "नया टिकट"
+msgstr "Yangi chipta"
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:53
 msgid "New and old title cannot be same"
-msgstr "नया और पुराना शीर्षक एक समान नहीं हो सकता"
+msgstr "Yangi va eski nom bir xil bo'lishi mumkin emas"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:86
 msgid "New and updated customers sync automatically between Helpdesk and ERPNext."
-msgstr ""
+msgstr "Yangi va yangilangan mijozlar Yordam xizmati va ERPNext o'rtasida avtomatik ravishda sinxronlashtiriladi."
 
 #: desk/src/components/Settings/NewTeamModal.vue:4
 msgid "New team"
-msgstr "नई टीम"
+msgstr "Yangi jamoa"
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:51
 msgid "New title is required"
-msgstr "नए शीर्षक की आवश्यकता है"
+msgstr "Yangi sarlavha talab qilinadi"
 
 #: desk/src/components/Settings/General/General.vue:50
 msgid "New users will have to be manually registered by system managers."
-msgstr ""
+msgstr "Yangi foydalanuvchilar tizim menejerlari tomonidan qo'lda ro'yxatdan o'tkazilishi kerak bo'ladi."
 
 #: desk/src/components/modals/ShortcutsModal.vue:107
 msgid "Next ticket"
-msgstr "अगला टिकट"
+msgstr "Keyingi chipta"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:216
 msgid "No Answer"
-msgstr "कोई जवाब नहीं"
+msgstr "Javob yo'q"
 
 #: desk/src/components/ListViewBuilder.vue:345
 msgid "No Data Found"
-msgstr "डाटा प्राप्त नहीं हुआ"
+msgstr "Ma'lumotlar topilmadi"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
-msgstr "{0} के लिए कोई ईमेल खाता नहीं मिला"
+msgstr "{0} uchun elektron pochta hisobi topilmadi"
 
 #: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
-msgstr ""
+msgstr "Joriy foydalanuvchi uchun HD Agent yozuvi yo'q"
 
 #: desk/src/components/Settings/Holiday/HolidayList.vue:20
 msgid "No Holiday list found"
-msgstr "कोई अवकाश सूची नहीं मिली"
+msgstr "Bayramlar ro'yxati topilmadi"
 
 #: desk/src/components/Settings/Sla/SlaPolicyList.vue:20
 msgid "No SLA found"
-msgstr ""
+msgstr "Hech qanday xizmat ko'rsatish shartlari topilmadi"
 
 #: helpdesk/api/dashboard.py:452
 msgid "No Team"
-msgstr "कोई टीम नहीं"
+msgstr "Jamoa yo'q"
 
 #: desk/src/components/customer/ContactCard.vue:115
 #: desk/src/components/customer/ContactCard.vue:144
@@ -3747,39 +3749,39 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
 msgid "No additional comments"
-msgstr "कोई अतिरिक्त टिप्पणी नहीं"
+msgstr "Qo'shimcha izohlar yo'q"
 
 #: desk/src/components/ticket-agent/AssignTo.vue:144
 msgid "No agents found"
-msgstr "कोई एजेंट नहीं मिला"
+msgstr "Agentlar topilmadi"
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:425
 msgid "No articles found for the applied filters. Try adjusting or clearing your filters."
-msgstr ""
+msgstr "Qo'llanilgan filtrlar uchun hech qanday maqola topilmadi. Filtrlaringizni sozlashga yoki tozalashga harakat qiling."
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:428
 msgid "No articles found in the following category."
-msgstr ""
+msgstr "Quyidagi kategoriyada hech qanday maqola topilmadi."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:20
 msgid "No assignment rule found"
-msgstr ""
+msgstr "Hech qanday topshiriq qoidasi topilmadi"
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:105
 msgid "No average metrics"
-msgstr ""
+msgstr "O'rtacha ko'rsatkichlar yo'q"
 
 #: desk/src/components/knowledge-base/CategoryFolderContainer.vue:17
 msgid "No categories available"
-msgstr ""
+msgstr "Hech qanday kategoriya mavjud emas"
 
 #: desk/src/components/Settings/EmailEdit.vue:344
 msgid "No changes made"
-msgstr "कोई बदलाव नहीं किया गया"
+msgstr "Hech qanday o'zgartirish kiritilmadi"
 
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
-msgstr ""
+msgstr "Hech qanday jadval qo'shilmagan"
 
 #: desk/src/components/customer/CustomerContactTab.vue:29
 msgid "No contacts found"
@@ -3787,7 +3789,7 @@ msgstr ""
 
 #: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
-msgstr ""
+msgstr "Qo'llanilgan filtrlar uchun kontaktlar topilmadi. Filtrlaringizni sozlashga yoki tozalashga harakat qiling."
 
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
 msgid "No contacts to add"
@@ -3799,15 +3801,15 @@ msgstr ""
 
 #: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
-msgstr ""
+msgstr "Qo'llanilgan filtrlar uchun mijozlar topilmadi. Filtrlaringizni sozlashga yoki tozalashga harakat qiling."
 
 #: desk/src/components/Settings/EmailAccountList.vue:46
 msgid "No email account found"
-msgstr ""
+msgstr "Elektron pochta hisobi topilmadi"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:283
 msgid "No feedback"
-msgstr "कोई प्रतिक्रिया नहीं"
+msgstr "Fikr-mulohaza yo'q"
 
 #: desk/src/components/contact/ContactFeedback.vue:16
 msgid "No feedback yet"
@@ -3815,52 +3817,52 @@ msgstr ""
 
 #: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
-msgstr ""
+msgstr "Hech qanday maydon topilmadi"
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:94
 msgid "No members found"
-msgstr "कोई सदस्य नहीं मिला"
+msgstr "Hech qanday a'zo topilmadi"
 
 #: desk/src/pages/MobileNotifications.vue:68
 msgid "No new notifications"
-msgstr "कोई नए संदेश नहीं"
+msgstr "Yangi bildirishnomalar yo'q"
 
 #: desk/src/pages/home/components/PendingTickets.vue:258
 msgid "No new tickets assigned to you in the last 7 days"
-msgstr ""
+msgstr "So'nggi 7 kun ichida sizga yangi chiptalar tayinlanmadi"
 
 #: desk/src/components/ticket-agent/TicketNavigation.vue:25
 msgid "No next ticket"
-msgstr "अगला टिकट उपलब्ध नहीं है"
+msgstr "Keyingi chipta yo'q"
 
 #: desk/src/components/ticket-agent/AssignTo.vue:33
 msgid "No one"
-msgstr ""
+msgstr "Hech kim"
 
 #: desk/src/pages/home/components/PendingTickets.vue:261
 msgid "No pending tickets"
-msgstr "कोई लंबित टिकट नहीं"
+msgstr "Kutilayotgan chiptalar yo'q"
 
 #: desk/src/components/ticket-agent/TicketNavigation.vue:10
 msgid "No previous ticket"
-msgstr "कोई पूर्व टिकट नहीं"
+msgstr "Avvalgi chipta yo'q"
 
 #: desk/src/pages/home/components/PendingTickets.vue:94
 msgid "No reason"
-msgstr "कोई कारण नहीं"
+msgstr "Hech qanday sabab yo'q"
 
 #: desk/src/pages/home/components/PendingTickets.vue:257
 msgid "No recently assigned tickets"
-msgstr ""
+msgstr "Yaqinda tayinlangan chiptalar yo'q"
 
 #: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
-msgstr ""
+msgstr "Natija yo'q"
 
 #: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
-msgstr "कोई परिणाम नहीं मिला"
+msgstr "Hech qanday natija topilmadi"
 
 #: desk/src/components/contact/FeedbackList.vue:28
 msgid "No reviews found"
@@ -3869,28 +3871,28 @@ msgstr ""
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:91
 msgid "No saved replies found"
-msgstr ""
+msgstr "Saqlangan javoblar topilmadi"
 
 #: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
-msgstr "कोई टिकट नहीं मिला"
+msgstr "Chiptalar topilmadi"
 
 #: desk/src/pages/ticket/Tickets.vue:202
 msgid "No tickets found for the applied filters. Try adjusting or clearing your filters."
-msgstr ""
+msgstr "Qo'llanilgan filtrlar uchun chiptalar topilmadi. Filtrlaringizni sozlashga yoki tozalashga harakat qiling."
 
 #: desk/src/pages/ticket/Tickets.vue:198
 msgid "No tickets found for this view. Try adjusting your filters or creating a new view."
-msgstr ""
+msgstr "Bu ko'rinish uchun chiptalar topilmadi. Filtrlaringizni sozlashga yoki yangi ko'rinish yaratishga harakat qiling."
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:99
 msgid "No tickets found to preview."
-msgstr ""
+msgstr "Oldindan ko'rish uchun chiptalar topilmadi."
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:84
 msgid "No tickets selected"
-msgstr ""
+msgstr "Hech qanday chipta tanlanmagan"
 
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
 msgid "No user linked to contact {0}"
@@ -3898,85 +3900,85 @@ msgstr ""
 
 #: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
-msgstr "अनुमति नहीं"
+msgstr "Ruxsat berilmagan"
 
 #: desk/src/pages/home/components/PendingTickets.vue:69
 msgid "Not Assigned"
-msgstr "सौंपा नहीं गया है"
+msgstr "Tayinlanmagan"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:10
 msgid "Not Saved"
-msgstr ""
+msgstr "Saqlanmagan"
 
 #: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
-msgstr "सेट नहीं"
+msgstr "O'rnatilmagan"
 
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:250
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.py:270
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.py:363
 msgid "Not Specified"
-msgstr ""
+msgstr "Belgilanmagan"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:14
 msgid "Not installed"
-msgstr ""
+msgstr "O'rnatilmagan"
 
 #. Label of a Link in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Notification Settings"
-msgstr ""
+msgstr "Bildirishnoma sozlamalari"
 
 #: desk/src/components/layouts/Sidebar.vue:36
 #: desk/src/components/notifications/Notifications.vue:16
 #: desk/src/pages/MobileNotifications.vue:6
 msgid "Notifications"
-msgstr "सूचनाएं"
+msgstr "Bildirishnomalar"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:146
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:227
 msgid "Old Condition"
-msgstr "पुरानी स्थिति"
+msgstr "Eski holat"
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:88
 msgid "Old Conditions"
-msgstr "पुरानी स्थितियाँ"
+msgstr "Eski shartlar"
 
 #. Label of the on_hold_since (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "On Hold Since"
-msgstr "तब से रुका हुआ है"
+msgstr "Kutilayotgan vaqtdan beri"
 
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
-msgstr "टिकट की स्थिति पर"
+msgstr "Chipta holatida"
 
 #: helpdesk/api/ticket.py:75
 msgid "Only administrators can delete tickets."
-msgstr ""
+msgstr "Chiptalarni faqat administratorlar o'chirishi mumkin."
 
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.py:29
 msgid "Only one default view is allowed per user for {0}"
-msgstr ""
+msgstr "{0} uchun har bir foydalanuvchi uchun faqat bitta standart ko'rinishga ruxsat beriladi"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:29
 msgid "Only the 'color' and 'order' fields of the 'Closed' status can be modified."
-msgstr ""
+msgstr "Faqat \"Yopiq\" holatining \"rangi\" va \"tartibi\" maydonlarini o'zgartirish mumkin."
 
 #. Option for the 'Category' (Select) field in DocType 'HD Ticket Status'
 #. Option in a Select field in the tickets Web Form
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
 msgid "Open"
-msgstr "खुला"
+msgstr "Ochiq"
 
 #: desk/src/components/modals/ShortcutsModal.vue:78
 msgid "Open command palette"
-msgstr ""
+msgstr "Buyruqlar palitrasini ochish"
 
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
-msgstr ""
+msgstr "Fikrlar oynasini ochish"
 
 #: desk/src/components/contact/EditContactDialog.vue:147
 msgid "Open customer"
@@ -3984,120 +3986,122 @@ msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
 msgid "Open help"
-msgstr ""
+msgstr "Ochiq yordam"
 
 #: desk/src/components/Settings/EmailEdit.vue:37
 msgid "Open in Desk"
-msgstr ""
+msgstr "Ish stolida ochish"
 
 #: desk/src/components/modals/ShortcutsModal.vue:99
 msgid "Open reply box"
-msgstr ""
+msgstr "Javob qutisini ochish"
 
 #: desk/src/components/modals/ShortcutsModal.vue:79
 msgid "Open settings"
-msgstr "खुली सेटिंग"
+msgstr "Sozlamalarni ochish"
 
 #. Description of the 'Category' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Open: SLA continues. <br>\n"
 "Paused: SLA is paused. <br>\n"
 "Resolved: SLA timer stops."
-msgstr ""
+msgstr "Ochiq: SLA davom etmoqda. <br>\n"
+"To'xtatildi: SLA to'xtatildi. <br>\n"
+"Yechim topildi: SLA taymeri to'xtaydi."
 
 #. Label of the opening_date (Date) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Opening Date"
-msgstr ""
+msgstr "Ochilish sanasi"
 
 #. Label of the opening_time (Time) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Opening Time"
-msgstr "खुलने का समय"
+msgstr "Ochilish vaqti"
 
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Orange"
-msgstr "नारंगी"
+msgstr "To'q sariq"
 
 #. Label of the order (Int) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Order"
-msgstr "आदेश"
+msgstr "Buyurtma"
 
 #. Label of the order_by_tab (Tab Break) field in DocType 'HD View'
 #. Label of the order_by (Code) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Order By"
-msgstr "द्वारा आदेश"
+msgstr "Buyurtma berish muddati"
 
 #: desk/src/pages/dashboard/Dashboard.vue:249
 msgid "Organization Dashboard"
-msgstr ""
+msgstr "Tashkilot boshqaruv paneli"
 
 #: desk/src/pages/ticket/TicketFeedback.vue:50
 msgid "Other"
-msgstr "अन्य"
+msgstr "Boshqa"
 
 #: desk/src/components/CallArea.vue:37
 msgid "Outbound Call"
-msgstr ""
+msgstr "Chiquvchi qo'ng'iroq"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:204
 msgid "Outgoing"
-msgstr ""
+msgstr "Chiquvchi"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:199
 msgid "Outside working hours notice"
-msgstr "कार्य समय के बाहर की सूचना"
+msgstr "Ish vaqtidan tashqari ogohlantirish"
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:105
 msgid "Owner"
-msgstr "मालिक"
+msgstr "Egasi"
 
 #: desk/src/pages/InvalidPage.vue:11
 msgid "Page not found"
-msgstr "पृष्ठ नहीं मिला"
+msgstr "Sahifa topilmadi"
 
 #: desk/src/components/Settings/FieldDependency/FieldDependencyFieldsSelection.vue:5
 msgid "Parent field"
-msgstr "मूल फ़ील्ड"
+msgstr "Ota-ona maydoni"
 
 #: helpdesk/api/settings/field_dependency.py:47
 msgid "Parent field, child field, and parent-child mapping are required."
-msgstr ""
+msgstr "Ota-ona maydoni, bola maydoni va ota-ona-bola xaritalash talab qilinadi."
 
 #. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Partnership"
-msgstr "साझेदारी"
+msgstr "Hamkorlik"
 
 #: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
-msgstr "पासवर्ड"
+msgstr "Parol"
 
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:104
 msgid "Password must be at least 8 characters"
-msgstr "पासवर्ड कम से कम 8 वर्णों का होना चाहिए"
+msgstr "Parol kamida 8 ta belgidan iborat bo'lishi kerak"
 
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:107
 msgid "Password must contain lowercase, uppercase, number, and symbol"
-msgstr ""
+msgstr "Parol kichik, katta harflar, raqam va belgidan iborat bo'lishi kerak"
 
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:87
 msgid "Password updated successfully."
-msgstr ""
+msgstr "Parol muvaffaqiyatli yangilandi."
 
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:117
 msgid "Passwords do not match"
-msgstr "सांकेतिक शब्द मेल नहीं खाते"
+msgstr "Parollar mos kelmayapti"
 
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:36
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:123
 msgid "Passwords match"
-msgstr "पासवर्ड का मेल"
+msgstr "Parollar mos keldi"
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #. Option for the 'Category' (Select) field in DocType 'HD Ticket Status'
@@ -4105,42 +4109,42 @@ msgstr "पासवर्ड का मेल"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Paused"
-msgstr "रुका हुआ"
+msgstr "To'xtatildi"
 
 #: desk/src/pages/home/components/PendingTickets.vue:222
 msgid "Pending"
-msgstr "लंबित"
+msgstr "Kutilmoqda"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
 #: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
-msgstr "लंबित निमंत्रण"
+msgstr "Kutilayotgan taklifnomalar"
 
 #: desk/src/pages/home/Home.vue:353
 #: desk/src/pages/home/components/PendingTickets.vue:234
 #: desk/src/pages/home/components/PendingTickets.vue:238
 msgid "Pending Tickets"
-msgstr "लंबित टिकट"
+msgstr "Kutilayotgan chiptalar"
 
 #: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
-msgstr "चैनल के अनुसार कुल टिकटों का प्रतिशत"
+msgstr "Kanal bo'yicha jami chiptalarning foizi"
 
 #: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
-msgstr "प्राथमिकता के आधार पर कुल टिकटों का प्रतिशत"
+msgstr "Ustuvorlik bo'yicha jami chiptalarning foizi"
 
 #: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
-msgstr "टीम के अनुसार कुल टिकटों का प्रतिशत"
+msgstr "Jamoa bo'yicha jami chiptalarning foizi"
 
 #: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
-msgstr "टिकटों के प्रकार के अनुसार कुल टिकटों का प्रतिशत"
+msgstr "Turlar bo'yicha jami chiptalarning foizi"
 
 #: desk/src/pages/dashboard/Dashboard.vue:46
 msgid "Period"
-msgstr "अवधि"
+msgstr "Davr"
 
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #: desk/src/components/SavedRepliesSelectorModal.vue:170
@@ -4149,16 +4153,16 @@ msgstr "अवधि"
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:190
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 msgid "Personal"
-msgstr "निजी"
+msgstr "Shaxsiy"
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:54
 msgid "Personal mobile no"
-msgstr "व्यक्तिगत मोबाइल नंबर"
+msgstr "Shaxsiy mobil telefon raqami"
 
 #: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
-msgstr "फ़ोन"
+msgstr "Telefon"
 
 #: desk/src/components/contact/EditContactDialog.vue:24
 #: desk/src/components/contact/NewContactDialog.vue:42
@@ -4167,100 +4171,100 @@ msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
 msgid "Pick an option"
-msgstr "एक विकल्प चुनें"
+msgstr "Variantni tanlang"
 
 #: desk/src/pages/ticket/Tickets.vue:468
 msgid "Pin View"
-msgstr ""
+msgstr "Pin ko'rinishi"
 
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Pink"
-msgstr "गुलाबी"
+msgstr "Pushti"
 
 #. Label of the pinned (Check) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Pinned"
-msgstr ""
+msgstr "Mahkamlangan"
 
 #. Label of the placeholder (Data) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Placeholder"
-msgstr ""
+msgstr "Joylashtiruvchi"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.py:21
 msgid "Please add this priority in the <a href='/app/hd-service-level-agreement'>required SLA documents</a>"
-msgstr ""
+msgstr "Iltimos, ushbu ustuvorlikni <a href='/app/hd-service-level-agreement'>talab qilinadigan SLA hujjatlariga</a> qo'shing"
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:341
 msgid "Please add {0} priority in {1} SLA"
-msgstr ""
+msgstr "Iltimos, {1} SLA ga {0} ustuvorlik qo'shing"
 
 #: desk/src/components/Settings/Telephony/Telephony.vue:219
 msgid "Please configure your Exotel settings correctly"
-msgstr ""
+msgstr "Iltimos, Exotel sozlamalaringizni to'g'ri sozlang"
 
 #: desk/src/components/Settings/Telephony/Telephony.vue:215
 msgid "Please configure your Twilio settings correctly"
-msgstr ""
+msgstr "Iltimos, Twilio sozlamalaringizni to'g'ri sozlang"
 
 #: desk/src/components/layouts/Sidebar.vue:658
 msgid "Please create a new ticket to proceed with the next step."
-msgstr ""
+msgstr "Keyingi bosqichga o'tish uchun yangi chipta yarating."
 
 #: desk/src/pages/ticket/TicketNew.vue:83
 msgid "Please enter a subject to continue"
-msgstr ""
+msgstr "Davom etish uchun mavzu kiriting"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:368
 #: desk/src/pages/call-logs/CallLogModal.vue:376
 msgid "Please enter a valid phone number"
-msgstr ""
+msgstr "Iltimos, to'g'ri telefon raqamini kiriting"
 
 #: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
-msgstr ""
+msgstr "Taklifnoma yuborish uchun kamida bitta haqiqiy elektron pochta manzilini kiriting."
 
 #: desk/src/components/Settings/Teams/NewTeam.vue:129
 #: desk/src/pages/call-logs/CallLogModal.vue:264
 #: desk/src/pages/call-logs/CallLogModal.vue:310
 msgid "Please fill all required fields"
-msgstr ""
+msgstr "Iltimos, barcha majburiy maydonlarni to'ldiring"
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:240
 msgid "Please fill all required fields for Exotel"
-msgstr ""
+msgstr "Exotel uchun barcha kerakli maydonlarni to'ldiring"
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:236
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:204
 msgid "Please fill all required fields for Twilio"
-msgstr ""
+msgstr "Iltimos, Twilio uchun barcha kerakli maydonlarni to'ldiring"
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:303
 msgid "Please fill all the required fields"
-msgstr ""
+msgstr "Iltimos, barcha kerakli maydonlarni to'ldiring"
 
 #: desk/src/components/Settings/Sla/Modals/WorkDayModal.vue:244
 msgid "Please fix the errors in the form"
-msgstr ""
+msgstr "Iltimos, shakldagi xatolarni tuzating"
 
 #: helpdesk/api/saved_replies.py:11
 msgid "Please provide saved_reply_id"
-msgstr "कृपया saved_reply_id प्रदान करें"
+msgstr "Iltimos, saved_reply_id ni kiriting"
 
 #: desk/src/components/Settings/General/General.vue:239
 msgid "Please select at least one restriction option for teams in the settings."
-msgstr ""
+msgstr "Sozlamalarda jamoalar uchun kamida bitta cheklov variantini tanlang."
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.py:41
 msgid "Please select weekly off day"
-msgstr "कृपया साप्ताहिक अवकाश का दिन चुनें"
+msgstr "Iltimos, haftalik dam olish kunini tanlang"
 
 #: desk/src/components/Settings/Sla/SlaPolicyList.vue:32
 msgid "Policy name"
-msgstr "पॉलिसी का नाम"
+msgstr "Siyosat nomi"
 
 #: desk/src/components/contact/FeedbackList.vue:123
 msgid "Positive"
@@ -4270,51 +4274,51 @@ msgstr ""
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
-msgstr "पहले सकारात्मक"
+msgstr "Avval ijobiy"
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:10
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Prefer knowledge base"
-msgstr "ज्ञान आधार को प्राथमिकता दें"
+msgstr "Bilimlar bazasini afzal ko'ring"
 
 #: desk/src/components/Settings/Preferences/Preferences.vue:6
 msgid "Preferences"
-msgstr ""
+msgstr "Sozlamalar"
 
 #: desk/src/components/Settings/Preferences/Preferences.vue:75
 msgid "Preferences updated successfully."
-msgstr ""
+msgstr "Sozlamalar muvaffaqiyatli yangilandi."
 
 #: desk/src/pages/dashboard/Dashboard.vue:468
 msgid "Presets"
-msgstr ""
+msgstr "Oldindan o'rnatilgan sozlamalar"
 
 #: desk/src/pages/SearchAgent.vue:108
 msgid "Press enter to search"
-msgstr ""
+msgstr "Qidiruv uchun Enter tugmasini bosing"
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:11
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:4
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:26
 msgid "Preview"
-msgstr "पूर्व दर्शन"
+msgstr "Oldindan ko'rish"
 
 #: desk/src/components/modals/ShortcutsModal.vue:108
 msgid "Previous ticket"
-msgstr "पिछला टिकट"
+msgstr "Oldingi chipta"
 
 #: desk/src/components/contact/ContactInputRow.vue:20
 #: desk/src/components/customer/ContactCard.vue:31
 #: desk/src/components/customer/ContactCard.vue:36
 msgid "Primary"
-msgstr "प्राथमिक"
+msgstr "Asosiy"
 
 #. Label of the primary_contact (Link) field in DocType 'HD Customer'
 #: desk/src/components/customer/NewCustomerDialog.vue:64
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Primary Contact"
-msgstr "प्राथमिक संपर्क"
+msgstr "Asosiy aloqa"
 
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
 msgid "Primary contact must be one of the listed contacts"
@@ -4328,7 +4332,7 @@ msgstr ""
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
-msgstr ""
+msgstr "Ustuvorliklar"
 
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
@@ -4347,104 +4351,104 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
 msgid "Priority"
-msgstr "प्राथमिकता"
+msgstr "Ustuvorlik"
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:86
 msgid "Priority <u>{0}</u> must be included in the SLA {1}."
-msgstr ""
+msgstr "<u>{0}</u> ustuvorligi SLA ga kiritilishi kerak {1}."
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:75
 msgid "Priority {0} has been repeated."
-msgstr ""
+msgstr "{0} ustuvorligi takrorlandi."
 
 #: desk/src/components/layouts/Sidebar.vue:309
 #: desk/src/pages/ticket/Tickets.vue:377
 msgid "Private Views"
-msgstr "निजी दृश्य"
+msgstr "Shaxsiy qarashlar"
 
 #: desk/src/components/Settings/Teams/NewTeam.vue:30
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:11
 msgid "Product Experts"
-msgstr "उत्पाद विशेषज्ञ"
+msgstr "Mahsulot bo'yicha mutaxassislar"
 
 #: desk/src/components/Settings/NewTeamModal.vue:20
 msgid "Product experts"
-msgstr "उत्पाद विशेषज्ञ"
+msgstr "Mahsulot bo'yicha mutaxassislar"
 
 #: desk/src/components/Settings/Profile/Profile.vue:3
 msgid "Profile"
-msgstr ""
+msgstr "Profil"
 
 #: desk/src/components/Settings/Profile/Profile.vue:228
 msgid "Profile updated successfully."
-msgstr ""
+msgstr "Profil muvaffaqiyatli yangilandi."
 
 #. Label of the public (Check) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Public"
-msgstr "जनता"
+msgstr "Ommaviy"
 
 #: desk/src/components/layouts/Sidebar.vue:301
 #: desk/src/pages/ticket/Tickets.vue:392
 msgid "Public Views"
-msgstr "सार्वजनिक विचार"
+msgstr "Jamoatchilik qarashlari"
 
 #: desk/src/pages/knowledge-base/Article.vue:21
 msgid "Publish"
-msgstr "प्रकाशित करना"
+msgstr "Nashr qilish"
 
 #. Option for the 'Status' (Select) field in DocType 'HD Article'
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:443
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 msgid "Published"
-msgstr "प्रकाशित"
+msgstr "Nashr qilingan"
 
 #. Label of the published_on (Datetime) field in DocType 'HD Article'
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 msgid "Published On"
-msgstr "प्रकाशित"
+msgstr "Nashr qilingan sana"
 
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.py:24
 msgid "Published articles must have content."
-msgstr ""
+msgstr "Nashr qilingan maqolalar mazmunli bo'lishi kerak."
 
 #: desk/src/components/Settings/EmailEdit.vue:149
 msgid "Pull Emails"
-msgstr ""
+msgstr "Elektron pochta xabarlarini torting"
 
 #: desk/src/components/Settings/EmailEdit.vue:407
 msgid "Pulling emails, this may take a few minutes."
-msgstr ""
+msgstr "Elektron pochta xabarlarini olish jarayoni, bu bir necha daqiqa vaqt olishi mumkin."
 
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:36
 msgid "Quarterly"
-msgstr ""
+msgstr "Har chorakda"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
-msgstr ""
+msgstr "Navbatda"
 
 #. Label of the raised_by (Data) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Raised By (Email)"
-msgstr "(ईमेल) द्वारा जुटाया गया"
+msgstr "(Elektron pochta orqali) tomonidan to'plangan"
 
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:31
 msgid "Range"
-msgstr "श्रेणी"
+msgstr "Diapazon"
 
 #. Title of the email-feedback Web Form
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
 msgid "Rate Your Support Experience"
-msgstr ""
+msgstr "Qo'llab-quvvatlash tajribangizni baholang"
 
 #: desk/src/pages/ticket/TicketFeedback.vue:4
 msgid "Rate this ticket"
-msgstr ""
+msgstr "Ushbu chiptaga baho bering"
 
 #: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
-msgstr ""
+msgstr "Reytingli chiptalar"
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
@@ -4453,75 +4457,75 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
-msgstr "रेटिंग"
+msgstr "Reyting"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.py:23
 msgid "Rating must be between 0.2 and 1.0"
-msgstr ""
+msgstr "Reyting 0,2 va 1,0 oralig'ida bo'lishi kerak"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.py:19
 msgid "Rating {0} is not allowed"
-msgstr "रेटिंग {0} की अनुमति नहीं है"
+msgstr "{0} reytingiga ruxsat berilmaydi"
 
 #. Option for the 'Type' (Select) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "Reaction"
-msgstr "प्रतिक्रिया"
+msgstr "Reaksiya"
 
 #. Label of the reactions (Table) field in DocType 'HD Ticket Comment'
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 msgid "Reactions"
-msgstr "प्रतिक्रियाओं"
+msgstr "Reaksiyalar"
 
 #. Label of the read (Check) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "Read"
-msgstr "पढ़ना"
+msgstr "O'qing"
 
 #: desk/src/pages/home/components/PendingTickets.vue:41
 msgid "Reason"
-msgstr "कारण"
+msgstr "Sabab"
 
 #: desk/src/pages/home/components/PendingTickets.vue:226
 msgid "Recent"
-msgstr "हाल ही का"
+msgstr "Yaqinda"
 
 #: desk/src/pages/home/components/PendingTickets.vue:233
 msgid "Recent Tickets"
-msgstr "हाल के टिकट"
+msgstr "So'nggi chiptalar"
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:30
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:29
 msgid "Record Calls"
-msgstr ""
+msgstr "Qo'ng'iroqlarni yozib olish"
 
 #: desk/src/components/Settings/Holiday/HolidayView.vue:114
 msgid "Recurring Holidays"
-msgstr ""
+msgstr "Takroriy bayramlar"
 
 #. Label of the recurring_holidays (JSON) field in DocType 'HD Service Holiday
 #. List'
 #: desk/src/components/Settings/Holiday/HolidayView.vue:178
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Recurring holidays"
-msgstr ""
+msgstr "Takroriy ta'tillar"
 
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Red"
-msgstr "लाल"
+msgstr "Qizil"
 
 #. Label of the reference_tab (Tab Break) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Reference"
-msgstr "संदर्भ"
+msgstr "Malumotnoma"
 
 #. Label of the reference_ticket (Link) field in DocType 'HD Ticket Comment'
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 msgid "Reference Ticket"
-msgstr "संदर्भ टिकट"
+msgstr "Malumotnoma chiptasi"
 
 #. Label of the references_tab (Tab Break) field in DocType 'HD Customer'
 #. Label of the references_section (Section Break) field in DocType 'HD
@@ -4529,26 +4533,26 @@ msgstr "संदर्भ टिकट"
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "References"
-msgstr "संदर्भ"
+msgstr "Manbalar"
 
 #: desk/src/pages/home/Home.vue:11
 msgid "Refresh"
-msgstr "ताज़ा करना"
+msgstr "Yangilash"
 
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:75
 msgid "Refresh Apps"
-msgstr ""
+msgstr "Ilovalarni yangilash"
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.js:6
 msgid "Regenerate Search Index"
-msgstr ""
+msgstr "Qidiruv indeksini qayta yaratish"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
 #: desk/src/components/contact/ContactInputRow.vue:45
 #: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
-msgstr "निकालना"
+msgstr "Olib tashlash"
 
 #: desk/src/components/customer/ContactCard.vue:190
 #: desk/src/components/customer/ContactCard.vue:294
@@ -4557,16 +4561,16 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
-msgstr ""
+msgstr "Logotipni olib tashlash"
 
 #: desk/src/components/Settings/Profile/Profile.vue:197
 msgid "Remove Photo"
-msgstr "फ़ोटो हटाएँ"
+msgstr "Suratni olib tashlash"
 
 #: desk/src/components/view-controls/filter/Filter.vue:66
 #: desk/src/components/view-controls/filter/Filter.vue:67
 msgid "Remove filter"
-msgstr ""
+msgstr "Filtrni olib tashlash"
 
 #: desk/src/components/ImageAvatar.vue:25
 msgid "Remove image"
@@ -4582,24 +4586,24 @@ msgstr ""
 #: desk/src/components/ticket-agent/TicketSubjectModal.vue:21
 #: desk/src/pages/ticket/MobileTicketAgent.vue:132
 msgid "Rename"
-msgstr ""
+msgstr "Qayta nomlash"
 
 #: desk/src/components/ticket-agent/TicketSubjectModal.vue:24
 msgid "Rename (Ctrl + ⏎)"
-msgstr ""
+msgstr "Qayta nomlash (Ctrl + ⏎)"
 
 #: desk/src/components/ticket-agent/TicketSubjectModal.vue:23
 msgid "Rename (⌘ + ⏎)"
-msgstr ""
+msgstr "Qayta nomlash (⌘ + ⏎)"
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
-msgstr ""
+msgstr "Jamoa nomini o'zgartirish"
 
 #: desk/src/components/view-controls/filter/Filter.vue:58
 #: desk/src/components/view-controls/filter/Filter.vue:59
 msgid "Replace filter"
-msgstr ""
+msgstr "Filtrni almashtiring"
 
 #: desk/src/components/ImageAvatar.vue:17
 msgid "Replace image"
@@ -4608,44 +4612,44 @@ msgstr ""
 #. Option in a Select field in the tickets Web Form
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
 msgid "Replied"
-msgstr "उत्तर दिया"
+msgstr "Javob berildi"
 
 #: desk/src/components/EmailArea.vue:54
 msgid "Reply"
-msgstr "जवाब"
+msgstr "Javob"
 
 #: desk/src/components/EmailArea.vue:59
 msgid "Reply All"
-msgstr "सभी को उत्तर दें"
+msgstr "Hammaga javob berish"
 
 #. Label of the reply_from_agent_section (Section Break) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Reply From Agent"
-msgstr "एजेंट की ओर से जवाब"
+msgstr "Agentdan javob"
 
 #. Label of the reply_from_contact_section (Section Break) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Reply From Contact"
-msgstr "संपर्क से उत्तर"
+msgstr "Kontaktdan javob"
 
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:84
 msgid "Reply from agent"
-msgstr "एजेंट की ओर से जवाब"
+msgstr "Agentdan javob"
 
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:77
 msgid "Reply from contact"
-msgstr "संपर्क से जवाब"
+msgstr "Kontaktdan javob"
 
 #: desk/src/components/layouts/Sidebar.vue:494
 msgid "Reply on a ticket"
-msgstr "टिकट पर प्रतिक्रिया दें"
+msgstr "Chiptaga javob bering"
 
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
-msgstr "आवश्यक"
+msgstr "Majburiy"
 
 #: desk/src/pages/contact/Contact.vue:279
 msgid "Resend Invite"
@@ -4653,51 +4657,51 @@ msgstr ""
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
 msgid "Reset"
-msgstr ""
+msgstr "Qayta tiklash"
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:89
 #: desk/src/components/Settings/General/components/TicketSettings.vue:252
 msgid "Reset Content"
-msgstr ""
+msgstr "Kontentni asl holatiga qaytarish"
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:114
 msgid "Reset content"
-msgstr ""
+msgstr "Kontentni qayta tiklash"
 
 #: desk/src/components/view-controls/ColumnSettings.vue:93
 msgid "Reset to Default"
-msgstr ""
+msgstr "Standart holatga qaytarish"
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
 #: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
-msgstr "संकल्प"
+msgstr "Ruxsat"
 
 #. Label of the resolution_by (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution By"
-msgstr "संकल्प द्वारा"
+msgstr "Qaror qabul qilish muddati"
 
 #. Label of the resolution_date (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution Date"
-msgstr "संकल्प तिथि"
+msgstr "Qaror sanasi"
 
 #. Label of the resolution_details (Text Editor) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution Details"
-msgstr "संकल्प विवरण"
+msgstr "Ruxsat tafsilotlari"
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution Due"
-msgstr ""
+msgstr "Qaror qabul qilinishi kerak"
 
 #. Label of the resolution_failed_by (Duration) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution Failed By"
-msgstr "संकल्प विफल रहा"
+msgstr "Qaror qabul qilinmadi"
 
 #. Label of the resolution_time (Duration) field in DocType 'HD Service Level
 #. Priority'
@@ -4705,71 +4709,71 @@ msgstr "संकल्प विफल रहा"
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution Time"
-msgstr "संकल्प समय"
+msgstr "Ruxsat berish vaqti"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Resolved"
-msgstr "हल किया"
+msgstr "Hal qilindi"
 
 #. Label of the response_tab (Tab Break) field in DocType 'HD Ticket'
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:89
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Response"
-msgstr "प्रतिक्रिया"
+msgstr "Javob"
 
 #. Label of the response_by (Datetime) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Response By"
-msgstr "द्वारा प्रतिक्रिया"
+msgstr "Javob muallifi"
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
-msgstr ""
+msgstr "{1} qatoridagi {0} ustuvorligi uchun javob vaqti Ruxsat berish vaqtidan katta bo'lmasligi kerak."
 
 #. Label of the response_and_resolution_time_section (Section Break) field in
 #. DocType 'HD Service Level Agreement'
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:179
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Response and Resolution"
-msgstr "प्रतिक्रिया और समाधान"
+msgstr "Javob va qaror"
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:407
 msgid "Response is required"
-msgstr "उत्तर देना आवश्यक है"
+msgstr "Javob talab qilinadi"
 
 #. Label of the assign_within_team (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Restrict agent assignment to selected Team"
-msgstr ""
+msgstr "Agentni tanlangan jamoaga tayinlashni cheklash"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:57
 msgid "Restrict agent assignment to selected team"
-msgstr ""
+msgstr "Agentni tanlangan jamoaga tayinlashni cheklash"
 
 #. Label of the restrict_tickets_by_agent_group (Check) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Restrict tickets by Team"
-msgstr "टिकटों को टीम के आधार पर प्रतिबंधित करें"
+msgstr "Jamoa tomonidan chiptalarni cheklash"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:35
 msgid "Restrict tickets by team"
-msgstr "टिकटों को टीम के आधार पर प्रतिबंधित करें"
+msgstr "Jamoa bo'yicha chiptalarni cheklash"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:38
 msgid "Restrict tickets to be viewed and managed by team members only."
-msgstr ""
+msgstr "Chiptalarni faqat jamoa a'zolari ko'rishi va boshqarishi mumkin."
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:83
 msgid "Restrict visibility to these teams"
-msgstr ""
+msgstr "Ushbu jamoalarga ko'rinishni cheklash"
 
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
-msgstr "समीक्षा"
+msgstr "Sharhlar"
 
 #: desk/src/components/customer/RevokeInviteButton.vue:12
 msgid "Revoke Invite"
@@ -4781,31 +4785,31 @@ msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:215
 msgid "Ringing"
-msgstr "बज"
+msgstr "Jiringlamoqda"
 
 #: desk/src/components/Settings/InviteAgents.vue:19
 #: desk/src/components/customer/ContactCard.vue:165
 #: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
-msgstr "भूमिका"
+msgstr "Rol"
 
 #: desk/src/components/customer/ContactCard.vue:248
 msgid "Role updated successfully"
-msgstr "भूमिका सफलतापूर्वक अपडेट हो गई"
+msgstr "Rol muvaffaqiyatli yangilandi"
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Route Name"
-msgstr "मार्ग का नाम"
+msgstr "Yo'nalish nomi"
 
 #. Label of the rows (Code) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Rows"
-msgstr ""
+msgstr "Qatorlar"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:108
 msgid "Run an initial sync to reconcile existing records. New ones update automatically."
-msgstr ""
+msgstr "Mavjud yozuvlarni moslashtirish uchun dastlabki sinxronlashni ishga tushiring. Yangilari avtomatik ravishda yangilanadi."
 
 #. Label of the sla (Link) field in DocType 'HD Ticket'
 #. Label of the sla_tab (Tab Break) field in DocType 'HD Ticket'
@@ -4813,60 +4817,60 @@ msgstr ""
 #: desk/src/pages/ticket/MobileTicketAgent.vue:76
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "SLA"
-msgstr ""
+msgstr "SLA"
 
 #: desk/src/pages/home/components/PendingTickets.vue:232
 msgid "SLA Alerts"
-msgstr ""
+msgstr "SLA ogohlantirishlari"
 
 #. Label of the service_level_agreement_creation (Datetime) field in DocType
 #. 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "SLA Creation"
-msgstr ""
+msgstr "SLA yaratish"
 
 #. Label of the sla_mapping_section (Section Break) field in DocType 'HD Ticket
 #. Status'
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "SLA Mapping"
-msgstr ""
+msgstr "SLA xaritalash"
 
 #. Label of the agreement_status (Select) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "SLA Status"
-msgstr ""
+msgstr "SLA holati"
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:430
 msgid "SLA policy created successfully."
-msgstr ""
+msgstr "SLA siyosati muvaffaqiyatli yaratildi."
 
 #: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:167
 msgid "SLA policy deleted successfully."
-msgstr ""
+msgstr "SLA siyosati muvaffaqiyatli o'chirildi."
 
 #: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:139
 msgid "SLA policy duplicated successfully."
-msgstr ""
+msgstr "SLA siyosati muvaffaqiyatli nusxalandi."
 
 #: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:184
 msgid "SLA policy status updated successfully."
-msgstr ""
+msgstr "SLA siyosati holati muvaffaqiyatli yangilandi."
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:469
 msgid "SLA policy updated successfully."
-msgstr ""
+msgstr "SLA siyosati muvaffaqiyatli yangilandi."
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:478
 msgid "SLA set as default cannot be disabled"
-msgstr ""
+msgstr "Standart sifatida o'rnatilgan SLA o'chirib qo'yilishi mumkin emas"
 
 #: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:174
 msgid "SLA set as default cannot be disabled."
-msgstr ""
+msgstr "Standart sifatida o'rnatilgan SLA o'chirib qo'yilishi mumkin emas."
 
 #: desk/src/components/Settings/Sla/SlaPolicies.vue:11
 msgid "SLAs align your team and customers with defined timelines for a reliable experience. Learn more about SLA "
-msgstr ""
+msgstr "SLAlar ishonchli tajriba uchun jamoangiz va mijozlaringizni belgilangan muddatlar bilan moslashtiradi. SLA haqida ko'proq bilib oling "
 
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
@@ -4874,7 +4878,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Saturday"
-msgstr "शनिवार"
+msgstr "Shanba"
 
 #. Button label of the email-feedback Web Form
 #: desk/src/components/ListViewBuilder.vue:704
@@ -4897,53 +4901,53 @@ msgstr "शनिवार"
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
 msgid "Save"
-msgstr "बचाना"
+msgstr "Saqlash"
 
 #: desk/src/components/ListViewBuilder.vue:17
 msgid "Save Changes"
-msgstr "परिवर्तनों को सुरक्षित करें"
+msgstr "O'zgarishlarni saqlash"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:12
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:3
 #: desk/src/components/layouts/Sidebar.vue:617
 msgid "Saved Replies"
-msgstr ""
+msgstr "Saqlangan javoblar"
 
 #: desk/src/pages/ticket/Tickets.vue:371
 msgid "Saved Views"
-msgstr ""
+msgstr "Saqlangan ko'rishlar"
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:286
 msgid "Saved reply deleted successfully."
-msgstr ""
+msgstr "Saqlangan javob muvaffaqiyatli o'chirildi."
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:303
 msgid "Saved reply duplicated successfully."
-msgstr ""
+msgstr "Saqlangan javob muvaffaqiyatli nusxalandi."
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:326
 msgid "Saved reply saved successfully."
-msgstr ""
+msgstr "Saqlangan javob muvaffaqiyatli saqlandi."
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:389
 msgid "Saved reply updated successfully."
-msgstr ""
+msgstr "Saqlangan javob muvaffaqiyatli yangilandi."
 
 #: desk/src/components/Settings/Holiday/HolidayList.vue:29
 msgid "Schedule name"
-msgstr ""
+msgstr "Jadval nomi"
 
 #. Label of the scope (Select) field in DocType 'HD Saved Reply'
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:106
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:57
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 msgid "Scope"
-msgstr "दायरा"
+msgstr "Qo'llanish doirasi"
 
 #. Label of the script (Code) field in DocType 'HD Form Script'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 msgid "Script"
-msgstr "लिखी हुई कहानी"
+msgstr "Skript"
 
 #. Label of the search_tab (Tab Break) field in DocType 'HD Settings'
 #: desk/src/components/SavedRepliesSelectorModal.vue:27
@@ -4958,19 +4962,19 @@ msgstr "लिखी हुई कहानी"
 #: desk/src/components/layouts/Sidebar.vue:14 desk/src/pages/SearchAgent.vue:7
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Search"
-msgstr "खोज"
+msgstr "Qidiruv"
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.js:10
 msgid "Search Index Regenerated"
-msgstr ""
+msgstr "Qidiruv indeksi qayta yaratildi"
 
 #: helpdesk/helpdesk/report/ticket_search_analysis/ticket_search_analysis.py:40
 msgid "Search Score"
-msgstr "खोज स्कोर"
+msgstr "Qidiruv ballari"
 
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
-msgstr "खोज एजेंट..."
+msgstr "Qidiruv agentlari..."
 
 #: desk/src/components/customer/TicketsTab.vue:7
 msgid "Search by ID or Subject"
@@ -4982,52 +4986,52 @@ msgstr ""
 
 #: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
-msgstr "खोज फ़ील्ड..."
+msgstr "Qidiruv maydonlari..."
 
 #: desk/src/components/command-palette/CP.vue:126
 msgid "Search for \"{0}\""
-msgstr "\"{0} \" खोजें"
+msgstr "\"{0} \" ni qidiring"
 
 #: desk/src/pages/SearchAgent.vue:100
 msgid "Search index does not exist. Please build the index first."
-msgstr ""
+msgstr "Qidiruv indeksi mavjud emas. Iltimos, avval indeksni yarating."
 
 #: helpdesk/api/search.py:41
 msgid "Search index not available. Please contact administrator."
-msgstr ""
+msgstr "Qidiruv indeksi mavjud emas. Iltimos, administrator bilan bog'laning."
 
 #: helpdesk/api/search.py:17
 msgid "Search query must be at least 2 characters"
-msgstr ""
+msgstr "Qidiruv so'rovi kamida 2 ta belgidan iborat bo'lishi kerak"
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:20
 msgid "Search ticket"
-msgstr "टिकट खोजें"
+msgstr "Chipta qidirish"
 
 #: desk/src/pages/SearchAgent.vue:16
 msgid "Search tickets, comments, and communications..."
-msgstr "टिकट, टिप्पणियां और संदेश खोजें..."
+msgstr "Chiptalarni, sharhlarni va xabarlarni qidirish..."
 
 #: desk/src/components/command-palette/CP.vue:12
 msgid "Search tickets, emails, comments, or #234 to navigate to ticket"
-msgstr "टिकट, ईमेल, टिप्पणियाँ या #234 खोजें और टिकट पर जाएँ"
+msgstr "Chiptalarni qidirish, elektron pochta xabarlarini qidirish, sharhlar yoki #234 raqami orqali chiptaga o'tish"
 
 #: desk/src/components/view-controls/filter/FilterValueEditor.vue:33
 msgid "Search..."
-msgstr "खोज..."
+msgstr "Qidiruv..."
 
 #: desk/src/pages/SearchAgent.vue:137
 msgid "Searched for:"
-msgstr "खोज की गई:"
+msgstr "Qidiruv natijalari:"
 
 #: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
-msgstr "खोज जारी है..."
+msgstr "Qidirilmoqda..."
 
 #: desk/src/pages/home/components/PendingTickets.vue:147
 msgid "See all {0} tickets"
-msgstr "सभी टिकट देखें {0}"
+msgstr "Barcha {0} chiptalarni ko'rish"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:28
 #: desk/src/pages/call-logs/CallLogModal.vue:57
@@ -5035,11 +5039,11 @@ msgstr "सभी टिकट देखें {0}"
 #: desk/src/pages/call-logs/CallLogModal.vue:92
 #: desk/src/pages/call-logs/CallLogModal.vue:101
 msgid "Select"
-msgstr "चुनना"
+msgstr "Tanlang"
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
-msgstr "श्रेणी चुनना"
+msgstr "Kategoriyani tanlang"
 
 #: desk/src/components/contact/EditContactDialog.vue:161
 msgid "Select Customer"
@@ -5047,23 +5051,23 @@ msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
 msgid "Select Range"
-msgstr ""
+msgstr "Diapazonni tanlang"
 
 #: desk/src/components/ticket/TicketMergeModal.vue:55
 msgid "Select Ticket"
-msgstr ""
+msgstr "Chipta tanlang"
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:31
 msgid "Select Timezone"
-msgstr ""
+msgstr "Vaqt mintaqasini tanlang"
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:167
 msgid "Select a Default Priority."
-msgstr ""
+msgstr "Standart ustuvorlikni tanlang."
 
 #: desk/src/pages/ticket/TicketFeedback.vue:26
 msgid "Select a rating"
-msgstr "रेटिंग चुनें"
+msgstr "Reytingni tanlang"
 
 #: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
 msgid "Select country"
@@ -5072,45 +5076,45 @@ msgstr ""
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
-msgstr "श्रेणी का चयन करें"
+msgstr "Diapazonni tanlang"
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:78
 msgid "Select teams"
-msgstr "टीमों का चयन करें"
+msgstr "Jamoalarni tanlang"
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
-msgstr ""
+msgstr "Oldindan ko'rish uchun chiptani tanlang"
 
 #: desk/src/components/TimezoneControl.vue:5
 msgid "Select timezone"
-msgstr ""
+msgstr "Vaqt mintaqasini tanlang"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
 msgid "Select what type all tickets get by default."
-msgstr ""
+msgstr "Barcha chiptalar sukut bo'yicha qaysi turga kirishini tanlang."
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:41
 msgid "Select your weekly off day"
-msgstr "अपनी साप्ताहिक छुट्टी का दिन चुनें"
+msgstr "Haftalik dam olish kuningizni tanlang"
 
 #: desk/src/pages/ticket/TicketCustomer.vue:78
 msgid "Send"
-msgstr "भेजना"
+msgstr "Yuborish"
 
 #: desk/src/components/Settings/InviteAgents.vue:37
 msgid "Send Invites"
-msgstr "निमंत्रण भेजें"
+msgstr "Taklifnomalarni yuborish"
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:32
 msgid "Send Reply"
-msgstr ""
+msgstr "Javob yuborish"
 
 #. Label of the send_email_feedback_on_status (Link) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
-msgstr "प्रतिक्रिया भेजें"
+msgstr "Fikr-mulohaza yuboring"
 
 #: desk/src/pages/contact/Contact.vue:294
 msgid "Send reset password email"
@@ -5118,50 +5122,50 @@ msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
 msgid "Send to {0} tickets"
-msgstr ""
+msgstr "Chiptalarni {0} manziliga yuboring"
 
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:78
 msgid "Sent to all of the agents assigned to the ticket whenever a contact has replied."
-msgstr ""
+msgstr "Kontakt javob bergan har safar chiptaga biriktirilgan barcha agentlarga yuboriladi."
 
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:85
 msgid "Sent to all of the recipients associated with the ticket whenever an agent has replied."
-msgstr ""
+msgstr "Agent javob berganida, chipta bilan bog'liq barcha oluvchilarga yuboriladi."
 
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:73
 msgid "Sent to the user right after creating an email ticket."
-msgstr ""
+msgstr "Elektron pochta chiptasi yaratilgandan so'ng darhol foydalanuvchiga yuboriladi."
 
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:66
 msgid "Sent to the user who has raised the ticket after the ticket is closed or resolved."
-msgstr ""
+msgstr "Chipta yopilgandan yoki muammo hal qilingandan keyin chiptani ko'targan foydalanuvchiga yuboriladi."
 
 #: desk/src/components/layouts/Sidebar.vue:618
 msgid "Service Level Agreement"
-msgstr "सेवा स्तर समझौता"
+msgstr "Xizmat ko'rsatish darajasi shartnomasi"
 
 #: desk/src/components/Settings/Sla/SlaPolicies.vue:5
 msgid "Service Level Agreements (SLAs)"
-msgstr ""
+msgstr "Xizmat ko'rsatish darajasi shartnomalari (XDA)"
 
 #. Label of the service_level (Data) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Service Level Name"
-msgstr "सेवा स्तर का नाम"
+msgstr "Xizmat ko'rsatish darajasi nomi"
 
 #: helpdesk/api/settings/email.py:14
 msgid "Service not supported"
-msgstr ""
+msgstr "Xizmat qo'llab-quvvatlanmaydi"
 
 #: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
-msgstr "तय करना"
+msgstr "O'rnatish"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:4
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
-msgstr "फ़ोन नंबर सेट करें"
+msgstr "Telefon raqamini o'rnating"
 
 #: desk/src/components/customer/ContactCard.vue:265
 msgid "Set Primary Contact"
@@ -5169,11 +5173,11 @@ msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
 msgid "Set Resolution Time for Priority {0} in row {1}."
-msgstr ""
+msgstr "{1} qatoriga {0} ustuvorligi uchun aniqlik vaqtini o'rnating."
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:48
 msgid "Set Response Time for Priority {0} in row {1}."
-msgstr ""
+msgstr "{1} qatoridagi {0} ustuvorligi uchun javob berish vaqtini o'rnating."
 
 #: desk/src/components/customer/ContactCard.vue:156
 msgid "Set as Primary"
@@ -5181,7 +5185,7 @@ msgstr ""
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
-msgstr ""
+msgstr "Standart SLA sifatida o'rnatish"
 
 #: desk/src/components/contact/ContactInputRow.vue:32
 #: desk/src/components/contact/ContactInputRow.vue:36
@@ -5191,189 +5195,189 @@ msgstr ""
 #: desk/src/components/AvailabilityMenu.vue:5
 #: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
-msgstr ""
+msgstr "Holatni o'rnatish"
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:231
 msgid "Set the default status assigned when a ticket is created, and the status to apply when a ticket is reopened. If not specified, the default status from HD Settings will be used."
-msgstr ""
+msgstr "Chipta yaratilganda tayinlanadigan standart holatni va chipta qayta ochilganda qo'llaniladigan holatni o'rnating. Agar ko'rsatilmagan bo'lsa, HD sozlamalaridagi standart holat ishlatiladi."
 
 #: desk/src/components/Settings/Sla/SlaHolidays.vue:9
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
-msgstr ""
+msgstr "Oldindan belgilangan jadvalni tanlash yoki yangi jadval yaratish orqali ish kunlari, soatlari va bayramlarni belgilang."
 
 #: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
-msgstr ""
+msgstr "Jamoangiz qachon bog'lanish mumkinligini bilishi uchun mavjudligingizni sozlang."
 
 #: desk/src/components/Settings/Holiday/Holidays.vue:5
 msgid "Set your team’s working days, hours, and holidays using a template or custom schedule."
-msgstr ""
+msgstr "Shablon yoki maxsus jadval yordamida jamoangizning ish kunlari, soatlari va bayramlarini belgilang."
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:125
 msgid "Setting <strong>{0}</strong> as the default SLA removes <strong>{1}</strong> as the default SLA. You’ll need to add a condition in <strong>{1}</strong> for the SLA to work."
-msgstr ""
+msgstr "<strong>{0}</strong> ni standart SLA sifatida belgilash <strong>{1}</strong> ni standart SLA sifatida olib tashlaydi. SLA ishlashi uchun <strong>{1}</strong> ga shart qo'shishingiz kerak bo'ladi."
 
 #: desk/src/components/layouts/Sidebar.vue:574
 msgid "Setting up"
-msgstr "की स्थापना"
+msgstr "Sozlanmoqda"
 
 #. Label of the column_break_feto (Column Break) field in DocType 'HD Team'
 #: desk/src/components/layouts/Sidebar.vue:386
 #: desk/src/components/layouts/Sidebar.vue:632
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Settings"
-msgstr ""
+msgstr "Sozlamalar"
 
 #: desk/src/components/Settings/General/General.vue:253
 #: desk/src/components/Settings/General/General.vue:291
 #: desk/src/components/Settings/General/General.vue:300
 msgid "Settings updated"
-msgstr ""
+msgstr "Sozlamalar yangilandi"
 
 #: desk/src/components/Settings/EmailNotifications/Acknowledgement.vue:47
 #: desk/src/components/Settings/EmailNotifications/ReplyToAgents.vue:47
 #: desk/src/components/Settings/EmailNotifications/ReplyViaAgent.vue:47
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:77
 msgid "Settings updated successfully."
-msgstr ""
+msgstr "Sozlamalar muvaffaqiyatli yangilandi."
 
 #. Label of the setup_section (Section Break) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Setup"
-msgstr "स्थापित करना"
+msgstr "Sozlash; o'rnatish"
 
 #: desk/src/components/Settings/EmailAdd.vue:3
 msgid "Setup Email"
-msgstr ""
+msgstr "Elektron pochtani sozlash"
 
 #: desk/src/components/layouts/Sidebar.vue:461
 msgid "Setup SLA"
-msgstr ""
+msgstr "SLA ni sozlash"
 
 #: desk/src/pages/knowledge-base/Article.vue:649
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:167
 msgid "Share"
-msgstr "शेयर करना"
+msgstr "Ulashish"
 
 #. Label of the share_feedback_section (Section Break) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Share Feedback"
-msgstr "प्रतिक्रिया साझा करें"
+msgstr "Fikr-mulohazalaringizni ulashing"
 
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:65
 msgid "Share feedback"
-msgstr "प्रतिक्रिया साझा करें"
+msgstr "Fikr-mulohazalaringizni ulashing"
 
 #: desk/src/components/layouts/Sidebar.vue:381
 msgid "Shortcuts"
-msgstr ""
+msgstr "Yorliqlar"
 
 #: desk/src/components/HistoryBox.vue:10
 msgid "Show "
-msgstr ""
+msgstr "Shou "
 
 #. Label of the different_view (Check) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Show end users a different view"
-msgstr ""
+msgstr "Yakuniy foydalanuvchilarga boshqa ko'rinishni ko'rsatish"
 
 #: desk/src/pages/ticket/Tickets.vue:481
 msgid "Show in sidebar"
-msgstr ""
+msgstr "Yon panelda ko'rsatish"
 
 #: desk/src/components/modals/ShortcutsModal.vue:80
 msgid "Show keyboard shortcuts"
-msgstr ""
+msgstr "Klaviatura yorliqlarini ko'rsatish"
 
 #: desk/src/pages/home/components/PendingTickets.vue:154
 msgid "Showing {0} of {1} {2}"
-msgstr "{1} {2} में से {0} दिखा रहा है"
+msgstr "{0} / {1} {2} ko'rsatilmoqda"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:22
 msgid "Signature"
-msgstr "हस्ताक्षर"
+msgstr "Imzo"
 
 #. Description of the 'Condition' (Code) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Simple Python Expression, Example: doc.status == 'Open' and doc.ticket_type == 'Bug'"
-msgstr ""
+msgstr "Pythonda oddiy ifoda, misol: doc.status == 'Open' va doc.ticket_type == 'Bug'"
 
 #. Label of the skip_email_workflow (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Skip e-mail workflow"
-msgstr ""
+msgstr "Elektron pochta ish jarayonini o'tkazib yuborish"
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:26
 msgid "Skip email workflow"
-msgstr ""
+msgstr "Elektron pochta ish jarayonini o'tkazib yuborish"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:617
 msgid "Some error occurred while renaming assignment rule"
-msgstr ""
+msgstr "Topshiriq qoidasini qayta nomlashda xatolik yuz berdi"
 
 #: desk/src/components/Settings/Holiday/HolidayView.vue:399
 msgid "Some error occurred while renaming holiday list"
-msgstr ""
+msgstr "Bayramlar ro'yxatini qayta nomlashda xatolik yuz berdi"
 
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:368
 msgid "Some error occurred while renaming saved reply"
-msgstr ""
+msgstr "Saqlangan javobni qayta nomlashda xatolik yuz berdi"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:601
 msgid "Some error occurred while updating assignment rule"
-msgstr ""
+msgstr "Topshiriq qoidasini yangilashda xatolik yuz berdi"
 
 #: desk/src/components/Settings/Holiday/HolidayView.vue:389
 msgid "Some error occurred while updating holiday list"
-msgstr ""
+msgstr "Bayramlar ro'yxatini yangilashda xatolik yuz berdi"
 
 #: desk/src/components/view-controls/SortBy.vue:10
 #: desk/src/components/view-controls/SortBy.vue:22
 #: desk/src/components/view-controls/SortBy.vue:231
 msgid "Sort"
-msgstr "क्रम से लगाना"
+msgstr "Saralash"
 
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
-msgstr ""
+msgstr "Manba va maqsadli kategoriya bir xil bo'lmasligi kerak"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/api.py:339
 msgid "Source and target ticket cannot be same"
-msgstr ""
+msgstr "Manba va maqsadli chipta bir xil bo'lmasligi kerak"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/api.py:335
 msgid "Source ticket does not exist"
-msgstr "स्रोत टिकट मौजूद नहीं है"
+msgstr "Manba chiptasi mavjud emas"
 
 #. Label of the split_and_merge_section (Section Break) field in DocType 'HD
 #. Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Split and Merge"
-msgstr "विभाजित करें और विलय करें"
+msgstr "Ajratish va qo'shilish"
 
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.js:9
 msgid "Standard Form Scripts can't be modified, duplicate the script instead."
-msgstr ""
+msgstr "Standart shakl skriptlarini o'zgartirib bo'lmaydi, buning o'rniga skriptni nusxalash mumkin."
 
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.py:55
 msgid "Standard Views cannot be deleted."
-msgstr ""
+msgstr "Standart ko'rinishlarni o'chirib bo'lmaydi."
 
 #. Label of the start_date (Date) field in DocType 'HD Service Level Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Start Date"
-msgstr "आरंभ करने की तिथि"
+msgstr "Boshlanish sanasi"
 
 #. Label of the start_time (Time) field in DocType 'HD Service Day'
 #: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
 msgid "Start Time"
-msgstr "समय शुरू"
+msgstr "Boshlanish vaqti"
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:100
 msgid "Start Time can't be greater than or equal to End Time in row <u>{0}</u>."
-msgstr ""
+msgstr "Boshlanish vaqti <u>{0}</u> qatoridagi tugash vaqtidan katta yoki teng bo'lmasligi kerak."
 
 #. Label of the status (Select) field in DocType 'HD Article'
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
@@ -5391,59 +5395,61 @@ msgstr ""
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:31
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
 msgid "Status"
-msgstr "स्थिति"
+msgstr "Holat"
 
 #. Label of the auto_close_status (Link) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Status "
-msgstr "स्थिति "
+msgstr "Holat "
 
 #. Label of the status_category (Data) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Status Category"
-msgstr "स्थिति श्रेणी"
+msgstr "Holat toifasi"
 
 #. Label of the status_details (Section Break) field in DocType 'HD Service
 #. Level Agreement'
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:227
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Status Details"
-msgstr "स्थिति विवरण"
+msgstr "Holat tafsilotlari"
 
 #. Label of the status_order (Int) field in DocType 'HD Agent Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 msgid "Status Order"
-msgstr ""
+msgstr "Holat tartibi"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:382
 msgid "Status is required"
-msgstr "स्थिति आवश्यक है"
+msgstr "Holat talab qilinadi"
 
 #. Description of the 'Ticket Reopen status' (Link) field in DocType 'HD
 #. Service Level Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Status of the ticket, when a customer replies on the ticket with this SLA.\n\n"
 "If not selected, the value will be takes from HD Settings DocType."
-msgstr ""
+msgstr "Mijoz chiptaga ushbu SLA bilan javob berganida, chiptaning holati.\n\n"
+"Agar tanlanmagan bo'lsa, qiymat HD Sozlamalar DocType dan olinadi."
 
 #. Description of the 'Ticket Reopen status' (Link) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Status of the ticket, when a customer replies on the ticket."
-msgstr ""
+msgstr "Mijoz chiptaga javob berganida, chiptaning holati."
 
 #. Description of the 'Default Ticket Status' (Link) field in DocType 'HD
 #. Service Level Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Status of the ticket, when it is created in the system with this SLA.\n"
 "If not selected, the value will be taken from HD Settings DocType"
-msgstr ""
+msgstr "Tizimda ushbu SLA bilan yaratilgan chiptaning holati.\n"
+"Agar tanlanmagan bo'lsa, qiymat HD Sozlamalar DocType dan olinadi."
 
 #. Description of the 'Default ticket status' (Link) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Status of the ticket, when it is created in the system."
-msgstr ""
+msgstr "Tizimda yaratilgan chiptaning holati."
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
@@ -5454,27 +5460,27 @@ msgstr ""
 #: helpdesk/helpdesk/report/ticket_search_analysis/ticket_search_analysis.py:30
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
 msgid "Subject"
-msgstr "विषय"
+msgstr "Mavzu"
 
 #. Label of the subject_weight (Int) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Subject Weight"
-msgstr "विषय का वजन"
+msgstr "Obyektning og'irligi"
 
 #: desk/src/components/ticket/TicketSplitModal.vue:74
 msgid "Subject is required"
-msgstr "विषय आवश्यक है"
+msgstr "Mavzu shart"
 
 #: desk/src/pages/ticket/TicketFeedback.vue:8
 #: desk/src/pages/ticket/TicketNew.vue:96
 #: desk/src/pages/ticket/TicketNew.vue:120
 msgid "Submit"
-msgstr "जमा करना"
+msgstr "Yuborish"
 
 #. Label of the summary (Text Editor) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Summary"
-msgstr ""
+msgstr "Xulosa"
 
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
@@ -5482,80 +5488,80 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Sunday"
-msgstr "रविवार"
+msgstr "Yakshanba"
 
 #: desk/src/components/layouts/Sidebar.vue:366
 msgid "Support"
-msgstr "सहायता"
+msgstr "Qo'llab-quvvatlash"
 
 #. Name of a report
 #: helpdesk/helpdesk/report/support_hour_distribution/support_hour_distribution.json
 msgid "Support Hour Distribution"
-msgstr "सहायता घंटा वितरण"
+msgstr "Qo'llab-quvvatlash soatlarini taqsimlash"
 
 #. Label of a Link in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Support Policy"
-msgstr "समर्थन नीति"
+msgstr "Qo'llab-quvvatlash siyosati"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "Support Team"
-msgstr "सहायता दल"
+msgstr "Qo'llab-quvvatlash jamoasi"
 
 #: desk/src/components/Settings/Preferences/components/ThemeSwitcher.vue:11
 msgid "Switch between light, dark, or system theme"
-msgstr ""
+msgstr "Yorug'lik, qorong'i yoki tizim mavzusi o'rtasida almashinish"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:44
 msgid "Switch between outgoing email accounts when sending emails from your configured accounts."
-msgstr ""
+msgstr "Sozlangan hisoblaringizdan elektron pochta xabarlarini yuborishda chiquvchi elektron pochta hisoblari o'rtasida almashinish."
 
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.js:16
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.js:18
 msgid "Sync Customers"
-msgstr ""
+msgstr "Mijozlarni sinxronlashtirish"
 
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.js:22
 msgid "Sync all customers between ERPNext and Helpdesk? The sync runs in the background and can take a few minutes depending on the number of customers."
-msgstr ""
+msgstr "Barcha mijozlar ERPNext va Helpdesk o'rtasida sinxronlashtirilsinmi? Sinxronizatsiya fonda ishlaydi va mijozlar soniga qarab bir necha daqiqa vaqt olishi mumkin."
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:216
 msgid "Sync completed successfully"
-msgstr ""
+msgstr "Sinxronizatsiya muvaffaqiyatli yakunlandi"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:3
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:39
 msgid "Sync customers between Helpdesk and ERPNext."
-msgstr ""
+msgstr "Mijozlarni Yordam xizmati va ERPNext o'rtasida sinxronlashtiring."
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:120
 msgid "Sync now"
-msgstr ""
+msgstr "Hozir sinxronlashtiring"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:197
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.js:35
 msgid "Sync started"
-msgstr ""
+msgstr "Sinxronizatsiya boshlandi"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:104
 msgid "Sync your existing customers"
-msgstr ""
+msgstr "Mavjud mijozlaringizni sinxronlashtiring"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:120
 msgid "Syncing…"
-msgstr ""
+msgstr "Sinxronlash…"
 
 #. Label of the synonyms (Table) field in DocType 'HD Synonyms'
 #: helpdesk/helpdesk/doctype/hd_synonyms/hd_synonyms.json
 msgid "Synonyms"
-msgstr ""
+msgstr "Sinonimlar"
 
 #. Label of the is_system (Check) field in DocType 'HD Ticket Type'
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "System"
-msgstr "प्रणाली"
+msgstr "Tizim"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
@@ -5586,26 +5592,26 @@ msgstr "प्रणाली"
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "System Manager"
-msgstr "सिस्टम प्रबंधक"
+msgstr "Tizim menejeri"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.py:12
 msgid "System types can not be deleted"
-msgstr ""
+msgstr "Tizim turlarini o'chirib bo'lmaydi"
 
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:22
 msgid "Tampered Access"
-msgstr "छेड़छाड़ की गई पहुंच"
+msgstr "Buzilgan kirish"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/api.py:337
 msgid "Target ticket does not exist"
-msgstr ""
+msgstr "Maqsadli chipta mavjud emas"
 
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Teal"
-msgstr ""
+msgstr "Moviy"
 
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
@@ -5622,105 +5628,105 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Team"
-msgstr "टीम"
+msgstr "Jamoa"
 
 #: desk/src/components/Settings/Teams/NewTeam.vue:29
 msgid "Team Name"
-msgstr "टीम का नाम"
+msgstr "Jamoa nomi"
 
 #. Label of the agent_groups_section (Section Break) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Team Restrictions"
-msgstr "टीम प्रतिबंध"
+msgstr "Jamoa cheklovlari"
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:269
 msgid "Team can now access all tickets."
-msgstr ""
+msgstr "Jamoa endi barcha chiptalarga kirish huquqiga ega."
 
 #: desk/src/components/Settings/NewTeamModal.vue:52
 msgid "Team created"
-msgstr "टीम ने बनाया"
+msgstr "Jamoa yaratildi"
 
 #: desk/src/components/Settings/Teams/NewTeam.vue:140
 msgid "Team created successfully."
-msgstr ""
+msgstr "Jamoa muvaffaqiyatli yaratildi."
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:162
 #: desk/src/components/Settings/Teams/TeamsList.vue:185
 msgid "Team deleted successfully."
-msgstr ""
+msgstr "Jamoa muvaffaqiyatli o'chirildi."
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:184
 msgid "Team disabled successfully."
-msgstr ""
+msgstr "Jamoa muvaffaqiyatli o'chirib qo'yildi."
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:183
 msgid "Team enabled successfully."
-msgstr ""
+msgstr "Jamoa muvaffaqiyatli yoqildi."
 
 #: desk/src/components/Settings/Teams/TeamsList.vue:51
 msgid "Team name"
-msgstr "टीम का नाम"
+msgstr "Jamoa nomi"
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:56
 msgid "Team renamed successfully."
-msgstr ""
+msgstr "Jamoa nomi muvaffaqiyatli o'zgartirildi."
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:270
 msgid "Team will only see their own tickets."
-msgstr ""
+msgstr "Jamoa faqat o'z chiptalarini ko'radi."
 
 #. Label of the teams (Table MultiSelect) field in DocType 'HD Saved Reply'
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:74
 #: desk/src/components/Settings/Teams/TeamsList.vue:3
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 msgid "Teams"
-msgstr "टीमें"
+msgstr "Jamoalar"
 
 #: desk/src/components/Settings/Telephony/Telephony.vue:6
 msgid "Telephony"
-msgstr ""
+msgstr "Telefoniya"
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:281
 #: desk/src/components/Settings/Telephony/Telephony.vue:260
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:233
 msgid "Telephony settings updated successfully."
-msgstr ""
+msgstr "Telefoniya sozlamalari muvaffaqiyatli yangilandi."
 
 #: desk/src/pages/ticket/TicketFeedback.vue:54
 msgid "Tell us more"
-msgstr "हमें और अधिक बताएँ"
+msgstr "Batafsil ma'lumot bering"
 
 #. Label of the template (Link) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Template"
-msgstr ""
+msgstr "Andoza"
 
 #. Label of the template_name (Data) field in DocType 'HD Ticket Template'
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Template Name"
-msgstr ""
+msgstr "Andoza nomi"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:12
 msgid "The 'Closed' status cannot be renamed."
-msgstr ""
+msgstr "\"Yopiq\" holatini qayta nomlab bo'lmaydi."
 
 #: helpdesk/extends/assignment_rule.py:20
 msgid "The Assign Condition JSON '{0}' is invalid: </br> {1}"
-msgstr ""
+msgstr "JSON '{0}' tayinlash sharti yaroqsiz: </br> {1}"
 
 #: helpdesk/extends/assignment_rule.py:28
 msgid "The Unassign Condition JSON '{0}' is invalid: </br> {1}"
-msgstr ""
+msgstr "JSON '{0}' topshiriqni bekor qilish sharti yaroqsiz: </br> {1}"
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:147
 msgid "The assignment condition '{0}' is invalid: {1}"
-msgstr ""
+msgstr "'{0}' topshiriq sharti noto'g'ri: {1}"
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:154
 msgid "The assignment condition json '{0}' is invalid: {1}"
-msgstr ""
+msgstr "json '{0}' topshiriq sharti yaroqsiz: {1}"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
 msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
@@ -5728,15 +5734,15 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
-msgstr ""
+msgstr "Foydalanuvchi mijoz portalidan chiptani yopishga harakat qilganda, fikr-mulohaza oynasi ko'rsatiladi."
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.py:54
 msgid "The holiday on {0} is not between From Date and To Date"
-msgstr ""
+msgstr "{0} sanasidagi ta'til \"Boshlash sanasi\" va \"Keyingi sana\" oralig'ida emas"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
-msgstr "दिनों की संख्या 1 या अधिक होनी चाहिए"
+msgstr "Kunlar soni 1 yoki undan ko'p bo'lishi kerak"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
 msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
@@ -5744,23 +5750,23 @@ msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
 msgid "The status for sending feedback must be of <u>Resolved</u> category."
-msgstr ""
+msgstr "Fikr-mulohaza yuborish holati <u>toifasida bo'lishi kerak.</u> toifasi hal qilindi."
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:83
 msgid "The ticket status will automatically change whenever the agent respond to a ticket."
-msgstr ""
+msgstr "Agent chiptaga javob berganida, chipta holati avtomatik ravishda o'zgaradi."
 
 #: desk/src/components/Settings/Preferences/components/ThemeSwitcher.vue:6
 msgid "Theme"
-msgstr "विषय"
+msgstr "Mavzu"
 
 #: desk/src/components/knowledge-base/CategoryFolderContainer.vue:18
 msgid "There are no categories published at the moment."
-msgstr ""
+msgstr "Hozirda nashr etilgan kategoriyalar yo'q."
 
 #: helpdesk/extends/assignment_rule.py:14
 msgid "There should be at least 1 assignment rule for ticket"
-msgstr ""
+msgstr "Chipta uchun kamida 1 ta topshiriq qoidasi bo'lishi kerak"
 
 #: desk/src/components/customer/ContactCard.vue:223
 msgid "They'll get access to tickets raised by everyone in the organisation."
@@ -5772,12 +5778,12 @@ msgstr ""
 
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
-msgstr ""
+msgstr "Ushbu Topshiriq Qoidasi {0}jamoasiga bog'langan.</br> Foydalanuvchi {1} Topshiriq Qoidasiga qo'shilgan, ammo bog'langan Jamoaga qo'shilmagan. Jamoa tuzilishining to'g'riligiga ishonch hosil qilish uchun foydalanuvchini {2} ga qo'shing."
 
 #: desk/src/components/ticket/TicketMergeModal.vue:79
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
-msgstr ""
+msgstr "Bu harakat qaytarib bo'lmaydigan."
 
 #: desk/src/components/customer/ContactCard.vue:266
 msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
@@ -5785,48 +5791,48 @@ msgstr ""
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
 msgid "This date is calculated based on configured SLAs, working hours, and holidays."
-msgstr ""
+msgstr "Bu sana tuzilgan SLAlar, ish vaqti va bayramlar asosida hisoblanadi."
 
 #. Description of a DocType
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "This doctype will be deprecated in the future"
-msgstr ""
+msgstr "Ushbu hujjat turi kelajakda eskiradi"
 
 #. Description of the 'Instantly send e-mail' (Check) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "This field is used to send an email instantly without adding it into the queue. If this field is checked, the email will be sent immediately after clicking the \"Send\" button, instead of being added to the email queue for later processing."
-msgstr ""
+msgstr "Bu maydon elektron pochtani navbatga qo'shmasdan darhol yuborish uchun ishlatiladi. Agar bu maydon belgilangan bo'lsa, elektron pochta keyinchalik qayta ishlash uchun elektron pochta navbatiga qo'shilish o'rniga \"Yuborish\" tugmasini bosgandan so'ng darhol yuboriladi."
 
 #. Description of the 'Skip e-mail workflow' (Check) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "This field is used to skip email-related workflows for tickets. If this field is checked, no emails will be sent related to tickets, such as new ticket creation, status updates, or notifications."
-msgstr ""
+msgstr "Bu maydon chiptalar uchun elektron pochta bilan bog'liq ish jarayonlarini o'tkazib yuborish uchun ishlatiladi. Agar bu maydon belgilangan bo'lsa, chiptalar bilan bog'liq yangi chipta yaratish, holat yangilanishlari yoki bildirishnomalar kabi hech qanday elektron pochta xabarlari yuborilmaydi."
 
 #: helpdesk/www/helpdesk/index.py:26
 msgid "This method is only meant for developer mode"
-msgstr ""
+msgstr "Bu usul faqat dasturchi rejimi uchun mo'ljallangan"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/api.py:373
 msgid "This ticket (#{0}) has been merged with ticket <a href = '/helpdesk/tickets/{1}'>#{1}</a>."
-msgstr ""
+msgstr "Ushbu chipta (#{0}) <a href = '/helpdesk/tickets/{1}'>#{1}</a> chiptasi bilan birlashtirildi."
 
 #: helpdesk/helpdesk/doctype/hd_ticket/api.py:514
 msgid "This ticket has been split to a new ticket. Please follow up on ticket <a href={0}>#{1}</a>."
-msgstr ""
+msgstr "Bu chipta yangi chiptaga bo'lindi. Iltimos, <a href={0}>#{1}</a> chiptasi haqida ma'lumot oling."
 
 #: desk/src/pages/ticket/Tickets.vue:544
 msgid "This view is public, and will be removed for all users."
-msgstr ""
+msgstr "Bu ko'rinish hammaga ochiq va barcha foydalanuvchilar uchun olib tashlanadi."
 
 #: desk/src/components/ListViewBuilder.vue:699
 msgid "This view is public. Changes made will be visible to everyone."
-msgstr ""
+msgstr "Bu ko'rinish hammaga ochiq. Kiritilgan o'zgarishlar hammaga ko'rinadi."
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:249
 msgid "This will reset the content to the default message."
-msgstr ""
+msgstr "Bu kontentni standart xabarga qaytaradi."
 
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
@@ -5834,7 +5840,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Thursday"
-msgstr "गुरुवार"
+msgstr "Payshanba"
 
 #. Label of the ticket (Link) field in DocType 'HD Email Feedback'
 #. Label of the reference_ticket (Link) field in DocType 'HD Notification'
@@ -5848,23 +5854,23 @@ msgstr "गुरुवार"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
 msgid "Ticket"
-msgstr "टिकट"
+msgstr "Chipta"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
-msgstr "टिकट #{0}: हमें आपका अनुरोध प्राप्त हो गया है"
+msgstr "Chipta #{0}: Biz sizning so'rovingizni qabul qildik"
 
 #. Name of a report
 #. Label of a Link in the Helpdesk Workspace
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.json
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Analytics"
-msgstr "टिकट विश्लेषण"
+msgstr "Chipta tahlili"
 
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
-msgstr ""
+msgstr "Chipta konfiguratsiyasi"
 
 #: desk/src/components/customer/TicketsTab.vue:218
 msgid "Ticket ID"
@@ -5872,20 +5878,20 @@ msgstr ""
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
 msgid "Ticket Info"
-msgstr "टिकट की जानकारी"
+msgstr "Chipta haqida ma'lumot"
 
 #: desk/src/components/modals/ShortcutsModal.vue:85
 msgid "Ticket Management"
-msgstr "टिकट प्रबंधन"
+msgstr "Chiptalarni boshqarish"
 
 #. Label of the is_merged (Check) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Ticket Merged"
-msgstr "टिकट विलय हो गया"
+msgstr "Chipta birlashtirildi"
 
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:40
 msgid "Ticket Not Found"
-msgstr "टिकट नहीं मिला"
+msgstr "Chipta topilmadi"
 
 #: desk/src/components/layouts/Sidebar.vue:620
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:50
@@ -5893,7 +5899,7 @@ msgstr "टिकट नहीं मिला"
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:37
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.py:105
 msgid "Ticket Priority"
-msgstr "टिकट प्राथमिकता"
+msgstr "Chipta ustuvorligi"
 
 #. Label of the ticket_reopen_status (Link) field in DocType 'HD Service Level
 #. Agreement'
@@ -5901,35 +5907,35 @@ msgstr "टिकट प्राथमिकता"
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Ticket Reopen status"
-msgstr "टिकट पुनः खोलने की स्थिति"
+msgstr "Chipta qayta ochilish holati"
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:18
 msgid "Ticket Routing"
-msgstr ""
+msgstr "Chiptalarni yo'naltirish"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:4
 msgid "Ticket Settings"
-msgstr ""
+msgstr "Chipta sozlamalari"
 
 #. Label of the ticket_split_from (Link) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Ticket Split From"
-msgstr "टिकट विभाजन से"
+msgstr "Chiptani ajratish"
 
 #: desk/src/components/ticket/TicketMergeModal.vue:65
 msgid "Ticket Subject"
-msgstr ""
+msgstr "Chipta mavzusi"
 
 #. Name of a report
 #. Label of a Link in the Helpdesk Workspace
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.json
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Summary"
-msgstr ""
+msgstr "Chipta xulosasi"
 
 #: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
-msgstr "टिकट ट्रेंड"
+msgstr "Chiptalar trendi"
 
 #. Label of the ticket_type_section (Section Break) field in DocType 'HD
 #. Settings'
@@ -5942,67 +5948,67 @@ msgstr "टिकट ट्रेंड"
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.py:94
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Type"
-msgstr ""
+msgstr "Chipta turi"
 
 #: desk/src/pages/ticket/TicketCustomer.vue:325
 msgid "Ticket closed successfully."
-msgstr ""
+msgstr "Chipta muvaffaqiyatli yopildi."
 
 #: desk/src/components/ticket-agent/TicketHeader.vue:218
 msgid "Ticket deleted successfully."
-msgstr ""
+msgstr "Chipta muvaffaqiyatli o'chirildi."
 
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:21
 msgid "Ticket does not exist."
-msgstr ""
+msgstr "Chipta mavjud emas."
 
 #: desk/src/components/ticket/TicketMergeModal.vue:192
 msgid "Ticket merged successfully."
-msgstr ""
+msgstr "Chipta muvaffaqiyatli birlashtirildi."
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
-msgstr ""
+msgstr "Chipta fikr-mulohaza bilan hal qilinishi kerak"
 
 #: desk/src/pages/ticket/TicketAgent.vue:33
 #: helpdesk/helpdesk/doctype/hd_ticket/api.py:63
 msgid "Ticket not found"
-msgstr "टिकट नहीं मिला"
+msgstr "Chipta topilmadi"
 
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:40
 msgid "Ticket not found for the provided key."
-msgstr ""
+msgstr "Berilgan kalit uchun chipta topilmadi."
 
 #: desk/src/pages/ticket/TicketCustomer.vue:164
 msgid "Ticket not found."
-msgstr ""
+msgstr "Chipta topilmadi."
 
 #. Label of the raised_outside_working_hours (Check) field in DocType 'HD
 #. Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Ticket raised outside working hours"
-msgstr "कार्य समय के बाहर टिकट जारी किया गया"
+msgstr "Chipta ish vaqtidan tashqarida olindi"
 
 #: desk/src/components/ticket/TicketSplitModal.vue:79
 msgid "Ticket split successfully."
-msgstr ""
+msgstr "Chipta muvaffaqiyatli bo'lindi."
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:155
 msgid "Ticket status"
-msgstr "टिकट की स्थिति"
+msgstr "Chipta holati"
 
 #: desk/src/components/ticket/TicketMergeModal.vue:189
 msgid "Ticket to merged with is required"
-msgstr ""
+msgstr "Birlashtirish uchun chipta talab qilinadi"
 
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
-msgstr ""
+msgstr "Chipta muvaffaqiyatli yangilandi."
 
 #. Name of a report
 #: helpdesk/helpdesk/report/ticket_search_analysis/ticket_search_analysis.json
 msgid "Ticket-Search Analysis"
-msgstr "टिकट-खोज विश्लेषण"
+msgstr "Chipta qidiruvi tahlili"
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
@@ -6016,48 +6022,48 @@ msgstr "टिकट-खोज विश्लेषण"
 #: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
 #: helpdesk/api/dashboard.py:302
 msgid "Tickets"
-msgstr "टिकट"
+msgstr "Chiptalar"
 
 #: desk/src/pages/home/components/PendingTickets.vue:242
 msgid "Tickets approaching or breached SLA"
-msgstr ""
+msgstr "Chiptalar SLAga yaqinlashib kelmoqda yoki ularni buzmoqda"
 
 #: desk/src/pages/home/components/PendingTickets.vue:243
 msgid "Tickets assigned to you in the last 7 days"
-msgstr ""
+msgstr "So'nggi 7 kun ichida sizga tayinlangan chiptalar"
 
 #: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
-msgstr "चैनल के अनुसार टिकट"
+msgstr "Kanal bo'yicha chiptalar"
 
 #: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
-msgstr ""
+msgstr "Ustuvorlik bo'yicha chiptalar"
 
 #: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
-msgstr "टीम द्वारा टिकट"
+msgstr "Jamoa tomonidan chiptalar"
 
 #: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
-msgstr "टिकट प्रकार के अनुसार"
+msgstr "Turi bo'yicha chiptalar"
 
 #: helpdesk/api/ticket.py:65
 msgid "Tickets can only be assigned to agents"
-msgstr ""
+msgstr "Chiptalar faqat agentlarga berilishi mumkin"
 
 #: desk/src/components/ticket/TicketMergeModal.vue:29
 msgid "Tickets must meet the following conditions:"
-msgstr ""
+msgstr "Chiptalar quyidagi shartlarga javob berishi kerak:"
 
 #: desk/src/pages/home/components/PendingTickets.vue:244
 msgid "Tickets that are awaiting your response"
-msgstr "जिन टिकटों पर आपकी प्रतिक्रिया का इंतजार है"
+msgstr "Javobingizni kutayotgan chiptalar"
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
 #: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
-msgstr "समय क्षेत्र"
+msgstr "Vaqt mintaqasi"
 
 #. Label of the title (Data) field in DocType 'HD Article'
 #. Label of the title (Data) field in DocType 'HD Saved Reply'
@@ -6069,24 +6075,24 @@ msgstr "समय क्षेत्र"
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 msgid "Title"
-msgstr "शीर्षक"
+msgstr "Sarlavha"
 
 #. Label of the title_slug (Data) field in DocType 'HD Article'
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 msgid "Title Slug"
-msgstr ""
+msgstr "Sarlavha Slug"
 
 #: desk/src/components/Settings/NewTeamModal.vue:48
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:397
 msgid "Title is required"
-msgstr "शीर्षक आवश्यक है"
+msgstr "Sarlavha talab qilinadi"
 
 #. Label of the user_to (Link) field in DocType 'HD Notification'
 #: desk/src/components/EmailEditor.vue:34
 #: desk/src/pages/call-logs/CallLogModal.vue:33
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "To"
-msgstr "को"
+msgstr "Kimga"
 
 #. Label of the to_date (Date) field in DocType 'HD Service Holiday List'
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
@@ -6095,71 +6101,71 @@ msgstr "को"
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:24
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:24
 msgid "To Date"
-msgstr "तारीख तक"
+msgstr "Hozirgi kungacha"
 
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.py:45
 msgid "To Date cannot be before From Date"
-msgstr ""
+msgstr "To Date belgisi \"From Date\" belgisidan oldin bo'lishi mumkin emas"
 
 #: desk/src/components/Settings/Holiday/HolidayView.vue:92
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:157
 msgid "To date"
-msgstr "तारीख तक"
+msgstr "Hozirgi kungacha"
 
 #: desk/src/pages/call-logs/CallLogModal.vue:366
 msgid "To is required"
-msgstr "की आवश्यकता है"
+msgstr "Talab qilinadi"
 
 #: desk/src/components/Settings/EmailEdit.vue:268
 msgid "To know more about setting up email accounts, click"
-msgstr "ईमेल खाते सेट अप करने के बारे में अधिक जानने के लिए, क्लिक करें"
+msgstr "Elektron pochta hisoblarini sozlash haqida ko'proq bilish uchun bosing"
 
 #: desk/src/pages/dashboard/Dashboard.vue:472
 #: desk/src/pages/dashboard/Dashboard.vue:474
 msgid "Today"
-msgstr "आज"
+msgstr "Bugun"
 
 #: desk/src/components/layouts/Sidebar.vue:262
 msgid "Toggle theme"
-msgstr ""
+msgstr "Mavzuni yoqish/o'chirish"
 
 #: helpdesk/helpdesk/report/ticket_search_analysis/ticket_search_analysis.py:35
 msgid "Top Result"
-msgstr "शीर्ष परिणाम"
+msgstr "Eng yaxshi natija"
 
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:98
 msgid "Total"
-msgstr "कुल"
+msgstr "Jami"
 
 #. Label of the total_hold_time (Duration) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Total Hold Time"
-msgstr "कुल प्रतीक्षा समय"
+msgstr "Umumiy kutish vaqti"
 
 #. Label of the total_holidays (Int) field in DocType 'HD Service Holiday List'
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Total Holidays"
-msgstr "कुल छुट्टियाँ"
+msgstr "Jami ta'tillar"
 
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.py:126
 msgid "Total Ticket"
-msgstr "कुल टिकट"
+msgstr "Jami chipta"
 
 #: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
-msgstr "कुल निर्मित टिकटों की संख्या"
+msgstr "Yaratilgan chiptalarning umumiy soni"
 
 #: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
-msgstr "प्राथमिकता के आधार पर कुल टिकट"
+msgstr "Ustuvorlik bo'yicha jami chiptalar"
 
 #: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
-msgstr "टीम के अनुसार कुल टिकट"
+msgstr "Jamoa bo'yicha jami chiptalar"
 
 #: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
-msgstr "प्रकार के अनुसार कुल टिकट"
+msgstr "Turlar bo'yicha jami chiptalar"
 
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
@@ -6167,12 +6173,12 @@ msgstr "प्रकार के अनुसार कुल टिकट"
 #: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Tuesday"
-msgstr "मंगलवार"
+msgstr "Seshanba"
 
 #: desk/src/components/Settings/Telephony/Telephony.vue:72
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:4
 msgid "Twilio"
-msgstr ""
+msgstr "Twilio"
 
 #. Label of the type (Select) field in DocType 'HD Field Layout'
 #. Label of the notification_type (Select) field in DocType 'HD Notification'
@@ -6183,11 +6189,11 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Type"
-msgstr "प्रकार"
+msgstr "Turi"
 
 #: desk/src/pages/ticket/TicketCustomer.vue:69
 msgid "Type a message"
-msgstr "एक संदेश टाइप करें"
+msgstr "Xabar yozing"
 
 #: desk/src/components/customer/InviteContactDialog.vue:19
 msgid "Type an email address"
@@ -6195,51 +6201,51 @@ msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
-msgstr "टाइप आवश्यक है"
+msgstr "Turi talab qilinadi"
 
 #. Label of the url_method (Data) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "URL/Method"
-msgstr "यूआरएल/विधि"
+msgstr "URL/Metod"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
-msgstr ""
+msgstr "Elektron pochta xabarini yuborib bo‘lmadi. Iltimos, standart chiquvchi elektron pochta hisobini o‘rnating."
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:199
 msgid "Unassignment Condition"
-msgstr ""
+msgstr "Tayinlovni bekor qilish sharti"
 
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:16
 msgid "Unauthorized Access"
-msgstr ""
+msgstr "Ruxsatsiz kirish"
 
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:16
 msgid "Unauthorized access."
-msgstr ""
+msgstr "Ruxsatsiz kirish."
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 msgid "Unavailable"
-msgstr ""
+msgstr "Mavjud emas"
 
 #: desk/src/components/layouts/Sidebar.vue:587
 msgid "Understanding ticket view"
-msgstr ""
+msgstr "Chipta ko'rinishini tushunish"
 
 #: desk/src/pages/ticket/Tickets.vue:468
 msgid "Unpin View"
-msgstr ""
+msgstr "Olib tashlash ko'rinishi"
 
 #: desk/src/pages/knowledge-base/Article.vue:21
 msgid "Unpublish"
-msgstr ""
+msgstr "Nashrni bekor qilish"
 
 #: desk/src/components/UnsavedBadge.vue:8
 #: desk/src/components/contact/EditContactDialog.vue:12
 #: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
-msgstr ""
+msgstr "Saqlanmagan"
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:164
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:449
@@ -6254,7 +6260,7 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:214
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
-msgstr ""
+msgstr "Saqlanmagan o'zgarishlar"
 
 #: helpdesk/api/ticket_stats.py:26
 msgid "Unsupported doctype '{0}' for ticket stats."
@@ -6262,29 +6268,29 @@ msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
 msgid "Untitled"
-msgstr ""
+msgstr "Nomsiz"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:12
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:47
 msgid "Update"
-msgstr ""
+msgstr "Yangilash"
 
 #: desk/src/components/Settings/EmailEdit.vue:142
 msgid "Update Account"
-msgstr ""
+msgstr "Hisobni yangilash"
 
 #. Label of the update_status_to (Link) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Update status to"
-msgstr "स्थिति को अपडेट करें"
+msgstr "Holatni yangilash"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:41
 msgid "Upload"
-msgstr ""
+msgstr "Yuklash"
 
 #: desk/src/components/Settings/Profile/Profile.vue:198
 msgid "Upload Photo"
-msgstr ""
+msgstr "Surat yuklash"
 
 #: desk/src/components/ImageAvatar.vue:78
 msgid "Upload an image in PNG or JPG format"
@@ -6296,7 +6302,7 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
 msgid "Uploading {0}%"
-msgstr ""
+msgstr "{0} % yuklanmoqda"
 
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
@@ -6313,12 +6319,12 @@ msgstr ""
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.py:83
 msgid "User"
-msgstr "उपयोगकर्ता"
+msgstr "Foydalanuvchi"
 
 #. Label of the user_resolution_time (Duration) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
-msgstr "उपयोगकर्ता समाधान समय"
+msgstr "Foydalanuvchi qaror vaqti"
 
 #: desk/src/components/contact/FeedbackList.vue:6
 msgid "User Reviews"
@@ -6326,12 +6332,12 @@ msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
 msgid "User Signup"
-msgstr "उपयोगकर्ता पंजीकरण"
+msgstr "Foydalanuvchi ro'yxatdan o'tishi"
 
 #. Label of the users (Table MultiSelect) field in DocType 'HD Team'
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Users"
-msgstr ""
+msgstr "Foydalanuvchilar"
 
 #. Label of the agreement_details_section (Section Break) field in DocType 'HD
 #. Service Level Agreement'
@@ -6339,42 +6345,42 @@ msgstr ""
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:132
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Valid From"
-msgstr "मान्य तिथि से"
+msgstr "Amal qilish muddati"
 
 #: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
-msgstr "कीमत"
+msgstr "Qiymat"
 
 #. Label of the via_customer_portal (Check) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/web_form/tickets/tickets.json
 msgid "Via Customer Portal"
-msgstr "ग्राहक पोर्टल के माध्यम से"
+msgstr "Mijozlar portali orqali"
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:241
 msgid "View Assignment rule"
-msgstr ""
+msgstr "Topshiriq qoidasini ko'rish"
 
 #: desk/src/pages/ticket/Tickets.vue:652
 msgid "View {0}"
-msgstr "दृश्य {0}"
+msgstr "{0} ni ko'rish"
 
 #. Label of the views (Int) field in DocType 'HD Article'
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 msgid "Views"
-msgstr "दृश्य"
+msgstr "Ko'rishlar"
 
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Violet"
-msgstr ""
+msgstr "Binafsha rang"
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:10
 msgid "Was this article Helpful?"
-msgstr "क्या यह लेख उपयोगी था?"
+msgstr "Ushbu maqola foydali bo'ldimi?"
 
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
@@ -6382,61 +6388,61 @@ msgstr "क्या यह लेख उपयोगी था?"
 #: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Wednesday"
-msgstr "बुधवार"
+msgstr "Chorshanba"
 
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:34
 msgid "Weekly"
-msgstr "साप्ताहिक"
+msgstr "Haftalik"
 
 #. Label of the weekly_off (Check) field in DocType 'HD Holiday'
 #. Label of the weekly_off (Select) field in DocType 'HD Service Holiday List'
 #: helpdesk/helpdesk/doctype/hd_holiday/hd_holiday.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 msgid "Weekly Off"
-msgstr "साप्ताहिक अवकाश"
+msgstr "Haftalik dam olish"
 
 #. Description of the 'Auto update status' (Check) field in DocType 'HD
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "When enabled, the ticket status will automatically change to the status selected below whenever the agent responds to a ticket.\n"
-msgstr ""
+msgstr "Yoqilganda, agent chiptaga javob berganida, chipta holati avtomatik ravishda quyida tanlangan holatga o'zgaradi.\n"
 
 #. Label of the word (Data) field in DocType 'HD Stopword'
 #. Label of the word (Data) field in DocType 'HD Synonyms'
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 #: helpdesk/helpdesk/doctype/hd_synonyms/hd_synonyms.json
 msgid "Word"
-msgstr "शब्द"
+msgstr "So'z"
 
 #: desk/src/components/Settings/Sla/SlaHolidays.vue:5
 msgid "Work Schedule and Holidays"
-msgstr ""
+msgstr "Ish jadvali va bayramlar"
 
 #. Label of the workday (Select) field in DocType 'HD Service Day'
 #: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
 msgid "Workday"
-msgstr ""
+msgstr "Ish kuni"
 
 #: desk/src/components/Settings/Sla/Modals/WorkDayModal.vue:274
 msgid "Workday added successfully."
-msgstr ""
+msgstr "Ish kuni muvaffaqiyatli qo'shildi."
 
 #: desk/src/components/Settings/Sla/Modals/WorkDayModal.vue:259
 msgid "Workday updated successfully."
-msgstr ""
+msgstr "Ish kuni muvaffaqiyatli yangilandi."
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:111
 msgid "Workday {0} has been repeated."
-msgstr ""
+msgstr "Ish kuni {0} takrorlandi."
 
 #. Label of the workflow_tab (Tab Break) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Workflow"
-msgstr ""
+msgstr "Ish oqimi"
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:4
 msgid "Workflow & Knowledge Base Settings"
-msgstr ""
+msgstr "Ish oqimi va bilim bazasi sozlamalari"
 
 #. Label of the support_and_resolution_section_break (Section Break) field in
 #. DocType 'HD Service Level Agreement'
@@ -6444,31 +6450,31 @@ msgstr ""
 #. Level Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Working Hours"
-msgstr "कार्य के घंटे"
+msgstr "Ish vaqti"
 
 #: desk/src/pages/knowledge-base/Article.vue:172
 #: desk/src/pages/knowledge-base/NewArticle.vue:55
 msgid "Write your article here..."
-msgstr "अपना लेख यहाँ लिखें..."
+msgstr "Maqolangizni shu yerga yozing..."
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:31
 msgid "Write your email signature here."
-msgstr ""
+msgstr "Elektron pochta imzongizni bu yerga yozing."
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:13
 msgid "Write your reply..."
-msgstr ""
+msgstr "Javobingizni yozing..."
 
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:37
 msgid "Yearly"
-msgstr "सालाना"
+msgstr "Yillik"
 
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "Yellow"
-msgstr "पीला"
+msgstr "Sariq"
 
 #: helpdesk/api/ticket_stats.py:35
 msgid "You are not allowed to view another agent's stats."
@@ -6476,47 +6482,47 @@ msgstr ""
 
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
-msgstr ""
+msgstr "Sizga ushbu boshqaruv paneli ma'lumotlarini ko'rishga ruxsat berilmagan."
 
 #: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
-msgstr ""
+msgstr "Sizga ushbu resursga kirishga ruxsat berilmagan."
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
-msgstr ""
+msgstr "Sizga izoh qo'shishga ruxsat berilmagan"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
-msgstr ""
+msgstr "Siz agent sifatida javob berishga ruxsatsizsiz"
 
 #: desk/src/App.vue:41
 msgid "You are now offline."
-msgstr ""
+msgstr "Siz endi oflaynsiz."
 
 #: desk/src/App.vue:34
 msgid "You are now online."
-msgstr ""
+msgstr "Siz endi onlaynsiz."
 
 #: desk/src/components/telephony/CallUI.vue:33
 msgid "You can change the default calling medium from the settings"
-msgstr ""
+msgstr "Siz standart qo'ng'iroq vositasini sozlamalardan o'zgartirishingiz mumkin"
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:138
 msgid "You cannot disable the default SLA."
-msgstr ""
+msgstr "Siz standart SLA ni o'chirib qo'yolmaysiz."
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:41
 msgid "You cannot set more than one Default Priority."
-msgstr ""
+msgstr "Siz bir nechta standart ustuvorlikni o'rnata olmaysiz."
 
 #: helpdesk/api/assignment_rule.py:8
 msgid "You do not have permission to access Assignment Rules"
-msgstr ""
+msgstr "Sizda Topshiriq Qoidalariga kirish huquqi yo'q"
 
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
 msgid "You do not have permission to access this resource"
-msgstr ""
+msgstr "Sizda ushbu resursga kirish uchun ruxsat yo'q"
 
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
 msgid "You do not have permission to update contacts"
@@ -6524,27 +6530,27 @@ msgstr ""
 
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
-msgstr ""
+msgstr "Sizda bu chiptaga kirish huquqi yo'q yoki u endi mavjud emas."
 
 #: desk/src/pages/InvalidPage.vue:15
 msgid "You don't have permission to view this page, or it no longer exists."
-msgstr ""
+msgstr "Sizda bu sahifani ko'rishga ruxsat yo'q yoki u endi mavjud emas."
 
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:29
 msgid "You have already provided feedback for this ticket."
-msgstr ""
+msgstr "Siz ushbu chipta uchun allaqachon fikr-mulohazalaringizni bildirgansiz."
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:132
 msgid "You must set one SLA as Default. Please check the Default SLA option."
-msgstr ""
+msgstr "Siz bitta SLA ni standart sifatida o'rnatishingiz kerak. Iltimos, Standart SLA opsiyasini tekshiring."
 
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:394
 msgid "Your old conditions will be overwritten. Are you sure you want to save?"
-msgstr ""
+msgstr "Eski shartlaringiz ustidan yozib qo'yiladi. Saqlashni xohlaysizmi?"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
-msgstr "आपका प्रदर्शन है"
+msgstr "Sizning unumdorligingiz"
 
 #: desk/src/components/customer/ContactCard.vue:116
 msgid "active ticket"
@@ -6556,152 +6562,152 @@ msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:46
 msgid "assigned you a ticket"
-msgstr "आपको एक टिकट सौंपा गया है"
+msgstr "sizga chipta tayinladi"
 
 #: desk/src/components/ticket-agent/AssignTo.vue:29
 msgid "assignees"
-msgstr ""
+msgstr "topshiriq beruvchilar"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:477
 msgid "average"
-msgstr "औसत"
+msgstr "o'rtacha"
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:13
 msgid "back to email event list"
-msgstr ""
+msgstr "elektron pochta tadbirlari ro'yxatiga qaytish"
 
 #: desk/src/components/HistoryBox.vue:12
 msgid "changes from"
-msgstr "परिवर्तन से"
+msgstr "o'zgarishlar"
 
 #: desk/src/pages/ticket/Tickets.vue:651
 msgid "created"
-msgstr "बनाया था"
+msgstr "yaratilgan"
 
 #: desk/src/components/Settings/EmailNotifications/NotificationList.vue:42
 msgid "customize {0}"
-msgstr ""
+msgstr "{0} ni sozlash"
 
 #: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
-msgstr "दिन"
+msgstr "kunlar"
 
 #: desk/src/pages/ticket/Tickets.vue:563
 msgid "deleted"
-msgstr "हटाए गए"
+msgstr "o'chirildi"
 
 #: desk/src/components/ticket/TicketSplitModal.vue:7
 msgid "emails/ comments"
-msgstr "ईमेल/टिप्पणियाँ"
+msgstr "elektron pochta xabarlari/izohlar"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:473
 msgid "excellent"
-msgstr "उत्कृष्ट"
+msgstr "a'lo darajada"
 
 #: desk/src/components/ticket/TicketSplitModal.vue:8
 msgid "from this email onwards will be moved to new ticket."
-msgstr ""
+msgstr "ushbu elektron pochtadan boshlab yangi chiptaga o'tkaziladi."
 
 #: desk/src/pages/home/components/RecentFeedback.vue:475
 msgid "good"
-msgstr "अच्छा"
+msgstr "yaxshi"
 
 #. Option for the 'Type' (Select) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "group_by"
-msgstr ""
+msgstr "guruh_tomonidan"
 
 #: desk/src/components/CallArea.vue:16
 msgid "has made a call"
-msgstr "फोन किया है"
+msgstr "qo'ng'iroq qildi"
 
 #: desk/src/components/CallArea.vue:15
 msgid "has reached out"
-msgstr "संपर्क किया है"
+msgstr "qo'lini uzatdi"
 
 #: desk/src/pages/MobileNotifications.vue:49
 msgid "has reopened the ticket"
-msgstr "टिकट दोबारा खोल दिया गया है"
+msgstr "chiptani qayta ochdi"
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:78
 #: desk/src/components/Settings/General/components/TicketSettings.vue:237
 msgid "here"
-msgstr "यहाँ"
+msgstr "Bu yerga"
 
 #: desk/src/components/Settings/FieldDependency/FieldDependencyList.vue:21
 #: desk/src/components/Settings/Sla/SlaPolicies.vue:19
 msgid "here."
-msgstr ""
+msgstr "Bu yerga."
 
 #: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
-msgstr "घंटे"
+msgstr "soat"
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:15
 msgid "in"
-msgstr "में"
+msgstr "ichida"
 
 #: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
-msgstr "बस अब"
+msgstr "hozirgina"
 
 #. Option for the 'Type' (Select) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "kanban"
-msgstr ""
+msgstr "kanban"
 
 #. Option for the 'Type' (Select) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "list"
-msgstr "सूची"
+msgstr "ro'yxat"
 
 #: desk/src/pages/MobileNotifications.vue:43
 msgid "mentioned you in ticket"
-msgstr "टिकट में आपका जिक्र किया गया है"
+msgstr "chiptada sizni tilga oldim"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:479
 msgid "poor"
-msgstr ""
+msgstr "kambag'al"
 
 #: desk/src/pages/knowledge-base/Article.vue:197
 msgid "published by"
-msgstr ""
+msgstr "tomonidan nashr etilgan"
 
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 msgid "purple"
-msgstr ""
+msgstr "binafsha rang"
 
 #: desk/src/components/customer/TicketStats.vue:32
 msgid "reviews"
-msgstr "समीक्षा"
+msgstr "sharhlar"
 
 #: helpdesk/api/dashboard.py:242
 msgid "stars"
-msgstr "सितारे"
+msgstr "yulduzlar"
 
 #. Label of the synonym (Data) field in DocType 'HD Synonym'
 #: helpdesk/helpdesk/doctype/hd_synonym/hd_synonym.json
 msgid "synonym"
-msgstr ""
+msgstr "sinonim"
 
 #: desk/src/pages/home/components/PendingTickets.vue:158
 msgid "ticket"
-msgstr "टिकट"
+msgstr "chipta"
 
 #: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:68
 msgid "to enable this integration."
-msgstr ""
+msgstr "ushbu integratsiyani ta'minlash uchun."
 
 #: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
-msgstr "इसे देखा"
+msgstr "buni ko'rdi"
 
 #: desk/src/pages/knowledge-base/Article.vue:85
 msgid "views"
-msgstr "दृश्य"
+msgstr "ko'rishlar"
 
 #: desk/src/components/contact/ContactCustomers.vue:53
 msgid "{0} Customers"
@@ -6717,11 +6723,11 @@ msgstr ""
 
 #: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
-msgstr ""
+msgstr "{0} hozirda yo'q."
 
 #: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
-msgstr ""
+msgstr "{0} hozirda mavjud emas."
 
 #: desk/src/components/EmailMultiSelect.vue:265
 msgid "{0} is not an existing contact"
@@ -6733,33 +6739,33 @@ msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:307
 msgid "{0} item(s) deleted successfully"
-msgstr ""
+msgstr "{0} element(lar) muvaffaqiyatli o'chirildi"
 
 #: desk/src/components/ListViewBuilder.vue:321
 msgid "{0} item(s) queued for deletion"
-msgstr ""
+msgstr "{0} element(lar) oʻchirish uchun navbatga qoʻyildi"
 
 #: desk/src/pages/SearchAgent.vue:117
 msgid "{0} matches"
-msgstr "{0} मिलान"
+msgstr "{0} mosliklar"
 
 #: desk/src/pages/home/components/RecentFeedback.vue:46
 msgid "{0} reviews"
-msgstr "{0} समीक्षाएँ"
+msgstr "{0} sharhlar"
 
 #: desk/src/pages/ticket/Tickets.vue:510
 msgid "{0} view is currently public. Changing it to private will hide it for all the users."
-msgstr ""
+msgstr "{0} ko'rinishi hozirda hammaga ochiq. Uni shaxsiy qilib o'zgartirsangiz, u barcha foydalanuvchilar uchun yashiriladi."
 
 #: desk/src/pages/ticket/Tickets.vue:490
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
-msgstr ""
+msgstr "{0} ko'rinishi hozirda yon panelda ko'rinib turibdi. Uni yashirish uni yon paneldan olib tashlaydi."
 
 #: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
-msgstr ""
+msgstr "{0} · Oxirgi faol {1}"
 
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.py:156
 msgid "{} people reacted to your comment"
-msgstr ""
+msgstr "Sizning sharhingizga {} kishi munosabat bildirdi"
 

--- a/helpdesk/locale/vi.po
+++ b/helpdesk/locale/vi.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-15 18:51\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-29 21:58\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Vietnamese\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr ""
@@ -108,14 +108,6 @@ msgstr ""
 msgid "A workday with this name already exists"
 msgstr ""
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr "API"
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr ""
@@ -132,7 +124,7 @@ msgstr ""
 msgid "Account"
 msgstr "Tài Khoản"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr "Thông Tin & Bảo Mật Tài Khoản"
 
@@ -152,11 +144,9 @@ msgstr "Hành Động"
 msgid "Action Required"
 msgstr ""
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr ""
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "Chức năng"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr ""
 msgid "Active"
 msgstr "Đang hoạt động"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr ""
 
@@ -175,7 +165,7 @@ msgid "Active: The agent is available and working.<br>\n"
 "Unavailable: The agent is off and unavailable."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "Hoạt Động"
@@ -193,10 +183,11 @@ msgid "Add Column"
 msgstr "Thêm Cột"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr "Thêm Email"
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "Thêm bộ lọc..."
 
@@ -206,6 +197,10 @@ msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
 msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:148
@@ -244,7 +239,7 @@ msgstr ""
 msgid "Add condition group"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "Thêm bộ lọc"
 
@@ -278,6 +273,12 @@ msgstr "Thêm mục tiêu thời gian xung quanh các mốc hỗ trợ như th�
 msgid "Add to Holidays"
 msgstr "Thêm vào ngày lễ"
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr ""
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr ""
@@ -295,17 +296,14 @@ msgid "Administrator"
 msgstr "Quản Trị Viên"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -316,6 +314,7 @@ msgstr "Quản Trị Viên"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -335,6 +334,7 @@ msgstr ""
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -342,6 +342,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -376,18 +377,9 @@ msgstr "Các nhân viên sẽ không còn có thể xem và tạo các phản h�
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "Tất Cả"
 
@@ -508,6 +500,14 @@ msgstr "Bạn có chắc chắn muốn đóng phiếu hỗ trợ này không?"
 msgid "Are you sure you want to delete these articles?"
 msgstr "Bạn có chắc chắn muốn xóa các bài viết này không?"
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr ""
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr ""
@@ -543,6 +543,10 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
 msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
@@ -595,16 +599,11 @@ msgstr "Giao một phiếu hỗ trợ cho một nhân viên"
 msgid "Assign ticket"
 msgstr "Giao phiếu hỗ trợ"
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr ""
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -618,7 +617,7 @@ msgstr "Người được chuyển nhượng"
 msgid "Assignee Rules"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr ""
 
@@ -626,7 +625,7 @@ msgstr ""
 msgid "Assignees"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr ""
 
@@ -692,10 +691,6 @@ msgstr ""
 msgid "Assignment rule {0} updated successfully."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr "Cần ít nhất một email"
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -712,10 +707,6 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
 msgstr "Cần ít nhất một nhóm"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
-msgstr ""
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
@@ -766,7 +757,7 @@ msgid "Automation"
 msgstr "Tự động hóa"
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr ""
@@ -802,7 +793,7 @@ msgstr "Thời gian phản hồi trung bình"
 msgid "Average Time Metrics"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr ""
 
@@ -810,24 +801,36 @@ msgstr ""
 msgid "Average response and resolution metrics not available"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
 msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
@@ -840,11 +843,11 @@ msgstr ""
 msgid "Avg. resolution time"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr ""
 
@@ -867,11 +870,6 @@ msgstr ""
 msgid "Base Support Rotation"
 msgstr ""
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "URL cơ sở"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -885,11 +883,11 @@ msgstr "Dựa trên Chính sách HR của bạn, chọn ngày kết thúc kỳ p
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr "Dựa trên Chính sách HR của bạn, chọn ngày bắt đầu kỳ phân bổ nghỉ phép"
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr ""
 
@@ -944,11 +942,6 @@ msgstr ""
 msgid "Busy"
 msgstr "Bận"
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "Nút"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr "CSV"
@@ -973,19 +966,31 @@ msgstr ""
 msgid "Caller"
 msgstr "Người Gọi"
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr "Cuộc gọi"
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr ""
 
@@ -1025,7 +1030,7 @@ msgstr "Không thể kích hoạt quy tắc mà không thêm người dùng vào
 msgid "Cannot merge General category"
 msgstr ""
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr ""
 
@@ -1073,11 +1078,11 @@ msgstr ""
 msgid "Category updated successfully."
 msgstr "Danh mục được cập nhật thành công."
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr ""
 
@@ -1085,7 +1090,7 @@ msgstr ""
 msgid "Change"
 msgstr "Thay đổi"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "Đổi mật khẩu"
@@ -1098,10 +1103,9 @@ msgstr "Đổi Ảnh"
 msgid "Change language of the application."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
-msgstr "Thay đổi ảnh"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
+msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
 msgid "Change priority"
@@ -1123,7 +1127,7 @@ msgstr "Thay đổi loại phiếu hỗ trợ"
 msgid "Change timezone of the application."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr ""
 
@@ -1136,7 +1140,7 @@ msgstr ""
 msgid "Child field"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr ""
 
@@ -1189,7 +1193,7 @@ msgstr "Xóa Sắp Xếp"
 msgid "Clear Table"
 msgstr "Xóa Bảng"
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr ""
 
@@ -1204,6 +1208,10 @@ msgstr "Xóa tất cả bộ lọc"
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
 msgstr "Nhấp vào Thêm vào Ngày lễ. Điều này sẽ điền bảng ngày lễ với tất cả các ngày rơi vào ngày nghỉ hàng tuần đã chọn. Lặp lại quy trình để điền ngày cho tất cả các ngày lễ hàng tuần của bạn"
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:47
@@ -1223,7 +1231,7 @@ msgstr "Đóng phiếu hỗ trợ"
 msgid "Closed"
 msgstr "Đã đóng"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr ""
 
@@ -1250,7 +1258,7 @@ msgstr "Cột"
 msgid "Comma separated emails to invite."
 msgstr "Các email được phân tách bằng dấu phẩy để mời."
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr ""
 
@@ -1283,7 +1291,7 @@ msgstr ""
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "Bình luận"
@@ -1296,6 +1304,11 @@ msgstr "Giao tiếp"
 msgid "Communication ID is required"
 msgstr ""
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
+msgstr "Công ty"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
 msgstr "Đã hoàn thành"
@@ -1307,7 +1320,7 @@ msgstr "Đã hoàn thành"
 msgid "Condition"
 msgstr "Tình trạng"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr "Định Cấu Hình"
 
@@ -1331,6 +1344,10 @@ msgstr ""
 msgid "Configure your telephony settings."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1356,10 +1373,11 @@ msgstr ""
 msgid "Connect your support email"
 msgstr "Kết nối email hỗ trợ của bạn"
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1373,26 +1391,30 @@ msgstr "Liên hệ"
 msgid "Contact HTML"
 msgstr "HTML Liên hệ"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
 msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
-msgstr "Đã mời liên hệ thành công."
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
-msgstr "Liên hệ với email này đã tồn tại"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
+msgstr ""
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
 msgstr "Liên hệ"
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
+msgstr ""
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
 #. Label of the content (Text Editor) field in DocType 'HD Article'
@@ -1415,7 +1437,7 @@ msgstr "Sao chép URL phiếu hỗ trợ"
 msgid "Copy ticket id"
 msgstr "Sao chép mã phiếu hỗ trợ"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr ""
 
@@ -1423,7 +1445,11 @@ msgstr ""
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr ""
 
@@ -1431,11 +1457,20 @@ msgstr ""
 msgid "Could not send feedback email,due to: {0}"
 msgstr ""
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "Quốc gia"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1446,9 +1481,13 @@ msgstr "Tạo"
 msgid "Create & invite a contact"
 msgstr "Tạo và mời một liên hệ"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
-msgstr "Tạo liên hệ mới"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
+msgstr "Tạo Khách hàng"
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
 msgid "Create View"
@@ -1482,12 +1521,6 @@ msgstr ""
 msgid "Creating a ticket"
 msgstr ""
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr ""
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr "Hành động tùy chỉnh"
@@ -1512,12 +1545,21 @@ msgid "Custom Views"
 msgstr ""
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
 msgstr "Khách hàng"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
+msgstr ""
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1528,17 +1570,33 @@ msgstr "Tên khách hàng"
 msgid "Customer Portal"
 msgstr ""
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
-msgstr "Khách hàng tạo thành công."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr "Loại Khách hàng"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr "Cổng thông tin khách hàng"
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
 msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
+msgstr "Khách hàng"
 
 #: desk/src/components/layouts/Sidebar.vue:595
 msgid "Customers & Contacts"
@@ -1565,6 +1623,8 @@ msgstr "Lam"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "Nguy hiểm"
@@ -1665,18 +1725,26 @@ msgstr ""
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr ""
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "Đã cập nhật giá trị mặc định"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr "Xóa Liên hệ"
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1693,6 +1761,10 @@ msgstr ""
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
 msgstr "Xóa {0}"
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
+msgstr ""
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
 #. Label of the description (Text Editor) field in DocType 'HD Holiday'
@@ -1740,7 +1812,7 @@ msgstr ""
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1826,7 +1898,12 @@ msgstr "Tài liệu"
 msgid "Document Type"
 msgstr "Loại tài liệu"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr ""
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "Tên miền"
@@ -1868,6 +1945,10 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
 msgstr "Sao chép phản hồi đã lưu"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
 #: desk/src/pages/call-logs/CallLogModal.vue:68
@@ -1917,7 +1998,8 @@ msgstr ""
 msgid "Easily invite new agents, managers, or admins."
 msgstr ""
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1926,6 +2008,14 @@ msgstr "Chỉnh sửa"
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
 msgstr "Chỉnh sửa Nhật ký cuộc gọi"
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
+msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:70
 #: desk/src/components/Settings/EmailEdit.vue:63
@@ -1944,10 +2034,10 @@ msgstr "Chỉnh sửa tiêu đề"
 msgid "Edit your email account"
 msgstr ""
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "Email"
 
@@ -1975,8 +2065,9 @@ msgstr "Tài khoản email"
 msgid "Email Content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
 msgstr "ID email"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
@@ -2002,22 +2093,22 @@ msgstr ""
 msgid "Email account updated successfully"
 msgstr ""
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr ""
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr "Cài đặt Email đã được cập nhật thành công."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr "Email không được để trống"
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "Email"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr "Email & Chữ ký"
 
@@ -2055,8 +2146,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr ""
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2081,8 +2170,6 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2105,20 +2192,24 @@ msgstr "Giờ kết thúc"
 msgid "Enter a name for this HD Service Holiday List."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr "Vui lòng nhập một email hợp lệ"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr "Vui lòng nhập một số điện thoại hợp lệ"
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr ""
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
 msgstr ""
 
 #: helpdesk/api/knowledge_base.py:86
@@ -2129,22 +2220,18 @@ msgstr ""
 msgid "Error processing email at index {0}, message: {1}"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr ""
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "Lỗi khi kết nối với tài khoản email {0}"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr ""
 
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
 msgstr "Excel"
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
+msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
 #: desk/src/components/Settings/Telephony/Telephony.vue:96
@@ -2172,11 +2259,6 @@ msgstr ""
 msgid "Export Type"
 msgstr "Loại Xuất"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr ""
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2184,6 +2266,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "Thất bại"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2218,11 +2304,11 @@ msgstr ""
 msgid "Failed to save Twilio settings"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr ""
 
@@ -2251,6 +2337,7 @@ msgstr "Favicon"
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2288,12 +2375,16 @@ msgstr ""
 msgid "Feedback Rating"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
+msgstr ""
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
 msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
@@ -2338,13 +2429,14 @@ msgid "Field dependency updated successfully."
 msgstr ""
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "Trường"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "Bộ lọc"
@@ -2354,7 +2446,8 @@ msgstr "Bộ lọc"
 msgid "Find out all of the variables that can be used in the content"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "Họ Tên"
 
@@ -2362,6 +2455,10 @@ msgstr "Họ Tên"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
 msgstr "Phản hồi lần đầu vào"
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
+msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -2386,10 +2483,6 @@ msgstr "Thời gian phản hồi đầu tiên"
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
 msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
-msgstr "Tên không được để trống"
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
@@ -2480,6 +2573,10 @@ msgstr "Toàn cầu"
 msgid "Go to Ticket #{0}"
 msgstr "Đi tới Phiếu hỗ trợ #{0}"
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr ""
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2509,19 +2606,12 @@ msgid "Group By Field"
 msgstr "Trường nhóm theo"
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
 msgstr ""
 
 #. Name of a DocType
@@ -2554,24 +2644,36 @@ msgstr ""
 msgid "HD Comment Reaction"
 msgstr "Phản ứng bình luận HD"
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr ""
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr ""
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
 msgstr ""
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
 msgstr ""
 
 #. Name of a DocType
@@ -2592,21 +2694,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
 msgstr ""
 
 #. Name of a DocType
@@ -2648,11 +2735,6 @@ msgstr ""
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
-msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
 msgstr ""
 
 #. Name of a DocType
@@ -2750,12 +2832,6 @@ msgstr ""
 msgid "Helpdesk"
 msgstr ""
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr ""
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2772,11 +2848,6 @@ msgstr ""
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
 msgstr "Ẩn "
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr ""
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
@@ -2846,15 +2917,8 @@ msgstr ""
 msgid "ID"
 msgstr "Mã số"
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "Địa Chỉ IP"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2941,6 +3005,11 @@ msgstr "Hộp thư đến"
 msgid "Incoming"
 msgstr "Đang đến"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr "Cá nhân"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr "Đã khởi tạo"
@@ -2954,7 +3023,7 @@ msgstr ""
 msgid "Instantly send e-mail"
 msgstr ""
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "Không đủ quyền cho {0}"
 
@@ -2968,13 +3037,13 @@ msgstr ""
 msgid "Introduction"
 msgstr "Giới thiệu"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
-msgstr "Email không hợp lệ"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
+msgstr "Địa chỉ email không hợp lệ"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
 #: desk/src/components/Settings/Holiday/HolidayView.vue:325
@@ -2982,22 +3051,42 @@ msgstr "Email không hợp lệ"
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr "Trường dữ liệu không hợp lệ, vui lòng kiểm tra lại xem tất cả đã được điền đủ và đúng giá trị chưa."
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr "Loại tệp không hợp lệ, chỉ cho phép ảnh PNG và JPG"
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
 msgstr "Số điện thoại không hợp lệ"
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr ""
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
+msgstr ""
+
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
@@ -3008,12 +3097,29 @@ msgstr ""
 msgid "Invite agents"
 msgstr "Mời nhân viên"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
-msgstr "Mời với tư cách người dùng"
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
+msgstr "Mời làm Người dùng"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr "Đã mời"
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
 msgstr ""
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
@@ -3030,6 +3136,11 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "Là mặc định"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr ""
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3057,6 +3168,10 @@ msgstr ""
 #. Label of the setup_complete (Check) field in DocType 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
 msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:114
@@ -3093,11 +3208,9 @@ msgstr "Phím tắt"
 msgid "Knowledge Base"
 msgstr "Cơ sở Kiến thức"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3131,9 +3244,9 @@ msgstr "Cuối cùng"
 msgid "Last 3 Months"
 msgstr "3 Tháng Qua"
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr ""
 
@@ -3174,7 +3287,8 @@ msgstr "Phản hồi cuối của khách hàng"
 msgid "Last Month"
 msgstr "Tháng trước"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "Họ"
 
@@ -3183,24 +3297,33 @@ msgstr "Họ"
 msgid "Last Week"
 msgstr "Tuần trước"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr ""
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
 msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
+msgstr "Mới nhất"
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -3217,26 +3340,6 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
 msgstr "Thông báo cho khách hàng rằng họ đang yêu cầu hỗ trợ ngoài giờ làm việc và khi nào họ có thể nhận được phản hồi."
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "Liên kết"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr "Tùy chọn liên kết"
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr "Liên kết tới khách hàng"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
-msgstr "Liên kết tới bản ghi khách hàng"
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #. Label of the list_tab (Tab Break) field in DocType 'HD View'
@@ -3264,6 +3367,8 @@ msgstr "Tải cột mặc định"
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "Tải thêm"
 
@@ -3286,6 +3391,8 @@ msgstr "Đăng nhập vào đám mây Frappe"
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr "Biểu tượng"
@@ -3324,7 +3431,7 @@ msgstr ""
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr "Quản lý các câu trả lời soạn sẵn để phản hồi các thắc mắc của khách hàng."
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr "Quản lý email tài khoản và chữ ký email của bạn để giao tiếp."
 
@@ -3343,6 +3450,10 @@ msgstr ""
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
+msgstr "Quản lý"
 
 #: desk/src/pages/MobileNotifications.vue:11
 #: desk/src/pages/MobileNotifications.vue:14
@@ -3364,7 +3475,7 @@ msgstr ""
 #. Option for the 'Type' (Select) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "Mention"
-msgstr "Đề cập đến"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:158
 msgid "Merge"
@@ -3395,6 +3506,20 @@ msgstr ""
 #: desk/src/components/layouts/Sidebar.vue:640
 msgid "Mobile App Installation"
 msgstr "Cài đặt Ứng dụng di động"
+
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr "Số điện thoại di động"
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr ""
 
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
@@ -3436,7 +3561,7 @@ msgid "My Tickets"
 msgstr ""
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3447,8 +3572,9 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3458,6 +3584,10 @@ msgstr "Tên"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
 msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
+msgstr "Tên là bắt buộc"
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
 #. Ticket Status'
@@ -3469,10 +3599,18 @@ msgstr ""
 msgid "Navigation"
 msgstr "Điều hướng"
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "Không bao giờ"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3581,11 +3719,11 @@ msgstr "Không trả lời"
 msgid "No Data Found"
 msgstr "Không tìm thấy dữ liệu"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr ""
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr ""
 
@@ -3597,8 +3735,14 @@ msgstr ""
 msgid "No SLA found"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
 msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
@@ -3633,19 +3777,27 @@ msgstr ""
 msgid "No changes made"
 msgstr "Không có thay đổi nào được thực hiện"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr "Không có thay đổi nào để lưu"
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr ""
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr ""
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr ""
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
@@ -3657,7 +3809,11 @@ msgstr "Không tìm thấy email tài khoản"
 msgid "No feedback"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr ""
 
@@ -3697,19 +3853,25 @@ msgstr ""
 msgid "No recently assigned tickets"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr ""
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
 msgstr "Không tìm thấy kết quả nào"
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
+msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:91
 msgid "No saved replies found"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr ""
@@ -3730,7 +3892,11 @@ msgstr "Không tìm thấy phiếu hỗ trợ nào để xem trước."
 msgid "No tickets selected"
 msgstr ""
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr ""
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "Không được phép"
 
@@ -3742,7 +3908,7 @@ msgstr ""
 msgid "Not Saved"
 msgstr "Chưa được lưu"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "Chưa được đặt"
 
@@ -3781,11 +3947,6 @@ msgstr ""
 msgid "On Hold Since"
 msgstr "Tạm dừng kể từ"
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr ""
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr ""
@@ -3816,6 +3977,10 @@ msgstr "Mở bảng lệnh"
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
 msgstr "Mở hộp bình luận"
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
+msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
 msgid "Open help"
@@ -3904,7 +4069,12 @@ msgstr ""
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr "Hợp tác"
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "Mật khẩu"
 
@@ -3942,6 +4112,7 @@ msgid "Pending"
 msgstr "Đang chờ xử lý"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr "Lời mời Đang chờ"
 
@@ -3951,19 +4122,19 @@ msgstr "Lời mời Đang chờ"
 msgid "Pending Tickets"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr ""
 
@@ -3984,14 +4155,15 @@ msgstr "Cá nhân"
 msgid "Personal mobile no"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "Điện thoại"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
-msgstr "Số điện thoại"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
+msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
 msgid "Pick an option"
@@ -4047,7 +4219,7 @@ msgstr "Vui lòng nhập chủ đề để tiếp tục"
 msgid "Please enter a valid phone number"
 msgstr "Vui lòng nhập số điện thoại hợp lệ"
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr ""
 
@@ -4090,34 +4262,15 @@ msgstr "Vui lòng chọn ngày nghỉ hàng tuần"
 msgid "Policy name"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
 msgstr ""
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr "Khóa Mô tả Bài đăng"
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr "Danh sách khóa tuyến đăng"
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr "Chuỗi tuyến đăng"
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
-msgstr "Khóa tiêu đề đăng"
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:10
@@ -4151,14 +4304,32 @@ msgstr "Xem trước"
 msgid "Previous ticket"
 msgstr "Phiếu hỗ trợ trước"
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "Chính"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "Liên hệ chính"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr ""
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr "Ưu tiên"
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4166,9 +4337,10 @@ msgstr "Ưu tiên"
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4248,17 +4420,6 @@ msgstr ""
 msgid "Quarterly"
 msgstr "Hàng quý"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "Tùy chọn Truy vấn"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr "Chuỗi tuyến đường truy vấn"
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "Đang xếp hàng"
@@ -4281,14 +4442,14 @@ msgstr ""
 msgid "Rate this ticket"
 msgstr "Đánh giá phiếu hỗ trợ này"
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr ""
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4384,8 +4545,15 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "Xóa"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4395,10 +4563,19 @@ msgstr ""
 msgid "Remove Photo"
 msgstr "Xóa Ảnh"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
-msgstr "Xóa ảnh"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr "Xóa hình ảnh"
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
+msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
 #: desk/src/components/Settings/Teams/TeamsList.vue:161
@@ -4417,6 +4594,15 @@ msgstr ""
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
 msgstr ""
 
 #. Option in a Select field in the tickets Web Form
@@ -4456,16 +4642,13 @@ msgstr ""
 msgid "Reply on a ticket"
 msgstr "Phản hồi phiếu hỗ trợ"
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr ""
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
 msgstr ""
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
@@ -4486,6 +4669,7 @@ msgid "Reset to Default"
 msgstr "Đặt lại về Mặc định"
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr "Giải pháp"
@@ -4539,18 +4723,6 @@ msgstr "Phản hồi"
 msgid "Response By"
 msgstr "Phản hồi bởi"
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr "Tùy chọn phản hồi"
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr "Đường dẫn khóa kết quả phản hồi"
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr "Thời gian phản hồi cho mức ưu tiên {0} ở hàng {1} không thể lớn hơn Thời gian giải quyết."
@@ -4593,28 +4765,18 @@ msgstr ""
 msgid "Restrict visibility to these teams"
 msgstr "Hạn chế quyền hiển thị cho các nhóm này"
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr "Trường xem trước kết quả"
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr "Trường Định tuyến Kết quả"
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr "Trường Tiêu đề Kết quả"
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
+msgstr ""
+
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:215
@@ -4622,8 +4784,14 @@ msgid "Ringing"
 msgstr "Đang đổ chuông"
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "Vai trò"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr ""
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4722,9 +4890,9 @@ msgstr "Thứ Bảy"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4800,17 +4968,19 @@ msgstr ""
 msgid "Search Score"
 msgstr ""
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr "Tên thông số cụm từ tìm kiếm"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "Tìm kiếm trường..."
 
@@ -4850,6 +5020,7 @@ msgstr "Tìm kiếm..."
 msgid "Searched for:"
 msgstr "Đã tìm kiếm:"
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr "Đang tìm kiếm..."
@@ -4869,6 +5040,10 @@ msgstr "Chọn"
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
 msgstr "Chọn danh mục"
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
+msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
 msgid "Select Range"
@@ -4890,6 +5065,10 @@ msgstr "Chọn Mức ưu tiên Mặc định."
 msgid "Select a rating"
 msgstr "Chọn một mức đánh giá"
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr ""
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4902,6 +5081,10 @@ msgstr "Chọn nhóm"
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
 msgstr "Chọn phiếu hỗ trợ để xem trước"
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
 msgid "Select what type all tickets get by default."
@@ -4927,6 +5110,10 @@ msgstr ""
 #. Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
 msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
@@ -4967,7 +5154,7 @@ msgstr "Tên Cấp độ Dịch vụ"
 msgid "Service not supported"
 msgstr "Dịch vụ không được hỗ trợ"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "Đặt"
 
@@ -4975,6 +5162,10 @@ msgstr "Đặt"
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
 msgstr "Thiết lập số điện thoại"
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
+msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
 msgid "Set Resolution Time for Priority {0} in row {1}."
@@ -4984,12 +5175,21 @@ msgstr ""
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr "Đặt Thời gian Phản hồi cho Mức ưu tiên {0} ở hàng {1}."
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr ""
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr ""
 
@@ -5001,7 +5201,7 @@ msgstr ""
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr "Đặt ngày, giờ và ngày làm việc bằng cách chọn lịch trình được xác định trước hoặc tạo lịch mới."
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr ""
 
@@ -5135,23 +5335,6 @@ msgstr "Có lỗi xảy ra khi cập nhật danh sách ngày nghỉ"
 msgid "Sort"
 msgstr "Sắp xếp"
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr "DocType nguồn"
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "Tên nguồn"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr "Loại nguồn"
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr ""
@@ -5196,6 +5379,8 @@ msgstr ""
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5262,6 +5447,7 @@ msgstr ""
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5373,21 +5559,16 @@ msgstr "Hệ thống"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5426,8 +5607,6 @@ msgstr ""
 msgid "Teal"
 msgstr ""
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5438,7 +5617,6 @@ msgstr ""
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5544,6 +5722,10 @@ msgstr ""
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr ""
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr ""
@@ -5554,6 +5736,10 @@ msgstr "Ngày nghỉ vào {0} không nằm giữa Từ ngày và Đến ngày"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
@@ -5576,6 +5762,14 @@ msgstr ""
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr ""
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr ""
@@ -5583,6 +5777,10 @@ msgstr ""
 #: desk/src/components/ticket/TicketMergeModal.vue:79
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
 msgstr ""
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
@@ -5652,7 +5850,7 @@ msgstr "Thứ năm"
 msgid "Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr "Yêu cầu hỗ trợ #{0}: Chúng tôi đã nhận được yêu cầu của bạn"
 
@@ -5666,6 +5864,10 @@ msgstr ""
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
+msgstr ""
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
 msgstr ""
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
@@ -5725,7 +5927,7 @@ msgstr ""
 msgid "Ticket Summary"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr ""
 
@@ -5758,7 +5960,7 @@ msgstr ""
 msgid "Ticket merged successfully."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr ""
 
@@ -5793,12 +5995,6 @@ msgstr ""
 msgid "Ticket to merged with is required"
 msgstr ""
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr ""
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr ""
@@ -5810,12 +6006,15 @@ msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr ""
 
@@ -5827,19 +6026,19 @@ msgstr ""
 msgid "Tickets assigned to you in the last 7 days"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr ""
 
@@ -5856,6 +6055,7 @@ msgid "Tickets that are awaiting your response"
 msgstr ""
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr ""
 
@@ -5945,19 +6145,19 @@ msgstr "Tổng ngày lễ"
 msgid "Total Ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr ""
 
@@ -5989,6 +6189,10 @@ msgstr "Loại"
 msgid "Type a message"
 msgstr "Nhập tin nhắn"
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr "Loại là bắt buộc"
@@ -5998,7 +6202,7 @@ msgstr "Loại là bắt buộc"
 msgid "URL/Method"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr "Không thể gửi email. Vui lòng thiết lập tài khoản email gửi đi mặc định."
 
@@ -6032,6 +6236,8 @@ msgid "Unpublish"
 msgstr "Hủy xuất bản"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr ""
 
@@ -6048,6 +6254,10 @@ msgstr ""
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:214
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
+msgstr ""
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
@@ -6076,10 +6286,13 @@ msgstr "Tải lên"
 msgid "Upload Photo"
 msgstr "Tải lên Ảnh"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
-msgstr "Tải ảnh lên"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
+msgstr "Tải hình ảnh lên"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
 msgid "Uploading {0}%"
@@ -6088,17 +6301,13 @@ msgstr ""
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6110,6 +6319,10 @@ msgstr "Người dùng"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
 msgstr "Thời gian giải quyết của người dùng"
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
+msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
 msgid "User Signup"
@@ -6128,7 +6341,7 @@ msgstr "Người dùng"
 msgid "Valid From"
 msgstr "Có hiệu lực từ"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "Giá trị"
 
@@ -6257,19 +6470,23 @@ msgstr "Hàng năm"
 msgid "Yellow"
 msgstr "Vàng"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr ""
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr ""
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr "Bạn không được phép truy cập tài nguyên này."
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr ""
 
@@ -6297,6 +6514,14 @@ msgstr ""
 msgid "You do not have permission to access Assignment Rules"
 msgstr "Bạn không có quyền truy cập vào các Quy tắc phân công"
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr ""
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr ""
@@ -6319,6 +6544,14 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:46
@@ -6349,7 +6582,7 @@ msgstr "đã tạo"
 msgid "customize {0}"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr "ngày"
 
@@ -6400,7 +6633,7 @@ msgstr "tại đây"
 msgid "here."
 msgstr ""
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr "giờ"
 
@@ -6408,7 +6641,7 @@ msgstr "giờ"
 msgid "in"
 msgstr "trong"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "vừa rồi"
 
@@ -6441,7 +6674,11 @@ msgstr ""
 msgid "purple"
 msgstr "tím"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr "đánh giá"
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr ""
 
@@ -6458,7 +6695,7 @@ msgstr "vé"
 msgid "to enable this integration."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr "đã xem nội dung này"
 
@@ -6466,12 +6703,32 @@ msgstr "đã xem nội dung này"
 msgid "views"
 msgstr "lượt xem"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr ""
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
 msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:307
@@ -6498,7 +6755,7 @@ msgstr ""
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr ""
 

--- a/helpdesk/locale/zh.po
+++ b/helpdesk/locale/zh.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2026-06-14 11:18+0000\n"
-"PO-Revision-Date: 2026-06-15 18:51\n"
+"POT-Creation-Date: 2026-06-28 11:13+0000\n"
+"PO-Revision-Date: 2026-06-29 21:58\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Chinese Simplified\n"
 "MIME-Version: 1.0\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid " commented"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:181
+#: helpdesk/api/dashboard.py:182
 msgid "% SLA Fulfilled"
 msgstr "SLA达成率"
 
-#: helpdesk/api/dashboard.py:186
+#: helpdesk/api/dashboard.py:187
 #, python-format
 msgid "% of tickets created that were resolved within SLA"
 msgstr "在SLA时限内解决的工单创建百分比"
@@ -108,14 +108,6 @@ msgstr ""
 msgid "A workday with this name already exists"
 msgstr ""
 
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#. Label of the api_sb (Section Break) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "API"
-msgstr "API"
-
 #: desk/src/components/Settings/Teams/TeamEdit.vue:263
 msgid "Access all team tickets"
 msgstr ""
@@ -132,7 +124,7 @@ msgstr ""
 msgid "Account"
 msgstr "科目"
 
-#: desk/src/components/Settings/Profile/Profile.vue:102
+#: desk/src/components/Settings/Profile/Profile.vue:104
 msgid "Account Info & Security"
 msgstr ""
 
@@ -152,11 +144,9 @@ msgstr "操作"
 msgid "Action Required"
 msgstr "需要处理"
 
-#. Description of the 'On click (Javascript)' (Code) field in DocType 'HD
-#. Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Action to perform when clicking the button. The doc will be available as `this`"
-msgstr "点击按钮时执行的操作。文档将作为`this`可用"
+#: desk/src/pages/contact/Contact.vue:303
+msgid "Actions"
+msgstr "操作"
 
 #. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
 #: desk/src/components/Settings/Assignment Rules/AssignmentSchedule.vue:42
@@ -164,7 +154,7 @@ msgstr "点击按钮时执行的操作。文档将作为`this`可用"
 msgid "Active"
 msgstr "激活"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:404
+#: desk/src/components/ticket-agent/AssignTo.vue:384
 msgid "Active now"
 msgstr ""
 
@@ -175,7 +165,7 @@ msgid "Active: The agent is available and working.<br>\n"
 "Unavailable: The agent is off and unavailable."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:448
+#: desk/src/pages/ticket/MobileTicketAgent.vue:452
 #: desk/src/pages/ticket/TicketCustomer.vue:182
 msgid "Activity"
 msgstr "活动"
@@ -193,10 +183,11 @@ msgid "Add Column"
 msgstr "添加列"
 
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:91
+#: desk/src/components/contact/EditContactDialog.vue:70
 msgid "Add Email"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Add Filter..."
 msgstr "添加筛选器..."
 
@@ -206,6 +197,10 @@ msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
 msgid "Add New Article"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:99
+msgid "Add Phone"
 msgstr ""
 
 #: desk/src/components/view-controls/SortBy.vue:148
@@ -244,7 +239,7 @@ msgstr "添加条件"
 msgid "Add condition group"
 msgstr "添加条件组"
 
-#: desk/src/components/view-controls/filter/Filter.vue:60
+#: desk/src/components/view-controls/filter/Filter.vue:81
 msgid "Add filter"
 msgstr "添加筛选器"
 
@@ -278,6 +273,12 @@ msgstr "在支持里程碑前后添加时间目标，例如首次回复和分辨
 msgid "Add to Holidays"
 msgstr "添加至假期"
 
+#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:101
+msgid "Add to recipients"
+msgstr ""
+
 #: desk/src/components/Settings/Agents.vue:4
 msgid "Add, manage agents and assign roles to them."
 msgstr "添加、管理客服人员并为其分配角色。"
@@ -295,17 +296,14 @@ msgid "Administrator"
 msgstr "管理员"
 
 #. Name of a role
-#. Label of the to_agent (Link) field in DocType 'HD Escalation Rule'
 #. Label of a Link in the Helpdesk Workspace
 #: desk/src/components/layouts/Sidebar.vue:612
 #: desk/src/pages/dashboard/Dashboard.vue:70
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -316,6 +314,7 @@ msgstr "管理员"
 #: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 #: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -335,6 +334,7 @@ msgstr ""
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -342,6 +342,7 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Agent Manager"
@@ -376,18 +377,9 @@ msgstr ""
 #. Name of a role
 #: desk/src/components/SavedRepliesSelectorModal.vue:165
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:323
+#: desk/src/components/contact/FeedbackList.vue:121
 #: desk/src/components/ticket/TicketSplitModal.vue:6
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
-#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
-#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
-#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
-#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "All"
 msgstr "全部"
 
@@ -508,6 +500,14 @@ msgstr ""
 msgid "Are you sure you want to delete these articles?"
 msgstr ""
 
+#: desk/src/pages/contact/Contact.vue:102
+msgid "Are you sure you want to delete this contact? The contact will be permanently deleted and unlinked from any associated customers and tickets."
+msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Are you sure you want to delete this customer? The reference to this customer will be removed from all the related tickets."
+msgstr ""
+
 #: desk/src/components/ticket-agent/TicketHeader.vue:204
 msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
 msgstr ""
@@ -543,6 +543,10 @@ msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:111
 msgid "Are you sure you want to remove the logo?"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
 msgstr ""
 
 #: desk/src/components/Settings/EmailNotifications/Notification.vue:116
@@ -595,16 +599,11 @@ msgstr ""
 msgid "Assign ticket"
 msgstr ""
 
-#. Label of the assign_to_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Assign to"
-msgstr "分配至"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:39
 msgid "Assign yourself"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:236
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
 msgid "Assigned To"
@@ -618,7 +617,7 @@ msgstr "负责人"
 msgid "Assignee Rules"
 msgstr "负责人分配规则"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:522
+#: desk/src/components/ticket-agent/AssignTo.vue:502
 msgid "Assignee's updated successfully."
 msgstr ""
 
@@ -626,14 +625,14 @@ msgstr ""
 msgid "Assignees"
 msgstr "负责人列表"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:604
+#: desk/src/components/ticket-agent/AssignTo.vue:584
 msgid "Assignees updated successfully."
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'HD Notification'
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "Assignment"
-msgstr "分派"
+msgstr "分配任务"
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:122
 msgid "Assignment Condition"
@@ -692,10 +691,6 @@ msgstr ""
 msgid "Assignment rule {0} updated successfully."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:137
-msgid "At least one email is required"
-msgstr ""
-
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
 msgid "At least one enabled Active status is required."
@@ -712,10 +707,6 @@ msgstr "必须为{0}评级启用至少一个反馈选项"
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
 msgid "At least one team is required"
 msgstr ""
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:28
-msgid "At-least one of priority, team and ticket type is required"
-msgstr "必须至少填写优先级、团队或工单类型中的一项"
 
 #. Label of the attachment (Attach) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
@@ -766,7 +757,7 @@ msgid "Automation"
 msgstr "自动化"
 
 #. Label of the availability (Link) field in DocType 'HD Agent'
-#: desk/src/components/Settings/Profile/Profile.vue:111
+#: desk/src/components/Settings/Profile/Profile.vue:113
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 msgid "Availability"
 msgstr ""
@@ -802,7 +793,7 @@ msgstr "平均响应时间"
 msgid "Average Time Metrics"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:364
+#: helpdesk/api/dashboard.py:374
 msgid "Average feedback rating per day is around {0} stars"
 msgstr "每日平均反馈评分约为{0}星"
 
@@ -810,25 +801,37 @@ msgstr "每日平均反馈评分约为{0}星"
 msgid "Average response and resolution metrics not available"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:286
+#: helpdesk/api/dashboard.py:293
 msgid "Average tickets per day is around {0}"
 msgstr "每日平均工单数约为{0}"
 
-#: helpdesk/api/dashboard.py:231
+#: helpdesk/api/dashboard.py:238
 msgid "Avg. Feedback Rating"
 msgstr "平均反馈评分"
 
-#: helpdesk/api/dashboard.py:196
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:197
 msgid "Avg. First Response"
 msgstr "平均首次响应"
 
-#: helpdesk/api/dashboard.py:215
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:216
 msgid "Avg. Resolution"
 msgstr "平均解决"
 
-#: helpdesk/api/dashboard.py:236
-msgid "Avg. feedback rating for the tickets resolved"
-msgstr "已解决工单的平均反馈评分"
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr ""
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. feedback rating for tickets resolved in this period"
+msgstr ""
 
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:121
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:290
@@ -840,11 +843,11 @@ msgstr ""
 msgid "Avg. resolution time"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:202
+#: helpdesk/api/dashboard.py:203
 msgid "Avg. time taken to first respond to a ticket"
 msgstr "首次响应工单的平均耗时"
 
-#: helpdesk/api/dashboard.py:221
+#: helpdesk/api/dashboard.py:222
 msgid "Avg. time taken to resolve a ticket"
 msgstr "解决工单的平均耗时"
 
@@ -867,11 +870,6 @@ msgstr ""
 msgid "Base Support Rotation"
 msgstr "基础支持轮换"
 
-#. Label of the base_url (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Base URL"
-msgstr "基本网址"
-
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
 #: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
 msgid "Based On"
@@ -885,11 +883,11 @@ msgstr "根据人力资源政策选择假期分配周期结束日期"
 msgid "Based on your HR Policy, select your leave allocation period's start date"
 msgstr "根据人力资源政策选择假期分配周期开始日期"
 
-#: desk/src/components/EmailEditor.vue:53
+#: desk/src/components/EmailEditor.vue:57
 msgid "Bcc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:83
+#: desk/src/components/EmailEditor.vue:91
 msgid "Bcc:"
 msgstr ""
 
@@ -944,11 +942,6 @@ msgstr ""
 msgid "Busy"
 msgstr "忙"
 
-#. Label of the button_section (Section Break) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Button"
-msgstr "按钮"
-
 #: desk/src/components/ticket/ExportModal.vue:15
 msgid "CSV"
 msgstr "CSV"
@@ -973,19 +966,31 @@ msgstr "通话时长（秒）"
 msgid "Caller"
 msgstr "主叫方"
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:466
+#: desk/src/pages/ticket/MobileTicketAgent.vue:470
 msgid "Calls"
 msgstr "通话记录"
 
-#: desk/src/components/Settings/InviteAgents.vue:162
+#: desk/src/components/Settings/InviteAgents.vue:164
 msgid "Can invite new agents, manage tickets, create custom views and manage public views."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:170
+#: desk/src/components/Settings/InviteAgents.vue:172
 msgid "Can manage all aspects of Helpdesk."
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:154
+#: desk/src/components/customer/InviteContactDialog.vue:134
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:137
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:156
 msgid "Can work on tickets, create custom views and manage private views."
 msgstr ""
 
@@ -1025,7 +1030,7 @@ msgstr "未添加用户时无法启用规则。"
 msgid "Cannot merge General category"
 msgstr "无法合并通用类别"
 
-#: helpdesk/integrations/erpnext/utils.py:100
+#: helpdesk/integrations/erpnext/utils.py:103
 msgid "Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict manually first."
 msgstr ""
 
@@ -1073,11 +1078,11 @@ msgstr "类别必须至少包含一篇文章"
 msgid "Category updated successfully."
 msgstr "类别更新成功."
 
-#: desk/src/components/EmailEditor.vue:43
+#: desk/src/components/EmailEditor.vue:47
 msgid "Cc"
 msgstr ""
 
-#: desk/src/components/EmailEditor.vue:69
+#: desk/src/components/EmailEditor.vue:73
 msgid "Cc:"
 msgstr ""
 
@@ -1085,7 +1090,7 @@ msgstr ""
 msgid "Change"
 msgstr "更改"
 
-#: desk/src/components/Settings/Profile/Profile.vue:152
+#: desk/src/components/Settings/Profile/Profile.vue:154
 #: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
 msgid "Change Password"
 msgstr "更改密码"
@@ -1098,9 +1103,8 @@ msgstr ""
 msgid "Change language of the application."
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Change photo"
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:169
+msgid "Change operator ({0})"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:88
@@ -1123,7 +1127,7 @@ msgstr ""
 msgid "Change timezone of the application."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:147
+#: desk/src/components/Settings/Profile/Profile.vue:149
 msgid "Change your account password for security."
 msgstr ""
 
@@ -1136,7 +1140,7 @@ msgstr "渠道"
 msgid "Child field"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:151
+#: desk/src/components/view-controls/filter/Filter.vue:190
 msgid "Choose a field"
 msgstr ""
 
@@ -1189,7 +1193,7 @@ msgstr "清除排序"
 msgid "Clear Table"
 msgstr "清除表格"
 
-#: desk/src/components/view-controls/filter/Filter.vue:71
+#: desk/src/components/view-controls/filter/Filter.vue:93
 msgid "Clear all"
 msgstr ""
 
@@ -1204,6 +1208,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
 msgid "Click on Add to Holidays. This will populate the holidays table with all the dates that fall on the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
 msgstr "点击'添加至假期'，系统将填充所选周休日期的假期表，重复操作可填充所有周休日期"
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
+msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleListItem.vue:69
 #: desk/src/components/Settings/Holiday/HolidayListItem.vue:47
@@ -1223,7 +1231,7 @@ msgstr ""
 msgid "Closed"
 msgstr "已关闭"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:351
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:369
 msgid "Closed or rated tickets cannot be updated by non-agents"
 msgstr "非客服人员无法更新已关闭或已评分工单"
 
@@ -1250,7 +1258,7 @@ msgstr "列"
 msgid "Comma separated emails to invite."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Comma separated values"
 msgstr ""
 
@@ -1283,7 +1291,7 @@ msgstr "评论人"
 
 #. Label of the comments_section (Section Break) field in DocType 'HD Settings'
 #: desk/src/pages/SearchAgent.vue:353
-#: desk/src/pages/ticket/MobileTicketAgent.vue:458
+#: desk/src/pages/ticket/MobileTicketAgent.vue:462
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Comments"
 msgstr "评论"
@@ -1296,6 +1304,11 @@ msgstr "沟通"
 msgid "Communication ID is required"
 msgstr ""
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
+msgstr "公司"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:209
 msgid "Completed"
 msgstr "已完成"
@@ -1307,7 +1320,7 @@ msgstr "已完成"
 msgid "Condition"
 msgstr "条件"
 
-#: desk/src/components/Settings/Profile/Profile.vue:137
+#: desk/src/components/Settings/Profile/Profile.vue:139
 msgid "Configure"
 msgstr ""
 
@@ -1331,6 +1344,10 @@ msgstr ""
 msgid "Configure your telephony settings."
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:233
+#: desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
 #: desk/src/pages/knowledge-base/NewArticle.vue:147
 #: desk/src/pages/ticket/MobileTicketAgent.vue:156
@@ -1356,10 +1373,11 @@ msgstr "确认覆盖"
 msgid "Connect your support email"
 msgstr ""
 
-#. Label of the contact (Link) field in DocType 'HD Organization Contact Item'
 #. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:43
 #: desk/src/components/layouts/Sidebar.vue:614
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
+#: desk/src/pages/customer/Customer.vue:167
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
@@ -1373,26 +1391,30 @@ msgstr "联系人"
 msgid "Contact HTML"
 msgstr "联系HTML"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:185
-msgid "Contact created successfully."
-msgstr ""
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:298
-msgid "Contact invited successfully."
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
 msgstr ""
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:84
 msgid "Contact updated successfully."
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:238
-msgid "Contact with email already exists"
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
 msgstr ""
 
-#. Label of the contacts (Table) field in DocType 'HD Organization'
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4
+#: desk/src/pages/contact/Contact.vue:326 desk/src/pages/contact/Contacts.vue:6
+#: desk/src/pages/customer/Customer.vue:75
+#: desk/src/pages/customer/Customer.vue:151
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Contacts"
 msgstr "联系人"
+
+#: desk/src/components/customer/InviteContactDialog.vue:168
+msgid "Contacts added successfully"
+msgstr ""
 
 #. Label of the content_section (Section Break) field in DocType 'HD Article'
 #. Label of the content (Text Editor) field in DocType 'HD Article'
@@ -1415,7 +1437,7 @@ msgstr ""
 msgid "Copy ticket id"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:669
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:687
 msgid "Could not an email due to: {0}"
 msgstr "无法发送邮件，原因：{0}"
 
@@ -1423,7 +1445,11 @@ msgstr "无法发送邮件，原因：{0}"
 msgid "Could not find the `name` column in tabHD Ticket"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:830
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:848
 msgid "Could not send an acknowledgement email due to: {0}"
 msgstr "无法发送确认邮件，原因：{0}"
 
@@ -1431,11 +1457,20 @@ msgstr "无法发送确认邮件，原因：{0}"
 msgid "Could not send feedback email,due to: {0}"
 msgstr "无法发送反馈邮件，原因：{0}"
 
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:36
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "国家"
+
 #: desk/src/components/Settings/EmailAdd.vue:152
 #: desk/src/components/Settings/NewTeamModal.vue:7
-#: desk/src/components/desk/global/NewContactDialog.vue:39
+#: desk/src/components/contact/NewContactDialog.vue:105
+#: desk/src/components/customer/NewCustomerDialog.vue:104
 #: desk/src/components/layouts/Sidebar.vue:544
 #: desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
 #: desk/src/pages/knowledge-base/NewArticle.vue:29
 msgid "Create"
@@ -1446,9 +1481,13 @@ msgstr "创建"
 msgid "Create & invite a contact"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:3
-msgid "Create New Contact"
-msgstr "创建新联系人"
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:397 desk/src/pages/ticket/Tickets.vue:401
 msgid "Create View"
@@ -1482,12 +1521,6 @@ msgstr ""
 msgid "Creating a ticket"
 msgstr ""
 
-#. Label of the criterion_section (Section Break) field in DocType 'HD
-#. Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Criterion"
-msgstr "条件标准"
-
 #: desk/src/components/layouts/Sidebar.vue:627
 msgid "Custom Actions"
 msgstr ""
@@ -1512,12 +1545,21 @@ msgid "Custom Views"
 msgstr ""
 
 #. Label of the customer (Link) field in DocType 'HD Ticket'
-#: desk/src/components/desk/global/NewContactDialog.vue:141
+#: desk/src/components/contact/EditContactDialog.vue:122
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:129
+#: desk/src/components/customer/NewCustomerDialog.vue:14
 #: desk/src/components/layouts/Sidebar.vue:615
-#: desk/src/pages/desk/contact/ContactDialog.vue:58
+#: desk/src/pages/contact/Contact.vue:79
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Customer"
 msgstr "客户"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:130
+msgid "Customer Manager"
+msgstr ""
 
 #. Label of the customer_name (Data) field in DocType 'HD Customer'
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
@@ -1528,17 +1570,33 @@ msgstr "客户名称"
 msgid "Customer Portal"
 msgstr ""
 
-#: desk/src/components/desk/global/NewCustomerDialog.vue:62
-msgid "Customer created successfully."
-msgstr "客户创建成功."
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:31
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr "客户类型"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:142
+msgid "Customer created"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
+msgstr ""
 
 #: desk/src/components/layouts/Sidebar.vue:357
 msgid "Customer portal"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:82
-msgid "Customer updated successfully."
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
 msgstr ""
+
+#: desk/src/pages/customer/Customer.vue:198
+#: desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
+msgstr "客户"
 
 #: desk/src/components/layouts/Sidebar.vue:595
 msgid "Customers & Contacts"
@@ -1565,6 +1623,8 @@ msgstr "蓝绿色"
 
 #: desk/src/components/layouts/Sidebar.vue:340
 #: desk/src/components/layouts/Sidebar.vue:391
+#: desk/src/pages/contact/Contact.vue:308
+#: desk/src/pages/customer/Customer.vue:211
 #: desk/src/pages/knowledge-base/Article.vue:658
 msgid "Danger"
 msgstr "危险"
@@ -1665,18 +1725,26 @@ msgstr "默认工单类型"
 msgid "Define who receives the tickets and how they’re distributed among agents."
 msgstr "定义工单接收人及其在客服人员间的分配方式。"
 
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63
 #: desk/src/components/ListViewBuilder.vue:233
 #: desk/src/components/ListViewBuilder.vue:237
 #: desk/src/components/ListViewBuilder.vue:243
 #: desk/src/components/ticket-agent/TicketHeader.vue:209
 #: desk/src/components/ticket-agent/TicketHeader.vue:279
 #: desk/src/components/ticket-agent/TicketHeader.vue:281
+#: desk/src/pages/contact/Contact.vue:312
+#: desk/src/pages/customer/Customer.vue:215
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
 #: desk/src/pages/ticket/Tickets.vue:534
 msgid "Delete"
 msgstr "删除"
+
+#: desk/src/pages/customer/Customer.vue:92
+msgid "Delete Contact"
+msgstr ""
 
 #: desk/src/pages/ticket/Tickets.vue:530
 msgid "Delete View"
@@ -1693,6 +1761,10 @@ msgstr ""
 #: desk/src/pages/ticket/Tickets.vue:539
 msgid "Delete {0}"
 msgstr "删除{0}"
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
+msgstr ""
 
 #. Label of the description (Text) field in DocType 'HD Article Category'
 #. Label of the description (Text Editor) field in DocType 'HD Holiday'
@@ -1740,7 +1812,7 @@ msgstr ""
 #. Notification'
 #. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
 #: desk/src/pages/ticket/MobileTicketAgent.vue:81
-#: desk/src/pages/ticket/MobileTicketAgent.vue:442
+#: desk/src/pages/ticket/MobileTicketAgent.vue:446
 #: desk/src/pages/ticket/TicketCustomer.vue:183
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -1826,7 +1898,12 @@ msgstr ""
 msgid "Document Type"
 msgstr "单据类型"
 
+#: desk/src/components/contact/EditContactDialog.vue:45
+msgid "Doe"
+msgstr ""
+
 #. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:50
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
 msgid "Domain"
 msgstr "行业"
@@ -1867,6 +1944,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:178
 msgid "Duplicate Saved reply"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
 msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:64
@@ -1917,7 +1998,8 @@ msgstr ""
 msgid "Easily invite new agents, managers, or admins."
 msgstr ""
 
-#: desk/src/pages/home/Home.vue:36
+#: desk/src/pages/contact/Contact.vue:31
+#: desk/src/pages/customer/Customer.vue:26 desk/src/pages/home/Home.vue:36
 #: desk/src/pages/knowledge-base/Article.vue:626
 #: desk/src/pages/ticket/Tickets.vue:519
 msgid "Edit"
@@ -1926,6 +2008,14 @@ msgstr "编辑"
 #: desk/src/pages/call-logs/CallLogModal.vue:221
 msgid "Edit Call Log"
 msgstr "编辑通话记录"
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr ""
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
+msgstr ""
 
 #: desk/src/components/Settings/EmailAdd.vue:70
 #: desk/src/components/Settings/EmailEdit.vue:63
@@ -1944,10 +2034,10 @@ msgstr ""
 msgid "Edit your email account"
 msgstr ""
 
-#. Label of the email (Data) field in DocType 'HD Desk Account Request'
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:59
+#: desk/src/components/contact/EditContactDialog.vue:52
+#: desk/src/components/customer/NewCustomerDialog.vue:85
 #: desk/src/pages/SearchAgent.vue:184
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 msgid "Email"
 msgstr "邮件"
 
@@ -1975,9 +2065,10 @@ msgstr "邮件账户"
 msgid "Email Content"
 msgstr "邮件内容"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:110
-msgid "Email Id"
-msgstr "邮箱"
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
+msgstr "电子邮件"
 
 #. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
 #. Settings'
@@ -2002,22 +2093,22 @@ msgstr ""
 msgid "Email account updated successfully"
 msgstr "邮件账户更新成功。"
 
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr ""
+
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
 msgid "Email settings updated successfully."
 msgstr "电子邮件设置已成功更新."
 
-#: desk/src/components/desk/global/NewContactDialog.vue:234
-msgid "Email should not be empty"
-msgstr ""
-
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:40
 #: desk/src/pages/SearchAgent.vue:352
-#: desk/src/pages/desk/contact/ContactDialog.vue:42
-#: desk/src/pages/ticket/MobileTicketAgent.vue:453
+#: desk/src/pages/ticket/MobileTicketAgent.vue:457
 msgid "Emails"
 msgstr "电子邮件"
 
-#: desk/src/components/Settings/Profile/Profile.vue:126
+#: desk/src/components/Settings/Profile/Profile.vue:128
 msgid "Emails & Signature"
 msgstr ""
 
@@ -2055,8 +2146,6 @@ msgid "Enable feedback for Customer Portal"
 msgstr "为客户门户启用反馈功能"
 
 #. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
-#. Label of the is_enabled (Check) field in DocType 'HD Action'
-#. Label of the is_enabled (Check) field in DocType 'HD Escalation Rule'
 #. Label of the enabled (Check) field in DocType 'HD Form Script'
 #. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
 #. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
@@ -2081,8 +2170,6 @@ msgstr "为客户门户启用反馈功能"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
@@ -2105,20 +2192,24 @@ msgstr "结束时间"
 msgid "Enter a name for this HD Service Holiday List."
 msgstr "请输入此HD服务假日列表的名称。"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:236
-msgid "Enter a valid email"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:255
-msgid "Enter a valid phone number"
-msgstr ""
-
 #: desk/src/components/Settings/General/components/Branding.vue:11
 msgid "Enter brand name"
 msgstr "请输入品牌名称"
 
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr ""
+
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
 msgid "Enter the new name for the team"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr ""
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
 msgstr ""
 
 #: helpdesk/api/knowledge_base.py:86
@@ -2129,22 +2220,18 @@ msgstr "移动文章至类别时出错"
 msgid "Error processing email at index {0}, message: {1}"
 msgstr ""
 
-#: desk/src/pages/desk/customer/CustomerDialog.vue:85
-msgid "Error updating customer"
-msgstr ""
-
 #: helpdesk/overrides/email_account.py:142
 msgid "Error while connecting to email account {0}"
 msgstr "连接到电子邮箱帐号{0}时出错"
-
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.py:43
-msgid "Escalation rule already exists for this criteria"
-msgstr "此条件已存在升级规则"
 
 #: desk/src/components/ticket/ExportModal.vue:11
 #: desk/src/components/ticket/ExportModal.vue:19
 msgid "Excel"
 msgstr "Excel"
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
+msgstr ""
 
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
 #: desk/src/components/Settings/Telephony/Telephony.vue:96
@@ -2172,11 +2259,6 @@ msgstr "导出全部{0}条记录"
 msgid "Export Type"
 msgstr "导出类型"
 
-#. Label of the is_external_link (Check) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "External link"
-msgstr "外部链接"
-
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: desk/src/pages/call-logs/CallLogModal.vue:211
 #: desk/src/pages/ticket/Tickets.vue:217 desk/src/pages/ticket/Tickets.vue:230
@@ -2184,6 +2266,10 @@ msgstr "外部链接"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Failed"
 msgstr "失败"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr ""
 
 #: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
 msgid "Failed to create category"
@@ -2218,11 +2304,11 @@ msgstr ""
 msgid "Failed to save Twilio settings"
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:526
+#: desk/src/components/ticket-agent/AssignTo.vue:506
 msgid "Failed to update Assignee's."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:610
+#: desk/src/components/ticket-agent/AssignTo.vue:590
 msgid "Failed to update Assignees."
 msgstr ""
 
@@ -2251,6 +2337,7 @@ msgstr "网站图标"
 #. Label of the feedback (Select) field in DocType 'HD Article Feedback'
 #. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
 #. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/contact/Contact.vue:88 desk/src/pages/contact/Contact.vue:179
 #: desk/src/pages/home/components/RecentFeedback.vue:199
 #: desk/src/pages/home/components/RecentFeedback.vue:319
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
@@ -2288,13 +2375,17 @@ msgstr "反馈已存在"
 msgid "Feedback Rating"
 msgstr "反馈评分"
 
-#: helpdesk/api/dashboard.py:370
+#: helpdesk/api/dashboard.py:380
 msgid "Feedback Trend"
 msgstr "反馈趋势"
 
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:167
 msgid "Feedback email has been sent to the customer"
 msgstr "反馈邮件已发送至客户"
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
+msgstr ""
 
 #: desk/src/components/knowledge-base/ArticleFeedback.vue:79
 msgid "Feedback submitted successfully."
@@ -2338,13 +2429,14 @@ msgid "Field dependency updated successfully."
 msgstr ""
 
 #. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:29
 #: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
 msgid "Fields"
 msgstr "字段"
 
 #. Label of the filters_tab (Tab Break) field in DocType 'HD View'
 #. Label of the filters (Code) field in DocType 'HD View'
-#: desk/src/components/view-controls/filter/Filter.vue:150
+#: desk/src/components/view-controls/filter/Filter.vue:189
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Filters"
 msgstr "过滤条件"
@@ -2354,7 +2446,8 @@ msgstr "过滤条件"
 msgid "Find out all of the variables that can be used in the content"
 msgstr "查看可在内容中使用的所有变量"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:118
+#: desk/src/components/contact/EditContactDialog.vue:35
+#: desk/src/components/customer/NewCustomerDialog.vue:70
 msgid "First Name"
 msgstr "姓名"
 
@@ -2362,6 +2455,10 @@ msgstr "姓名"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "First Responded On"
 msgstr "首次回复时间"
+
+#: desk/src/components/customer/TicketsTab.vue:224
+msgid "First Response"
+msgstr ""
 
 #. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -2386,10 +2483,6 @@ msgstr "首次响应时间"
 #: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
 msgid "First Response Time for Tickets"
 msgstr "工单首次响应时间"
-
-#: desk/src/components/desk/global/NewContactDialog.vue:246
-msgid "First name should not be empty"
-msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
@@ -2480,6 +2573,10 @@ msgstr ""
 msgid "Go to Ticket #{0}"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr ""
+
 #. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
 #. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
@@ -2509,8 +2606,6 @@ msgid "Group By Field"
 msgstr "分组字段"
 
 #. Name of a role
-#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
-#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Guest"
 msgstr "访客"
@@ -2518,11 +2613,6 @@ msgstr "访客"
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
 msgid "Guide users to articles before tickets."
 msgstr ""
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "HD Action"
-msgstr "HD操作"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -2554,25 +2644,37 @@ msgstr "HD文章反馈"
 msgid "HD Comment Reaction"
 msgstr ""
 
+#. Name of a role
 #. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
 msgid "HD Customer"
 msgstr "HD客户"
 
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Customer Manager"
+msgstr ""
+
 #. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "HD Desk Account Request"
-msgstr "HD服务台账户申请"
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
+msgstr ""
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
 msgid "HD Email Feedback"
 msgstr "HD邮件反馈"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "HD Escalation Rule"
-msgstr "HD升级规则"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -2593,21 +2695,6 @@ msgstr "HD假日"
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
 msgid "HD Notification"
 msgstr "HD通知"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-msgid "HD Organization"
-msgstr "HD组织"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_organization_contact_item/hd_organization_contact_item.json
-msgid "HD Organization Contact Item"
-msgstr "HD组织联系人项"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "HD Portal Signup Request"
-msgstr "HD门户注册申请"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
@@ -2649,11 +2736,6 @@ msgstr "HD设置"
 #: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
 msgid "HD Stopword"
 msgstr "HD停用词"
-
-#. Name of a DocType
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "HD Support Search Source"
-msgstr "HD支持搜索源"
 
 #. Name of a DocType
 #: helpdesk/helpdesk/doctype/hd_synonym/hd_synonym.json
@@ -2750,12 +2832,6 @@ msgstr "服务台"
 msgid "Helpdesk"
 msgstr "服务台"
 
-#. Name of a role
-#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
-#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
-msgid "Helpdesk Contact"
-msgstr "服务台联系人"
-
 #. Label of a Card Break in the Helpdesk Workspace
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Helpdesk Reports"
@@ -2772,11 +2848,6 @@ msgstr "您好"
 #: desk/src/components/HistoryBox.vue:10
 msgid "Hide "
 msgstr "隐藏 "
-
-#. Label of the cond_hidden (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "Hide condition"
-msgstr "隐藏条件"
 
 #. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
 #. Field'
@@ -2846,15 +2917,8 @@ msgstr "我已知悉，继续添加条件"
 msgid "ID"
 msgstr "编号"
 
-#. Label of the ip_address (Data) field in DocType 'HD Desk Account Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-msgid "IP Address"
-msgstr "IP地址"
-
-#. Label of the button_icon (Data) field in DocType 'HD Action'
 #. Label of the icon (Data) field in DocType 'HD Article Category'
 #. Label of the icon (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Icon"
@@ -2941,6 +3005,11 @@ msgstr "收件箱"
 msgid "Incoming"
 msgstr "入站"
 
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr "个人"
+
 #: desk/src/pages/call-logs/CallLogModal.vue:212
 msgid "Initiated"
 msgstr "已发起"
@@ -2954,7 +3023,7 @@ msgstr ""
 msgid "Instantly send e-mail"
 msgstr "立即发送邮件"
 
-#: helpdesk/utils.py:32
+#: helpdesk/utils.py:31
 msgid "Insufficient Permission for {0}"
 msgstr "{0} 权限不足"
 
@@ -2968,12 +3037,12 @@ msgstr "整数值"
 msgid "Introduction"
 msgstr "介绍"
 
-#: helpdesk/api/agent.py:69
+#: helpdesk/api/agent.py:37
 msgid "Invalid availability"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:267
-msgid "Invalid email"
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:478
@@ -2982,22 +3051,42 @@ msgstr ""
 msgid "Invalid fields, check if all are filled in and values are correct."
 msgstr "字段数据无效，请检查是否已填写所有必填项且数值正确。"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:283
-#: desk/src/pages/desk/contact/ContactDialog.vue:284
-msgid "Invalid file type, only PNG and JPG images are allowed"
-msgstr ""
-
 #: helpdesk/api/settings/email_notifications.py:112
 msgid "Invalid notification"
 msgstr "无效通知"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:67
-#: desk/src/pages/desk/contact/ContactDialog.vue:277
 msgid "Invalid phone number"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:251
+msgid "Invitation Expired"
+msgstr ""
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation expired. Resend to invite again."
+msgstr ""
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
+msgstr "邀请"
+
 #: desk/src/components/Settings/InviteAgents.vue:3
 msgid "Invite Agents"
+msgstr ""
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:87
@@ -3008,13 +3097,30 @@ msgstr "邀请客服"
 msgid "Invite agents"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:35
-msgid "Invite as user"
-msgstr ""
+#: desk/src/components/contact/NewContactDialog.vue:100
+#: desk/src/pages/contact/Contact.vue:269
+msgid "Invite as User"
+msgstr "邀请成为用户"
 
 #: desk/src/components/Settings/InviteAgents.vue:11
 msgid "Invite by email"
 msgstr "通过邮件邀请"
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invite sent. Waiting for the user to accept."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr ""
+
+#: desk/src/pages/contact/Contact.vue:257
+msgid "Invited"
+msgstr "已邀请"
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
+msgstr ""
 
 #. Label of the is_active (Check) field in DocType 'HD Agent'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
@@ -3030,6 +3136,11 @@ msgstr "是否为客户门户"
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 msgid "Is Default"
 msgstr "默认"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr ""
 
 #. Label of the is_standard (Check) field in DocType 'HD Form Script'
 #. Label of the is_standard (Check) field in DocType 'HD View'
@@ -3058,6 +3169,10 @@ msgstr "是否置顶"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Is setup complete"
 msgstr "设置是否完成"
+
+#: desk/src/components/contact/EditContactDialog.vue:38
+msgid "John"
+msgstr ""
 
 #: desk/src/components/command-palette/CP.vue:114
 msgid "Jump to"
@@ -3093,11 +3208,9 @@ msgstr "键盘快捷键"
 msgid "Knowledge Base"
 msgstr "知识库"
 
-#. Label of the button_label (Data) field in DocType 'HD Action'
 #. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
 #. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
 #. Label of the label (Data) field in DocType 'HD View'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 #: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -3131,9 +3244,9 @@ msgstr "最近"
 msgid "Last 3 Months"
 msgstr "过去3个月"
 
-#: desk/src/pages/home/components/CardBase.vue:108
-#: desk/src/pages/home/components/CardBase.vue:110
-#: desk/src/pages/home/components/CardBase.vue:111
+#: desk/src/components/ChartCardBase.vue:169
+#: desk/src/components/ChartCardBase.vue:171
+#: desk/src/components/ChartCardBase.vue:172
 msgid "Last 3 months"
 msgstr ""
 
@@ -3174,7 +3287,8 @@ msgstr ""
 msgid "Last Month"
 msgstr "上个月"
 
-#: desk/src/components/desk/global/NewContactDialog.vue:126
+#: desk/src/components/contact/EditContactDialog.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:77
 msgid "Last Name"
 msgstr "姓"
 
@@ -3183,24 +3297,33 @@ msgstr "姓"
 msgid "Last Week"
 msgstr "上周"
 
-#: desk/src/pages/home/components/AgentTicketsCard.vue:35
-#: desk/src/pages/home/components/AvgTimeCard.vue:50
-#: desk/src/pages/home/components/CardBase.vue:82
-#: desk/src/pages/home/components/CardBase.vue:101
-#: desk/src/pages/home/components/CardBase.vue:103
-#: desk/src/pages/home/components/CardBase.vue:104
+#: desk/src/components/BarChartCard.vue:79
+#: desk/src/components/ChartCardBase.vue:135
+#: desk/src/components/ChartCardBase.vue:162
+#: desk/src/components/ChartCardBase.vue:164
+#: desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
 msgid "Last month"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
 msgstr ""
 
 #: desk/src/components/Settings/Assignment Rules/AssigneeRules.vue:95
 msgid "Last user assigned by this rule"
 msgstr "本规则最后分配的用户"
 
-#: desk/src/pages/home/components/CardBase.vue:94
-#: desk/src/pages/home/components/CardBase.vue:96
-#: desk/src/pages/home/components/CardBase.vue:97
+#: desk/src/components/ChartCardBase.vue:155
+#: desk/src/components/ChartCardBase.vue:157
+#: desk/src/components/ChartCardBase.vue:158
 msgid "Last week"
 msgstr ""
+
+#: desk/src/components/contact/FeedbackList.vue:122
+msgid "Latest"
+msgstr "最新"
 
 #. Label of the layout (Code) field in DocType 'HD Field Layout'
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
@@ -3216,26 +3339,6 @@ msgstr "了解条件设置"
 #. 'HD Settings'
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Let customers know they're raising a ticket outside working hours, and when they can expect a reply."
-msgstr ""
-
-#. Option for the 'Source Type' (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link"
-msgstr "链接"
-
-#. Label of the link_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Link Options"
-msgstr "链接选项"
-
-#: desk/src/pages/desk/contact/ContactDialog.vue:62
-msgid "Link to a customer"
-msgstr ""
-
-#: desk/src/components/desk/global/NewContactDialog.vue:32
-msgid "Link to a customer record"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
@@ -3264,6 +3367,8 @@ msgstr "加载默认列"
 
 #: desk/src/components/Settings/Agents.vue:174
 #: desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:84
+#: desk/src/components/customer/TicketsTab.vue:142
 msgid "Load More"
 msgstr "加载更多"
 
@@ -3286,6 +3391,8 @@ msgstr "登录 Frappe Cloud"
 
 #. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Logo"
 msgstr "Logo"
@@ -3324,7 +3431,7 @@ msgstr ""
 msgid "Manage pre-defined responses that can be used to respond to customer queries."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:130
+#: desk/src/components/Settings/Profile/Profile.vue:132
 msgid "Manage your account emails and email signature for communication."
 msgstr ""
 
@@ -3343,6 +3450,10 @@ msgstr ""
 #: desk/src/components/Settings/Profile/Profile.vue:4
 msgid "Manage your profile information."
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
+msgstr "经理"
 
 #: desk/src/pages/MobileNotifications.vue:11
 #: desk/src/pages/MobileNotifications.vue:14
@@ -3396,6 +3507,20 @@ msgstr "杂项"
 msgid "Mobile App Installation"
 msgstr ""
 
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr "手机号码"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:94
+msgid "Mobile Number"
+msgstr "手机号码"
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr ""
+
 #. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
 #. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
 #. List'
@@ -3436,7 +3561,7 @@ msgid "My Tickets"
 msgstr ""
 
 #. Label of the category_name (Data) field in DocType 'HD Article Category'
-#. Label of the organization_name (Data) field in DocType 'HD Organization'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
 #. Label of the brand_name (Data) field in DocType 'HD Settings'
 #. Label of the team_name (Data) field in DocType 'HD Team'
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:46
@@ -3447,8 +3572,9 @@ msgstr ""
 #: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:42
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/customer/NewCustomerDialog.vue:21
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_team/hd_team.json
 msgid "Name"
@@ -3458,6 +3584,10 @@ msgstr "名称"
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Name Weight"
 msgstr "名称权重"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
+msgstr "必须填写名称"
 
 #. Description of the 'Label (customer view)' (Data) field in DocType 'HD
 #. Ticket Status'
@@ -3469,10 +3599,18 @@ msgstr "客户门户显示的名称<br>（例如：已回复 → 等待响应）
 msgid "Navigation"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:124
+msgid "Negative"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:392
 #: desk/src/pages/home/components/RecentFeedback.vue:410
 msgid "Negative first"
 msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "从不"
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:16
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesList.vue:19
@@ -3581,11 +3719,11 @@ msgstr "未答复"
 msgid "No Data Found"
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:496
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:514
 msgid "No Email Account found for {0}"
 msgstr ""
 
-#: helpdesk/api/agent.py:73
+#: helpdesk/api/agent.py:41
 msgid "No HD Agent record for current user"
 msgstr ""
 
@@ -3597,9 +3735,15 @@ msgstr ""
 msgid "No SLA found"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:442
+#: helpdesk/api/dashboard.py:452
 msgid "No Team"
 msgstr "无团队"
+
+#: desk/src/components/customer/ContactCard.vue:115
+#: desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
+msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:206
 msgid "No additional comments"
@@ -3633,19 +3777,27 @@ msgstr ""
 msgid "No changes made"
 msgstr "未作更改"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:239
-msgid "No changes to save"
-msgstr ""
-
 #: desk/src/pages/home/Home.vue:88
 msgid "No charts added"
 msgstr ""
 
-#: desk/src/pages/desk/contact/Contacts.vue:82
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr ""
+
+#: desk/src/pages/contact/Contacts.vue:66
 msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
-#: desk/src/pages/desk/customer/Customers.vue:91
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:114
+msgid "No country found"
+msgstr ""
+
+#: desk/src/pages/customer/Customers.vue:69
 msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
 msgstr ""
 
@@ -3657,7 +3809,11 @@ msgstr "未找到电子邮件帐户"
 msgid "No feedback"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterFieldList.vue:46
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:55
 msgid "No fields found"
 msgstr ""
 
@@ -3697,19 +3853,25 @@ msgstr ""
 msgid "No recently assigned tickets"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:64
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:83
 msgid "No results"
 msgstr ""
 
+#: desk/src/components/EmailMultiSelect.vue:137
 #: desk/src/components/Settings/Assignment Rules/AssigneeSearch.vue:79
 msgid "No results found"
 msgstr "未找到匹配结果"
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
+msgstr ""
 
 #: desk/src/components/SavedRepliesSelectorModal.vue:113
 #: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:91
 msgid "No saved replies found"
 msgstr ""
 
+#: desk/src/components/customer/TicketsTab.vue:47
 #: desk/src/pages/ticket/Tickets.vue:192
 msgid "No tickets found"
 msgstr ""
@@ -3730,7 +3892,11 @@ msgstr ""
 msgid "No tickets selected"
 msgstr ""
 
-#: helpdesk/api/ticket.py:76 helpdesk/utils.py:182
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr ""
+
+#: helpdesk/api/ticket.py:76 helpdesk/utils.py:187
 msgid "Not Allowed"
 msgstr "不允许"
 
@@ -3742,7 +3908,7 @@ msgstr ""
 msgid "Not Saved"
 msgstr "尚未保存"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:203
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:220
 msgid "Not Set"
 msgstr "空值"
 
@@ -3781,11 +3947,6 @@ msgstr ""
 msgid "On Hold Since"
 msgstr "挂起时间"
 
-#. Label of the action (Code) field in DocType 'HD Action'
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
-msgid "On click (Javascript)"
-msgstr "点击时（Javascript）"
-
 #: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
 msgid "On ticket status"
 msgstr ""
@@ -3815,6 +3976,10 @@ msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:100
 msgid "Open comment box"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:147
+msgid "Open customer"
 msgstr ""
 
 #: desk/src/components/modals/ShortcutsModal.vue:81
@@ -3906,7 +4071,12 @@ msgstr ""
 msgid "Parent field, child field, and parent-child mapping are required."
 msgstr "必须填写父字段、子字段及父子映射关系。"
 
-#: desk/src/components/Settings/Profile/Profile.vue:144
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr "合伙企业"
+
+#: desk/src/components/Settings/Profile/Profile.vue:146
 msgid "Password"
 msgstr "密码"
 
@@ -3944,6 +4114,7 @@ msgid "Pending"
 msgstr "待处理"
 
 #: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
 msgid "Pending Invites"
 msgstr "待处理邀请"
 
@@ -3953,19 +4124,19 @@ msgstr "待处理邀请"
 msgid "Pending Tickets"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:554
+#: helpdesk/api/dashboard.py:564
 msgid "Percentage of total tickets by channel"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:514
+#: helpdesk/api/dashboard.py:524
 msgid "Percentage of total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:448
+#: helpdesk/api/dashboard.py:458
 msgid "Percentage of total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:481
+#: helpdesk/api/dashboard.py:491
 msgid "Percentage of total tickets by type"
 msgstr ""
 
@@ -3986,13 +4157,14 @@ msgstr "个人"
 msgid "Personal mobile no"
 msgstr ""
 
-#: desk/src/components/desk/global/NewContactDialog.vue:133
+#: desk/src/components/contact/EditContactDialog.vue:82
 #: desk/src/components/ticket/SetContactPhoneModal.vue:25
 msgid "Phone"
 msgstr "电话"
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:50
-msgid "Phone Nos"
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:42
+msgid "Photo"
 msgstr ""
 
 #: desk/src/pages/ticket/TicketFeedback.vue:36
@@ -4049,7 +4221,7 @@ msgstr ""
 msgid "Please enter a valid phone number"
 msgstr ""
 
-#: desk/src/components/Settings/InviteAgents.vue:185
+#: desk/src/components/Settings/InviteAgents.vue:187
 msgid "Please enter at least one valid email to send an invite."
 msgstr ""
 
@@ -4092,34 +4264,15 @@ msgstr "请选择每周休息日"
 msgid "Policy name"
 msgstr ""
 
+#: desk/src/components/contact/FeedbackList.vue:123
+msgid "Positive"
+msgstr ""
+
 #: desk/src/pages/home/components/RecentFeedback.vue:388
 #: desk/src/pages/home/components/RecentFeedback.vue:411
 #: desk/src/pages/home/components/RecentFeedback.vue:415
 msgid "Positive first"
 msgstr ""
-
-#. Label of the post_description_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Description Key"
-msgstr "发布说明密钥"
-
-#. Label of the post_route_key_list (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route Key List"
-msgstr "发布路径密钥列表"
-
-#. Label of the post_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Route String"
-msgstr "邮政路线字符串"
-
-#. Label of the post_title_key (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Post Title Key"
-msgstr "帖子标题密钥"
 
 #. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
 #: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:10
@@ -4153,14 +4306,32 @@ msgstr "预览"
 msgid "Previous ticket"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "首选"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:64
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "首选联系人"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr ""
+
 #. Label of the priorities (Table) field in DocType 'HD Service Level
 #. Agreement'
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
 msgid "Priorities"
 msgstr "优先级"
 
-#. Label of the priority (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_priority (Link) field in DocType 'HD Escalation Rule'
 #. Label of the priority (Link) field in DocType 'HD Service Level Priority'
 #. Label of the priority_section (Section Break) field in DocType 'HD Settings'
 #. Label of the priority (Link) field in DocType 'HD Ticket'
@@ -4168,9 +4339,10 @@ msgstr "优先级"
 #. Label of a field in the tickets Web Form
 #: desk/src/components/Settings/Assignment Rules/AssignmentRuleView.vue:59
 #: desk/src/components/Settings/Assignment Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/customer/TicketsTab.vue:221
+#: desk/src/components/customer/TicketsTab.vue:254
 #: desk/src/pages/SearchAgent.vue:68 desk/src/pages/SearchAgent.vue:69
 #: desk/src/pages/home/components/PendingTickets.vue:35
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -4250,17 +4422,6 @@ msgstr ""
 msgid "Quarterly"
 msgstr "每季"
 
-#. Label of the query_options_sb (Section Break) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Options"
-msgstr "查询选项"
-
-#. Label of the query_route (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Query Route String"
-msgstr "查询路径字符串"
-
 #: desk/src/pages/call-logs/CallLogModal.vue:213
 msgid "Queued"
 msgstr "排队"
@@ -4283,14 +4444,14 @@ msgstr "评价您的支持体验"
 msgid "Rate this ticket"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:373
+#: helpdesk/api/dashboard.py:383
 msgid "Rated Tickets"
 msgstr "已评分工单"
 
 #. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
 #. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
 #: desk/src/pages/home/components/RecentFeedback.vue:318
-#: helpdesk/api/dashboard.py:384
+#: helpdesk/api/dashboard.py:394
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 #: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
 msgid "Rating"
@@ -4386,8 +4547,15 @@ msgstr "重新生成搜索索引"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:48
 #: desk/src/components/Settings/Profile/UserEmailSettings.vue:75
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
 msgid "Remove"
 msgstr "移除"
+
+#: desk/src/components/customer/ContactCard.vue:190
+#: desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr ""
 
 #: desk/src/components/Settings/General/components/Branding.vue:110
 msgid "Remove Logo"
@@ -4397,9 +4565,18 @@ msgstr ""
 msgid "Remove Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:30
-#: desk/src/pages/desk/customer/CustomerDialog.vue:27
-msgid "Remove photo"
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Remove filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr "移除图片"
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
 msgstr ""
 
 #: desk/src/components/Settings/Teams/TeamEdit.vue:252
@@ -4419,6 +4596,15 @@ msgstr ""
 
 #: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
 msgid "Rename team"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:58
+#: desk/src/components/view-controls/filter/Filter.vue:59
+msgid "Replace filter"
+msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
 msgstr ""
 
 #. Option in a Select field in the tickets Web Form
@@ -4458,17 +4644,14 @@ msgstr ""
 msgid "Reply on a ticket"
 msgstr ""
 
-#. Label of the request_key (Data) field in DocType 'HD Desk Account Request'
-#. Label of the request_key (Data) field in DocType 'HD Portal Signup Request'
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
-msgid "Request Key"
-msgstr "请求密钥"
-
 #. Label of the required (Check) field in DocType 'HD Ticket Template Field'
 #: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
 msgid "Required"
 msgstr "必填"
+
+#: desk/src/pages/contact/Contact.vue:279
+msgid "Resend Invite"
+msgstr ""
 
 #: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
 msgid "Reset"
@@ -4488,6 +4671,7 @@ msgid "Reset to Default"
 msgstr "恢复默认"
 
 #. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:230
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "Resolution"
 msgstr "解决方案"
@@ -4541,18 +4725,6 @@ msgstr "响应"
 msgid "Response By"
 msgstr "回复人"
 
-#. Label of the response_options_sb (Section Break) field in DocType 'HD
-#. Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Options"
-msgstr "响应选项"
-
-#. Label of the response_result_key_path (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Response Result Key Path"
-msgstr "响应结果关键路径"
-
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:65
 msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
 msgstr "第{1}行优先级{0}的响应时间不能超过解决时间"
@@ -4595,37 +4767,33 @@ msgstr ""
 msgid "Restrict visibility to these teams"
 msgstr ""
 
-#. Label of the result_preview_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Preview Field"
-msgstr "结果预览字段"
-
-#. Label of the result_route_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Route Field"
-msgstr "结果路径字段"
-
-#. Label of the result_title_field (Data) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Result Title Field"
-msgstr "结果标题字段"
-
 #: desk/src/pages/home/Home.vue:341
 #: desk/src/pages/home/components/RecentFeedback.vue:7
 #: desk/src/pages/home/components/RecentFeedback.vue:22
 msgid "Reviews"
 msgstr "审核记录"
 
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:215
 msgid "Ringing"
 msgstr "铃声"
 
 #: desk/src/components/Settings/InviteAgents.vue:19
+#: desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
 msgid "Role"
 msgstr "角色"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr "角色更新成功。"
 
 #. Label of the route_name (Data) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
@@ -4724,9 +4892,9 @@ msgstr "星期六"
 #: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
 #: desk/src/components/Settings/Telephony/Telephony.vue:17
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:168
+#: desk/src/components/customer/EditCustomerDialog.vue:73
 #: desk/src/pages/call-logs/CallLogModal.vue:225
-#: desk/src/pages/desk/contact/ContactDialog.vue:72
-#: desk/src/pages/desk/customer/CustomerDialog.vue:38
 #: desk/src/pages/home/Home.vue:27
 #: desk/src/pages/knowledge-base/Article.vue:152
 #: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
@@ -4802,17 +4970,19 @@ msgstr "搜索索引已重新生成"
 msgid "Search Score"
 msgstr "搜索评分"
 
-#. Label of the search_term_param_name (Data) field in DocType 'HD Support
-#. Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Search Term Param Name"
-msgstr "搜索字词Param Name"
-
 #: desk/src/components/ticket-agent/AssignTo.vue:62
 msgid "Search agents..."
 msgstr ""
 
-#: desk/src/components/view-controls/filter/Filter.vue:90
+#: desk/src/components/customer/TicketsTab.vue:7
+msgid "Search by ID or Subject"
+msgstr ""
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:77
+msgid "Search country"
+msgstr ""
+
+#: desk/src/components/view-controls/filter/Filter.vue:112
 msgid "Search fields..."
 msgstr "搜索字段..."
 
@@ -4852,6 +5022,7 @@ msgstr "搜索..."
 msgid "Searched for:"
 msgstr ""
 
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:77
 #: desk/src/pages/SearchAgent.vue:111
 msgid "Searching..."
 msgstr ""
@@ -4870,6 +5041,10 @@ msgstr "单选"
 
 #: desk/src/pages/knowledge-base/NewArticle.vue:19
 msgid "Select Category"
+msgstr ""
+
+#: desk/src/components/contact/EditContactDialog.vue:161
+msgid "Select Customer"
 msgstr ""
 
 #: desk/src/pages/dashboard/Dashboard.vue:25
@@ -4892,6 +5067,10 @@ msgstr "选择默认优先级。"
 msgid "Select a rating"
 msgstr ""
 
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:21
+msgid "Select country"
+msgstr ""
+
 #: desk/src/pages/home/components/AvgTimeMetrics.vue:37
 #: desk/src/pages/home/components/RecentFeedback.vue:151
 msgid "Select range"
@@ -4903,6 +5082,10 @@ msgstr ""
 
 #: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
 msgid "Select ticket to preview"
+msgstr ""
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
 msgstr ""
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:132
@@ -4930,6 +5113,10 @@ msgstr ""
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
 msgid "Send feedback when"
 msgstr "发送反馈时机"
+
+#: desk/src/pages/contact/Contact.vue:294
+msgid "Send reset password email"
+msgstr ""
 
 #: desk/src/components/ticket-agent/BulkReplyModal.vue:33
 msgid "Send to {0} tickets"
@@ -4969,13 +5156,17 @@ msgstr "服务水平协议名"
 msgid "Service not supported"
 msgstr ""
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:202
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:219
 msgid "Set"
 msgstr "设置"
 
 #: desk/src/components/ticket/SetContactPhoneModal.vue:4
 #: desk/src/components/ticket/SetContactPhoneModal.vue:7
 msgid "Set Phone Number"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:56
@@ -4986,12 +5177,21 @@ msgstr "请在第{1}行为优先级{0}设置解决时间。"
 msgid "Set Response Time for Priority {0} in row {1}."
 msgstr "为第{1}行的优先级{0}设置响应时间。"
 
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr ""
+
 #: desk/src/components/Settings/Sla/SlaPolicyView.vue:75
 msgid "Set as default SLA"
 msgstr ""
 
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr ""
+
 #: desk/src/components/AvailabilityMenu.vue:5
-#: desk/src/components/AvailabilityMenuMobile.vue:22
+#: desk/src/components/AvailabilityMenuMobile.vue:25
 msgid "Set status"
 msgstr ""
 
@@ -5003,7 +5203,7 @@ msgstr ""
 msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
 msgstr ""
 
-#: desk/src/components/Settings/Profile/Profile.vue:115
+#: desk/src/components/Settings/Profile/Profile.vue:117
 msgid "Set your availability so your team knows when you're reachable."
 msgstr ""
 
@@ -5137,23 +5337,6 @@ msgstr ""
 msgid "Sort"
 msgstr "排序"
 
-#. Label of the source_doctype (Link) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source DocType"
-msgstr "源DocType"
-
-#. Label of the source_name (Data) field in DocType 'HD Support Search Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Name"
-msgstr "源名称"
-
-#. Label of the source_type (Select) field in DocType 'HD Support Search
-#. Source'
-#: helpdesk/helpdesk/doctype/hd_support_search_source/hd_support_search_source.json
-msgid "Source Type"
-msgstr "来源类型"
-
 #: helpdesk/api/knowledge_base.py:125
 msgid "Source and target category cannot be same"
 msgstr "源类别和目标类别不能相同"
@@ -5198,6 +5381,8 @@ msgstr "第<u>{0}</u>行的开始时间不能大于或等于结束时间。"
 #. Label of the status_section (Section Break) field in DocType 'HD Settings'
 #. Label of the status (Link) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:220
+#: desk/src/components/customer/TicketsTab.vue:249
 #: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
 #: desk/src/pages/call-logs/CallLogModal.vue:53
 #: desk/src/pages/home/components/PendingTickets.vue:32
@@ -5266,6 +5451,7 @@ msgstr "在系统中创建工单时的工单状态。"
 
 #. Label of the subject (Data) field in DocType 'HD Ticket'
 #. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:219
 #: desk/src/pages/home/components/PendingTickets.vue:29
 #: desk/src/pages/ticket/TicketNew.vue:63
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5377,21 +5563,16 @@ msgstr "系统"
 
 #. Name of a role
 #: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
-#: helpdesk/helpdesk/doctype/hd_action/hd_action.json
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
 #: helpdesk/helpdesk/doctype/hd_article/hd_article.json
 #: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
 #: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
 #: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
-#: helpdesk/helpdesk/doctype/hd_organization/hd_organization.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
 #: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
@@ -5430,8 +5611,6 @@ msgstr "目标工单不存在"
 msgid "Teal"
 msgstr "青蓝色"
 
-#. Label of the team (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_team (Link) field in DocType 'HD Escalation Rule'
 #. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
 #. Label of the team (Link) field in DocType 'HD Saved Reply Team'
 #. Label of the agent_group (Link) field in DocType 'HD Ticket'
@@ -5442,7 +5621,6 @@ msgstr "青蓝色"
 #: desk/src/pages/SearchAgent.vue:50 desk/src/pages/SearchAgent.vue:51
 #: desk/src/pages/dashboard/Dashboard.vue:57
 #: desk/src/pages/home/components/PendingTickets.vue:38
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
 #: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -5548,6 +5726,10 @@ msgstr ""
 msgid "The assignment condition json '{0}' is invalid: {1}"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:297
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr ""
+
 #: desk/src/components/Settings/General/components/TicketSettings.vue:13
 msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
 msgstr ""
@@ -5558,6 +5740,10 @@ msgstr "在{0}这个节日之间不在开始日期和结束日期之间"
 
 #: desk/src/components/Settings/General/components/TicketSettings.vue:187
 msgid "The number of days must be 1 or more"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:279
+msgid "The selected customer {0} is not linked to the contact {1}.Please select a valid customer or update the contact's linked customers."
 msgstr ""
 
 #: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
@@ -5580,6 +5766,14 @@ msgstr ""
 msgid "There should be at least 1 assignment rule for ticket"
 msgstr ""
 
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr ""
+
 #: helpdesk/extends/assignment_rule.py:51
 msgid "This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but not in the linked Team. Please add the user in the {2} to ensure proper team structure."
 msgstr ""
@@ -5587,6 +5781,10 @@ msgstr ""
 #: desk/src/components/ticket/TicketMergeModal.vue:79
 #: desk/src/components/ticket/TicketSplitModal.vue:24
 msgid "This action is irreversible."
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid "This contact will become the primary point of contact and will be able to view tickets raised by all other contacts in the organisation."
 msgstr ""
 
 #: desk/src/components/ticket/TicketCustomerSidebar.vue:68
@@ -5656,7 +5854,7 @@ msgstr "星期四"
 msgid "Ticket"
 msgstr "工单"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:817
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:835
 msgid "Ticket #{0}: We've received your request"
 msgstr ""
 
@@ -5671,6 +5869,10 @@ msgstr "工单分析"
 #: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
 msgid "Ticket Configuration"
 msgstr "工单配置"
+
+#: desk/src/components/customer/TicketsTab.vue:218
+msgid "Ticket ID"
+msgstr ""
 
 #: desk/src/components/ticket-agent/TicketDetailsTab.vue:55
 msgid "Ticket Info"
@@ -5729,7 +5931,7 @@ msgstr ""
 msgid "Ticket Summary"
 msgstr "工单摘要"
 
-#: helpdesk/api/dashboard.py:292
+#: helpdesk/api/dashboard.py:299
 msgid "Ticket Trend"
 msgstr "工单趋势"
 
@@ -5762,7 +5964,7 @@ msgstr "工单不存在。"
 msgid "Ticket merged successfully."
 msgstr ""
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:341
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:359
 msgid "Ticket must be resolved with a feedback"
 msgstr "工单必须附带反馈才能解决"
 
@@ -5797,12 +5999,6 @@ msgstr ""
 msgid "Ticket to merged with is required"
 msgstr ""
 
-#. Label of the ticket_type (Link) field in DocType 'HD Escalation Rule'
-#. Label of the to_ticket_type (Link) field in DocType 'HD Escalation Rule'
-#: helpdesk/helpdesk/doctype/hd_escalation_rule/hd_escalation_rule.json
-msgid "Ticket type"
-msgstr "工单类型"
-
 #: desk/src/pages/ticket/TicketCustomer.vue:298
 msgid "Ticket updated successfully."
 msgstr ""
@@ -5814,12 +6010,15 @@ msgstr "工单搜索分析"
 
 #: desk/src/components/command-palette/CP.vue:98
 #: desk/src/components/ticket-agent/TicketHeader.vue:173
-#: desk/src/pages/SearchAgent.vue:351
-#: desk/src/pages/ticket/MobileTicketAgent.vue:418
+#: desk/src/pages/SearchAgent.vue:351 desk/src/pages/contact/Contact.vue:71
+#: desk/src/pages/contact/Contact.vue:173
+#: desk/src/pages/customer/Customer.vue:66
+#: desk/src/pages/customer/Customer.vue:145
+#: desk/src/pages/ticket/MobileTicketAgent.vue:422
 #: desk/src/pages/ticket/TicketCustomer.vue:354
 #: desk/src/pages/ticket/TicketNew.vue:296 desk/src/pages/ticket/Tickets.vue:6
-#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:154
-#: helpdesk/api/dashboard.py:295
+#: desk/src/pages/ticket/Tickets.vue:686 helpdesk/api/dashboard.py:155
+#: helpdesk/api/dashboard.py:302
 msgid "Tickets"
 msgstr "工单"
 
@@ -5831,19 +6030,19 @@ msgstr ""
 msgid "Tickets assigned to you in the last 7 days"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:553
+#: helpdesk/api/dashboard.py:563
 msgid "Tickets by Channel"
 msgstr "按渠道统计工单"
 
-#: helpdesk/api/dashboard.py:513 helpdesk/api/dashboard.py:521
+#: helpdesk/api/dashboard.py:523 helpdesk/api/dashboard.py:531
 msgid "Tickets by Priority"
 msgstr "按优先级统计工单"
 
-#: helpdesk/api/dashboard.py:447 helpdesk/api/dashboard.py:455
+#: helpdesk/api/dashboard.py:457 helpdesk/api/dashboard.py:465
 msgid "Tickets by Team"
 msgstr "按团队统计工单"
 
-#: helpdesk/api/dashboard.py:480 helpdesk/api/dashboard.py:488
+#: helpdesk/api/dashboard.py:490 helpdesk/api/dashboard.py:498
 msgid "Tickets by Type"
 msgstr "按类型统计工单"
 
@@ -5860,6 +6059,7 @@ msgid "Tickets that are awaiting your response"
 msgstr ""
 
 #: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:111
 msgid "Timezone"
 msgstr "时区"
 
@@ -5949,19 +6149,19 @@ msgstr "总假期"
 msgid "Total Ticket"
 msgstr "工单总数"
 
-#: helpdesk/api/dashboard.py:159
+#: helpdesk/api/dashboard.py:160
 msgid "Total number of tickets created"
 msgstr "创建的工单总数"
 
-#: helpdesk/api/dashboard.py:522
+#: helpdesk/api/dashboard.py:532
 msgid "Total tickets by priority"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:456
+#: helpdesk/api/dashboard.py:466
 msgid "Total tickets by team"
 msgstr ""
 
-#: helpdesk/api/dashboard.py:489
+#: helpdesk/api/dashboard.py:499
 msgid "Total tickets by type"
 msgstr ""
 
@@ -5993,6 +6193,10 @@ msgstr "类型"
 msgid "Type a message"
 msgstr ""
 
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr ""
+
 #: desk/src/pages/call-logs/CallLogModal.vue:360
 msgid "Type is required"
 msgstr ""
@@ -6002,7 +6206,7 @@ msgstr ""
 msgid "URL/Method"
 msgstr "URL/方法"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:650
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:668
 msgid "Unable to send email. Please setup default outgoing email account."
 msgstr ""
 
@@ -6036,6 +6240,8 @@ msgid "Unpublish"
 msgstr "取消发布"
 
 #: desk/src/components/UnsavedBadge.vue:8
+#: desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
 msgid "Unsaved"
 msgstr "未保存"
 
@@ -6053,6 +6259,10 @@ msgstr "未保存"
 #: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
 msgid "Unsaved changes"
 msgstr "未保存的修改"
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
+msgstr ""
 
 #: desk/src/pages/call-logs/CallLogModal.vue:8
 msgid "Untitled"
@@ -6080,10 +6290,13 @@ msgstr "上传"
 msgid "Upload Photo"
 msgstr ""
 
-#: desk/src/pages/desk/contact/ContactDialog.vue:21
-#: desk/src/pages/desk/customer/CustomerDialog.vue:18
-msgid "Upload photo"
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
 msgstr ""
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
+msgstr "上传图片"
 
 #: desk/src/components/Settings/General/components/LogoUpload.vue:38
 msgid "Uploading {0}%"
@@ -6092,17 +6305,13 @@ msgstr "上传进度{0}%"
 #. Label of the user (Link) field in DocType 'HD Agent'
 #. Label of the user (Link) field in DocType 'HD Article Feedback'
 #. Label of the user (Data) field in DocType 'HD Comment Reaction'
-#. Label of the user (Link) field in DocType 'HD Desk Account Request'
 #. Label of the user (Link) field in DocType 'HD Field Layout'
-#. Label of the user (Link) field in DocType 'HD Portal Signup Request'
 #. Label of the user (Link) field in DocType 'HD Team Member'
 #. Label of the user (Link) field in DocType 'HD View'
 #: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
 #: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
 #: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
-#: helpdesk/helpdesk/doctype/hd_desk_account_request/hd_desk_account_request.json
 #: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
-#: helpdesk/helpdesk/doctype/hd_portal_signup_request/hd_portal_signup_request.json
 #: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
 #: helpdesk/helpdesk/doctype/hd_view/hd_view.json
 #: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
@@ -6114,6 +6323,10 @@ msgstr "用户"
 #: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
 msgid "User Resolution Time"
 msgstr "用户解决时间"
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
+msgstr ""
 
 #: desk/src/components/Settings/General/General.vue:42
 msgid "User Signup"
@@ -6132,7 +6345,7 @@ msgstr "用户"
 msgid "Valid From"
 msgstr "生效日期"
 
-#: desk/src/components/view-controls/filter/FilterValueEditor.vue:90
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:109
 msgid "Value"
 msgstr "值"
 
@@ -6261,19 +6474,23 @@ msgstr "每年"
 msgid "Yellow"
 msgstr "黄色"
 
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr ""
+
 #: helpdesk/api/dashboard.py:36
 msgid "You are not allowed to view this dashboard data."
 msgstr "您无权查看此仪表板数据。"
 
-#: helpdesk/utils.py:181
+#: helpdesk/utils.py:186
 msgid "You are not permitted to access this resource."
 msgstr "您无权访问此资源"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:563
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:581
 msgid "You are not permitted to add a comment"
 msgstr "您无权添加评论"
 
-#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:589
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:607
 msgid "You are not permitted to reply as an agent"
 msgstr ""
 
@@ -6301,6 +6518,14 @@ msgstr "您无法设置多个默认优先级。"
 msgid "You do not have permission to access Assignment Rules"
 msgstr ""
 
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr ""
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr ""
+
 #: desk/src/pages/ticket/TicketAgent.vue:37
 msgid "You don't have access to this ticket, or it no longer exists."
 msgstr ""
@@ -6323,6 +6548,14 @@ msgstr ""
 
 #: desk/src/pages/home/components/RecentFeedback.vue:51
 msgid "Your performance is"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr ""
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
 msgstr ""
 
 #: desk/src/pages/MobileNotifications.vue:46
@@ -6353,7 +6586,7 @@ msgstr "已创建"
 msgid "customize {0}"
 msgstr "自定义{0}"
 
-#: helpdesk/api/dashboard.py:217 helpdesk/api/dashboard.py:219
+#: helpdesk/api/dashboard.py:218 helpdesk/api/dashboard.py:220
 msgid "days"
 msgstr "天"
 
@@ -6404,7 +6637,7 @@ msgstr "此处"
 msgid "here."
 msgstr ""
 
-#: helpdesk/api/dashboard.py:198 helpdesk/api/dashboard.py:200
+#: helpdesk/api/dashboard.py:199 helpdesk/api/dashboard.py:201
 msgid "hrs"
 msgstr "时长(小时)"
 
@@ -6412,7 +6645,7 @@ msgstr "时长(小时)"
 msgid "in"
 msgstr "包括"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:416
+#: desk/src/components/ticket-agent/AssignTo.vue:396
 msgid "just now"
 msgstr "刚刚"
 
@@ -6445,7 +6678,11 @@ msgstr ""
 msgid "purple"
 msgstr "紫色"
 
-#: helpdesk/api/dashboard.py:235
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr "评审"
+
+#: helpdesk/api/dashboard.py:242
 msgid "stars"
 msgstr "星级"
 
@@ -6462,7 +6699,7 @@ msgstr "工单"
 msgid "to enable this integration."
 msgstr ""
 
-#: desk/src/pages/ticket/MobileTicketAgent.vue:527
+#: desk/src/pages/ticket/MobileTicketAgent.vue:531
 msgid "viewed this"
 msgstr ""
 
@@ -6470,12 +6707,32 @@ msgstr ""
 msgid "views"
 msgstr "视图"
 
-#: desk/src/components/ticket-agent/AssignTo.vue:573
+#: desk/src/components/contact/ContactCustomers.vue:53
+msgid "{0} Customers"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr ""
+
+#: desk/src/components/ticket-agent/AssignTo.vue:553
 msgid "{0} is currently away."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:572
+#: desk/src/components/ticket-agent/AssignTo.vue:552
 msgid "{0} is currently unavailable."
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr ""
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
 msgstr ""
 
 #: desk/src/components/ListViewBuilder.vue:307
@@ -6502,7 +6759,7 @@ msgstr ""
 msgid "{0} view is currently visible in the sidebar. Hiding it will remove it from the sidebar."
 msgstr ""
 
-#: desk/src/components/ticket-agent/AssignTo.vue:417
+#: desk/src/components/ticket-agent/AssignTo.vue:397
 msgid "{0} · Last active {1}"
 msgstr ""
 


### PR DESCRIPTION
## What

Brings `helpdesk/locale` on `main-hotfix` up to date with `develop` in one commit, replacing five individual backports that all touch the same `.po`/`.pot` files:

- #3517 — chore: sync translations from crowdin
- #3522 — chore: update POT file
- #3539 — chore: update POT file
- #3531 — chore: added german translations
- #3554 — added missing msgstr for translation

## Why not backport them individually

`main-hotfix` is ~37k lines behind `develop` on translations, so mergify's cherry-picks conflict. #3641 (the backport of #3517) was opened with **188 unresolved conflict markers committed across 30 `.po` files** — GitHub still reported it as `MERGEABLE`, because the markers are inside the commit rather than a merge conflict. #3573 shipped exactly this way earlier and put broken code on `main-hotfix`.

Taking the directory wholesale sidesteps the cherry-pick entirely. The tree here is byte-identical to `develop`'s `helpdesk/locale`, so there is nothing to resolve.

## Scope

33 files, all under `helpdesk/locale/`. No source changes. Includes `uz.po`, which `main-hotfix` did not have.

`main.pot` now lists strings from develop-only features. That is cosmetic — it is regenerated by the POT workflow — and it is already true of every POT backport.

## How to test

- `grep -rn '<<<<<<<' helpdesk/locale/` returns nothing
- `git diff upstream/develop -- helpdesk/locale` is empty
- Switch the portal to a non-English locale and confirm strings render

## Follow-up

#3641 should be closed unmerged, and the `backport main-hotfix` label removed from #3517, once this lands.