### PR TITLE
fix(rtl): use logical spacing/text-align classes instead of physical ones

### DIFF
--- a/desk/src/components/CommentTextEditor.vue
+++ b/desk/src/components/CommentTextEditor.vue
@@ -52,7 +52,7 @@
                     </button>
                   </template>
                 </FileUploader>
-                <div class="h-4 w-[2px] border-s ml-1" />
+                <div class="h-4 w-[2px] border-s ms-1" />
               </div>
               <EditorFixedMenu :items="fullToolbar" />
             </div>

--- a/desk/src/components/CompactEditor.vue
+++ b/desk/src/components/CompactEditor.vue
@@ -36,7 +36,7 @@
                 </button>
               </template>
             </FileUploader>
-            <div class="h-4 w-[2px] border-s ml-1" />
+            <div class="h-4 w-[2px] border-s ms-1" />
           </div>
           <EditorFixedMenu :items="fullToolbar" />
         </div>

--- a/desk/src/components/EmailEditor.vue
+++ b/desk/src/components/EmailEditor.vue
@@ -184,7 +184,7 @@
                   <ZapIcon class="h-4 w-4" />
                 </button>
               </Tooltip>
-              <div class="h-4 w-[2px] border-s ml-1" />
+              <div class="h-4 w-[2px] border-s ms-1" />
             </div>
             <EditorFixedMenu :items="fullToolbar" />
           </div>

--- a/desk/src/components/EmailMultiSelect.vue
+++ b/desk/src/components/EmailMultiSelect.vue
@@ -83,7 +83,7 @@
                   @mousedown.prevent="onSelect(option.value)"
                 >
                   <UserAvatar
-                    class="mr-0.5 shrink-0"
+                    class="me-0.5 shrink-0"
                     :name="getUsernameLabel(option.label)"
                     size="lg"
                   />
@@ -102,10 +102,10 @@
         </ComboboxRoot>
       </div>
     </div>
-    <ErrorMessage class="mt-2 pl-2" v-if="error" :message="error" />
+    <ErrorMessage class="mt-2 ps-2" v-if="error" :message="error" />
     <div
       v-if="info"
-      class="whitespace-pre-line text-sm text-ink-blue-6 mt-2 pl-2"
+      class="whitespace-pre-line text-sm text-ink-blue-6 mt-2 ps-2"
     >
       {{ info }}
     </div>

--- a/desk/src/components/MultipleAvatar.vue
+++ b/desk/src/components/MultipleAvatar.vue
@@ -26,7 +26,7 @@
         :text="avatar.name"
       >
         <Avatar
-          class="user-avatar -mr-1.5 ring-2 ring-[var(--surface-base)] transition hover:z-20 hover:scale-110"
+          class="user-avatar -me-1.5 ring-2 ring-[var(--surface-base)] transition hover:z-20 hover:scale-110"
           shape="circle"
           :image="avatar.image"
           :label="avatar.label"
@@ -36,7 +36,7 @@
       </Tooltip>
       <Tooltip v-if="overflowCount" :text="overflowNames">
         <div
-          class="user-avatar relative z-10 -mr-1.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-surface-gray-3 text-xs text-ink-gray-7 ring-2 ring-[var(--surface-base)]"
+          class="user-avatar relative z-10 -me-1.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-surface-gray-3 text-xs text-ink-gray-7 ring-2 ring-[var(--surface-base)]"
         >
           +{{ overflowCount }}
         </div>

--- a/desk/src/components/Settings/EmailAccountCard.vue
+++ b/desk/src/components/Settings/EmailAccountCard.vue
@@ -5,7 +5,7 @@
     <!-- avatar and name -->
     <div class="flex justify-between items-center gap-2">
       <EmailProviderIcon :logo="emailIcon[emailAccount.service]" />
-      <div class="rtl:text-right">
+      <div class="rtl:text-end">
         <p class="text-p-base-medium text-ink-gray-7">
           {{ __(emailAccount.email_account_name) }}
         </p>

--- a/desk/src/components/Settings/Preferences/components/ThemeSwitcher.vue
+++ b/desk/src/components/Settings/Preferences/components/ThemeSwitcher.vue
@@ -44,7 +44,7 @@
                     <div class="size-1.5 bg-[#28C840] rounded-full" />
                   </div>
                   <div
-                    class="flex items-start justify-between gap-2 p-2.5 pr-0 pb-1 min-h-[41px]"
+                    class="flex items-start justify-between gap-2 p-2.5 pe-0 pb-1 min-h-[41px]"
                   >
                     <div
                       class="flex items-center flex-1 gap-1 text-xs-semibold text-ink-gray-5"
@@ -138,7 +138,7 @@ const themeOptions: {
     panes: [
       {
         tone: "light",
-        containerClass: "pl-5 pt-3.5 bg-surface-gray-2 rounded-t-[10.5px]",
+        containerClass: "ps-5 pt-3.5 bg-surface-gray-2 rounded-t-[10.5px]",
         screenClass: "bg-white rounded-tl-sm",
       },
     ],
@@ -150,7 +150,7 @@ const themeOptions: {
     panes: [
       {
         tone: "dark",
-        containerClass: "pl-5 pt-3.5 bg-surface-gray-2 rounded-t-[10.5px]",
+        containerClass: "ps-5 pt-3.5 bg-surface-gray-2 rounded-t-[10.5px]",
         screenClass: "bg-gray-900 rounded-tl-sm",
       },
     ],
@@ -163,13 +163,13 @@ const themeOptions: {
       {
         tone: "light",
         containerClass:
-          "flex flex-1 pl-5 pt-3.5 bg-surface-gray-2 rounded-tl-[10.5px]",
+          "flex flex-1 ps-5 pt-3.5 bg-surface-gray-2 rounded-tl-[10.5px]",
         screenClass: "bg-white rounded-tl-sm w-full",
       },
       {
         tone: "dark",
         containerClass:
-          "flex flex-1 pl-5 pt-3.5 bg-surface-gray-3 rounded-tr-[10.5px]",
+          "flex flex-1 ps-5 pt-3.5 bg-surface-gray-3 rounded-tr-[10.5px]",
         screenClass: "bg-gray-900 rounded-tl-sm w-full",
       },
     ],

--- a/desk/src/components/Settings/SettingsModal.vue
+++ b/desk/src/components/Settings/SettingsModal.vue
@@ -14,7 +14,7 @@
           class="flex-col rounded-l-lg w-56 shrink-0 ps-1 py-1 bg-surface-sidebar overflow-y-auto hide-scrollbar"
         >
           <h1
-            class="h-7.5 px-2 py-[7px] my-[3px] flex cursor-pointer gap-1.5 text-xs-medium text-ink-gray-5 transition-all duration-300 ease-in-out sticky top-0 z-10 bg-surface-sidebar ml-1"
+            class="h-7.5 px-2 py-[7px] my-[3px] flex cursor-pointer gap-1.5 text-xs-medium text-ink-gray-5 transition-all duration-300 ease-in-out sticky top-0 z-10 bg-surface-sidebar ms-1"
           >
             {{ __("Account") }}
           </h1>
@@ -23,14 +23,14 @@
 
             <div
               v-if="!tab.hideLabel"
-              class="h-7.5 px-2 py-[7px] my-[3px] flex cursor-pointer gap-1.5 text-xs-medium text-ink-gray-5 transition-all duration-300 ease-in-out sticky top-0 z-10 bg-surface-sidebar ml-1"
+              class="h-7.5 px-2 py-[7px] my-[3px] flex cursor-pointer gap-1.5 text-xs-medium text-ink-gray-5 transition-all duration-300 ease-in-out sticky top-0 z-10 bg-surface-sidebar ms-1"
             >
               <Tooltip :text="__(tab.label)" placement="right">
                 <span class="truncate">{{ __(tab.label) }}</span>
               </Tooltip>
             </div>
 
-            <nav class="space-y-[3px] pr-2 pl-1">
+            <nav class="space-y-[3px] pe-2 ps-1">
               <button
                 v-for="item in tab.items"
                 :key="item.label"

--- a/desk/src/components/Settings/Teams/components/AgentSelector.vue
+++ b/desk/src/components/Settings/Teams/components/AgentSelector.vue
@@ -34,7 +34,7 @@
             ref="search"
             :value="query"
             autocomplete="off"
-            class="bg-transparent p-0 outline-none border-0 text-base text-ink-gray-8 h-full placeholder:text-ink-gray-4 focus:outline-none focus:ring-0 focus:border-0 w-full select-none rtl:text-right"
+            class="bg-transparent p-0 outline-none border-0 text-base text-ink-gray-8 h-full placeholder:text-ink-gray-4 focus:outline-none focus:ring-0 focus:border-0 w-full select-none rtl:text-end"
             placeholder="Type agent name or email"
             @focus="showOptions = true"
             @click="showOptions = true"

--- a/desk/src/components/ViewBreadcrumbs.vue
+++ b/desk/src/components/ViewBreadcrumbs.vue
@@ -6,7 +6,7 @@
     >
       {{ isMobileView ? "..." : label }}
     </router-link>
-    <span class="ml-0.5 text-base text-ink-gray-4" aria-hidden="true"> / </span>
+    <span class="ms-0.5 text-base text-ink-gray-4" aria-hidden="true"> / </span>
     <Dropdown :options="options">
       <template #default="{ open }">
         <Button

--- a/desk/src/components/contact/ContactCustomers.vue
+++ b/desk/src/components/contact/ContactCustomers.vue
@@ -7,7 +7,7 @@
         :text="customer.name"
       >
         <Avatar
-          class="-mr-1.5 cursor-pointer ring-2 ring-[var(--surface-base)] transition hover:z-10 hover:scale-110"
+          class="-me-1.5 cursor-pointer ring-2 ring-[var(--surface-base)] transition hover:z-10 hover:scale-110"
           shape="circle"
           size="sm"
           :image="customer.image"
@@ -17,13 +17,13 @@
       </Tooltip>
       <div
         v-if="remainingCustomers.length"
-        class="relative -mr-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-surface-gray-2 text-2xs font-medium text-ink-gray-6 ring-2 ring-[var(--surface-white)]"
+        class="relative -me-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-surface-gray-2 text-2xs font-medium text-ink-gray-6 ring-2 ring-[var(--surface-white)]"
       >
         +{{ remainingCustomers.length }}
       </div>
     </div>
     <span
-      class="text-sm text-ink-gray-8 ml-2"
+      class="text-sm text-ink-gray-8 ms-2"
       :class="customers.length === 1 && 'cursor-pointer'"
       v-on="
         customers.length === 1

--- a/desk/src/components/contact/FeedbackList.vue
+++ b/desk/src/components/contact/FeedbackList.vue
@@ -48,7 +48,7 @@
             </span>
             <p class="min-w-0 flex-1 truncate text-sm">
               <span class="text-ink-gray-5"># {{ ticket.name }}</span>
-              <span class="ml-1 font-medium text-ink-gray-7">{{
+              <span class="ms-1 font-medium text-ink-gray-7">{{
                 ticket.subject
               }}</span>
             </p>

--- a/desk/src/components/customer/NewCustomerDialog.vue
+++ b/desk/src/components/customer/NewCustomerDialog.vue
@@ -38,7 +38,7 @@
               v-model="state.country"
             >
               <template #prefix>
-                <LucideMapPin class="size-4 mr-1.5" />
+                <LucideMapPin class="size-4 me-1.5" />
               </template>
             </Link>
           </div>

--- a/desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue
+++ b/desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue
@@ -84,7 +84,7 @@
               :key="country.name"
               :ref="(el) => setItemRef(el as HTMLElement | null, idx)"
               type="button"
-              class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-base text-ink-gray-7 outline-none"
+              class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-start text-base text-ink-gray-7 outline-none"
               :class="
                 idx === highlightedIndex
                   ? 'bg-surface-gray-3'

--- a/desk/src/components/layouts/AppSidebar.vue
+++ b/desk/src/components/layouts/AppSidebar.vue
@@ -19,7 +19,7 @@
           >
             <span class="flex items-center gap-1.5 text-sm font-medium">
               <span
-                class="lucide-chevron-right size-4 shrink-0 text-ink-gray-9 transition-transform duration-300 ease-in-out -ml-0.5"
+                class="lucide-chevron-right size-4 shrink-0 text-ink-gray-9 transition-transform duration-300 ease-in-out -ms-0.5"
                 :class="{ 'rotate-90': isSectionOpen(section.label) }"
               />
               <span class="truncate leading-snug">{{ section.label }}</span>

--- a/desk/src/components/ticket-agent/analytics/TicketTimeline.vue
+++ b/desk/src/components/ticket-agent/analytics/TicketTimeline.vue
@@ -23,7 +23,7 @@
       >
         <div
           ref="rail"
-          class="flex w-max min-w-full items-start pl-12 pr-16 pb-16 pt-8"
+          class="flex w-max min-w-full items-start ps-12 pe-16 pb-16 pt-8"
         >
           <template v-for="(segment, index) in segments" :key="index">
             <Tooltip

--- a/desk/src/components/ticket/TicketMergeModal.vue
+++ b/desk/src/components/ticket/TicketMergeModal.vue
@@ -29,7 +29,7 @@
                       __("Tickets must meet the following conditions:")
                     }}</span
                   >
-                  <ul class="list-disc pl-4 mt-1 space-y-1">
+                  <ul class="list-disc ps-4 mt-1 space-y-1">
                     <li
                       v-for="(condition, index) in mergeConditions"
                       :key="index"

--- a/desk/src/components/view-controls/filter/Filter.vue
+++ b/desk/src/components/view-controls/filter/Filter.vue
@@ -43,13 +43,13 @@
                     <div
                       v-for="filter in activeFilters"
                       :key="filter.index"
-                      class="group flex h-8 w-full items-center gap-2 rounded px-1.5 hover:bg-surface-gray-2 pl-0"
+                      class="group flex h-8 w-full items-center gap-2 rounded px-1.5 hover:bg-surface-gray-2 ps-0"
                     >
                       <Button
                         variant="ghost"
                         :label="filterSummary(filter)"
                         :tooltip="filterSummary(filter)"
-                        class="!h-full min-w-0 flex-1 !justify-start !px-0 hover:!bg-transparent !pl-1.5"
+                        class="!h-full min-w-0 flex-1 !justify-start !px-0 hover:!bg-transparent !ps-1.5"
                         @click="editFilter(filter)"
                       >
                         <template #prefix>

--- a/desk/src/pages/contact/Contact.vue
+++ b/desk/src/pages/contact/Contact.vue
@@ -4,7 +4,7 @@
   >
     <LayoutHeader>
       <template #left-header>
-        <Breadcrumbs :items="breadcrumbs" class="-ml-[2px]" />
+        <Breadcrumbs :items="breadcrumbs" class="-ms-[2px]" />
       </template>
     </LayoutHeader>
     <div

--- a/desk/src/pages/customer/Customer.vue
+++ b/desk/src/pages/customer/Customer.vue
@@ -4,7 +4,7 @@
   >
     <LayoutHeader>
       <template #left-header>
-        <Breadcrumbs :items="breadcrumbs" class="-ml-[2px]" />
+        <Breadcrumbs :items="breadcrumbs" class="-ms-[2px]" />
       </template>
     </LayoutHeader>
     <div

--- a/desk/src/pages/ticket/TicketTextEditor.vue
+++ b/desk/src/pages/ticket/TicketTextEditor.vue
@@ -54,7 +54,7 @@
               @click="openFileSelector()"
               size="xs"
               icon="lucide-paperclip"
-              class="mr-2"
+              class="me-2"
             />
           </template>
         </FileUploader>


### PR DESCRIPTION
## Problem

Hardcoded physical spacing/text-align classes (`ml-`/`mr-`, `pl-`/`pr-`, `text-left`/`text-right`) don't mirror when `dir="rtl"` is applied — margin/padding stays on the same physical side and text stays left/right-anchored regardless of direction.

## Fix

Safe subset only: `ml-/mr-` → `ms-/me-`, `pl-/pr-` → `ps-/pe-`, `text-left/right` → `text-start/end`. Behavior-preserving for LTR (these resolve to the same physical side when direction is `ltr`) and correct under `dir="rtl"`.

Deliberately does **not** touch `left-`/`right-` (positioning), `border-l/r` (side border width), or transforms (`translate-x` etc.) — those can sit right next to a converted class and interact with it in a way that needs a human to look, so a blind swap risks moving something to the wrong place.

## How this was done

Converted mechanically with a small script that has its own 15+-case self-test (variant prefixes, negatives, arbitrary values, fractions all covered; verified `px-`/`mx-`/`left-`/`right-`/`border-l-r`/`translate-x` are never touched), then spot-checked by hand. Zero remaining `ml-/mr-/pl-/pr-/text-left/text-right` instances after conversion.
