### PR TITLE
fix(sla): freeze resolution overdue timer while ticket is paused

### DIFF
--- a/desk/src/components/ticket-agent/TicketSLA.vue
+++ b/desk/src/components/ticket-agent/TicketSLA.vue
@@ -18,7 +18,9 @@
         <Popover
           placement="bottom"
           :show="openCard === card.title"
-          @update:show="(open: boolean) => (openCard = open ? card.title : null)"
+          @update:show="
+            (open: boolean) => (openCard = open ? card.title : null)
+          "
         >
           <template #target>
             <LucideInfo
@@ -101,10 +103,15 @@ function cardDetails(card: SLACard) {
   if (metric.dueBy) {
     rows.push({ label: "Due by", value: fmt(metric.dueBy), danger: false });
   }
-  if (metric.state === "hold") {
+  // A breached-then-paused metric reads as plain "Overdue", so the pause has to
+  // be visible here or the frozen number looks arbitrary.
+  if (
+    metric.state === "hold" ||
+    (metric.state === "overdue" && onHoldSince())
+  ) {
     rows.push({
       label: "On hold since",
-      value: fmt(ticket.value.doc.on_hold_since as string),
+      value: fmt(onHoldSince()),
       danger: false,
     });
   }
@@ -139,6 +146,10 @@ function cardDetails(card: SLACard) {
     });
   }
   return rows;
+}
+
+function onHoldSince(): string {
+  return (ticket.value?.doc?.on_hold_since as string) || "";
 }
 
 function fmt(date: string): string {

--- a/desk/src/composables/useSLA.ts
+++ b/desk/src/composables/useSLA.ts
@@ -104,7 +104,7 @@ export function useSLA(ticket: Ref<TicketLike | null | undefined>): {
         "orange",
         {
           dueBy: d.response_by,
-        }
+        },
       );
     }
     const overdue = coarseDuration(d.response_by);
@@ -170,10 +170,16 @@ export function useSLA(ticket: Ref<TicketLike | null | undefined>): {
         "due",
         `Due in ${coarseDuration(d.resolution_by)}`,
         "violet",
-        { dueBy: d.resolution_by }
+        { dueBy: d.resolution_by },
       );
     }
-    const overdue = coarseDuration(d.resolution_by);
+    // Paused after the deadline: freeze at the breach, hold time is not lateness.
+    // The pause itself stays in the popover; the card has room for one fact, and
+    // a failed SLA outranks a pause that ends the moment the customer replies.
+    const paused = d.status_category === "Paused" && Boolean(d.on_hold_since);
+    const overdue = paused
+      ? shortDuration(d.on_hold_since, d.resolution_by)
+      : coarseDuration(d.resolution_by);
     return metric("overdue", `Overdue by ${overdue}`, "red", {
       dueBy: d.resolution_by,
       delay: `+${overdue}`,
@@ -187,7 +193,7 @@ function metric(
   state: SLAState,
   value: string,
   color: SLAMetric["color"],
-  extra: Partial<Pick<SLAMetric, "dueBy" | "actual" | "delay">>
+  extra: Partial<Pick<SLAMetric, "dueBy" | "actual" | "delay">>,
 ): SLAMetric {
   return {
     state,


### PR DESCRIPTION
A ticket paused after its resolution deadline showed an "Overdue by" number that kept climbing while the SLA clock was stopped, with nothing on the card or popover saying the ticket was on hold.

- Freeze the overdue duration at `on_hold_since` when the ticket is paused, so it reports the breach that happened before the pause instead of counting hold time as lateness.
- Show the "On hold since" row for `overdue` metrics, not just `hold`.

The card keeps reading "Overdue" rather than "On Hold" here: the SLA already failed before the pause (`agreement_status: "Failed"`), and a blue "On Hold" would hide that.