### PR TITLE
fix: localize ticket detail UI

### DIFF
--- a/desk/src/components/CommunicationArea.vue
+++ b/desk/src/components/CommunicationArea.vue
@@ -7,7 +7,7 @@
         <Button
           ref="sendEmailRef"
           variant="ghost"
-          label="Reply"
+          :label="__('Reply')"
           :class="[
             showEmailBox ? '!bg-surface-gray-4 hover:!bg-surface-gray-3' : '',
           ]"
@@ -19,7 +19,7 @@
         </Button>
         <Button
           variant="ghost"
-          label="Comment"
+          :label="__('Comment')"
           :class="[
             showCommentBox ? '!bg-surface-gray-4 hover:!bg-surface-gray-3' : '',
           ]"
@@ -79,10 +79,10 @@
             ref="commentTextEditorRef"
             :label="
               isMobileView
-                ? 'Comment'
+                ? __('Comment')
                 : isMac
-                ? 'Comment (⌘ + ⏎)'
-                : 'Comment (Ctrl + ⏎)'
+                ? __('Comment (⌘ + ⏎)')
+                : __('Comment (Ctrl + ⏎)')
             "
             :ticketId="ticketId"
             :editable="showCommentBox"

--- a/desk/src/components/ticket-agent/TicketActivityPanel.vue
+++ b/desk/src/components/ticket-agent/TicketActivityPanel.vue
@@ -82,17 +82,17 @@ const tabs: ComputedRef<TabObject[]> = computed(() => {
   const _tabs: TabObject[] = [
     {
       name: "activity",
-      label: "Activity",
+      label: __("Activity"),
       icon: ActivityIcon,
     },
     {
       name: "email",
-      label: "Emails",
+      label: __("Emails"),
       icon: EmailIcon,
     },
     {
       name: "comment",
-      label: "Comments",
+      label: __("Comments"),
       icon: CommentIcon,
     },
   ];
@@ -100,7 +100,7 @@ const tabs: ComputedRef<TabObject[]> = computed(() => {
   if (isCallingEnabled.value) {
     _tabs.push({
       name: "call",
-      label: "Calls",
+      label: __("Calls"),
       icon: PhoneIcon,
     });
   }
@@ -175,7 +175,7 @@ const _activities = computed(() => {
     return {
       type: "history",
       key: h.creation,
-      content: h.action ? h.action : "viewed this",
+      content: h.action ? h.action : __("viewed this"),
       creation: h.creation,
       user: h.user.name + " ",
     };

--- a/desk/src/components/ticket-agent/TicketActivityPanel.vue
+++ b/desk/src/components/ticket-agent/TicketActivityPanel.vue
@@ -215,7 +215,7 @@ const _activities = computed(() => {
         if (
           nextActivity &&
           nextActivity.user === currentActivity.user &&
-          nextActivity.content !== "viewed this" &&
+          nextActivity.content !== __("viewed this") &&
           !nextActivity.content.includes("assigned") &&
           !nextActivity.content.includes("unassigned")
         ) {

--- a/desk/src/components/ticket-agent/TicketSLA.vue
+++ b/desk/src/components/ticket-agent/TicketSLA.vue
@@ -75,16 +75,16 @@ const openCard = ref<string | null>(null);
 const cards = computed<SLACard[]>(() =>
   [
     {
-      title: "First Response",
+      title: __("First Response"),
       metric: firstResponse.value,
-      fulfilledLabel: "Fulfilled",
-      actualLabel: "Responded on",
+      fulfilledLabel: __("Fulfilled"),
+      actualLabel: __("Responded on"),
     },
     {
-      title: "Resolution",
+      title: __("Resolution"),
       metric: resolution.value,
-      fulfilledLabel: "Fulfilled",
-      actualLabel: "Resolved on",
+      fulfilledLabel: __("Fulfilled"),
+      actualLabel: __("Resolved on"),
     },
   ].filter((card): card is SLACard => Boolean(card.metric))
 );
@@ -99,11 +99,11 @@ function cardDetails(card: SLACard) {
   const metric = card.metric;
   const rows = [];
   if (metric.dueBy) {
-    rows.push({ label: "Due by", value: fmt(metric.dueBy), danger: false });
+    rows.push({ label: __("Due by"), value: fmt(metric.dueBy), danger: false });
   }
   if (metric.state === "hold") {
     rows.push({
-      label: "On hold since",
+      label: __("On hold since"),
       value: fmt(ticket.value.doc.on_hold_since as string),
       danger: false,
     });
@@ -119,13 +119,15 @@ function cardDetails(card: SLACard) {
   }
   if (metric.delay) {
     rows.push({
-      label: metric.delayInWorkingHours ? "Delay (working hours)" : "Delay",
+      label: metric.delayInWorkingHours
+        ? __("Delay (working hours)")
+        : __("Delay"),
       value: metric.delay,
       danger: true,
     });
     if (metric.calendarDelay) {
       rows.push({
-        label: "Delay (total)",
+        label: __("Delay (total)"),
         value: `+${metric.calendarDelay}`,
         danger: true,
       });
@@ -133,7 +135,7 @@ function cardDetails(card: SLACard) {
   }
   if (metric.fulfilledIn) {
     rows.push({
-      label: "Fulfilled in",
+      label: __("Fulfilled in"),
       value: metric.fulfilledIn,
       danger: false,
     });

--- a/desk/src/composables/useSLA.ts
+++ b/desk/src/composables/useSLA.ts
@@ -108,7 +108,7 @@ export function useSLA(ticket: Ref<TicketLike | null | undefined>): {
       );
     }
     const overdue = coarseDuration(d.response_by);
-    return metric("overdue", `Overdue by ${overdue}`, "red", {
+    return metric("overdue", __("Overdue by {0}", [overdue]), "red", {
       dueBy: d.response_by,
       delay: `+${overdue}`,
     });
@@ -129,7 +129,7 @@ export function useSLA(ticket: Ref<TicketLike | null | undefined>): {
       d.on_hold_since &&
       pausedBeforeBreach
     ) {
-      return metric("hold", "On Hold", "blue", { dueBy: d.resolution_by });
+      return metric("hold", __("On Hold"), "blue", { dueBy: d.resolution_by });
     }
 
     if (d.resolution_date) {
@@ -174,7 +174,7 @@ export function useSLA(ticket: Ref<TicketLike | null | undefined>): {
       );
     }
     const overdue = coarseDuration(d.resolution_by);
-    return metric("overdue", `Overdue by ${overdue}`, "red", {
+    return metric("overdue", __("Overdue by {0}", [overdue]), "red", {
       dueBy: d.resolution_by,
       delay: `+${overdue}`,
     });


### PR DESCRIPTION
## Summary

Route additional ticket-detail UI strings through the existing translation
helper so localized Helpdesk installations do not fall back to English for
common agent-facing actions and SLA details.

## Changes

- Translate Reply / Comment controls and comment editor labels
- Translate ticket activity tabs (Activity, Emails, Comments, Calls)
- Translate the fallback activity text `viewed this`
- Translate SLA card labels and details
- Replace the hardcoded `Overdue by ${...}` text with a placeholder-based
  translation string
- Translate the on-hold SLA state

## Why

Several common ticket-detail strings were still hardcoded in English even when
translations existed in the locale catalogue. This caused mixed-language UI on
localized installations.

## Testing

Tested on:

- Frappe 16.31.0
- Helpdesk 1.29.0
- Dutch (`nl`)

Verified that the affected labels render through the translation catalogue and
that the production frontend build succeeds.