### PR TITLE
fix: install @framework/ui deps before dev and build

### DIFF
--- a/desk/package.json
+++ b/desk/package.json
@@ -4,9 +4,10 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
+    "dev": "yarn install-framework-ui && vite",
+    "build": "yarn install-framework-ui && vite build",
     "serve": "vite preview",
+    "install-framework-ui": "[ -f ../../frappe/ui/node_modules/.yarn-integrity ] || (cd ../../frappe/ui && yarn install)",
     "postinstall": "patch-package"
   },
   "dependencies": {

--- a/desk/src/components/TicketField.vue
+++ b/desk/src/components/TicketField.vue
@@ -27,7 +27,7 @@ import FieldLabel from "@/components/FieldLabel.vue";
 import TicketPriority from "@/components/TicketPriority.vue";
 import { APIOptions, Field, FieldValue } from "@/types";
 import { parseApiOptions } from "@/utils";
-import { Link } from "@framework/ui/components/Link/index.ts";
+import { Link } from "@framework/ui";
 import {
   Combobox,
   createResource,

--- a/desk/vite.config.js
+++ b/desk/vite.config.js
@@ -112,6 +112,7 @@ export default defineConfig(async ({ mode }) => {
         // each so its Combobox shares helpdesk's frappe-ui, not a second copy.
         "vue",
         "frappe-ui",
+        "reka-ui",
         "@tiptap/core",
         "@tiptap/pm",
         "prosemirror-state",


### PR DESCRIPTION
`@framework/ui` is a `link:` dependency, so yarn never installs its own dependencies and `yarn build` fails on missing imports.

`dev` and `build` now run `yarn install` in `frappe/ui` first, skipped when `node_modules/.yarn-integrity` shows a complete install is already there.
