### PR TITLE
fix(a11y): add alt text to images missing it

### DIFF
--- a/desk/src/components/AttachmentItem.vue
+++ b/desk/src/components/AttachmentItem.vue
@@ -23,7 +23,7 @@
         >
           {{ content }}
         </div>
-        <img v-if="isImage" :src="url" class="m-auto rounded border" />
+        <img v-if="isImage" :src="url" :alt="label" class="m-auto rounded border" />
         <video
           v-if="isVideo"
           :src="url"

--- a/desk/src/components/Settings/EmailProviderIcon.vue
+++ b/desk/src/components/Settings/EmailProviderIcon.vue
@@ -3,7 +3,7 @@
     class="flex size-8 cursor-pointer items-center justify-center rounded-full bg-surface-gray-2 hover:bg-surface-gray-3"
     :class="{ 'ring-2 ring-outline-blue-4': selected }"
   >
-    <img v-if="logoValue" :src="logoValue" class="size-4.5" />
+    <img v-if="logoValue" :src="logoValue" :alt="serviceName || 'Email provider'" class="size-4.5" />
     <LucideMail v-else class="size-4.5 text-ink-gray-7" />
   </div>
   <p v-if="serviceName" class="text-center text-p-xs text-ink-gray-7">

--- a/desk/src/components/Settings/Preferences/components/ThemeSwitcher.vue
+++ b/desk/src/components/Settings/Preferences/components/ThemeSwitcher.vue
@@ -52,6 +52,7 @@
                       <img
                         v-if="logoIsImage"
                         :src="logo as string"
+                        alt=""
                         class="size-5 object-cover"
                       />
                       <component

--- a/desk/src/composables/useApps.ts
+++ b/desk/src/composables/useApps.ts
@@ -59,7 +59,7 @@ export function useApps() {
     icon: markRaw(AppsIcon),
     submenu: apps.value.map((app) => ({
       label: app.title,
-      icon: h("img", { src: app.logo }),
+      icon: h("img", { src: app.logo, alt: "" }),
       onClick: () => window.open(app.route, "_self"),
     })),
   }));


### PR DESCRIPTION
## Problem

Several images across the desk frontend had no `alt` attribute.

## Fix

Same pattern as the sibling fix already sent to frappe/crm: icon-next-to-visible-label images (app menu, theme preview) get `alt=""`; a standalone image with no adjacent label (the attachment preview) gets a real description from the filename already in scope.

`Apps.vue` no longer exists on `develop` — its app-menu icon moved into `useApps.ts`'s `appMenuItems()`, fixed there instead. `AttachmentItem.vue` also gained video-attachment support since I last looked — kept that as-is and added the alt fix alongside it.
