### PR TITLE
fix: consider holidays for outside working hours banner

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py
+++ b/helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py
@@ -402,7 +402,10 @@ class HDServiceLevelAgreement(Document):
 
     def is_working_time(self, date_time, working_hours):
         day_of_week = get_weekdays()[date_time.weekday()]
-        start_time, end_time = working_hours.get(day_of_week, (0, 0))
+        # empty window on non-working days
+        start_time, end_time = working_hours.get(
+            day_of_week, (timedelta(), timedelta())
+        )
         date_time = timedelta(
             hours=date_time.hour, minutes=date_time.minute, seconds=date_time.second
         )
@@ -468,6 +471,18 @@ class HDServiceLevelAgreement(Document):
             current_date = add_to_date(current_date, days=1)
 
         return total_seconds
+
+    def get_next_working_day_start(self, from_date):
+        """Start of the first working day after from_date, skipping holidays."""
+        working_hours = self.get_working_hours()
+        holidays = set(self.get_holidays())
+        # a year of lookahead is plenty; None means the calendar has no working day
+        for offset in range(1, 366):
+            next_date = getdate(add_to_date(from_date, days=offset, as_datetime=True))
+            day_name = next_date.strftime("%A")
+            if day_name in working_hours and next_date not in holidays:
+                return get_datetime(next_date) + working_hours[day_name][0]
+        return None
 
     def get_holidays(self):
         res = []

--- a/helpdesk/helpdesk/doctype/hd_ticket/api.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/api.py
@@ -5,12 +5,7 @@ import frappe
 from bs4 import BeautifulSoup
 from frappe import _
 from frappe.model.document import get_controller
-from frappe.utils import (
-    add_to_date,
-    get_datetime,
-    get_user_info_for_avatar,
-    now_datetime,
-)
+from frappe.utils import get_user_info_for_avatar, now_datetime
 from frappe.utils.caching import redis_cache
 from pypika import Criterion, Order
 
@@ -783,23 +778,9 @@ def get_ticket_assignees(ticket: str) -> list[dict]:
 
 
 def show_banner_next_day(ticket):
-    sla = ticket.get_sla()
-    working_hours = sla.get_working_hours()
-    now = now_datetime()
-    creation_date = get_datetime(ticket.creation)
-    next_date = add_to_date(creation_date, days=1)
-    next_date_day_name = next_date.strftime("%A")
-    if next_date_day_name not in working_hours:
-        return True
-
-    start_time = working_hours[next_date_day_name][0]
-
-    next_day_start_datetime = (
-        next_date.replace(hour=0, minute=0, second=0, microsecond=0) + start_time
-    )
-    if now > next_day_start_datetime:
-        return False
-    return True
+    """Show the banner until the first working day after the ticket was raised begins."""
+    next_start = ticket.get_sla().get_next_working_day_start(ticket.creation)
+    return next_start is None or now_datetime() <= next_start
 
 
 @frappe.whitelist()

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -1,6 +1,5 @@
 import json
 import uuid
-from datetime import timedelta
 from email.utils import parseaddr
 
 import frappe
@@ -13,7 +12,6 @@ from frappe.desk.form.assign_to import get as get_assignees
 from frappe.email.email_body import get_message_id
 from frappe.model.document import Document
 from frappe.permissions import add_permission, update_permission_property
-from frappe.query_builder import DocType, Order
 from frappe.utils import add_to_date, cint, get_string_between, getdate, now_datetime
 from pypika.functions import Count
 from pypika.queries import Query
@@ -1020,47 +1018,13 @@ class HDTicket(Document):
         return frappe.get_doc("HD Service Level Agreement", self.sla)
 
     def is_currently_outside_working_hours(self):
-        """Return True if current time is outside this SLA's working hours."""
-
+        """Return True if today is a holiday or now is outside this SLA's working hours."""
         sla = self.get_sla()
         if not sla:
             return False
-
-        current_date = getdate()
-        now = now_datetime()
-
-        current_td = timedelta(
-            hours=now.hour,
-            minutes=now.minute,
-            seconds=now.second,
-            microseconds=now.microsecond,
-        )
-
-        day_name = current_date.strftime("%A")
-        Holiday = DocType("HD Holiday")
-
-        # Check holidays for this SLA
-        holidays = (
-            frappe.qb.from_(Holiday)
-            .select(Holiday.holiday_date)
-            .where(Holiday.parent == sla.name)
-            .run(pluck=True)
-        )
-
-        if current_date in holidays:
+        if getdate() in sla.get_holidays():
             return True
-
-        working_hours = sla.get_working_hours()
-        # No working hours today
-        if day_name not in working_hours:
-            return True
-
-        start_time, end_time = working_hours[day_name]
-
-        # Outside working hours
-        if not (start_time <= current_td < end_time):
-            return True
-        return False
+        return not sla.is_working_time(now_datetime(), sla.get_working_hours())
 
     def set_default_status(self):
         if self.is_new():

--- a/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
@@ -881,6 +881,34 @@ class TestHDTicket(IntegrationTestCase):
             banner_shown = show_outside_hours_banner(ticket.name)["show"]
             self.assertFalse(banner_shown)
 
+    def test_ticket_outside_working_hours_next_day_holiday(self):
+        tuesday = add_to_date(get_current_week_monday(), days=1)
+        add_holiday(getdate(tuesday), "Test Holiday")
+        self.addCleanup(remove_holidays)
+
+        with self.freeze_time(get_current_week_monday(hours=20)):
+            ticket = make_ticket(priority="High")
+            self.assertTrue(ticket.raised_outside_working_hours)
+
+        ticket.reload()
+        with self.freeze_time(add_to_date(get_current_week_monday(hours=14), days=1)):
+            # Tuesday is a holiday, so the banner stays up
+            self.assertTrue(show_outside_hours_banner(ticket.name)["show"])
+
+        with self.freeze_time(add_to_date(get_current_week_monday(hours=14), days=2)):
+            # Wednesday is the next working day
+            self.assertFalse(show_outside_hours_banner(ticket.name)["show"])
+
+    def test_ticket_raised_on_holiday(self):
+        tuesday_afternoon = add_to_date(get_current_week_monday(hours=14), days=1)
+        add_holiday(getdate(tuesday_afternoon), "Test Holiday")
+        self.addCleanup(remove_holidays)
+
+        with self.freeze_time(tuesday_afternoon):
+            ticket = make_ticket(priority="High")
+            self.assertTrue(ticket.raised_outside_working_hours)
+            self.assertTrue(show_outside_hours_banner(ticket.name)["show"])
+
     def test_contact_ticket_visibility(self):
         """
         Test case to validate that contact can only see the tickets raised by them only.


### PR DESCRIPTION
## Problem

The "raised outside working hours" banner ignores holidays.

1. `HDTicket.is_currently_outside_working_hours` queries `HD Holiday` with `parent == sla.name`. But `HD Holiday` rows belong to an **HD Service Holiday List**, not to the SLA, so the query returns nothing unless the SLA and its holiday list happen to share a name. On any real setup, holidays are silently ignored:
   - A ticket raised during a holiday is stamped `raised_outside_working_hours = 0`, so it can never show the banner.
   - The banner disappears during a holiday at the start of what would be normal working hours.
2. `show_banner_next_day` only looks one calendar day ahead. If the day after creation is a holiday (or a weekend), it either hides the banner too early or — for weekend-raised tickets — never expires it, so the banner reappears every following out-of-hours period.

## Fix

- `is_currently_outside_working_hours` now uses the SLA's own `get_holidays()` and reuses `is_working_time()` (40 lines → 8).
- New `HDServiceLevelAgreement.get_next_working_day_start(from_date)` walks forward past weekends and holidays; `show_banner_next_day` shows the banner until that moment.
- `is_working_time` had a latent `TypeError` on non-working days: its fallback compared `int` to `timedelta`. The fallback is now an empty `timedelta` window.

## Tests

Two new cases in `test_hd_ticket.py`:
- ticket raised the evening before a holiday: banner stays up through the holiday, gone after the next working day starts
- ticket raised during working hours **on** a holiday: flagged and banner shown

All existing outside-working-hours, banner, and SLA holiday tests pass.