### PR TITLE
fix: use the passed-in user for team permission checks

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.py
+++ b/helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.py
@@ -39,7 +39,7 @@ def has_permission(doc, user=None):
         if not is_team_restriction_applied:
             return True
         else:
-            user_team = get_agents_team()
+            user_team = get_agents_team(user)
             user_team_names = [team["team_name"] for team in user_team]
             if not user_team_names:
                 return False
@@ -82,7 +82,7 @@ def permission_query(user):
     team_cond = "`tabHD Saved Reply`.scope = 'Team'"
 
     if is_team_restriction_applied:
-        user_team = get_agents_team()
+        user_team = get_agents_team(user)
         user_team_names = [team["team_name"] for team in user_team]
         if user_team_names:
             team_names_escaped = ", ".join(

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -1407,13 +1407,13 @@ def _agent_has_permission(doc, user: str) -> bool:
         except (ValueError, TypeError):
             return False
 
-    teams = get_agents_team()
+    teams = get_agents_team(user)
     if any(team.get("ignore_restrictions") for team in teams):
         return True
 
     team_names = [t.team_name for t in teams]
     is_team_member = frappe.db.exists(
-        "HD Team Member", {"parent": ["in", team_names], "user": frappe.session.user}
+        "HD Team Member", {"parent": ["in", team_names], "user": user}
     )
     return bool(is_team_member) and doc.get("agent_group") in team_names
 
@@ -1451,7 +1451,7 @@ def _agent_query(user: str) -> str | None:
         query += " OR (`tabHD Ticket`.agent_group is null OR `tabHD Ticket`.agent_group = '')"
 
     # An agent on a team with `ignore_restrictions` set can see every team's tickets.
-    teams = get_agents_team()
+    teams = get_agents_team(user)
     if any(team.get("ignore_restrictions") for team in teams):
         all_teams = frappe.get_all("HD Team", pluck="name")
         if not all_teams:

--- a/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
@@ -15,7 +15,11 @@ from helpdesk.helpdesk.doctype.hd_ticket.api import (
     show_outside_hours_banner,
     split_ticket,
 )
-from helpdesk.helpdesk.doctype.hd_ticket.hd_ticket import close_tickets_after_n_days
+from helpdesk.helpdesk.doctype.hd_ticket.hd_ticket import (
+    close_tickets_after_n_days,
+    has_permission,
+    permission_query,
+)
 from helpdesk.test_utils import (
     SLA_PRIORITY_NAME,
     add_comment,
@@ -29,6 +33,7 @@ from helpdesk.test_utils import (
     make_priority,
     make_sla,
     make_status,
+    make_team,
     make_ticket,
     remove_holidays,
     set_ticket_status_and_communication_date,
@@ -2262,6 +2267,29 @@ class TestHDTicket(IntegrationTestCase):
 
         self.assertEqual(ticket.sla, SLA_PRIORITY_NAME)
         self.assertFalse(ticket.total_hold_time)
+
+    def test_permission_check_answers_for_passed_user_not_session(self):
+        """A check made on behalf of another user must use that user's teams.
+
+        Session is an agent on the ticket's team, the checked user is not, so a
+        session-bound lookup would wrongly grant access.
+        """
+        make_team("Team A", members=[agent])
+        make_team("Team B", members=[agent2])
+        frappe.db.set_single_value("HD Settings", "restrict_tickets_by_agent_group", 1)
+        self.addCleanup(
+            frappe.db.set_single_value,
+            "HD Settings",
+            "restrict_tickets_by_agent_group",
+            0,
+        )
+
+        ticket = make_ticket(agent_group="Team B", raised_by=non_agent)
+
+        frappe.set_user(agent2)
+        self.assertTrue(has_permission(ticket, user=agent2))
+        self.assertFalse(has_permission(ticket, user=agent))
+        self.assertNotIn("Team B", permission_query(agent))
 
     def tearDown(self):
         frappe.set_user("Administrator")

--- a/helpdesk/utils.py
+++ b/helpdesk/utils.py
@@ -221,7 +221,9 @@ def agent_manager_only(fn):
     return wrapper
 
 
-def get_agents_team():
+def get_agents_team(user: str | None = None):
+    """Teams the user belongs to. Defaults to the session user."""
+    user = user or frappe.session.user
     Team = frappe.qb.DocType("HD Team")
     TeamMember = frappe.qb.DocType("HD Team Member")
 
@@ -229,7 +231,7 @@ def get_agents_team():
         frappe.qb.from_(TeamMember)
         .join(Team)
         .on(Team.name == TeamMember.parent)
-        .where(TeamMember.user == frappe.session.user)
+        .where(TeamMember.user == user)
         .where(Team.disabled == 0)
         .select(Team.team_name, Team.ignore_restrictions)
         .run(as_dict=True)


### PR DESCRIPTION
**Issue**

Closes https://github.com/frappe/helpdesk/issues/3687

`_agent_has_permission()` and `permission_query()` receive a `user`, then ask `get_agents_team()` for the *session* user's teams. Any check made on behalf of someone else (Permission Inspector, `frappe.has_permission(doc=..., user=...)`) is answered with the caller's team membership. Same bug in HD Saved Reply's `has_permission()` and `permission_query()`.

**Solution**

`get_agents_team()` takes an optional `user`, defaulting to the session user. All four callers that already have a `user` now pass it. `helpdesk/api/auth.py` keeps the default since it builds the boot payload for the logged-in user.
