### PR TITLE
fix: prefill template fields with meta default on new ticket page

### DIFF
--- a/desk/src/pages/ticket/TicketNew.vue
+++ b/desk/src/pages/ticket/TicketNew.vue
@@ -207,7 +207,7 @@ const template = createResource({
 
 function setupTemplateFields(fields) {
   fields.forEach((field: Field) => {
-    templateFields[field.fieldname] = "";
+    templateFields[field.fieldname] = field.default || "";
   });
 }
 

--- a/desk/src/pages/ticket/TicketNew.vue
+++ b/desk/src/pages/ticket/TicketNew.vue
@@ -207,7 +207,11 @@ const template = createResource({
 
 function setupTemplateFields(fields) {
   fields.forEach((field: Field) => {
-    templateFields[field.fieldname] = field.default || "";
+    // Frappe stores defaults as strings, and "0" on a Check is truthy in JS.
+    templateFields[field.fieldname] =
+      field.fieldtype === "Check"
+        ? Number(field.default) || 0
+        : field.default || "";
   });
 }
 

--- a/desk/src/types.ts
+++ b/desk/src/types.ts
@@ -260,6 +260,7 @@ export interface Field {
   disabled?: boolean;
   placeholder?: string | null;
   readonly?: boolean;
+  default?: string | null;
 }
 
 export type FieldValue = string | number | boolean | null | undefined | Dayjs;

--- a/helpdesk/helpdesk/doctype/hd_ticket_template/api.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket_template/api.py
@@ -100,6 +100,7 @@ def get_fields(template: str, fetch: Literal["Custom Field", "DocField"]):
             QBFetch.link_filters,
             QBFetch.depends_on,
             QBFetch.mandatory_depends_on,
+            QBFetch.default,
             fields.fieldname,
             fields.hide_from_customer,
             fields.required,
@@ -113,7 +114,7 @@ def get_fields(template: str, fetch: Literal["Custom Field", "DocField"]):
         .orderby(fields.idx)
         .run(as_dict=True)
     )
-    docfields = ["link_filters", "depends_on", "mandatory_depends_on"]
+    docfields = ["link_filters", "depends_on", "mandatory_depends_on", "default"]
 
     for df in docfields:
         for field in result:


### PR DESCRIPTION
Template fields on the new ticket page were always initialized empty, ignoring the field's `default` set in meta (DocField / Custom Field / Property Setter).

- `get_one` API now returns `default` for each template field
- New ticket page prefills the field value with it

**Test:** set a default on an HD Ticket field via Customize Form, add it to the ticket template, open the new ticket page. The field comes prefilled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)