### PR TITLE
feat(tickets): bulk edit and bulk assign from the selection banner

### DIFF
--- a/desk/src/components/ListViewBuilder.vue
+++ b/desk/src/components/ListViewBuilder.vue
@@ -86,9 +86,19 @@
     </ListRows>
     <ListSelectBanner v-if="options.showSelectBanner">
       <template #actions="{ selections, unselectAll }">
-        <Dropdown :options="selectBannerOptions(selections, unselectAll)">
-          <Button icon="lucide-more-horizontal" variant="ghost" />
-        </Dropdown>
+        <div class="flex items-center gap-1">
+          <Button
+            v-for="action in selectBannerOptions(selections, unselectAll, true)"
+            :key="action.label"
+            :label="action.label"
+            :icon-left="action.icon"
+            variant="ghost"
+            @click="action.onClick"
+          />
+          <Dropdown :options="selectBannerOptions(selections, unselectAll)">
+            <Button icon="lucide-more-horizontal" variant="ghost" />
+          </Dropdown>
+        </div>
       </template>
     </ListSelectBanner>
   </ListView>
@@ -394,7 +404,12 @@ const exposeFunctions = {
   unselectAll: () => {},
 };
 
-function selectBannerOptions(selections: Set<string>, unselectAll = () => {}) {
+/** Banner actions. `inline` picks the ones shown as buttons; the rest fill the "..." menu. */
+function selectBannerOptions(
+  selections: Set<string>,
+  unselectAll = () => {},
+  inline = false
+) {
   exposeFunctions["unselectAll"] = unselectAll;
 
   // Get the user-provided actions
@@ -417,8 +432,9 @@ function selectBannerOptions(selections: Set<string>, unselectAll = () => {}) {
       onClick: () => action.onClick?.(selections),
     }));
 
-  // Return combined actions
-  return [...userActions, ...defaultActions];
+  return [...userActions, ...defaultActions].filter(
+    (action) => Boolean(action.inline) === inline
+  );
 }
 
 const rows = computed(() => {

--- a/desk/src/components/ticket-agent/AssignTo.vue
+++ b/desk/src/components/ticket-agent/AssignTo.vue
@@ -44,9 +44,9 @@
               <span v-if="ghost" class="text-ink-gray-4">
                 {{ __("Set Assignee") }}...
               </span>
-              <span v-else class="text-ink-gray-5 leading-5">{{
-                __("No one")
-              }}</span>
+              <span v-else class="text-ink-gray-5 leading-5">
+                {{ emptyLabel }}
+              </span>
             </template>
           </div>
           <template #suffix>
@@ -208,9 +208,18 @@ const props = withDefaults(defineProps<Props>(), {
 
 const { hideLabel, ghost } = props;
 
-const ticket = inject(TicketSymbol)!;
-const assignees = inject(AssigneeSymbol)!;
-const activities = inject(ActivitiesSymbol)!;
+// No ticket in context (bulk assign) means nothing to save to: the picker then
+// just reports its selection through v-model and the parent decides what to do.
+const ticket = inject(TicketSymbol, null);
+const assignees = inject(AssigneeSymbol, null);
+const activities = inject(ActivitiesSymbol, null);
+const selection = defineModel<string[]>({ default: () => [] });
+
+// On a ticket the trigger reports state ("No one" is assigned); standalone it is
+// an input still waiting on a choice, so it reads as a placeholder.
+const emptyLabel = computed(() =>
+  ticket ? __("No one") : __("Select agents")
+);
 
 const { getUser } = useUserStore();
 const currentUser = computed(() => getUser("")); // empty string returns current user
@@ -231,7 +240,7 @@ const snapshotAssignees = ref<LocalAssignee[]>([]);
 
 // Sync from injected assignees when popover is not open
 watch(
-  () => assignees.value?.data,
+  () => assignees?.value?.data,
   (data) => {
     if (!popoverIsOpen.value && data) {
       localAssignees.value = [...data];
@@ -239,6 +248,21 @@ watch(
   },
   { immediate: true, deep: true }
 );
+
+// Standalone mode: the selection itself is the output, so publish it live.
+watch(
+  localAssignees,
+  (list) => {
+    if (!ticket) selection.value = list.map((a) => a.name);
+  },
+  { deep: true }
+);
+
+// Standalone mode: let the parent clear the picker (e.g. on dialog open).
+watch(selection, (names) => {
+  if (ticket || names.length || !localAssignees.value.length) return;
+  localAssignees.value = [];
+});
 
 // Watch popover open/close — same pattern as old AssignToBody
 watch(popoverIsOpen, (isOpen) => {
@@ -258,6 +282,7 @@ watch(popoverIsOpen, (isOpen) => {
     // Closing after a real open: compute diff and save
     hasBeenOpened.value = false;
     searchText.value = "";
+    if (!ticket) return;
     const currentNames = localAssignees.value.map((a) => a.name);
     const oldNames = snapshotAssignees.value.map((a) => a.name);
     const added = currentNames.filter((n) => !oldNames.includes(n));
@@ -494,7 +519,7 @@ async function logActivity(action: string) {
   await call("frappe.client.insert", {
     doc: {
       doctype: "HD Ticket Activity",
-      ticket: ticket.value?.name,
+      ticket: ticket?.value?.name,
       action,
     },
   });
@@ -505,7 +530,7 @@ const addAssigneesResource = createResource({
   url: "frappe.desk.form.assign_to.add",
   makeParams: (addedAssignees: string[]) => ({
     doctype: "HD Ticket",
-    name: ticket.value?.name,
+    name: ticket?.value?.name,
     assign_to: addedAssignees,
   }),
   onSuccess: () => {
@@ -519,7 +544,7 @@ const removeAssigneesResource = createResource({
   url: "helpdesk.api.doc.remove_assignments",
   makeParams: (removedAssignees: string[]) => ({
     doctype: "HD Ticket",
-    name: ticket.value?.name,
+    name: ticket?.value?.name,
     assignees: removedAssignees,
   }),
 });
@@ -576,8 +601,8 @@ async function saveAssignees(added: string[], removed: string[]) {
       toast.success(__("Assignees updated successfully."));
     }, successDelay);
 
-    assignees.value.reload();
-    activities.value.reload();
+    assignees?.value.reload();
+    activities?.value.reload();
   } catch {
     toast.error(__("Failed to update Assignees."));
     localAssignees.value = [...snapshotAssignees.value];

--- a/desk/src/components/ticket-agent/BulkAssignModal.vue
+++ b/desk/src/components/ticket-agent/BulkAssignModal.vue
@@ -1,0 +1,63 @@
+<template>
+  <Dialog v-model:open="open" :title="__('Assign')">
+    <template #default>
+      <AssignTo v-model="assignees" hide-label />
+    </template>
+    <template #actions>
+      <div class="flex items-center justify-end gap-2">
+        <Button :label="__('Cancel')" @click="open = false" />
+        <Button
+          variant="solid"
+          :loading="loading"
+          :disabled="!assignees.length"
+          :label="__('Assign {0} tickets', selections.size)"
+          @click="submit"
+        />
+      </div>
+    </template>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import AssignTo from "@/components/ticket-agent/AssignTo.vue";
+import { __ } from "@/translation";
+import { Button, call, Dialog, toast } from "frappe-ui";
+import { ref, watch } from "vue";
+
+const ASSIGN_METHOD = "frappe.desk.form.assign_to.add_multiple";
+
+const open = defineModel<boolean>();
+
+const props = defineProps<{
+  selections: Set<string>;
+}>();
+const emit = defineEmits<{
+  (e: "success"): void;
+}>();
+
+const assignees = ref<string[]>([]);
+const loading = ref(false);
+
+async function submit() {
+  if (!assignees.value.length) return;
+  const ticketIds = Array.from(props.selections);
+  loading.value = true;
+  try {
+    // `add_multiple` reads the raw form_dict, so the lists go as JSON strings.
+    await call(ASSIGN_METHOD, {
+      doctype: "HD Ticket",
+      name: JSON.stringify(ticketIds),
+      assign_to: JSON.stringify(assignees.value),
+    });
+    open.value = false;
+    toast.success(__("Assigned {0} tickets", ticketIds.length));
+    emit("success");
+  } finally {
+    loading.value = false;
+  }
+}
+
+watch(open, (isOpen) => {
+  if (isOpen) assignees.value = [];
+});
+</script>

--- a/desk/src/components/ticket-agent/BulkEditModal.vue
+++ b/desk/src/components/ticket-agent/BulkEditModal.vue
@@ -10,7 +10,7 @@
         />
         <component
           v-if="field"
-          :is="control"
+          :is="getFieldComponent(field.fieldtype)"
           :key="fieldname"
           :field="field"
           :model-value="value"
@@ -24,7 +24,6 @@
         <Button
           variant="solid"
           :loading="loading"
-          :disabled="!fieldname"
           :label="__('Update {0} tickets', selections.size)"
           @click="submit"
         />
@@ -39,12 +38,12 @@ import { getMeta } from "@/stores/meta";
 import { __ } from "@/translation";
 import { getFieldComponent } from "@framework/ui/fields";
 import { Button, call, Combobox, Dialog, toast } from "frappe-ui";
-import { computed, ref, watch } from "vue";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 
 const BULK_UPDATE_METHOD =
   "frappe.desk.doctype.bulk_update.bulk_update.submit_cancel_or_update_docs";
 
-// frappe runs the update inline below this count and enqueues it above.
+// frappe runs the update inline below this count, enqueues above.
 const BACKGROUND_THRESHOLD = 20;
 
 // Fieldtypes that hold no value, so there is nothing to bulk set.
@@ -78,6 +77,12 @@ const fieldname = ref<string | null>(null);
 const value = ref<any>(null);
 const loading = ref(false);
 
+let pending: {
+  taskId: string;
+  toastId: string | number;
+  total: number;
+} | null = null;
+
 const editableFields = computed(() =>
   getFields().filter(
     (field: any) =>
@@ -95,59 +100,88 @@ const fieldOptions = computed(() =>
     .sort((a, b) => a.label.localeCompare(b.label))
 );
 
-const field = computed(() =>
-  editableFields.value.find((f: any) => f.fieldname === fieldname.value)
+const selectedField = computed(
+  () =>
+    editableFields.value.find((f: any) => f.fieldname === fieldname.value) ??
+    null
 );
 
-// The fieldtype registry picks the control; the docfield doubles as its meta.
-const control = computed(() =>
-  field.value ? getFieldComponent(field.value.fieldtype) : null
+// Its own label would repeat the Combobox; the default placeholder is the raw doctype.
+const field = computed(
+  () =>
+    selectedField.value && {
+      ...selectedField.value,
+      label: __("Value"),
+      placeholder: __("Select {0}", selectedField.value.label),
+    }
 );
 
 async function submit() {
-  if (!fieldname.value) return;
+  if (!fieldname.value) {
+    toast.error(__("Select a field"));
+    return;
+  }
+  // Blanking a mandatory field fails `doc.save()` on every ticket.
+  if (selectedField.value.reqd && (value.value ?? "") === "") {
+    toast.error(__("{0} is required", selectedField.value.label));
+    return;
+  }
+
   const docnames = Array.from(props.selections);
+  const total = docnames.length;
+  const inBackground = total >= BACKGROUND_THRESHOLD;
+  const taskId = `bulk-edit-${Math.random().toString(36).slice(2, 10)}`;
   loading.value = true;
   try {
-    await call(BULK_UPDATE_METHOD, {
+    if (inBackground) $socket.emit("task_subscribe", taskId);
+    const failed = await call(BULK_UPDATE_METHOD, {
       doctype: "HD Ticket",
       docnames,
       action: "update",
       data: { [fieldname.value]: value.value ?? null },
+      task_id: taskId,
     });
     open.value = false;
-    if (docnames.length < BACKGROUND_THRESHOLD) {
-      toast.success(__("Updated {0} tickets", docnames.length));
-      emit("success");
-    } else {
-      toast.success(
-        __("Updating {0} tickets in the background", docnames.length)
-      );
-      reloadWhenDone();
+
+    if (inBackground) {
+      if (pending) toast.dismiss(pending.toastId);
+      const toastId = toast.loading(__("Updating {0} tickets…", total));
+      pending = { taskId, toastId, total };
+      return;
     }
+    // The inline path returns the docnames it could not update.
+    if (failed?.length) {
+      toast.warning(
+        __("Updated {0} of {1} tickets", total - failed.length, total)
+      );
+    } else {
+      toast.success(__("Updated {0} tickets", total));
+    }
+    emit("success");
   } finally {
     loading.value = false;
   }
 }
 
-/** The enqueued job reports through `frappe.publish_progress` on the user room. */
-function reloadWhenDone() {
-  const onProgress = ({ percent }: { percent: number }) => {
-    if (percent < 100) return;
-    $socket.off("progress", onProgress);
-    toast.success(__("Bulk edit completed"));
-    emit("success");
-  };
-  $socket.on("progress", onProgress);
+// Unrelated jobs publish `progress` on the user room too, so match the id.
+function onProgress(data: { percent: number; task_id?: string }) {
+  if (!pending || data.task_id !== pending.taskId || data.percent < 100) return;
+  // Same id replaces the pending toast.
+  toast.success(__("Updated {0} tickets", pending.total), {
+    id: pending.toastId,
+  });
+  pending = null;
+  emit("success");
 }
 
 watch(open, (isOpen) => {
-  if (!isOpen) return;
-  fieldname.value = null;
-  value.value = null;
+  if (isOpen) fieldname.value = null;
 });
 
 watch(fieldname, () => {
   value.value = null;
 });
+
+onMounted(() => $socket.on("progress", onProgress));
+onUnmounted(() => $socket.off("progress", onProgress));
 </script>

--- a/desk/src/components/ticket-agent/BulkEditModal.vue
+++ b/desk/src/components/ticket-agent/BulkEditModal.vue
@@ -1,0 +1,153 @@
+<template>
+  <Dialog v-model:open="open" :title="__('Edit')">
+    <template #default>
+      <div class="flex flex-col gap-4">
+        <Combobox
+          v-model="fieldname"
+          :label="__('Field')"
+          :options="fieldOptions"
+          :placeholder="__('Select a field')"
+        />
+        <component
+          v-if="field"
+          :is="control"
+          :key="fieldname"
+          :field="field"
+          :model-value="value"
+          @update:model-value="(newValue: any) => (value = newValue)"
+        />
+      </div>
+    </template>
+    <template #actions>
+      <div class="flex items-center justify-end gap-2">
+        <Button :label="__('Cancel')" @click="open = false" />
+        <Button
+          variant="solid"
+          :loading="loading"
+          :disabled="!fieldname"
+          :label="__('Update {0} tickets', selections.size)"
+          @click="submit"
+        />
+      </div>
+    </template>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { globalStore } from "@/stores/globalStore";
+import { getMeta } from "@/stores/meta";
+import { __ } from "@/translation";
+import { getFieldComponent } from "@framework/ui/fields";
+import { Button, call, Combobox, Dialog, toast } from "frappe-ui";
+import { computed, ref, watch } from "vue";
+
+const BULK_UPDATE_METHOD =
+  "frappe.desk.doctype.bulk_update.bulk_update.submit_cancel_or_update_docs";
+
+// frappe runs the update inline below this count and enqueues it above.
+const BACKGROUND_THRESHOLD = 20;
+
+// Fieldtypes that hold no value, so there is nothing to bulk set.
+const NO_VALUE_TYPES = new Set([
+  "Section Break",
+  "Column Break",
+  "Tab Break",
+  "Fold",
+  "Heading",
+  "HTML",
+  "Image",
+  "Button",
+  "Table",
+  "Table MultiSelect",
+  "Read Only",
+]);
+
+const open = defineModel<boolean>();
+
+const props = defineProps<{
+  selections: Set<string>;
+}>();
+const emit = defineEmits<{
+  (e: "success"): void;
+}>();
+
+const { $socket } = globalStore();
+const { getFields } = getMeta("HD Ticket");
+
+const fieldname = ref<string | null>(null);
+const value = ref<any>(null);
+const loading = ref(false);
+
+const editableFields = computed(() =>
+  getFields().filter(
+    (field: any) =>
+      field.fieldname &&
+      !NO_VALUE_TYPES.has(field.fieldtype) &&
+      !field.hidden &&
+      !field.read_only &&
+      !field.is_virtual
+  )
+);
+
+const fieldOptions = computed(() =>
+  editableFields.value
+    .map((field: any) => ({ label: __(field.label), value: field.fieldname }))
+    .sort((a, b) => a.label.localeCompare(b.label))
+);
+
+const field = computed(() =>
+  editableFields.value.find((f: any) => f.fieldname === fieldname.value)
+);
+
+// The fieldtype registry picks the control; the docfield doubles as its meta.
+const control = computed(() =>
+  field.value ? getFieldComponent(field.value.fieldtype) : null
+);
+
+async function submit() {
+  if (!fieldname.value) return;
+  const docnames = Array.from(props.selections);
+  loading.value = true;
+  try {
+    await call(BULK_UPDATE_METHOD, {
+      doctype: "HD Ticket",
+      docnames,
+      action: "update",
+      data: { [fieldname.value]: value.value ?? null },
+    });
+    open.value = false;
+    if (docnames.length < BACKGROUND_THRESHOLD) {
+      toast.success(__("Updated {0} tickets", docnames.length));
+      emit("success");
+    } else {
+      toast.success(
+        __("Updating {0} tickets in the background", docnames.length)
+      );
+      reloadWhenDone();
+    }
+  } finally {
+    loading.value = false;
+  }
+}
+
+/** The enqueued job reports through `frappe.publish_progress` on the user room. */
+function reloadWhenDone() {
+  const onProgress = ({ percent }: { percent: number }) => {
+    if (percent < 100) return;
+    $socket.off("progress", onProgress);
+    toast.success(__("Bulk edit completed"));
+    emit("success");
+  };
+  $socket.on("progress", onProgress);
+}
+
+watch(open, (isOpen) => {
+  if (!isOpen) return;
+  fieldname.value = null;
+  value.value = null;
+});
+
+watch(fieldname, () => {
+  value.value = null;
+});
+</script>

--- a/desk/src/components/ticket-agent/BulkReplyModal.vue
+++ b/desk/src/components/ticket-agent/BulkReplyModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <Dialog v-model:open="open" :title="__('Bulk Reply')" size="2xl">
+  <Dialog v-model:open="open" :title="__('Reply')" size="2xl">
     <template #default>
       <div class="flex flex-col gap-4">
         <p class="text-p-sm">

--- a/desk/src/pages/ticket/Tickets.vue
+++ b/desk/src/pages/ticket/Tickets.vue
@@ -56,6 +56,16 @@
       :selections="listSelections"
       @success="listViewRef?.unselectAll()"
     />
+    <BulkEditModal
+      v-model="showBulkEditModal"
+      :selections="listSelections"
+      @success="reset(true)"
+    />
+    <BulkAssignModal
+      v-model="showBulkAssignModal"
+      :selections="listSelections"
+      @success="reset(true)"
+    />
   </div>
 </template>
 
@@ -64,6 +74,8 @@ import { LayoutHeader, ListViewBuilder } from "@/components";
 import { TicketIcon } from "@/components/icons";
 import IndicatorIcon from "@/components/icons/IndicatorIcon.vue";
 import TicketPriority from "@/components/TicketPriority.vue";
+import BulkAssignModal from "@/components/ticket-agent/BulkAssignModal.vue";
+import BulkEditModal from "@/components/ticket-agent/BulkEditModal.vue";
 import BulkReplyModal from "@/components/ticket-agent/BulkReplyModal.vue";
 import ExportModal from "@/components/ticket/ExportModal.vue";
 import ViewBreadcrumbs from "@/components/ViewBreadcrumbs.vue";
@@ -110,14 +122,36 @@ const { getStatus } = useTicketStatusStore();
 const listSelections = ref(new Set());
 
 const showBulkReplyModal = ref(false);
+const showBulkEditModal = ref(false);
+const showBulkAssignModal = ref(false);
 
+// Lucide draws on two ink grids (2-22 and 3-21), so icons differ in optical size
+// inside the same 16px box. Scale the outliers to the 3-21 grid the rest sit on.
 const selectBannerActions = [
   {
-    label: __("Bulk Reply"),
-    icon: "lucide-corner-up-left",
+    label: __("Reply"),
+    icon: "lucide-corner-up-left scale-110",
+    inline: true,
     onClick: (selections: Set<string>) => {
       listSelections.value = new Set(selections);
       showBulkReplyModal.value = true;
+    },
+  },
+  {
+    label: __("Edit"),
+    icon: "lucide-pencil scale-90",
+    inline: true,
+    onClick: (selections: Set<string>) => {
+      listSelections.value = new Set(selections);
+      showBulkEditModal.value = true;
+    },
+  },
+  {
+    label: __("Assign"),
+    icon: "lucide-user-plus scale-90",
+    onClick: (selections: Set<string>) => {
+      listSelections.value = new Set(selections);
+      showBulkAssignModal.value = true;
     },
   },
   {
@@ -211,38 +245,32 @@ const options = computed(() => ({
 
 function handleResponseByField(row: any, item: string) {
   if (!row.sla) return null; // nothing promised, so nothing to report against
-  if (!row.first_responded_on && dayjs(item).isBefore(new Date())) {
-    return h(Badge, {
-      label: __("Failed"),
-      theme: "red",
-      variant: "subtle",
-    });
+  if (row.first_responded_on) {
+    // no target means it was never breached, so responding at all fulfils it
+    const fulfilled = !item || dayjs(row.first_responded_on).isBefore(item);
+    return slaOutcomeBadge(fulfilled);
   }
-  if (row.first_responded_on && dayjs(row.first_responded_on).isBefore(item)) {
-    return h(Badge, {
-      label: __("Fulfilled"),
-      theme: "gray",
+  if (!item) return null;
+  if (dayjs(item).isBefore(dayjs())) return slaOutcomeBadge(false);
+  return h(
+    Tooltip,
+    {
+      text: dayjs(item).format("LLLL"),
+    },
+    h(Badge, {
+      label: shortDuration(item),
       variant: "subtle",
-    });
-  } else if (dayjs(row.first_responded_on).isAfter(item)) {
-    return h(Badge, {
-      label: __("Failed"),
-      theme: "red",
-      variant: "subtle",
-    });
-  } else {
-    return h(
-      Tooltip,
-      {
-        text: dayjs(item).format("LLLL"),
-      },
-      h(Badge, {
-        label: shortDuration(item),
-        variant: "subtle",
-        theme: "orange",
-      })
-    );
-  }
+      theme: "orange",
+    })
+  );
+}
+
+function slaOutcomeBadge(fulfilled: boolean) {
+  return h(Badge, {
+    label: fulfilled ? __("Fulfilled") : __("Failed"),
+    theme: fulfilled ? "gray" : "red",
+    variant: "subtle",
+  });
 }
 
 function handleResolutionByField(row: any, item: string) {
@@ -256,23 +284,12 @@ function handleResolutionByField(row: any, item: string) {
     });
   }
   if (row.resolution_date) {
-    const fulfilled = dayjs(row.resolution_date).isBefore(
-      dayjs(row.resolution_by)
-    );
-    return h(Badge, {
-      label: fulfilled ? __("Fulfilled") : __("Failed"),
-      theme: fulfilled ? "gray" : "red",
-      variant: "subtle",
-    });
+    const fulfilled = !item || dayjs(row.resolution_date).isBefore(dayjs(item));
+    return slaOutcomeBadge(fulfilled);
   }
+  if (!item) return null;
   // In progress but the resolution deadline has already passed.
-  if (dayjs(item).isBefore(dayjs())) {
-    return h(Badge, {
-      label: __("Failed"),
-      theme: "red",
-      variant: "subtle",
-    });
-  }
+  if (dayjs(item).isBefore(dayjs())) return slaOutcomeBadge(false);
   // In progress with a future deadline: show the live countdown.
   return h(
     Tooltip,

--- a/desk/src/pages/ticket/Tickets.vue
+++ b/desk/src/pages/ticket/Tickets.vue
@@ -125,12 +125,10 @@ const showBulkReplyModal = ref(false);
 const showBulkEditModal = ref(false);
 const showBulkAssignModal = ref(false);
 
-// Lucide draws on two ink grids (2-22 and 3-21), so icons differ in optical size
-// inside the same 16px box. Scale the outliers to the 3-21 grid the rest sit on.
 const selectBannerActions = [
   {
     label: __("Reply"),
-    icon: "lucide-corner-up-left scale-110",
+    icon: "lucide-corner-up-left",
     inline: true,
     onClick: (selections: Set<string>) => {
       listSelections.value = new Set(selections);
@@ -138,17 +136,9 @@ const selectBannerActions = [
     },
   },
   {
-    label: __("Edit"),
-    icon: "lucide-pencil scale-90",
-    inline: true,
-    onClick: (selections: Set<string>) => {
-      listSelections.value = new Set(selections);
-      showBulkEditModal.value = true;
-    },
-  },
-  {
     label: __("Assign"),
-    icon: "lucide-user-plus scale-90",
+    icon: "lucide-user-plus",
+    inline: true,
     onClick: (selections: Set<string>) => {
       listSelections.value = new Set(selections);
       showBulkAssignModal.value = true;
@@ -160,6 +150,14 @@ const selectBannerActions = [
     onClick: (selections: Set<string>) => {
       listSelections.value = new Set(selections);
       showExportModal.value = true;
+    },
+  },
+  {
+    label: __("Edit"),
+    icon: "lucide-pencil",
+    onClick: (selections: Set<string>) => {
+      listSelections.value = new Set(selections);
+      showBulkEditModal.value = true;
     },
   },
 ];

--- a/helpdesk/api/doc.py
+++ b/helpdesk/api/doc.py
@@ -15,6 +15,8 @@ from helpdesk.utils import (
     parse_call_logs,
 )
 
+SLA_ROW_FIELDS = ["sla", "status", "first_responded_on", "resolution_date"]
+
 
 @frappe.whitelist()
 def get_list_data(
@@ -113,8 +115,9 @@ def get_list_data(
     rows.append("name") if "name" not in rows else rows
     if doctype == "HD Ticket":
         rows.append("_seen") if "_seen" not in rows else rows
-        # the SLA columns render nothing without it, and no saved view lists it
-        rows.append("sla") if "sla" not in rows else rows
+        # the SLA columns can't tell fulfilled from due without these, and no saved view lists them
+        for field in SLA_ROW_FIELDS:
+            rows.append(field) if field not in rows else rows
     data = (
         frappe.get_list(
             doctype,

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
@@ -107,6 +107,7 @@
    "oldfieldname": "status",
    "oldfieldtype": "Select",
    "options": "HD Ticket Status",
+   "reqd": 1,
    "search_index": 1
   },
   {


### PR DESCRIPTION
Adds **Edit** and **Assign** to the ticket list selection banner, next to the existing Reply.

- **Edit** — sets a field on every selected ticket via `submit_cancel_or_update_docs`. 
- **Assign** — assigns agents via `add_multiple`, reusing the ticket view's own agent picker.

Uses same api as desk's list view

Reply and Assign are buttons; Export, Edit and Delete sit in the `⋯` menu.

Also fixes the SLA columns in custom list views: saved views send only their own column keys as `rows`, so `first_responded_on` / `resolution_date` never reached the client and a responded ticket still showed a ticking countdown.

## Screenshot

<img width="695" height="200" alt="image" src="https://github.com/user-attachments/assets/09f68dc6-02e5-44b9-ad00-e91cc5766980" />


<img width="1453" height="824" alt="image" src="https://github.com/user-attachments/assets/577cf25a-7b31-40a5-931b-0b19cb4859cd" />


<img width="1453" height="824" alt="image" src="https://github.com/user-attachments/assets/232d4f6a-c7de-4b19-b907-aa7a94f857ff" />


