### PR TITLE
fix: hide bulk reply, assign and edit from customer roles

### DIFF
--- a/desk/src/components/ListViewBuilder.vue
+++ b/desk/src/components/ListViewBuilder.vue
@@ -433,7 +433,8 @@ function selectBannerOptions(
     }));
 
   return [...userActions, ...defaultActions].filter(
-    (action) => Boolean(action.inline) === inline
+    (action) =>
+      Boolean(action.inline) === inline && (action.condition?.() ?? true)
   );
 }
 

--- a/desk/src/pages/ticket/Tickets.vue
+++ b/desk/src/pages/ticket/Tickets.vue
@@ -125,11 +125,15 @@ const showBulkReplyModal = ref(false);
 const showBulkEditModal = ref(false);
 const showBulkAssignModal = ref(false);
 
+// Replying, assigning and editing in bulk are agent-side actions only.
+const agentOnly = () => !isCustomerPortal.value;
+
 const selectBannerActions = [
   {
     label: __("Reply"),
     icon: "lucide-corner-up-left",
     inline: true,
+    condition: agentOnly,
     onClick: (selections: Set<string>) => {
       listSelections.value = new Set(selections);
       showBulkReplyModal.value = true;
@@ -139,6 +143,7 @@ const selectBannerActions = [
     label: __("Assign"),
     icon: "lucide-user-plus",
     inline: true,
+    condition: agentOnly,
     onClick: (selections: Set<string>) => {
       listSelections.value = new Set(selections);
       showBulkAssignModal.value = true;
@@ -155,6 +160,7 @@ const selectBannerActions = [
   {
     label: __("Edit"),
     icon: "lucide-pencil",
+    condition: agentOnly,
     onClick: (selections: Set<string>) => {
       listSelections.value = new Set(selections);
       showBulkEditModal.value = true;


### PR DESCRIPTION
### Problem

The bulk action banner on the tickets list showed **Reply**, **Assign** and **Edit** on the customer portal. These are agent-side operations and should not be offered to customers.

While fixing this, one related bug: `ListViewBuilder` accepted a `condition` on select-banner actions but never evaluated it, so the existing `condition` on the default **Delete** action (manager + non-customer-portal only) was dead. Delete was therefore also shown on the portal.

### Changes

- `desk/src/components/ListViewBuilder.vue`: select-banner actions now honour their `condition()`.
- `desk/src/pages/ticket/Tickets.vue`: Reply, Assign and Edit carry `condition: () => !isCustomerPortal`. Export stays available to everyone.

### How to test

1. Log in as a user whose only helpdesk role is `HD Customer` (or `HD Customer Manager`) and open the tickets list.
2. Select one or more tickets: the banner should show only **Export** (Delete stays hidden too, as its existing condition now applies).
3. Log in as an agent and repeat on the agent list: Reply, Assign, Export and Edit all appear as before.

### Linked issue

_None; reported directly._
