### PR TITLE
Enhance Ticket List with Priority Color Indicators

### DIFF
--- a/desk/src/components/desk/global/CustomIcons.vue
+++ b/desk/src/components/desk/global/CustomIcons.vue
@@ -93,21 +93,21 @@
         height="3"
         rx="1"
         transform="matrix(-1 0 0 1 2.5 6)"
-        fill="#A6B1B9"
+        fill="#2563EB"
       />
       <rect
         width="2"
         height="6"
         rx="1"
         transform="matrix(-1 0 0 1 5.5 3)"
-        fill="#A6B1B9"
+        fill="#2563EB"
       />
       <rect
         width="2"
         height="9"
         rx="1"
         transform="matrix(-1 0 0 1 8.5 0)"
-        fill="#EBEEF0"
+        fill="#DBEAFE"
       />
     </svg>
     <svg
@@ -124,21 +124,21 @@
         height="3"
         rx="1"
         transform="matrix(-1 0 0 1 2.5 6)"
-        fill="#A6B1B9"
+        fill="#16A34A"
       />
       <rect
         width="2"
         height="6"
         rx="1"
         transform="matrix(-1 0 0 1 5.5 3)"
-        fill="#EBEEF0"
+        fill="#DCFCE7"
       />
       <rect
         width="2"
         height="9"
         rx="1"
         transform="matrix(-1 0 0 1 8.5 0)"
-        fill="#EBEEF0"
+        fill="#DCFCE7"
       />
     </svg>
     <svg
@@ -155,21 +155,21 @@
         height="3"
         rx="1"
         transform="matrix(-1 0 0 1 2.5 6)"
-        fill="#A6B1B9"
+        fill="#F97316"
       />
       <rect
         width="2"
         height="6"
         rx="1"
         transform="matrix(-1 0 0 1 5.5 3)"
-        fill="#A6B1B9"
+        fill="#F97316"
       />
       <rect
         width="2"
         height="9"
         rx="1"
         transform="matrix(-1 0 0 1 8.5 0)"
-        fill="#A6B1B9"
+        fill="#F97316"
       />
     </svg>
     <svg

--- a/desk/src/components/ticket/TicketCustomerSidebar.vue
+++ b/desk/src/components/ticket/TicketCustomerSidebar.vue
@@ -68,7 +68,13 @@
       >
         <span class="w-[126px] text-sm text-gray-600">{{ field.label }}</span>
         <span class="text-base text-gray-800 flex-1">
-          {{ field.value }}
+          <Badge
+            v-if="field.isBadge"
+            :label="field.value"
+            :theme="field.theme"
+            variant="outline"
+          />
+          <span v-else>{{ field.value }}</span>
         </span>
       </div>
     </div>
@@ -78,10 +84,11 @@
 <script setup lang="ts">
 import { inject, computed } from "vue";
 import { ITicket } from "@/pages/ticket/symbols";
-import { Tooltip, Avatar } from "frappe-ui";
+import { Tooltip, Avatar, Badge } from "frappe-ui";
 import { dayjs } from "@/dayjs";
 import { formatTime } from "@/utils";
 import { Field } from "@/types";
+import { useTicketPriorityStore } from "@/stores/ticketPriority";
 
 const emit = defineEmits(["open"]);
 
@@ -186,6 +193,8 @@ const ticketBasicInfo = computed(() => [
   },
 ]);
 
+const priorityStore = useTicketPriorityStore();
+
 const ticketAdditionalInfo = computed(() => {
   const fields = [
     {
@@ -199,6 +208,8 @@ const ticketAdditionalInfo = computed(() => {
     {
       label: "Priority",
       value: ticket.data.priority,
+      isBadge: !!ticket.data.priority,
+      theme: priorityStore.getBadgeTheme(ticket.data.priority),
     },
   ];
   const custom_fields = ticket.data.template.fields

--- a/desk/src/pages/ticket/TicketCustomerTemplateFields.vue
+++ b/desk/src/pages/ticket/TicketCustomerTemplateFields.vue
@@ -9,7 +9,13 @@
     <div class="space-y-1.5">
       <span class="block text-sm text-gray-700"> Priority </span>
       <span class="block break-words text-base font-medium text-gray-900">
-        {{ ticket.data.priority }}
+        <Badge
+          v-if="ticket.data.priority"
+          :label="ticket.data.priority"
+          :theme="priorityStore.getBadgeTheme(ticket.data.priority)"
+          variant="outline"
+        />
+        <span v-else>-</span>
       </span>
     </div>
     <div v-for="data in slaData" :key="data.label" class="space-y-1.5">
@@ -45,11 +51,14 @@
 
 <script setup lang="ts">
 import { inject, computed } from "vue";
+import { Badge } from "frappe-ui";
 import { ITicket } from "./symbols";
 import { dayjs } from "@/dayjs";
 import { Field } from "@/types";
+import { useTicketPriorityStore } from "@/stores/ticketPriority";
 
 const ticket = inject(ITicket);
+const priorityStore = useTicketPriorityStore();
 
 const slaData = computed(() => {
   const responseSla =

--- a/desk/src/pages/ticket/Tickets.vue
+++ b/desk/src/pages/ticket/Tickets.vue
@@ -69,6 +69,7 @@ import ExportModal from "@/components/ticket/ExportModal.vue";
 import ViewBreadcrumbs from "@/components/ViewBreadcrumbs.vue";
 import ViewModal from "@/components/ViewModal.vue";
 import { useTicketStatusStore } from "@/stores/ticketStatus";
+import { useTicketPriorityStore } from "@/stores/ticketPriority";
 import { useAuthStore } from "@/stores/auth";
 import { dayjs } from "@/dayjs";
 import { createToast, getIcon, isCustomerPortal } from "@/utils";
@@ -98,6 +99,7 @@ const listViewRef = ref(null);
 const showExportModal = ref(false);
 
 const { textColorMap } = useTicketStatusStore();
+const priorityStore = useTicketPriorityStore();
 
 const listSelections = ref(new Set());
 const selectBannerActions = [
@@ -156,6 +158,16 @@ const options = {
       prefix: ({ row }) => {
         return h(IndicatorIcon, {
           class: textColorMap[row.status],
+        });
+      },
+    },
+    priority: {
+      custom: ({ item }) => {
+        if (!item) return null;
+        return h(Badge, {
+          label: item,
+          theme: priorityStore.getBadgeTheme(item),
+          variant: "outline",
         });
       },
     },

--- a/desk/src/stores/ticketPriority.ts
+++ b/desk/src/stores/ticketPriority.ts
@@ -1,0 +1,70 @@
+import { computed, ref } from "vue";
+import { defineStore } from "pinia";
+
+export const useTicketPriorityStore = defineStore("ticketPriority", () => {
+  const options = ref(["Urgent", "High", "Medium", "Low", "Unclassified"]);
+
+  const colorMap: Record<string, string> = {
+    Urgent: "red",
+    High: "orange",
+    Medium: "blue",
+    Low: "green",
+    Unclassified: "gray",
+  };
+
+  const badgeThemeMap: Record<string, string> = {
+    Urgent: "red",
+    High: "orange",
+    Medium: "blue",
+    Low: "green",
+    Unclassified: "gray",
+  };
+
+  const textColorMap: Record<string, string> = {
+    Urgent: "!text-red-600",
+    High: "!text-orange-600",
+    Medium: "!text-blue-600",
+    Low: "!text-green-600",
+    Unclassified: "!text-gray-600",
+  };
+
+  const badgeClasses: Record<string, string> = {
+    Urgent: "bg-red-50 text-red-700 border border-red-200 font-medium px-2 py-0.5 rounded-full text-xs inline-flex items-center gap-1.5",
+    High: "bg-orange-50 text-orange-700 border border-orange-200 font-medium px-2 py-0.5 rounded-full text-xs inline-flex items-center gap-1.5",
+    Medium: "bg-blue-50 text-blue-700 border border-blue-200 font-medium px-2 py-0.5 rounded-full text-xs inline-flex items-center gap-1.5",
+    Low: "bg-green-50 text-green-700 border border-green-200 font-medium px-2 py-0.5 rounded-full text-xs inline-flex items-center gap-1.5",
+    Unclassified: "bg-gray-50 text-gray-700 border border-gray-200 font-medium px-2 py-0.5 rounded-full text-xs inline-flex items-center gap-1.5",
+  };
+
+  const dotColorMap: Record<string, string> = {
+    Urgent: "bg-red-500",
+    High: "bg-orange-500",
+    Medium: "bg-blue-500",
+    Low: "bg-green-500",
+    Unclassified: "bg-gray-400",
+  };
+
+  function getBadgeTheme(priority: string): string {
+    return badgeThemeMap[priority] || "gray";
+  }
+
+  function getBadgeClass(priority: string): string {
+    return badgeClasses[priority] || badgeClasses.Unclassified;
+  }
+
+  function getDotClass(priority: string): string {
+    return dotColorMap[priority] || dotColorMap.Unclassified;
+  }
+
+  return {
+    options,
+    colorMap,
+    badgeThemeMap,
+    textColorMap,
+    badgeClasses,
+    dotColorMap,
+    getBadgeTheme,
+    getBadgeClass,
+    getDotClass,
+  };
+});


### PR DESCRIPTION
Enhanced the ticket list with color priority indicators to improve visual clarity and make ticket urgency easier to identify at a glance.

Changes

Added distinct colors for each ticket priority:

1. Urgent — Red
2. High — Orange
3. Medium — Blue
4. Low — Green

**Before**
    Priorities were displayed as plain text with a small priority indicator.
<img width="1600" height="556" alt="image" src="https://github.com/user-attachments/assets/b891f3bc-5b44-4858-859c-d7a71d8991ed" />

**After**
    Priorities are displayed as clearly distinguishable colored badges, making it easier to identify ticket urgency at a glance.
<img width="1627" height="799" alt="image" src="https://github.com/user-attachments/assets/a4f8296d-1133-4bc5-99f1-6441ac290978" />

**Testing**

> Verified the priority badges in the ticket list.

> Confirmed that Urgent, High, Medium, and Low priorities display with the expected colors.




