### PR TITLE
fix(hd-ticket): don't check update perms without a previous version

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -424,9 +424,9 @@ class HDTicket(Document):
         )
 
     def check_update_perms(self):
-        if self.is_new() or is_agent() or not self.via_customer_portal:
-            return
         old_doc = self.get_doc_before_save()
+        if not old_doc or is_agent() or not self.via_customer_portal:
+            return
         is_closed = old_doc.status == "Closed"
         is_rated = bool(old_doc.feedback)
         if is_closed or is_rated:

--- a/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
@@ -119,6 +119,15 @@ class TestHDTicket(IntegrationTestCase):
         ticket.insert()
         self.assertTrue(ticket.name)
 
+    def test_update_perms_skipped_without_a_previous_version(self):
+        # a before_insert hook that persists the ticket clears __islocal, so is_new()
+        # can be False on create while there is still no previous version to check
+        frappe.set_user(non_agent)
+        ticket = frappe.get_doc({**get_ticket_obj(), "via_customer_portal": 1})
+        ticket.set("__islocal", False)
+        ticket.check_update_perms()
+        frappe.set_user("Administrator")
+
     def test_parse_content_strips_html_comments(self):
         ticket = frappe.get_doc(get_ticket_obj())
         ticket.insert()


### PR DESCRIPTION
## Problem

Creating a ticket from the customer portal can fail with:

```
File "apps/helpdesk/helpdesk/helpdesk/doctype/hd_ticket/api.py", line 39, in new
    d = frappe.get_doc(doc).insert()
File "apps/helpdesk/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py", line 78, in before_validate
    self.check_update_perms()
File "apps/helpdesk/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py", line 430, in check_update_perms
    is_closed = old_doc.status == "Closed"
AttributeError: 'NoneType' object has no attribute 'status'
```

Seen on support.frappe.io for a non-agent portal user.

## Cause

`check_update_perms()` used `self.is_new()` as a stand-in for "there is a previous version to compare against":

```python
if self.is_new() or is_agent() or not self.via_customer_portal:
    return
old_doc = self.get_doc_before_save()
is_closed = old_doc.status == "Closed"
```

`is_new()` reads `__islocal`, and `Document.insert()` sets it to `True` before `run_before_save_methods()` — so normally the guard holds. But `__islocal` can be cleared *inside* the insert, in the `before_insert` window:

```
set("__islocal", True)        → is_new() == True
check_if_latest()             → load_doc_before_save() → _doc_before_save = None
run_method("before_insert")   ← anything here that persists the doc calls db_insert(),
                                which does set("__islocal", False)
set_new_name()
run_before_save_methods()     → before_validate → check_update_perms()
```

By the time `before_validate` runs, `is_new()` is `False` while `_doc_before_save` is still `None` (it was captured while the doc was local and is never re-read), so the guard falls through and the dereference raises.

This only bites non-agents creating via the portal — `is_agent()` and `not via_customer_portal` would otherwise short-circuit. Note that `api.new` sets `via_customer_portal = bool(frappe.session.user)`, which is always `True`.

## Fix

Guard on the previous doc itself instead of on `is_new()`. It is what the check actually needs, and it cannot be invalidated by `__islocal` being cleared mid-insert.

```python
old_doc = self.get_doc_before_save()
if not old_doc or is_agent() or not self.via_customer_portal:
    return
```

## How to test

`bench --site <site> run-tests --module helpdesk.helpdesk.doctype.hd_ticket.test_hd_ticket --test test_update_perms_skipped_without_a_previous_version`

The test creates a portal ticket as a non-agent with `__islocal` cleared (the state a persisting `before_insert` hook leaves behind) and calls `check_update_perms()`. On `develop` it errors with the exact `AttributeError` above; with this change it passes.

To reproduce end to end, add a Server Script on HD Ticket, event *Before Insert*, body `doc.save()`, then raise a ticket from the portal as a non-agent.

## Issue

No GitHub issue — reported via the production traceback above. Happy to file one and link it if preferred.
