### PR TITLE
fix: localize hardcoded helpdesk UI labels

### DIFF
--- a/desk/src/components/ListViewBuilder.vue
+++ b/desk/src/components/ListViewBuilder.vue
@@ -379,6 +379,7 @@ const list = createResource({
     data.columns.forEach((column) => {
       handleFetchFromField(column);
       handleColumnConfig(column);
+      column.label = __(column.label);
     });
     return data;
   },

--- a/desk/src/components/ticket-agent/TicketActivityPanel.vue
+++ b/desk/src/components/ticket-agent/TicketActivityPanel.vue
@@ -79,17 +79,17 @@ const tabs: ComputedRef<TabObject[]> = computed(() => {
   const _tabs: TabObject[] = [
     {
       name: "activity",
-      label: "Activity",
+      label: __("Activity"),
       icon: ActivityIcon,
     },
     {
       name: "email",
-      label: "Emails",
+      label: __("Emails"),
       icon: EmailIcon,
     },
     {
       name: "comment",
-      label: "Comments",
+      label: __("Comments"),
       icon: CommentIcon,
     },
   ];
@@ -97,7 +97,7 @@ const tabs: ComputedRef<TabObject[]> = computed(() => {
   if (isCallingEnabled.value) {
     _tabs.push({
       name: "call",
-      label: "Calls",
+      label: __("Calls"),
       icon: PhoneIcon,
     });
   }

--- a/desk/src/components/ticket/TicketAgentDetails.vue
+++ b/desk/src/components/ticket/TicketAgentDetails.vue
@@ -81,7 +81,7 @@ const firstResponseBadge = computed(() => {
     };
   } else {
     firstResponse = {
-      label: "Failed",
+      label: __("Failed"),
       color: "red",
     };
   }
@@ -125,7 +125,7 @@ const resolutionBadge = computed(() => {
     };
   } else {
     resolution = {
-      label: "Failed",
+      label: __("Failed"),
       color: "red",
     };
   }
@@ -144,13 +144,13 @@ function getCalculatedResolution() {
 
 const sections = computed(() => [
   {
-    label: "First Response",
+    label: __("First Response"),
     tooltipValue: dateFormat(props.ticket.response_by, dateTooltipFormat),
     badgeText: firstResponseBadge.value.label,
     badgeColor: firstResponseBadge.value.color,
   },
   {
-    label: "Resolution",
+    label: __("Resolution"),
     tooltipValue: dateFormat(
       props.ticket.resolution_date || props.ticket.resolution_by,
       dateTooltipFormat
@@ -159,8 +159,8 @@ const sections = computed(() => [
     badgeColor: resolutionBadge.value.color,
   },
   {
-    label: "Source",
-    value: props.ticket.via_customer_portal ? "Portal" : "Mail",
+    label: __("Source"),
+    value: props.ticket.via_customer_portal ? __("Portal") : __("Mail"),
   },
 ]);
 


### PR DESCRIPTION
## Summary

Wrap several hardcoded Helpdesk UI labels with the translation helper so they are properly localized in non-English installations.

## Changes

- Translate list view column labels returned by `get_list_data`
- Translate ticket activity tabs:
  - Activity
  - Emails
  - Comments
  - Calls
- Translate ticket SLA/details labels:
  - First Response
  - Resolution
  - Source
  - Portal / Mail
  - Failed

## Why

The translations already exist and `__()` resolves them correctly, but these labels were rendered directly without passing through the translation helper.

This caused mixed-language UI in localized Helpdesk installations.

## Testing

Tested on:

- Frappe 16.31.0
- Helpdesk 1.29.0
- Dutch (`nl`)

Verified that the previously hardcoded English labels now render through the existing translation catalogue.