### PR TITLE
feat(i18n): add Japanese locale (ja.po)

### DIFF
--- a/helpdesk/locale/ja.po
+++ b/helpdesk/locale/ja.po
@@ -1,0 +1,7218 @@
+# Japanese translations for Helpdesk.
+# Copyright (C) 2026 Frappe Technologies
+# This file is distributed under the same license as the Helpdesk project.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: frappe\n"
+"Report-Msgid-Bugs-To: hello@frappe.io\n"
+"POT-Creation-Date: 2026-08-09 10:59+0000\n"
+"PO-Revision-Date: 2026-08-21 05:28+0000\n"
+"Last-Translator: Kurage AI Project <info@exbridge.jp>\n"
+"Language: ja\n"
+"Language-Team: Japanese\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.8.0\n"
+
+#: desk/src/components/CommentBox.vue:14
+msgid " commented"
+msgstr " コメント済み"
+
+#: helpdesk/api/dashboard.py:187
+msgid "% SLA Fulfilled"
+msgstr "% SLA遵守"
+
+#: helpdesk/api/dashboard.py:192
+#, no-python-format
+msgid "% of tickets created that were resolved within SLA"
+msgstr "SLA内で解決したチケットの割合"
+
+#: desk/src/pages/SearchAgent.vue:120
+msgid "({0}s)"
+msgstr "({0}秒)"
+
+#: desk/src/components/tag/Tags.vue:62
+msgid "+{0} more"
+msgstr "+{0}件以上"
+
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:114
+msgid "- Default Ticket Status<br>"
+msgstr "- デフォルトのチケットステータス<br>"
+
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:116
+msgid "- Ticket Reopen Status<br>"
+msgstr "- チケット再開ステータス<br>"
+
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:92
+msgid "- {0} as Default Status<br>"
+msgstr "- {0} をデフォルトステータスとして設定<br>"
+
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:94
+msgid "- {0} as Reopen Status<br>"
+msgstr "- {0} を再開ステータスとして設定<br>"
+
+#. Description of the 'Feedback' (Select) field in DocType 'HD Article
+#. Feedback'
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
+msgid "0 is no feedback, 1 is Like, 2 is Dislike"
+msgstr "0はフィードバックなし、1はいいね、2はよくないね"
+
+#: desk/src/pages/home/components/AvgTimeMetrics.vue:178
+#: desk/src/pages/home/components/AvgTimeMetrics.vue:196
+msgid "1 Year"
+msgstr "1年間"
+
+#: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.py:154
+msgid "1 person reacted to your comment"
+msgstr "あなたのコメントに1人がリアクションしました"
+
+#: desk/src/pages/home/components/AvgTimeMetrics.vue:176
+#: desk/src/pages/home/components/AvgTimeMetrics.vue:188
+msgid "3 Months"
+msgstr "3ヶ月"
+
+#: desk/src/pages/home/components/AvgTimeMetrics.vue:177
+#: desk/src/pages/home/components/AvgTimeMetrics.vue:183
+#: desk/src/pages/home/components/AvgTimeMetrics.vue:192
+msgid "6 Months"
+msgstr "6ヶ月"
+
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:117
+msgid "<br>Please update HD Settings to use a different status before disabling this status."
+msgstr "<br>このステータスを無効にする前に、別のステータスを使用するようにHD設定を更新してください。"
+
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:95
+msgid "<br>Please update the SLA(s) to use a different status before disabling this status."
+msgstr "<br>このステータスを無効にする前に、別のステータスを使用するようにSLAを更新してください。"
+
+#. Introduction text of the email-feedback Web Form
+#: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
+msgid ""
+"<div class=\"ql-editor read-mode\"><p>Let us know if we solved your issue well. It’ll help us "
+"serve you better next time.</p></div>"
+msgstr "<div class=\"ql-editor read-mode\"><p>問題がうまく解決したかどうかお知らせください。次回のより良いサービス提供に役立てます。</p></div>"
+
+#. Header text in the Helpdesk Workspace
+#: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
+msgid "<span class=\"h3\" style=\"\"><a href=\"/helpdesk\">Visit Helpdesk</a></span>"
+msgstr "<span class=\"h3\" style=\"\"><a href=\"/helpdesk\">Helpdeskを開く</a></span>"
+
+#. Paragraph text in the Helpdesk Workspace
+#: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
+msgid "<span class=\"h4\">Helpdesk Configuration<br></span>"
+msgstr "<span class=\"h4\">Helpdesk設定<br></span>"
+
+#: desk/src/pages/PersonaForm.vue:224
+msgid "A Frappe partner or consultant"
+msgstr "Frappeパートナーまたはコンサルタント"
+
+#: desk/src/pages/PersonaForm.vue:223
+msgid "A friend or colleague"
+msgstr "友人または同僚"
+
+#: desk/src/pages/ticket/TicketNew.vue:69
+msgid "A short description"
+msgstr "短い説明"
+
+#: desk/src/components/Settings/Sla/Modals/WorkDayModal.vue:268
+msgid "A workday with this name already exists"
+msgstr "この名前の営業日が既に存在します"
+
+#: desk/src/components/Settings/Teams/TeamEdit.vue:263
+msgid "Access all team tickets"
+msgstr "すべてのチームチケットにアクセス"
+
+#: helpdesk/api/knowledge_base.py:15
+msgid "Access denied"
+msgstr "アクセス拒否"
+
+#: desk/src/components/Settings/Teams/TeamEdit.vue:262
+msgid "Access only this team's tickets"
+msgstr "このチームのチケットのみにアクセス"
+
+#: desk/src/components/Settings/SettingsModal.vue:19
+msgid "Account"
+msgstr "アカウント"
+
+#: desk/src/components/Settings/Profile/Profile.vue:108
+msgid "Account Info & Security"
+msgstr "アカウント情報とセキュリティ"
+
+#. Label of the acknowledgement_section (Section Break) field in DocType 'HD
+#. Settings'
+#: desk/src/components/Settings/EmailNotifications/NotificationList.vue:72
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Acknowledgement"
+msgstr "確認"
+
+#. Label of the action (Small Text) field in DocType 'HD Ticket Activity'
+#: helpdesk/helpdesk/doctype/hd_ticket_activity/hd_ticket_activity.json
+msgid "Action"
+msgstr "アクション"
+
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.py:26
+msgid "Action Required"
+msgstr "対応が必要"
+
+#: desk/src/pages/contact/Contact.vue:305
+msgid "Actions"
+msgstr "アクション"
+
+#. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
+#: Rules/AssignmentSchedule.vue:42 desk/src/components/Settings/Assignment
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+msgid "Active"
+msgstr "有効"
+
+#: desk/src/components/ticket-agent/AssignTo.vue:426
+msgid "Active now"
+msgstr "現在アクティブ"
+
+#. Description of the 'Category' (Select) field in DocType 'HD Agent Status'
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+msgid ""
+"Active: The agent is available and working.<br>\n"
+"Away: The agent is temporarily unreachable.<br>\n"
+"Unavailable: The agent is off and unavailable."
+msgstr ""
+"アクティブ：担当者が対応可能で業務中です。<br>\n"
+"離席中：担当者は一時的に連絡がつきません。<br>\n"
+"不在：担当者は休み中で対応できません。"
+
+#: desk/src/pages/ticket/MobileTicketAgent.vue:502 desk/src/pages/ticket/TicketCustomer.vue:182
+msgid "Activity"
+msgstr "アクティビティ"
+
+#: desk/src/components/tag/Tags.vue:38 desk/src/components/tag/Tags.vue:43
+msgid "Add"
+msgstr "追加"
+
+#: Rules/AssigneeSearch.vue:9 desk/src/components/Settings/Assignment
+msgid "Add Assignee"
+msgstr "担当者の追加"
+
+#: desk/src/pages/knowledge-base/Article.vue:638
+msgid "Add Category"
+msgstr "カテゴリの追加"
+
+#: desk/src/components/view-controls/ColumnSettings.vue:69
+msgid "Add Column"
+msgstr "列の追加"
+
+#: desk/src/components/Settings/Profile/UserEmailSettings.vue:89
+#: desk/src/components/contact/EditContactDialog.vue:68
+msgid "Add Email"
+msgstr "メールを追加"
+
+#: desk/src/components/view-controls/filter/Filter.vue:120
+msgid "Add Filter..."
+msgstr "フィルターを追加..."
+
+#: desk/src/components/Settings/Holiday/HolidayView.vue:173
+msgid "Add Holiday"
+msgstr "休日を追加"
+
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:132
+msgid "Add New Article"
+msgstr "新しい記事を作成"
+
+#: desk/src/components/contact/EditContactDialog.vue:97
+msgid "Add Phone"
+msgstr "電話番号を追加"
+
+#: desk/src/components/view-controls/SortBy.vue:148
+msgid "Add Sort"
+msgstr "並べ替えを追加"
+
+#. Label of the add_weekly_holidays (Section Break) field in DocType 'HD
+#. Service Holiday List'
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
+msgid "Add Weekly Holidays"
+msgstr "週次の休日を追加"
+
+#: desk/src/components/layouts/Sidebar.vue:297
+msgid "Add a comment on a ticket"
+msgstr "チケットにコメントを追加"
+
+#: Rules/AssignmentRulesSection.vue:17 desk/src/components/Settings/Assignment
+msgid "Add a condition"
+msgstr "条件を追加"
+
+#: desk/src/components/Settings/Sla/SlaAssignmentConditions.vue:14
+msgid "Add a custom condition"
+msgstr "カスタム条件を追加"
+
+#: desk/src/components/Questionnaire.vue:266
+msgid "Add a few words so we can continue"
+msgstr "続行するために、いくつかの言葉を入力してください"
+
+#: desk/src/pages/home/Home.vue:91
+msgid "Add charts to get started"
+msgstr "開始するにはチャートを追加してください"
+
+#: Rules/AssignmentRulesSection.vue:29 Rules/AssignmentRulesSection.vue:66
+#: desk/src/components/Settings/Assignment
+#: desk/src/components/Settings/Sla/SlaAssignmentConditions.vue:25
+msgid "Add condition"
+msgstr "条件を追加"
+
+#: Rules/AssignmentRulesSection.vue:72 desk/src/components/Settings/Assignment
+msgid "Add condition group"
+msgstr "条件グループを追加"
+
+#: desk/src/components/view-controls/filter/Filter.vue:89
+msgid "Add filter"
+msgstr "フィルターを追加"
+
+#: desk/src/components/Settings/Holiday/HolidayView.vue:146
+msgid "Add holidays here to make sure they’re excluded from SLA calculations."
+msgstr "SLAの計算から除外されるよう、ここに休日を追加してください。"
+
+#: desk/src/components/Settings/Teams/TeamEdit.vue:97
+msgid "Add members to this team to get started."
+msgstr "開始するには、このチームにメンバーを追加してください。"
+
+#: Rules/AssignmentRulesListView.vue:23 desk/src/components/Settings/Assignment
+#: desk/src/components/Settings/EmailAccountList.vue:53
+#: desk/src/components/Settings/Holiday/HolidayList.vue:23
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:74
+#: desk/src/components/Settings/Sla/SlaPolicyList.vue:23
+msgid "Add one to get started."
+msgstr "開始するには、1つ追加してください。"
+
+#: desk/src/components/Settings/Holiday/HolidayView.vue:127
+msgid "Add recurring holidays such as weekends."
+msgstr "週末などの定期的な休日を追加します。"
+
+#: desk/src/components/modals/ShortcutsModal.vue:92
+msgid "Add tags"
+msgstr "タグを追加"
+
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:204
+msgid "Add time targets around support milestones like first reply and resolution times."
+msgstr "最初の返信時間や解決時間など、サポートの節目に関する目標時間を追加します。"
+
+#. Label of the get_weekly_off_dates (Button) field in DocType 'HD Service
+#. Holiday List'
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
+msgid "Add to Holidays"
+msgstr "休日に追加"
+
+#: desk/src/components/EmailEditor.vue:37 desk/src/components/EmailEditor.vue:77
+#: desk/src/components/EmailEditor.vue:95
+msgid "Add to recipients"
+msgstr "受信者に追加"
+
+#: desk/src/components/Settings/Agents.vue:4
+msgid "Add, manage agents and assign roles to them."
+msgstr "担当者を追加、管理し、役割を割り当てます。"
+
+#. Label of the about (Code) field in DocType 'HD Ticket Template'
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+msgid "Additional Information"
+msgstr "詳細情報"
+
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "Administrator"
+msgstr "管理者"
+
+#. Name of a role
+#. Label of a Link in the Helpdesk Workspace
+#: desk/src/components/layouts/Sidebar.vue:402 desk/src/pages/dashboard/Dashboard.vue:70
+#: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
+#: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
+#: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_activity/hd_ticket_activity.json
+#: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
+msgid "Agent"
+msgstr "担当者"
+
+#. Label of a Card Break in the Helpdesk Workspace
+#: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
+msgid "Agent Configuration"
+msgstr "担当者設定"
+
+#: desk/src/pages/dashboard/Dashboard.vue:262
+msgid "Agent Dashboard"
+msgstr "担当者ダッシュボード"
+
+#. Name of a role
+#: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "Agent Manager"
+msgstr "担当者マネージャー"
+
+#. Label of the agent_name (Data) field in DocType 'HD Agent'
+#: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
+msgid "Agent Name"
+msgstr "担当者名"
+
+#. Label of the agent_status (Data) field in DocType 'HD Agent Status'
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+msgid "Agent Status"
+msgstr "担当者ステータス"
+
+#: desk/src/components/Settings/Agents.vue:109
+msgid "Agent name"
+msgstr "担当者名"
+
+#: desk/src/components/Settings/Agents.vue:3
+msgid "Agents"
+msgstr "担当者"
+
+#: desk/src/components/layouts/Sidebar.vue:381
+msgid "Agents & Teams"
+msgstr "担当者とチーム"
+
+#: desk/src/components/Settings/General/components/TicketSettings.vue:70
+msgid "Agents will no longer be able to view and create saved replies with global scope."
+msgstr "担当者は、グローバルスコープの定型返信を表示・作成できなくなります。"
+
+#: desk/src/components/SavedRepliesSelectorModal.vue:176
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:302
+#: desk/src/components/contact/FeedbackList.vue:118 desk/src/components/ticket/TicketSplitModal.vue:6
+msgid "All"
+msgstr "すべて"
+
+#: desk/src/pages/home/components/PendingTickets.vue:246
+msgid "All SLAs on track"
+msgstr "すべてのSLAが期限内です"
+
+#: desk/src/pages/home/components/RecentFeedback.vue:360
+#: desk/src/pages/home/components/RecentFeedback.vue:398
+#: desk/src/pages/home/components/RecentFeedback.vue:406
+msgid "All Time"
+msgstr "全期間"
+
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:322
+msgid "All articles from this category will move to General category."
+msgstr "このカテゴリのすべての記事は「一般」カテゴリに移動します。"
+
+#: desk/src/components/ticket/TicketMergeModal.vue:7
+msgid "All comments and emails from both tickets will be merged into the selected ticket"
+msgstr "2つのチケットからのコメントとメールはすべて選択されたチケットに統合されます"
+
+#: desk/src/pages/home/components/PendingTickets.vue:255
+msgid "All your assigned tickets have been responded to"
+msgstr "割り当てられたチケットは全て返信されました"
+
+#. Label of the allow_anyone_to_create_tickets (Check) field in DocType 'HD
+#. Settings'
+#: desk/src/components/Settings/General/components/TicketSettings.vue:109
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Allow anyone to create tickets"
+msgstr "誰でもチケットを作れるように"
+
+#. Description of the 'Enable comment reactions' (Check) field in DocType 'HD
+#. Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Allow users to react to comments with emojis"
+msgstr "絵文字でコメントにリアクションできるようにする"
+
+#: desk/src/components/Settings/General/components/TicketSettings.vue:26
+msgid "Allow users to react to comments with emojis."
+msgstr "絵文字でコメントにリアクションできるようにします。"
+
+#. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
+#. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+msgid "Amber"
+msgstr "アンバー"
+
+#: desk/src/pages/PersonaForm.vue:225
+msgid "An event or conference"
+msgstr "イベントや会議"
+
+#: desk/src/pages/PersonaForm.vue:217
+msgid "Another Frappe product (ERPNext, Frappe Cloud, etc.)"
+msgstr "別のFrappe製品（ERPNext、Frappe Cloudなど）"
+
+#: desk/src/components/Settings/General/components/TicketSettings.vue:113
+msgid "Anyone will be able to create tickets without any permission. e.g. from webform."
+msgstr "Webフォームなどから、権限のないユーザーもチケットを作成できるようになります。"
+
+#: desk/src/components/Settings/Preferences/Preferences.vue:26
+msgid "Appearance"
+msgstr "外観"
+
+#: desk/src/components/Settings/General/components/Branding.vue:17
+msgid "Appears in the left sidebar. Recommended size is minimum 32x32 px in PNG or SVG."
+msgstr "左サイドバーに表示されます。PNGまたはSVG形式で、32x32 px以上を推奨します。"
+
+#. Description of the 'Favicon' (Attach Image) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Appears next to the title in your browser tab. Recommended size is minimum 32x32 px in PNG or ICO"
+msgstr "ブラウザタブのタイトル横に表示されます。PNGまたはICO形式で、32x32 px以上を推奨します"
+
+#: desk/src/components/Settings/General/components/Branding.vue:29
+msgid "Appears next to the title in your browser tab. Recommended size is minimum 32x32 px in PNG or ICO."
+msgstr "ブラウザタブのタイトル横に表示されます。PNGまたはICO形式で、32x32 px以上を推奨します。"
+
+#. Label of the apply_sla_for_resolution (Check) field in DocType 'HD Service
+#. Level Agreement'
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+msgid "Apply SLA for Resolution Time"
+msgstr "解決時間にSLAを適用"
+
+#. Label of the apply_to (Select) field in DocType 'HD Form Script'
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+msgid "Apply To"
+msgstr "適用先"
+
+#. Label of the apply_on_new_page (Check) field in DocType 'HD Form Script'
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+msgid "Apply on new page"
+msgstr "新しいページに適用"
+
+#. Label of the enable_outside_hours_banner (Check) field in DocType 'HD
+#. Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Apply outside working hours"
+msgstr "営業時間外にも適用"
+
+#. Label of the apply_to_customer_portal (Check) field in DocType 'HD Form
+#. Script'
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+msgid "Apply to customer portal"
+msgstr "顧客ポータルに適用"
+
+#. Option for the 'Status' (Select) field in DocType 'HD Article'
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:451
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+msgid "Archived"
+msgstr "アーカイブ"
+
+#: desk/src/components/Settings/SettingsModal.vue:74
+msgid "Are you sure you want to change tabs? Unsaved changes will be lost."
+msgstr "タブを変更しますか？保存されていない変更は失われます。"
+
+#: desk/src/pages/ticket/TicketCustomer.vue:314
+msgid "Are you sure you want to close this ticket?"
+msgstr "このチケットをクローズしますか？"
+
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:205
+msgid "Are you sure you want to delete these articles?"
+msgstr "これらの記事を削除しますか？"
+
+#: desk/src/pages/contact/Contact.vue:104
+msgid ""
+"Are you sure you want to delete this contact? The contact will be permanently deleted and "
+"unlinked from any associated customers and tickets."
+msgstr "この連絡先を削除しますか？連絡先は完全に削除され、関連する顧客やチケットとのリンクも解除されます。"
+
+#: desk/src/pages/customer/Customer.vue:96
+msgid ""
+"Are you sure you want to delete this customer? The reference to this customer will be removed "
+"from all the related tickets."
+msgstr "この顧客を削除しますか？関連するすべてのチケットからこの顧客への参照が削除されます。"
+
+#: desk/src/components/ticket-agent/TicketHeader.vue:200
+msgid "Are you sure you want to delete this ticket? This is an irreversible action and cannot be undone."
+msgstr "このチケットを削除しますか？この操作は取り消せません。"
+
+#: desk/src/pages/knowledge-base/Article.vue:147
+msgid "Are you sure you want to discard changes?"
+msgstr "変更を破棄しますか？"
+
+#: desk/src/pages/knowledge-base/NewArticle.vue:145
+msgid "Are you sure you want to discard this article?"
+msgstr "この記事を破棄しますか？"
+
+#: Rules/AssignmentRuleView.vue:450 desk/src/components/Settings/Assignment
+#: desk/src/components/Settings/EmailNotifications/Notification.vue:103
+#: desk/src/components/Settings/FieldDependency/FieldDependency.vue:68
+#: desk/src/components/Settings/Holiday/HolidayView.vue:202
+#: desk/src/components/Settings/Profile/UserEmailSettings.vue:218
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:280
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:376
+#: desk/src/components/Settings/Teams/NewTeam.vue:109
+#: desk/src/components/Settings/Telephony/ExotelSettings.vue:215
+#: desk/src/components/Settings/Telephony/TwilioSettings.vue:184
+msgid "Are you sure you want to go back? Unsaved changes will be lost."
+msgstr "前の画面に戻りますか？保存されていない変更は失われます。"
+
+#: Rules/AssigneeSearch.vue:165 desk/src/components/Settings/Assignment
+msgid "Are you sure you want to leave? Unsaved changes will be lost."
+msgstr "この画面を離れますか？保存されていない変更は失われます。"
+
+#: desk/src/components/Settings/General/components/Branding.vue:111
+msgid "Are you sure you want to remove the logo?"
+msgstr "ロゴを削除しますか？"
+
+#: desk/src/components/customer/ContactCard.vue:295
+msgid "Are you sure you want to remove this contact from the customer?"
+msgstr "この顧客から連絡先を削除しますか？"
+
+#: desk/src/components/Settings/EmailNotifications/Notification.vue:116
+msgid "Are you sure you want to reset the content? Current content will be overridden."
+msgstr "内容をリセットしますか？現在の内容は上書きされます。"
+
+#. Label of the article (Link) field in DocType 'HD Article Feedback'
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:114
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
+msgid "Article"
+msgstr "記事"
+
+#: desk/src/pages/knowledge-base/Article.vue:514
+msgid "Article body cannot be set as empty."
+msgstr "記事本文を空にすることはできません。"
+
+#: desk/src/pages/knowledge-base/NewArticle.vue:118
+msgid "Article created successfully."
+msgstr "記事を作成しました。"
+
+#: desk/src/pages/knowledge-base/Article.vue:553
+msgid "Article deleted successfully."
+msgstr "記事を削除しました。"
+
+#: desk/src/pages/knowledge-base/Article.vue:649
+msgid "Article link copied to clipboard"
+msgstr "記事のリンクをクリップボードにコピーしました"
+
+#: desk/src/pages/knowledge-base/Article.vue:509
+msgid "Article title cannot be set as empty"
+msgstr "記事のタイトルを空にすることはできません"
+
+#: desk/src/pages/knowledge-base/Article.vue:540
+msgid "Article updated successfully."
+msgstr "記事を更新しました。"
+
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:359
+msgid "Articles deleted successfully."
+msgstr "記事を削除しました。"
+
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:235
+msgid "Articles moved successfully."
+msgstr "記事を移動しました。"
+
+#: desk/src/components/ticket-agent/BulkAssignModal.vue:2 desk/src/pages/ticket/Tickets.vue:139
+msgid "Assign"
+msgstr "割り当て"
+
+#: desk/src/components/layouts/Sidebar.vue:272
+msgid "Assign a ticket to an agent"
+msgstr "チケットを担当者に割り当てる"
+
+#: desk/src/components/modals/ShortcutsModal.vue:90
+msgid "Assign ticket"
+msgstr "チケットを割り当てる"
+
+#: desk/src/components/ticket-agent/BulkAssignModal.vue:13
+msgid "Assign {0} tickets"
+msgstr "{0}件のチケットを割り当てる"
+
+#: desk/src/pages/home/components/RecentActivity.vue:105
+msgid "Assigned"
+msgstr "割り当てられた"
+
+#: desk/src/components/customer/TicketsTab.vue:233
+#: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:62
+#: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:49
+msgid "Assigned To"
+msgstr "割り当てられた"
+
+#: desk/src/components/ticket-agent/BulkAssignModal.vue:53
+msgid "Assigned {0} tickets"
+msgstr "{0}のチケットが割り当てられている"
+
+#: desk/src/components/ticket-agent/AssignTo.vue:11
+msgid "Assignee"
+msgstr "担当者"
+
+#: Rules/AssigneeRules.vue:5 desk/src/components/Settings/Assignment
+msgid "Assignee Rules"
+msgstr "担当者ルール"
+
+#: Rules/AssigneeRules.vue:75 desk/src/components/Settings/Assignment
+msgid "Assignees"
+msgstr "担当者"
+
+#: desk/src/components/ticket-agent/AssignTo.vue:601
+msgid "Assignees updated successfully."
+msgstr "担当者を更新しました。"
+
+#: desk/src/pages/PersonaForm.vue:200
+msgid "Assigning tickets"
+msgstr "チケットの割り当て"
+
+#. Option for the 'Type' (Select) field in DocType 'HD Notification'
+#: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
+msgid "Assignment"
+msgstr "割り当て"
+
+#: Rules/AssignmentRuleView.vue:122 desk/src/components/Settings/Assignment
+msgid "Assignment Condition"
+msgstr "割り当て条件"
+
+#. Label of the filters_section (Section Break) field in DocType 'HD Service
+#. Level Agreement'
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:87
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+msgid "Assignment Conditions"
+msgstr "割り当て条件"
+
+#. Label of the assignment_rule (Link) field in DocType 'HD Team'
+#. Label of a Link in the Helpdesk Workspace
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
+msgid "Assignment Rule"
+msgstr "割り当てルール"
+
+#. Label of the assignment_rules_section (Section Break) field in DocType 'HD
+#. Settings'
+#: Rules/AssignmentRulesList.vue:5 desk/src/components/Settings/Assignment
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Assignment Rules"
+msgstr "割り当てルール"
+
+#: Rules/AssignmentRulesList.vue:11 desk/src/components/Settings/Assignment
+msgid ""
+"Assignment Rules automatically route tickets to the right team members based on predefined "
+"conditions."
+msgstr "割り当てルールは、事前に定義した条件に基づいて適切なチームメンバーへチケットを自動的に振り分けます。"
+
+#: Rules/AssignmentRuleView.vue:276 desk/src/components/Settings/Assignment
+msgid "Assignment Schedule"
+msgstr "割り当てスケジュール"
+
+#: Rules/AssignmentRulesListView.vue:29 desk/src/components/Settings/Assignment
+msgid "Assignment rule"
+msgstr "割り当てルール"
+
+#: Rules/AssignmentRuleView.vue:545 desk/src/components/Settings/Assignment
+msgid "Assignment rule created successfully."
+msgstr "割り当てルールを作成しました。"
+
+#: Rules/AssignmentRuleListItem.vue:130 desk/src/components/Settings/Assignment
+msgid "Assignment rule deleted successfully."
+msgstr "割り当てルールを削除しました。"
+
+#: Rules/AssignmentRuleListItem.vue:173 desk/src/components/Settings/Assignment
+msgid "Assignment rule duplicated successfully."
+msgstr "割り当てルールを複製しました。"
+
+#: Rules/AssignmentRuleView.vue:632 desk/src/components/Settings/Assignment
+msgid "Assignment rule updated successfully."
+msgstr "割り当てルールを更新しました。"
+
+#: Rules/AssignmentRuleListItem.vue:226 desk/src/components/Settings/Assignment
+msgid "Assignment rule {0} updated successfully."
+msgstr "割り当てルール{0}を更新しました。"
+
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:24
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py:28
+msgid "At least one enabled Active status is required."
+msgstr "有効な「対応中」ステータスが少なくとも1つ必要です。"
+
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:73
+msgid "At least one enabled status for <u>{0}</u> category must be enabled."
+msgstr "<u>{0}</u>カテゴリでは、少なくとも1つのステータスを有効にする必要があります。"
+
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.py:38
+msgid "At least one feedback option must be enabled for rating {0}"
+msgstr "評価{0}では、少なくとも1つのフィードバック項目を有効にする必要があります"
+
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:418
+msgid "At least one team is required"
+msgstr "少なくとも1つのチームが必要です"
+
+#. Label of the attachment (Attach) field in DocType 'HD Ticket'
+#. Label of a field in the tickets Web Form
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json helpdesk/helpdesk/web_form/tickets/tickets.json
+msgid "Attachment"
+msgstr "添付"
+
+#. Label of the author (Link) field in DocType 'HD Article'
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+msgid "Author"
+msgstr "作成者"
+
+#. Label of the auto_update_status (Check) field in DocType 'HD Settings'
+#: desk/src/components/Settings/General/components/TicketSettings.vue:80
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Auto update status"
+msgstr "ステータスの自動更新"
+
+#. Label of the auto_close_after_days (Int) field in DocType 'HD Settings'
+#: desk/src/components/Settings/General/components/TicketSettings.vue:176
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Auto-close after (Days)"
+msgstr "自動クローズまでの日数"
+
+#: desk/src/components/Settings/General/components/TicketSettings.vue:148
+msgid "Auto-close tickets that remain in a status for the specified number of days."
+msgstr "指定した日数にわたり同じステータスのチケットを自動的にクローズします。"
+
+#. Description of the 'Condition' (Code) field in DocType 'HD Service Level
+#. Agreement'
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+msgid "Auto-generated from the portal view — do not edit directly unless you know what you're doing! "
+msgstr "ポータルビューから自動生成されています。内容を理解している場合を除き、直接編集しないでください。 "
+
+#. Label of the auto_set_customer_from_contact (Check) field in DocType 'HD
+#. Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Auto-set customer from contact"
+msgstr "連絡先から顧客を自動設定"
+
+#. Label of the auto_close_tickets (Check) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Automatically Close Tickets when"
+msgstr "チケットを自動的に閉じる"
+
+#: desk/src/components/Settings/General/components/TicketSettings.vue:145
+msgid "Automatically close stale tickets"
+msgstr "古いチケットを自動的に閉じる"
+
+#. Description of the 'Auto-set customer from contact' (Check) field in DocType
+#. 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Automatically set the customer on a ticket based on the contact's linked customer(s)"
+msgstr "連絡先に紐づく顧客をチケットへ自動的に設定します"
+
+#. Label of a Card Break in the Helpdesk Workspace
+#: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
+msgid "Automation"
+msgstr "自動化"
+
+#. Label of the availability (Link) field in DocType 'HD Agent'
+#: desk/src/components/Settings/Profile/Profile.vue:117
+#: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
+msgid "Availability"
+msgstr "対応状況"
+
+#. Label of the availability_changed_on (Datetime) field in DocType 'HD Agent'
+#: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
+msgid "Availability Changed On"
+msgstr "対応状況の変更日時"
+
+#: desk/src/pages/home/components/ChartItem.vue:6
+msgid "Average First Response"
+msgstr "平均初回応答"
+
+#: desk/src/pages/home/Home.vue:317
+msgid "Average First Response Time"
+msgstr "平均初回応答時間"
+
+#: desk/src/pages/home/components/ChartItem.vue:16
+msgid "Average Resolution"
+msgstr "平均解決件数"
+
+#: desk/src/pages/home/Home.vue:329
+msgid "Average Resolution Time"
+msgstr "平均解決時間"
+
+#. Label of the avg_response_time (Duration) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Average Response Time"
+msgstr "平均応答時間"
+
+#: desk/src/pages/home/Home.vue:305 desk/src/pages/home/components/AvgTimeMetrics.vue:5
+msgid "Average Time Metrics"
+msgstr "平均時間の指標"
+
+#: helpdesk/api/dashboard.py:380
+msgid "Average feedback rating per day is around {0} stars"
+msgstr "1日あたりの平均フィードバック評価は約{0}星です"
+
+#: desk/src/pages/home/components/AvgTimeMetrics.vue:107
+msgid "Average response and resolution metrics not available"
+msgstr "平均応答時間と平均解決時間の指標は利用できません"
+
+#: helpdesk/api/dashboard.py:298
+msgid "Average tickets per day is around {0}"
+msgstr "1日あたりの平均チケット数は約{0}件です"
+
+#: helpdesk/api/dashboard.py:243
+msgid "Avg. Feedback Rating"
+msgstr "平均フィードバック評価"
+
+#: desk/src/components/customer/TicketStats.vue:13
+msgid "Avg. Feedback Received"
+msgstr "平均フィードバック受信数"
+
+#: helpdesk/api/dashboard.py:204
+msgid "Avg. First Response"
+msgstr "平均初回応答"
+
+#: desk/src/components/customer/TicketStats.vue:49
+msgid "Avg. First Response Time"
+msgstr "平均初回応答時間"
+
+#: helpdesk/api/dashboard.py:221
+msgid "Avg. Resolution"
+msgstr "平均解決件数"
+
+#: desk/src/components/customer/TicketStats.vue:62
+msgid "Avg. Resolution Time"
+msgstr "平均解決時間"
+
+#: helpdesk/api/dashboard.py:248
+msgid "Avg. feedback rating for tickets resolved in this period"
+msgstr "この期間に解決したチケットの平均フィードバック評価"
+
+#: desk/src/pages/home/components/AvgTimeMetrics.vue:121
+#: desk/src/pages/home/components/AvgTimeMetrics.vue:290
+msgid "Avg. first response time"
+msgstr "平均初回応答時間"
+
+#: desk/src/pages/home/components/AvgTimeMetrics.vue:130
+#: desk/src/pages/home/components/AvgTimeMetrics.vue:298
+msgid "Avg. resolution time"
+msgstr "平均解決時間"
+
+#: helpdesk/api/dashboard.py:210
+msgid "Avg. time taken to first respond to a ticket"
+msgstr "チケットへの初回応答にかかった平均時間"
+
+#: helpdesk/api/dashboard.py:227
+msgid "Avg. time taken to resolve a ticket"
+msgstr "チケットの解決にかかった平均時間"
+
+#. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+msgid "Away"
+msgstr "離席中"
+
+#: desk/src/components/Settings/EmailAdd.vue:145 desk/src/components/Settings/EmailEdit.vue:134
+#: desk/src/components/command-palette/CommandPalette.vue:158
+#: desk/src/components/command-palette/CommandPalette.vue:262
+msgid "Back"
+msgstr "戻る"
+
+#: desk/src/pages/InvalidPage.vue:25 desk/src/pages/ticket/TicketAgent.vue:44
+msgid "Back to Tickets"
+msgstr "チケットへ戻る"
+
+#. Label of the base_support_rotation (Link) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Base Support Rotation"
+msgstr "ベースサポートローテーション"
+
+#: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:9
+#: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:9
+msgid "Based On"
+msgstr "基準"
+
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:34
+msgid "Based on your HR Policy, select your leave allocation period's end date"
+msgstr "人事規程に基づき、休暇付与期間の終了日を選択してください"
+
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:27
+msgid "Based on your HR Policy, select your leave allocation period's start date"
+msgstr "人事規程に基づき、休暇付与期間の開始日を選択してください"
+
+#: desk/src/components/EmailEditor.vue:51
+msgid "Bcc"
+msgstr "Bcc"
+
+#: desk/src/components/EmailEditor.vue:85
+msgid "Bcc:"
+msgstr "Bcc:"
+
+#. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+msgid "Black"
+msgstr "ブラック"
+
+#. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
+#. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+msgid "Blue"
+msgstr "青"
+
+#: desk/src/components/Settings/General/components/Branding.vue:10
+msgid "Brand name"
+msgstr "ブランド名"
+
+#. Label of the branding_tab (Tab Break) field in DocType 'HD Settings'
+#: desk/src/components/Settings/General/components/Branding.vue:4
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Branding"
+msgstr "ブランド"
+
+#: desk/src/components/ListViewBuilder.vue:282
+msgid "Bulk Operation Failed"
+msgstr "一括操作に失敗しました"
+
+#: desk/src/components/ListViewBuilder.vue:285
+msgid "Bulk Operation Successful"
+msgstr "一括操作が完了しました"
+
+#: desk/src/components/ticket-agent/BulkReplyModal.vue:105
+msgid "Bulk reply sent successfully to 1 ticket."
+msgstr "1件のチケットに一括返信を送信しました。"
+
+#: desk/src/components/ticket-agent/BulkReplyModal.vue:106
+msgid "Bulk reply sent successfully to {0} tickets."
+msgstr "{0}件のチケットに一括返信を送信しました。"
+
+#: desk/src/components/Settings/Holiday/Holidays.vue:3
+msgid "Business Holidays"
+msgstr "休業日"
+
+#: desk/src/pages/call-logs/CallLogModal.vue:210
+msgid "Busy"
+msgstr "対応中"
+
+#: desk/src/components/ticket/ExportModal.vue:15
+msgid "CSV"
+msgstr "CSV"
+
+#: desk/src/pages/call-logs/CallLogDetailModal.vue:8
+msgid "Call Details"
+msgstr "通話詳細"
+
+#: desk/src/components/layouts/AppSidebar.vue:204
+msgid "Call Logs"
+msgstr "通話履歴"
+
+#: desk/src/pages/call-logs/CallLogModal.vue:81
+msgid "Call Received By"
+msgstr "電話応対者"
+
+#: desk/src/components/ticket-agent/TicketContact.vue:38
+msgid "Call contact"
+msgstr "連絡先に電話"
+
+#: desk/src/pages/call-logs/CallLogModal.vue:69
+msgid "Call duration in seconds"
+msgstr "通話時間（秒）"
+
+#: desk/src/pages/call-logs/CallLogModal.vue:93
+msgid "Caller"
+msgstr "発信者"
+
+#: desk/src/pages/ticket/MobileTicketAgent.vue:520
+msgid "Calls"
+msgstr "通話"
+
+#: desk/src/components/Settings/InviteAgents.vue:164
+msgid "Can invite new agents, manage tickets, create custom views and manage public views."
+msgstr "新しい担当者の招待、チケットの管理、カスタムビューの作成、公開ビューの管理ができます。"
+
+#: desk/src/components/Settings/InviteAgents.vue:172
+msgid "Can manage all aspects of Helpdesk."
+msgstr "Helpdeskのすべての機能を管理できます。"
+
+#: desk/src/components/customer/InviteContactDialog.vue:135
+msgid "Can raise tickets on behalf of the org and manage the tickets they raised."
+msgstr "組織を代表してチケットを起票し、自分が起票したチケットを管理できます。"
+
+#: desk/src/components/customer/InviteContactDialog.vue:138
+msgid "Can view all tickets raised by the org and assign other members as managers."
+msgstr "組織が起票したすべてのチケットを閲覧し、他のメンバーをマネージャーに指定できます。"
+
+#: desk/src/components/customer/ContactCard.vue:22
+msgid "Can view tickets raised by all contacts of the customer."
+msgstr "顧客のすべての連絡先が起票したチケットを閲覧できます。"
+
+#: desk/src/components/Settings/InviteAgents.vue:156
+msgid "Can work on tickets, create custom views and manage private views."
+msgstr "チケット対応、カスタムビューの作成、非公開ビューの管理ができます。"
+
+#: desk/src/components/ListViewBuilder.vue:740 desk/src/components/ticket-agent/BulkAssignModal.vue:8
+#: desk/src/components/ticket-agent/BulkEditModal.vue:23 desk/src/pages/home/Home.vue:44
+msgid "Cancel"
+msgstr "キャンセル"
+
+#: desk/src/components/Settings/InviteAgents.vue:63
+msgid "Cancel Invitation"
+msgstr "招待をキャンセル"
+
+#: desk/src/pages/call-logs/CallLogModal.vue:214
+msgid "Canceled"
+msgstr "キャンセル"
+
+#: helpdesk/integrations/erpnext/api.py:47
+msgid "Cannot Sync Customers"
+msgstr "顧客を同期できません"
+
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:110
+msgid "Cannot disable this status as it is linked in HD Settings:<br><br>"
+msgstr "HD設定で使用されているため、このステータスを無効にできません：<br><br>"
+
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:88
+msgid "Cannot disable this status as it is linked in the following SLAs:<br><br>"
+msgstr "次のSLAで使用されているため、このステータスを無効にできません：<br><br>"
+
+#: Rules/AssignmentRuleListItem.vue:198 desk/src/components/Settings/Assignment
+msgid "Cannot enable rule without adding users in it"
+msgstr "ユーザーを追加せずにルールを有効にすることはできません"
+
+#: helpdesk/api/knowledge_base.py:128
+msgid "Cannot merge General category"
+msgstr "「一般」カテゴリは統合できません"
+
+#: helpdesk/integrations/erpnext/utils.py:103
+msgid ""
+"Cannot rename: an unrelated {0} '{1}' already exists on the other side. Resolve the conflict "
+"manually first."
+msgstr "名前を変更できません：同期先に無関係な{0}「{1}」が既に存在します。先に競合を手動で解決してください。"
+
+#: desk/src/pages/knowledge-base/KnowledgeBaseCustomer.vue:24
+msgid "Categories"
+msgstr "カテゴリー"
+
+#. Label of the category (Select) field in DocType 'HD Agent Status'
+#. Label of the category (Link) field in DocType 'HD Article'
+#. Label of the category (Select) field in DocType 'HD Ticket Status'
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:105
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+msgid "Category"
+msgstr "カテゴリー"
+
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:175
+msgid "Category '{0}' link copied to clipboard"
+msgstr "カテゴリー\"{0}\"のリンクをクリップボードにコピーする"
+
+#: desk/src/pages/knowledge-base/Article.vue:330
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:266
+msgid "Category created successfully."
+msgstr "カテゴリを作成しました。"
+
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:337
+msgid "Category deleted successfully."
+msgstr "カテゴリを削除しました。"
+
+#: desk/src/components/ticket/TicketMergeModal.vue:188
+msgid "Category is required"
+msgstr "カテゴリは必須です"
+
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:374
+msgid "Category merged successfully."
+msgstr "カテゴリを統合しました。"
+
+#: helpdesk/api/knowledge_base.py:78 helpdesk/helpdesk/doctype/hd_article/hd_article.py:65
+msgid "Category must have atleast one article"
+msgstr "カテゴリには少なくとも1件の記事が必要です"
+
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:305
+msgid "Category updated successfully."
+msgstr "カテゴリを更新しました。"
+
+#: desk/src/components/EmailEditor.vue:41
+msgid "Cc"
+msgstr "Cc"
+
+#: desk/src/components/EmailEditor.vue:67
+msgid "Cc:"
+msgstr "Cc:"
+
+#: desk/src/components/Settings/General/components/LogoUpload.vue:40
+msgid "Change"
+msgstr "変更"
+
+#: desk/src/components/Settings/Profile/Profile.vue:158
+#: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:2
+msgid "Change Password"
+msgstr "パスワードを変更する"
+
+#: desk/src/components/Settings/Profile/Profile.vue:202
+msgid "Change Photo"
+msgstr "写真を変更する"
+
+#: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:9
+msgid "Change language of the application."
+msgstr "アプリケーションの表示言語を変更します。"
+
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:182
+msgid "Change operator ({0})"
+msgstr "変更オペレーター ({0})"
+
+#: desk/src/components/modals/ShortcutsModal.vue:88
+msgid "Change priority"
+msgstr "優先度を変更"
+
+#: desk/src/components/modals/ShortcutsModal.vue:91
+msgid "Change status"
+msgstr "ステータスを変更"
+
+#: desk/src/components/modals/ShortcutsModal.vue:89
+msgid "Change team"
+msgstr "チームを変更"
+
+#: desk/src/components/modals/ShortcutsModal.vue:87
+msgid "Change ticket type"
+msgstr "チケットタイプを変更"
+
+#: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:25
+msgid "Change timezone of the application."
+msgstr "アプリケーションのタイムゾーンを変更します。"
+
+#: desk/src/components/Settings/Profile/Profile.vue:153
+msgid "Change your account password for security."
+msgstr "セキュリティのため、アカウントのパスワードを変更します。"
+
+#. Label of a Card Break in the Helpdesk Workspace
+#: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
+msgid "Channels"
+msgstr "チャンネル"
+
+#: desk/src/components/Settings/FieldDependency/FieldDependencyFieldsSelection.vue:18
+msgid "Child field"
+msgstr "子フィールド"
+
+#: desk/src/components/view-controls/filter/Filter.vue:202
+msgid "Choose a field"
+msgstr "フィールドを選択する"
+
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:156
+msgid "Choose how long this SLA policy will be active."
+msgstr "このSLAポリシーを適用する期間を選択します。"
+
+#: Rules/AssigneeRules.vue:22 desk/src/components/Settings/Assignment
+msgid "Choose how tickets are distributed among selected assignees."
+msgstr "選択した担当者へのチケットの振り分け方法を指定します。"
+
+#: Rules/AssignmentRuleView.vue:280 desk/src/components/Settings/Assignment
+msgid "Choose the days of the week when this rule should be active."
+msgstr "このルールを適用する曜日を選択します。"
+
+#: desk/src/components/Settings/Holiday/HolidayView.vue:66
+msgid "Choose the duration of this holiday list."
+msgstr "この休日リストの適用期間を選択します。"
+
+#: desk/src/components/Settings/EmailAdd.vue:5
+msgid "Choose the email service provider you want to configure."
+msgstr "設定するメールサービスプロバイダーを選択します。"
+
+#: Rules/AssignmentRuleView.vue:127 desk/src/components/Settings/Assignment
+msgid "Choose which tickets are affected by this assignment rule."
+msgstr "この割り当てルールを適用するチケットを指定します。"
+
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:90
+msgid "Choose which tickets are affected by this policy."
+msgstr "このポリシーを適用するチケットを指定します。"
+
+#: Rules/AssignmentRuleView.vue:204 desk/src/components/Settings/Assignment
+msgid "Choose which tickets are affected by this un-assignment rule."
+msgstr "この割り当て解除ルールを適用するチケットを指定します。"
+
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:69
+msgid "Choose who can view and use this response."
+msgstr "この定型返信を閲覧・使用できるユーザーを指定します。"
+
+#: Rules/AssigneeRules.vue:78 desk/src/components/Settings/Assignment
+msgid "Choose who receives the tickets."
+msgstr "チケットの割り当て先を選択します。"
+
+#: desk/src/components/command-palette/CommandPalette.vue:261
+msgid "Clear"
+msgstr "クリア"
+
+#: desk/src/components/view-controls/SortBy.vue:160
+msgid "Clear Sort"
+msgstr "並べ替えをクリア"
+
+#. Label of the clear_table (Button) field in DocType 'HD Service Holiday List'
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
+msgid "Clear Table"
+msgstr "テーブルをクリア"
+
+#: desk/src/components/view-controls/filter/Filter.vue:101
+msgid "Clear all"
+msgstr "すべてクリア"
+
+#: desk/src/components/view-controls/filter/FilterTrigger.vue:17
+msgid "Clear all Filter"
+msgstr "すべてのフィルタをクリアする"
+
+#: desk/src/pages/SearchAgent.vue:86
+msgid "Clear all filters"
+msgstr "すべてのフィルターをクリアする"
+
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:46
+msgid ""
+"Click on Add to Holidays. This will populate the holidays table with all the dates that fall on "
+"the selected weekly off. Repeat the process for populating the dates for all your weekly holidays"
+msgstr "「休日に追加」をクリックすると、選択した週休日に該当する日付が休日テーブルに追加されます。すべての週休日についてこの操作を繰り返してください。"
+
+#: desk/src/components/EmailMultiSelect.vue:11
+msgid "Click to copy"
+msgstr "クリックしてコピーする"
+
+#: Rules/AssignmentRuleListItem.vue:69 desk/src/components/Settings/Assignment
+#: desk/src/components/Settings/Holiday/HolidayListItem.vue:47
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:174
+#: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:56
+#: desk/src/components/command-palette/CommandPalette.vue:263
+#: desk/src/pages/ticket/MobileTicketAgent.vue:209 desk/src/pages/ticket/TicketCustomer.vue:14
+msgid "Close"
+msgstr "閉じる"
+
+#: desk/src/pages/ticket/TicketCustomer.vue:313
+msgid "Close Ticket"
+msgstr "チケットを閉じる"
+
+#. Option in a Select field in the tickets Web Form
+#: helpdesk/helpdesk/web_form/tickets/tickets.json
+msgid "Closed"
+msgstr "クローズ"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:433
+msgid "Closed or rated tickets cannot be updated by non-agents"
+msgstr "クローズ済みまたは評価済みのチケットは、担当者以外は更新できません。"
+
+#. Label of the color (Select) field in DocType 'HD Agent Status'
+#. Label of the color (Color) field in DocType 'HD Service Holiday List'
+#. Label of the color (Select) field in DocType 'HD Ticket Status'
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+msgid "Color"
+msgstr "カラー"
+
+#. Label of the columns (Code) field in DocType 'HD View'
+#: desk/src/components/view-controls/ColumnSettings.vue:4
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "Columns"
+msgstr "列"
+
+#: desk/src/components/Settings/InviteAgents.vue:15
+msgid "Comma separated emails to invite."
+msgstr "招待するメールアドレスをカンマ区切りで入力します。"
+
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:113
+msgid "Comma separated values"
+msgstr "カンマ区切りの値"
+
+#: desk/src/components/command-palette/CommandPalette.vue:14
+msgid "Command Palette"
+msgstr "コマンドパレット"
+
+#. Label of the reference_comment (Link) field in DocType 'HD Notification'
+#: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
+msgid "Comment"
+msgstr "コメント"
+
+#: desk/src/components/CommentBox.vue:326
+msgid "Comment cannot be empty."
+msgstr "コメントを空にすることはできません。"
+
+#: desk/src/components/CommentBox.vue:316
+msgid "Comment deleted successfully."
+msgstr "コメントを削除しました。"
+
+#: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.py:67
+#: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.py:112
+msgid "Comment not found"
+msgstr "コメントが見つかりませんでした"
+
+#: desk/src/components/CommentBox.vue:342
+msgid "Comment updated successfully."
+msgstr "コメントを更新しました。"
+
+#: desk/src/pages/home/components/RecentActivity.vue:103
+msgid "Commented"
+msgstr "コメント済み"
+
+#. Label of the commented_by (Link) field in DocType 'HD Ticket Comment'
+#: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
+msgid "Commented By"
+msgstr "コメント投稿者"
+
+#. Label of the comments_section (Section Break) field in DocType 'HD Settings'
+#: desk/src/pages/SearchAgent.vue:353 desk/src/pages/ticket/MobileTicketAgent.vue:512
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Comments"
+msgstr "コメント"
+
+#: desk/src/components/modals/ShortcutsModal.vue:98
+msgid "Communication"
+msgstr "コミュニケーション"
+
+#: desk/src/components/ticket/TicketSplitModal.vue:76
+msgid "Communication ID is required"
+msgstr "コミュニケーションIDは必須です"
+
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Company"
+msgstr "会社"
+
+#: desk/src/pages/call-logs/CallLogModal.vue:209
+msgid "Completed"
+msgstr "完成した"
+
+#. Label of the condition (Code) field in DocType 'HD Service Level Agreement'
+#. Label of the condition_json (Code) field in DocType 'HD Service Level
+#. Agreement'
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+msgid "Condition"
+msgstr "条件"
+
+#: desk/src/components/Settings/Profile/Profile.vue:143
+msgid "Configure"
+msgstr "設定"
+
+#: desk/src/components/Settings/Telephony/ExotelSettings.vue:3
+msgid "Configure your Exotel settings for Helpdesk."
+msgstr "Helpdeskで使用するExotelを設定します。"
+
+#: desk/src/components/Settings/Telephony/Telephony.vue:100
+msgid "Configure your Exotel telephony integration settings here"
+msgstr "エクソテルの電話統合設定をここから設定します"
+
+#: desk/src/components/Settings/Telephony/TwilioSettings.vue:3
+msgid "Configure your Twilio settings for Helpdesk."
+msgstr "Helpdesk用のTwilio設定を行います。"
+
+#: desk/src/components/Settings/Telephony/Telephony.vue:76
+msgid "Configure your Twilio telephony integration settings here"
+msgstr "Twilioの電話統合設定をここから設定します"
+
+#: desk/src/components/Settings/Telephony/Telephony.vue:2
+msgid "Configure your telephony settings."
+msgstr "電話設定を設定する"
+
+#: desk/src/components/customer/ContactCard.vue:233 desk/src/components/customer/ContactCard.vue:271
+#: desk/src/components/customer/ContactCard.vue:300
+#: desk/src/components/customer/RevokeInviteButton.vue:11
+#: desk/src/components/layouts/CustomerPortalPermissionDialog.vue:45
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:327
+#: desk/src/pages/knowledge-base/NewArticle.vue:148 desk/src/pages/ticket/MobileTicketAgent.vue:206
+#: desk/src/pages/ticket/TicketCustomer.vue:317
+#: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.js:27
+msgid "Confirm"
+msgstr "確認する"
+
+#: desk/src/components/ListViewBuilder.vue:724
+msgid "Confirm Changes"
+msgstr "変更を確認"
+
+#: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:19
+msgid "Confirm Password"
+msgstr "パスワードを確認する"
+
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:414
+msgid "Confirm overwrite"
+msgstr "上書きを確認"
+
+#: desk/src/pages/PersonaForm.vue:235
+msgid "Connect my support email"
+msgstr "サポートメールを接続する"
+
+#: desk/src/components/layouts/Sidebar.vue:229
+msgid "Connect your support email"
+msgstr "サポートメールを接続する"
+
+#. Label of the contact (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:26
+#: desk/src/components/contact/NewContactDialog.vue:42 desk/src/components/layouts/Sidebar.vue:404
+#: desk/src/pages/customer/Customer.vue:169 helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:56
+#: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:44
+#: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:43
+#: helpdesk/helpdesk/report/ticket_summary/ticket_summary.py:72
+msgid "Contact"
+msgstr "連絡先"
+
+#. Label of the contact_html (HTML) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Contact HTML"
+msgstr "連絡先HTML"
+
+#: desk/src/components/customer/ContactCard.vue:313
+msgid "Contact removed successfully"
+msgstr "連絡先を削除しました"
+
+#: desk/src/components/ticket/SetContactPhoneModal.vue:84
+msgid "Contact updated successfully."
+msgstr "連絡先を更新しました。"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:277
+msgid "Contact {0} has no email address"
+msgstr "{0}の連絡先にはメールアドレスがありません"
+
+#. Label of the contacts (Table) field in DocType 'HD Customer'
+#: desk/src/components/customer/CustomerContactTab.vue:4 desk/src/pages/contact/Contact.vue:328
+#: desk/src/pages/contact/Contacts.vue:6 desk/src/pages/customer/Customer.vue:77
+#: desk/src/pages/customer/Customer.vue:153 helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Contacts"
+msgstr "連絡先"
+
+#: desk/src/components/customer/InviteContactDialog.vue:172
+msgid "Contacts added successfully"
+msgstr "連絡先を追加しました"
+
+#. Label of the content_section (Section Break) field in DocType 'HD Article'
+#. Label of the content (Text Editor) field in DocType 'HD Article'
+#. Label of the content (Text Editor) field in DocType 'HD Ticket Comment'
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
+msgid "Content"
+msgstr "内容"
+
+#. Label of the content_type (Data) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Content Type"
+msgstr "コンテンツタイプ"
+
+#: desk/src/components/modals/ShortcutsModal.vue:94
+msgid "Copy ticket URL"
+msgstr "チケットのURLをコピーする"
+
+#: desk/src/components/modals/ShortcutsModal.vue:93
+msgid "Copy ticket id"
+msgstr "チケットIDをコピーする"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:787
+msgid "Could not an email due to: {0}"
+msgstr "次の理由によりメールを送信できませんでした：{0}"
+
+#: helpdesk/patches/set_hd_ticket_naming_series.py:37
+msgid "Could not find the `name` column in tabHD Ticket"
+msgstr "`name`列をtabHDチケットで見つかりませんでした"
+
+#: helpdesk/patches/move_contact_dynamic_link_to_hd_customer.py:74
+msgid "Could not migrate contacts for {0} customer(s): {1}. Fix the underlying data and re-run the patch."
+msgstr "{0}件の顧客の連絡先を移行できませんでした：{1}。元データを修正してからパッチを再実行してください。"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:952
+msgid "Could not send an acknowledgement email due to: {0}"
+msgstr "{0}により確認メールを送ることができませんでした"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:172
+msgid "Could not send feedback email,due to: {0}"
+msgstr "次の理由によりフィードバックメールを送信できませんでした：{0}"
+
+#. Label of the country (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:35
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Country"
+msgstr "国"
+
+#: desk/src/components/Settings/EmailAdd.vue:152 desk/src/components/Settings/NewTeamModal.vue:7
+#: desk/src/components/contact/NewContactDialog.vue:102
+#: desk/src/components/customer/NewCustomerDialog.vue:99 desk/src/components/layouts/Sidebar.vue:334
+#: desk/src/components/tag/Tags.vue:182 desk/src/components/tag/Tags.vue:197
+#: desk/src/pages/call-logs/CallLogModal.vue:225 desk/src/pages/contact/Contacts.vue:11
+#: desk/src/pages/customer/Customers.vue:11 desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:12
+#: desk/src/pages/knowledge-base/NewArticle.vue:29 desk/src/pages/ticket/Tickets.vue:20
+msgid "Create"
+msgstr "作成する"
+
+#: desk/src/components/layouts/Sidebar.vue:327 desk/src/components/layouts/Sidebar.vue:333
+msgid "Create & invite a contact"
+msgstr "連絡先を作成して招待"
+
+#: desk/src/components/contact/NewContactDialog.vue:5
+msgid "Create Contact"
+msgstr "連絡先を作成"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:4
+msgid "Create Customer"
+msgstr "顧客を作成"
+
+#: desk/src/pages/ticket/Tickets.vue:412 desk/src/pages/ticket/Tickets.vue:416
+msgid "Create View"
+msgstr "ビューを作成する"
+
+#: desk/src/components/layouts/Sidebar.vue:262
+msgid "Create a ticket"
+msgstr "チケットを作成する"
+
+#: desk/src/components/layouts/Sidebar.vue:310
+msgid "Create an article"
+msgstr "記事を作成する"
+
+#: desk/src/components/Settings/Teams/TeamsList.vue:5
+msgid "Create and manage teams and assign agents to specific teams."
+msgstr "チームを作成・管理し、担当者を特定のチームに割り当てます。"
+
+#: desk/src/components/Settings/FieldDependency/FieldDependencyList.vue:13
+msgid ""
+"Create field dependencies to dynamically update options based on user selections. Learn more "
+"about field dependencies"
+msgstr "ユーザーの選択に応じて選択肢を動的に更新するフィールド依存関係を作成します。フィールド依存関係の詳細"
+
+#: desk/src/pages/PersonaForm.vue:237
+msgid "Create my first ticket"
+msgstr "私の最初のチケットを作ります"
+
+#: desk/src/components/Settings/Sla/SlaHolidays.vue:57
+msgid "Create new business holiday"
+msgstr "新しいビジネス休暇を作成する"
+
+#: desk/src/components/Settings/FieldDependency/FieldDependencyList.vue:69
+msgid "Created by"
+msgstr "作成者"
+
+#: desk/src/components/layouts/Sidebar.vue:373
+msgid "Creating a ticket"
+msgstr "チケットを作成する"
+
+#: desk/src/components/ViewModal.vue:22
+msgid "Current icon"
+msgstr "現在のアイコン"
+
+#: desk/src/components/layouts/Sidebar.vue:417
+msgid "Custom Actions"
+msgstr "カスタムアクション"
+
+#. Label of the outside_working_hours_message (Small Text) field in DocType 'HD
+#. Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Custom Outside Working Hours Message"
+msgstr "営業時間外のカスタムメッセージ"
+
+#: desk/src/pages/dashboard/Dashboard.vue:574 desk/src/pages/dashboard/Dashboard.vue:580
+#: desk/src/pages/home/components/AvgTimeMetrics.vue:179
+#: desk/src/pages/home/components/AvgTimeMetrics.vue:200
+#: desk/src/pages/home/components/RecentFeedback.vue:376
+#: desk/src/pages/home/components/RecentFeedback.vue:402
+msgid "Custom Range"
+msgstr "カスタム範囲"
+
+#: desk/src/components/layouts/Sidebar.vue:419
+msgid "Custom Views"
+msgstr "カスタムビュー"
+
+#. Label of the customer (Link) field in DocType 'HD Ticket'
+#: desk/src/components/contact/EditContactDialog.vue:120
+#: desk/src/components/customer/ContactCard.vue:169
+#: desk/src/components/customer/EditCustomerDialog.vue:30
+#: desk/src/components/customer/InviteContactDialog.vue:130
+#: desk/src/components/customer/NewCustomerDialog.vue:14 desk/src/components/layouts/Sidebar.vue:405
+#: desk/src/pages/contact/Contact.vue:81 helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Customer"
+msgstr "顧客"
+
+#: desk/src/components/customer/ContactCard.vue:177
+#: desk/src/components/customer/InviteContactDialog.vue:131
+#: desk/src/components/layouts/CustomerPortalPermissionDialog.vue:18
+msgid "Customer Manager"
+msgstr "顧客管理者"
+
+#. Label of the customer_name (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Name"
+msgstr "顧客名"
+
+#: desk/src/components/layouts/Sidebar.vue:393
+msgid "Customer Portal"
+msgstr "顧客ポータル"
+
+#. Label of the customer_type (Select) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:30
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Customer Type"
+msgstr "顧客タイプ"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:141
+msgid "Customer created"
+msgstr "顧客を作成しました"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:140
+msgid "Customer created · invitation sent to {0}"
+msgstr "顧客を作成しました · {0}に招待を送信しました"
+
+#: desk/src/components/customer/EditCustomerDialog.vue:119
+msgid "Customer name cannot be empty"
+msgstr "顧客名を空にすることはできません"
+
+#: desk/src/components/layouts/MobileSidebar.vue:109 desk/src/components/layouts/Sidebar.vue:150
+msgid "Customer portal"
+msgstr "顧客ポータル"
+
+#: desk/src/components/layouts/CustomerPortalPermissionDialog.vue:4
+msgid "Customer portal permissions have changed"
+msgstr "顧客ポータルの権限が変更されました"
+
+#: desk/src/components/layouts/CustomerPortalPermissionBanner.vue:10
+msgid "Customer portal update"
+msgstr "顧客ポータル更新"
+
+#: desk/src/components/customer/EditCustomerDialog.vue:136
+#: desk/src/components/customer/EditCustomerDialog.vue:150
+msgid "Customer updated"
+msgstr "顧客更新"
+
+#: desk/src/pages/customer/Customer.vue:200 desk/src/pages/customer/Customers.vue:6
+msgid "Customers"
+msgstr "顧客"
+
+#: desk/src/components/layouts/Sidebar.vue:385
+msgid "Customers & Contacts"
+msgstr "顧客と連絡先"
+
+#: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:82
+msgid "Customers are in sync"
+msgstr "顧客が同期している"
+
+#: desk/src/components/layouts/Sidebar.vue:414
+msgid "Customizations"
+msgstr "パーソナライゼーション"
+
+#: desk/src/components/Settings/EmailNotifications/NotificationList.vue:5
+msgid ""
+"Customize your email notification preferences to stay informed about important updates and "
+"activities."
+msgstr "重要な更新やアクティビティを受け取れるよう、メール通知を設定します。"
+
+#. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
+#. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+msgid "Cyan"
+msgstr "シアン"
+
+#: helpdesk/api/dashboard_tags.py:73
+msgid "Daily volume of the top {0} tags"
+msgstr "上位{0}タグの日別件数"
+
+#: desk/src/components/layouts/Sidebar.vue:135 desk/src/components/layouts/Sidebar.vue:184
+#: desk/src/pages/contact/Contact.vue:310 desk/src/pages/customer/Customer.vue:213
+#: desk/src/pages/knowledge-base/Article.vue:653
+msgid "Danger"
+msgstr "危険"
+
+#: desk/src/pages/dashboard/Dashboard.vue:634
+msgid "Dashboard"
+msgstr "ダッシュボード"
+
+#: desk/src/pages/home/Home.vue:264 desk/src/pages/home/Home.vue:286
+msgid "Dashboard saved"
+msgstr "保存されたダッシュボード"
+
+#. Label of the holiday_date (Date) field in DocType 'HD Holiday'
+#: helpdesk/api/dashboard_tags.py:74 helpdesk/helpdesk/doctype/hd_holiday/hd_holiday.json
+#: helpdesk/helpdesk/report/support_hour_distribution/support_hour_distribution.py:77
+msgid "Date"
+msgstr "日付"
+
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:29
+msgid "Day count for auto closing tickets cannot be negative or zero"
+msgstr "チケットを自動クローズする日数には1以上を指定してください"
+
+#: Rules/AssignmentSchedule.vue:38 desk/src/components/Settings/Assignment
+msgid "Days"
+msgstr "日"
+
+#: desk/src/components/Settings/EmailAccountCard.vue:53
+msgid "Default Inbox"
+msgstr "デフォルト受信トレイ"
+
+#. Label of the default_priority (Link) field in DocType 'HD Service Level
+#. Agreement'
+#. Label of the default_priority (Check) field in DocType 'HD Service Level
+#. Priority'
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+#: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
+msgid "Default Priority"
+msgstr "デフォルト優先度"
+
+#. Label of the default_sla (Check) field in DocType 'HD Service Level
+#. Agreement'
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+msgid "Default SLA"
+msgstr "デフォルト SLA"
+
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:32
+msgid "Default SLA turned off"
+msgstr "デフォルト SLA がオフ"
+
+#: desk/src/components/Settings/EmailAccountCard.vue:56
+msgid "Default Sending"
+msgstr "デフォルト送信"
+
+#: desk/src/components/Settings/EmailAccountCard.vue:50
+msgid "Default Sending and Inbox"
+msgstr "デフォルト送信・受信トレイ"
+
+#. Label of the default_ticket_status (Link) field in DocType 'HD Service Level
+#. Agreement'
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+msgid "Default Ticket Status"
+msgstr "デフォルトのチケットステータス"
+
+#: desk/src/pages/ticket/Tickets.vue:369
+msgid "Default Views"
+msgstr "デフォルトビュー"
+
+#: desk/src/components/ticket-agent/TicketHeader.vue:259
+#: desk/src/components/ticket-agent/TicketHeader.vue:270
+msgid "Default actions"
+msgstr "デフォルトアクション"
+
+#: desk/src/components/Settings/Telephony/Telephony.vue:45
+msgid "Default calling medium for logged in user"
+msgstr "ログインユーザーのデフォルト通話手段"
+
+#: desk/src/components/Settings/Telephony/Telephony.vue:42
+msgid "Default medium"
+msgstr "デフォルトメディア"
+
+#. Label of the default_priority (Link) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Default priority"
+msgstr "デフォルト優先度"
+
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.py:63
+msgid "Default template can not be deleted"
+msgstr "デフォルトテンプレートは削除できません"
+
+#. Label of the default_ticket_status (Link) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Default ticket status"
+msgstr "デフォルトのチケットステータス"
+
+#. Label of the default_ticket_type (Link) field in DocType 'HD Settings'
+#: desk/src/components/Settings/General/components/TicketSettings.vue:129
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Default ticket type"
+msgstr "デフォルトチケットタイプ"
+
+#: Rules/AssigneeRules.vue:9 desk/src/components/Settings/Assignment
+msgid "Define who receives the tickets and how they’re distributed among agents."
+msgstr "チケットの受信者と、担当者への振り分け方法を指定します。"
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:20
+#: desk/src/components/DeleteWithTicketsDialog.vue:63 desk/src/components/ListViewBuilder.vue:245
+#: desk/src/components/ListViewBuilder.vue:249 desk/src/components/ListViewBuilder.vue:255
+#: desk/src/components/ticket-agent/TicketHeader.vue:205
+#: desk/src/components/ticket-agent/TicketHeader.vue:274
+#: desk/src/components/ticket-agent/TicketHeader.vue:276 desk/src/pages/contact/Contact.vue:314
+#: desk/src/pages/customer/Customer.vue:217 desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:180
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:199
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:208
+msgid "Delete"
+msgstr "削除する"
+
+#: desk/src/pages/customer/Customer.vue:94
+msgid "Delete Contact"
+msgstr "連絡先を削除"
+
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:204
+msgid "Delete articles"
+msgstr "記事を削除"
+
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:321
+msgid "Delete category?"
+msgstr "カテゴリを削除しますか？"
+
+#: desk/src/components/DeleteWithTicketsDialog.vue:10
+msgid "Delete {0} ticket(s)"
+msgstr "{0}チケットを削除する"
+
+#. Label of the description (Text) field in DocType 'HD Article Category'
+#. Label of the description (Text Editor) field in DocType 'HD Holiday'
+#. Label of the description (Data) field in DocType 'HD Service Holiday List'
+#. Label of the description (Data) field in DocType 'HD Service Level
+#. Agreement'
+#. Label of the description (Text Editor) field in DocType 'HD Ticket'
+#. Label of the description (Small Text) field in DocType 'HD Ticket Priority'
+#. Label of the description (Small Text) field in DocType 'HD Ticket Type'
+#. Label of a field in the tickets Web Form
+#: Rules/AssignmentRuleView.vue:105 Rules/AssignmentRuleView.vue:106
+#: desk/src/components/Settings/Assignment desk/src/components/Settings/Holiday/HolidayView.vue:53
+#: desk/src/components/Settings/Holiday/HolidayView.vue:54
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:77
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:78
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_holiday/hd_holiday.json
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
+#: helpdesk/helpdesk/web_form/tickets/tickets.json
+msgid "Description"
+msgstr "説明"
+
+#. Label of the description_template (Text Editor) field in DocType 'HD Ticket
+#. Template'
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+msgid "Description Template"
+msgstr "説明テンプレート"
+
+#. Label of the description_weight (Int) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Description Weight"
+msgstr "説明の重み"
+
+#: desk/src/pages/ticket/TicketNew.vue:90 desk/src/pages/ticket/TicketNew.vue:115
+msgid "Detailed explanation"
+msgstr "詳細な説明"
+
+#. Label of the details_section (Section Break) field in DocType 'HD
+#. Notification'
+#. Label of the sb_details (Section Break) field in DocType 'HD Ticket'
+#: desk/src/pages/ticket/MobileTicketAgent.vue:131 desk/src/pages/ticket/MobileTicketAgent.vue:496
+#: desk/src/pages/ticket/TicketCustomer.vue:183
+#: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Details"
+msgstr "詳細"
+
+#: desk/src/components/Settings/General/components/TicketSettings.vue:67
+msgid "Disable global saved replies"
+msgstr "グローバル定型返信を無効にする"
+
+#. Label of the disable_saved_replies_global_scope (Check) field in DocType 'HD
+#. Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Disable saved replies with scope 'Global'"
+msgstr "適用範囲が「グローバル」の定型返信を無効にする"
+
+#: desk/src/components/Settings/General/General.vue:47
+msgid "Disable signup"
+msgstr "登録を無効にする"
+
+#. Label of the disabled (Check) field in DocType 'HD Team'
+#. Label of the disabled (Check) field in DocType 'HD Ticket Feedback Option'
+#. Label of the disabled (Check) field in DocType 'HD Ticket Priority'
+#. Label of the disabled (Check) field in DocType 'HD Ticket Type'
+#: desk/src/components/Settings/Teams/TeamsList.vue:65 helpdesk/helpdesk/doctype/hd_team/hd_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
+msgid "Disabled"
+msgstr "無効"
+
+#: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:29
+msgid "Disables all email notifications for the ticket - including creation, updates, and alerts."
+msgstr "チケットの作成、更新、アラートを含むすべてのメール通知を無効にします。"
+
+#: desk/src/components/TextEditor.vue:43 desk/src/components/ticket-agent/BulkReplyModal.vue:24
+#: desk/src/pages/knowledge-base/NewArticle.vue:27
+msgid "Discard"
+msgstr "破棄"
+
+#: desk/src/pages/knowledge-base/NewArticle.vue:144
+msgid "Discard Article"
+msgstr "記事を破棄"
+
+#: desk/src/pages/knowledge-base/Article.vue:146
+msgid "Discard changes?"
+msgstr "変更を破棄しますか？"
+
+#: desk/src/components/Settings/General/components/TicketSettings.vue:203
+msgid "Display a customizable banner message when customers raise tickets outside your working hours."
+msgstr "営業時間外に顧客がチケットを起票した際、カスタマイズ可能なバナーメッセージを表示します。"
+
+#. Description of the 'Ignore Restrictions' (Check) field in DocType 'HD Team'
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+msgid "Do not apply filters and restrictions to agents of this team"
+msgstr "このチームの担当者にはフィルターや制限を適用しない"
+
+#. Label of the do_not_restrict_tickets_without_an_agent_group (Check) field in
+#. DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Do not restrict tickets without a Team"
+msgstr "チームなしでチケットを制限しないでください"
+
+#: desk/src/components/Settings/General/components/TicketSettings.vue:52
+msgid "Do not restrict tickets without a team"
+msgstr "チームなしでチケットを制限しないでください"
+
+#. Label of the dt (Link) field in DocType 'HD Form Script'
+#. Label of the dt (Link) field in DocType 'HD View'
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "DocType"
+msgstr "DocType"
+
+#: desk/src/components/layouts/MobileSidebar.vue:123 desk/src/components/layouts/Sidebar.vue:164
+msgid "Docs"
+msgstr "ドキュメント"
+
+#. Label of the document_type (Link) field in DocType 'HD Field Layout'
+#: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
+msgid "Document Type"
+msgstr "ドキュメントタイプ"
+
+#: desk/src/components/contact/EditContactDialog.vue:43
+msgid "Doe"
+msgstr "Doe"
+
+#. Label of the domain (Data) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:48
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Domain"
+msgstr "ドメイン"
+
+#: desk/src/components/ticket/ExportModal.vue:32
+msgid "Download"
+msgstr "ダウンロード"
+
+#. Option for the 'Status' (Select) field in DocType 'HD Article'
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:447
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+msgid "Draft"
+msgstr "下書き"
+
+#: Rules/AssignmentRuleListItem.vue:72 Rules/AssignmentRuleListItem.vue:138
+#: desk/src/components/Settings/Assignment desk/src/components/Settings/Holiday/HolidayListItem.vue:50
+#: desk/src/components/Settings/Holiday/HolidayListItem.vue:90
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:177
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:241
+#: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:59
+#: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:100
+msgid "Duplicate"
+msgstr "複製"
+
+#: Rules/AssignmentRuleListItem.vue:53 desk/src/components/Settings/Assignment
+msgid "Duplicate Assignment Rule"
+msgstr "割り当てルールを複製"
+
+#: desk/src/components/Settings/Holiday/HolidayListItem.vue:30
+msgid "Duplicate Holiday List"
+msgstr "休日リストを複製"
+
+#: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:40
+msgid "Duplicate SLA Policy"
+msgstr "複製 SLA ポリシー"
+
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:158
+msgid "Duplicate Saved reply"
+msgstr "定型返信を複製"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:80
+msgid "Duplicate contacts are not allowed"
+msgstr "連絡先の重複は許可されていません"
+
+#: desk/src/pages/call-logs/CallLogModal.vue:64 desk/src/pages/call-logs/CallLogModal.vue:68
+msgid "Duration"
+msgstr "期間"
+
+#: desk/src/pages/call-logs/CallLogModal.vue:388
+msgid "Duration is required"
+msgstr "持続時間は必須"
+
+#: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:8
+msgid "ERPNext"
+msgstr "ERPNext"
+
+#. Label of the erpnext_customer (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "ERPNext Customer"
+msgstr "ERPNext顧客"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
+msgid "ERPNext HD Settings"
+msgstr "ERPNext HD設定"
+
+#: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:184
+msgid "ERPNext Integration is disabled"
+msgstr "ERPNext 統合が無効です"
+
+#: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:183
+msgid "ERPNext Integration is enabled"
+msgstr "ERPNext 統合が有効です"
+
+#: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:66
+msgid "ERPNext app"
+msgstr "ERPNext アプリ"
+
+#: helpdesk/integrations/erpnext/api.py:47
+msgid "ERPNext integration is not enabled"
+msgstr "ERPNext 統合が有効でない"
+
+#: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:205
+#: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.py:19
+msgid "ERPNext is not installed on your site. Please install ERPNext to enable this setting"
+msgstr "このサイトにはERPNextがインストールされていません。この設定を有効にするにはERPNextをインストールしてください。"
+
+#: desk/src/components/layouts/CustomerPortalPermissionDialog.vue:10
+msgid ""
+"Earlier, every contact could see all the tickets of their company. Now, contacts only see the "
+"tickets they raised themselves."
+msgstr "以前はすべての連絡先が会社の全チケットを閲覧できましたが、現在は自分が起票したチケットのみ閲覧できます。"
+
+#: desk/src/components/Settings/InviteAgents.vue:4
+msgid "Easily invite new agents, managers, or admins."
+msgstr "新しい担当者、マネージャー、管理者を簡単に招待できます。"
+
+#: desk/src/components/ticket-agent/BulkEditModal.vue:2 desk/src/pages/contact/Contact.vue:33
+#: desk/src/pages/customer/Customer.vue:28 desk/src/pages/home/Home.vue:36
+#: desk/src/pages/knowledge-base/Article.vue:621 desk/src/pages/ticket/Tickets.vue:156
+msgid "Edit"
+msgstr "編集する"
+
+#: desk/src/pages/call-logs/CallLogModal.vue:221
+msgid "Edit Call Log"
+msgstr "コールログを編集する"
+
+#: desk/src/components/contact/EditContactDialog.vue:8
+msgid "Edit Contact"
+msgstr "連絡先を編集する"
+
+#: desk/src/components/customer/EditCustomerDialog.vue:14
+msgid "Edit Customer"
+msgstr "顧客を編集"
+
+#: desk/src/components/Settings/EmailAdd.vue:70 desk/src/components/Settings/EmailEdit.vue:63
+msgid "Edit Domain"
+msgstr "ドメインを編集する"
+
+#: desk/src/components/Settings/EmailEdit.vue:3
+msgid "Edit Email"
+msgstr "メールを編集する"
+
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:147
+msgid "Edit Title"
+msgstr "タイトル編集"
+
+#: desk/src/components/Settings/EmailEdit.vue:4
+msgid "Edit your email account"
+msgstr "メールアカウントを編集する"
+
+#: desk/src/components/Settings/Profile/UserEmailSettings.vue:57
+#: desk/src/components/contact/EditContactDialog.vue:50
+#: desk/src/components/customer/NewCustomerDialog.vue:80 desk/src/pages/PersonaForm.vue:148
+#: desk/src/pages/SearchAgent.vue:184
+msgid "Email"
+msgstr "メール"
+
+#. Label of the email_account (Link) field in DocType 'HD Ticket'
+#. Label of a Link in the Helpdesk Workspace
+#: desk/src/components/Settings/Profile/UserEmailSettings.vue:56
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
+msgid "Email Account"
+msgstr "メールアカウント"
+
+#: desk/src/components/Settings/EmailAccountList.vue:3
+msgid "Email Accounts"
+msgstr "メールアカウント"
+
+#. Label of the feedback_email_content (Text) field in DocType 'HD Settings'
+#. Label of the acknowledgement_email_content (Text) field in DocType 'HD
+#. Settings'
+#. Label of the reply_email_to_agent_content (Text) field in DocType 'HD
+#. Label of the reply_via_agent_email_content (Text) field in DocType 'HD
+#: desk/src/components/Settings/EmailNotifications/Notification.vue:61
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Email Content"
+msgstr "メールの内容"
+
+#. Label of the email_id (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email ID"
+msgstr "メール ID"
+
+#. Label of the email_customisations_tab (Tab Break) field in DocType 'HD
+#. Settings'
+#: desk/src/components/Settings/EmailNotifications/NotificationList.vue:3
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Email Notifications"
+msgstr "メール通知"
+
+#: desk/src/components/Settings/Profile/UserEmailSettings.vue:3
+msgid "Email Settings"
+msgstr "メール設定"
+
+#: desk/src/components/Settings/EmailAdd.vue:309
+msgid "Email account created"
+msgstr "メールアカウント作成"
+
+#: desk/src/components/Settings/EmailAccountList.vue:27
+msgid "Email account name"
+msgstr "メールアカウント名"
+
+#: desk/src/components/Settings/EmailEdit.vue:471
+msgid "Email account updated successfully"
+msgstr "メールアカウントを更新しました"
+
+#. Description of the 'Email ID' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Email address of the primary contact"
+msgstr "主な連絡先のメールアドレス"
+
+#: desk/src/components/Settings/Profile/UserEmailSettings.vue:196
+msgid "Email settings updated successfully."
+msgstr "メール設定を更新しました。"
+
+#: desk/src/components/Settings/Profile/UserEmailSettings.vue:38 desk/src/pages/SearchAgent.vue:352
+#: desk/src/pages/ticket/MobileTicketAgent.vue:507
+msgid "Emails"
+msgstr "メール"
+
+#: desk/src/components/Settings/Profile/Profile.vue:132
+msgid "Emails & Signature"
+msgstr "メールと署名"
+
+#: desk/src/components/Settings/EmailEdit.vue:417
+msgid "Emails pulled successfully"
+msgstr "メールを取得しました"
+
+#. Label of the emoji (Data) field in DocType 'HD Comment Reaction'
+#: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
+msgid "Emoji"
+msgstr "絵文字"
+
+#: desk/src/components/view-controls/SortBy.vue:134
+msgid "Empty - Choose a field to sort by"
+msgstr "未指定 - 並べ替えるフィールドを選択"
+
+#. Label of the enable (Check) field in DocType 'HD Agent Status'
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+msgid "Enable"
+msgstr "有効にする"
+
+#: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:36
+msgid "Enable ERPNext Integration"
+msgstr "ERPNext 統合を有効にする"
+
+#. Label of the enable_comment_reactions (Check) field in DocType 'HD Settings'
+#: desk/src/components/Settings/General/components/TicketSettings.vue:23
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Enable comment reactions"
+msgstr "コメントの反応を有効にする"
+
+#. Label of the is_feedback_mandatory (Check) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Enable feedback for Customer Portal"
+msgstr "顧客ポータルへのフィードバックを有効にする"
+
+#. Label of the enabled (Check) field in DocType 'ERPNext HD Settings'
+#. Label of the enabled (Check) field in DocType 'HD Form Script'
+#. Label of the enabled (Check) field in DocType 'HD Service Level Agreement'
+#. Label of the enable_email_ticket_feedback (Check) field in DocType 'HD
+#. Settings'
+#. Label of the send_acknowledgement_email (Check) field in DocType 'HD
+#. Label of the enable_reply_email_to_agent (Check) field in DocType 'HD
+#. Label of the enable_reply_email_via_agent (Check) field in DocType 'HD
+#. Label of the enabled (Check) field in DocType 'HD Stopword'
+#. Label of the enabled (Check) field in DocType 'HD Ticket Status'
+#: Rules/AssignmentRuleView.vue:16 Rules/AssignmentRulesListView.vue:31
+#: desk/src/components/Settings/Assignment
+#: desk/src/components/Settings/EmailNotifications/Notification.vue:31
+#: desk/src/components/Settings/FieldDependency/FieldDependency.vue:13
+#: desk/src/components/Settings/FieldDependency/FieldDependencyList.vue:70
+#: desk/src/components/Settings/Sla/SlaPolicyList.vue:34
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:15
+#: desk/src/components/Settings/Teams/NewTeam.vue:12 desk/src/components/Settings/Teams/TeamEdit.vue:11
+#: desk/src/components/Settings/Telephony/ExotelSettings.vue:25
+#: desk/src/components/Settings/Telephony/TwilioSettings.vue:24
+#: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+#: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+msgid "Enabled"
+msgstr "有効"
+
+#. Label of the end_date (Date) field in DocType 'HD Service Level Agreement'
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+msgid "End Date"
+msgstr "終了日"
+
+#. Label of the end_time (Time) field in DocType 'HD Service Day'
+#: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
+msgid "End Time"
+msgstr "終了時刻"
+
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:22
+msgid "Enter a name for this HD Service Holiday List."
+msgstr "このHDサービス休日リストの名前を入力してください。"
+
+#: desk/src/components/Settings/General/components/Branding.vue:11
+msgid "Enter brand name"
+msgstr "ブランド名を入力する"
+
+#: desk/src/components/customer/InviteContactDialog.vue:12
+msgid "Enter email address"
+msgstr "メールアドレスを入力する"
+
+#: desk/src/components/Settings/Teams/RenameTeamModal.vue:64
+msgid "Enter the new name for the team"
+msgstr "チームの新しい名前を入力する"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:182
+msgid "Enter the primary contact's email"
+msgstr "主な連絡先のメールを入力する"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:178
+msgid "Enter the primary contact's first name"
+msgstr "主な連絡先のファーストネームを入力する"
+
+#: helpdesk/api/knowledge_base.py:86
+msgid "Error moving article to category"
+msgstr "記事をカテゴリへ移動中にエラーが発生しました"
+
+#: helpdesk/overrides/email_account.py:93
+msgid "Error processing email at index {0}, message: {1}"
+msgstr "インデックス{0}のメール処理中にエラーが発生しました。メッセージ：{1}"
+
+#: helpdesk/overrides/email_account.py:142
+msgid "Error while connecting to email account {0}"
+msgstr "メールアカウント{0}への接続中にエラーが発生しました"
+
+#: desk/src/components/ticket/ExportModal.vue:11 desk/src/components/ticket/ExportModal.vue:19
+msgid "Excel"
+msgstr "エクセル"
+
+#: desk/src/components/layouts/CustomerPortalPermissionDialog.vue:73
+msgid "Existing contacts are being made customer managers in the background"
+msgstr "既存の連絡先をバックグラウンドで顧客マネージャーに設定しています"
+
+#: desk/src/components/customer/InviteContactDialog.vue:24
+msgid "Existing users join instantly. Others get an invite."
+msgstr "既存ユーザーはすぐに参加し、それ以外のユーザーには招待が送信されます。"
+
+#: desk/src/components/Settings/Telephony/ExotelSettings.vue:4
+#: desk/src/components/Settings/Telephony/Telephony.vue:96
+msgid "Exotel"
+msgstr "エクソテル"
+
+#: desk/src/components/layouts/Sidebar.vue:347
+msgid "Explore customer portal"
+msgstr "顧客ポータルを探索"
+
+#: desk/src/pages/PersonaForm.vue:239
+msgid "Explore the product first"
+msgstr "まず製品を確認する"
+
+#: desk/src/components/ticket/ExportModal.vue:2 desk/src/pages/ticket/Tickets.vue:148
+msgid "Export"
+msgstr "エクスポート"
+
+#: desk/src/components/ticket/ExportModal.vue:26
+msgid "Export All {0} Record(s)"
+msgstr "{0}件のレコードをすべてエクスポート"
+
+#: desk/src/components/ticket/ExportModal.vue:7
+msgid "Export Type"
+msgstr "エクスポート形式"
+
+#. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
+#: desk/src/pages/call-logs/CallLogModal.vue:211 desk/src/pages/ticket/Tickets.vue:268
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Failed"
+msgstr "失敗した"
+
+#: desk/src/components/customer/TicketStats.vue:39
+msgid "Failed SLAs"
+msgstr "未達成のSLA"
+
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:278
+msgid "Failed to create category"
+msgstr "カテゴリー作成できませんでした"
+
+#: desk/src/components/Settings/EmailAdd.vue:315
+msgid "Failed to create email account, Invalid credentials"
+msgstr "認証情報が無効なため、メールアカウントを作成できませんでした"
+
+#: desk/src/components/ticket-agent/TicketHeader.vue:218
+msgid "Failed to delete ticket."
+msgstr "チケットを削除できませんでした。"
+
+#: desk/src/components/Settings/Telephony/ExotelSettings.vue:194
+#: desk/src/components/Settings/Telephony/Telephony.vue:195
+#: desk/src/components/Settings/Telephony/TwilioSettings.vue:172
+msgid "Failed to load telephony agent"
+msgstr "電話担当者を読み込めませんでした"
+
+#: desk/src/components/Settings/EmailEdit.vue:422
+msgid "Failed to pull emails"
+msgstr "メールを取得できませんでした"
+
+#: desk/src/components/Settings/Telephony/ExotelSettings.vue:259
+#: desk/src/components/Settings/Telephony/Telephony.vue:238
+msgid "Failed to save Exotel settings"
+msgstr "Exotel の設定を保存できませんでした"
+
+#: desk/src/components/Settings/Telephony/ExotelSettings.vue:251
+#: desk/src/components/Settings/Telephony/Telephony.vue:230
+#: desk/src/components/Settings/Telephony/TwilioSettings.vue:215
+msgid "Failed to save Twilio settings"
+msgstr "Twilio 設定を保存できなかった"
+
+#: desk/src/components/ticket-agent/AssignTo.vue:607
+msgid "Failed to update Assignees."
+msgstr "担当者を更新できませんでした。"
+
+#: Rules/AssignmentRuleListItem.vue:232 desk/src/components/Settings/Assignment
+msgid "Failed to update assignment rule {0}."
+msgstr "割り当てルールを更新できず {0}."
+
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:312
+msgid "Failed to update category."
+msgstr "カテゴリー更新できませんでした"
+
+#: desk/src/components/Settings/EmailEdit.vue:476
+msgid "Failed to update email account, Invalid credentials"
+msgstr "認証情報が正しくないため、メールアカウントを更新できませんでした"
+
+#: desk/src/components/Settings/FieldDependency/FieldDependencyList.vue:184
+msgid "Failed to update field dependency."
+msgstr "フィールド依存を更新できませんでした"
+
+#: desk/src/components/tag/Tags.vue:291
+msgid "Failed to update tags"
+msgstr "タグを更新できなかった"
+
+#. Label of the favicon (Attach Image) field in DocType 'HD Settings'
+#: desk/src/components/Settings/General/components/Branding.vue:27
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Favicon"
+msgstr "ファビコン"
+
+#. Label of the feedback (Select) field in DocType 'HD Article Feedback'
+#. Label of the feedback_section (Section Break) field in DocType 'HD Settings'
+#. Label of the feedback_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/ticket-agent/TicketFeedback.vue:2 desk/src/pages/contact/Contact.vue:90
+#: desk/src/pages/contact/Contact.vue:181 desk/src/pages/home/components/RecentFeedback.vue:199
+#: desk/src/pages/home/components/RecentFeedback.vue:319
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Feedback"
+msgstr "フィードバック"
+
+#. Label of the feedback_extra (Small Text) field in DocType 'HD Email
+#. Feedback'
+#. Label of a field in the email-feedback Web Form
+#: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
+#: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
+msgid "Feedback "
+msgstr "フィードバック "
+
+#. Label of the feedback_extra (Long Text) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Feedback (Extra)"
+msgstr "フィードバック（追加）"
+
+#. Label of the feedback (Link) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Feedback (Option)"
+msgstr "フィードバック (オプション)"
+
+#: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:30
+msgid "Feedback Already Exists"
+msgstr "フィードバックは既に登録されています"
+
+#. Label of the feedback_rating (Rating) field in DocType 'HD Email Feedback'
+#. Label of a field in the email-feedback Web Form
+#: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
+#: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
+msgid "Feedback Rating"
+msgstr "フィードバック評価"
+
+#: helpdesk/api/dashboard.py:387
+msgid "Feedback Trend"
+msgstr "フィードバック推移"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:170
+msgid "Feedback email has been sent to the customer"
+msgstr "フィードバックメールを顧客に送信しました"
+
+#: desk/src/components/contact/ContactFeedback.vue:20
+msgid "Feedback from this contact will appear here once available."
+msgstr "この連絡先からフィードバックが届くと、ここに表示されます。"
+
+#: desk/src/components/knowledge-base/ArticleFeedback.vue:79
+msgid "Feedback submitted successfully."
+msgstr "フィードバックを送信しました。"
+
+#: desk/src/components/ticket-agent/BulkEditModal.vue:7
+msgid "Field"
+msgstr "フィールド"
+
+#. Label of the fieldname (Data) field in DocType 'HD Ticket Template Field'
+#: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
+msgid "Field (fieldname)"
+msgstr "フィールド (フィールド名)"
+
+#: desk/src/components/Settings/FieldDependency/FieldDependencyList.vue:6
+msgid "Field Dependencies"
+msgstr "フィールド依存性"
+
+#: desk/src/components/layouts/Sidebar.vue:418
+msgid "Field Dependency"
+msgstr "フィールド依存"
+
+#: desk/src/components/Settings/FieldDependency/FieldDependency.vue:303
+msgid "Field Dependency created successfully"
+msgstr "フィールド依存関係を作成しました"
+
+#: desk/src/components/Settings/FieldDependency/FieldDependency.vue:304
+msgid "Field Dependency updated successfully"
+msgstr "フィールド依存関係を更新しました"
+
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.py:25
+msgid "Field `{0}` does not exist in Ticket"
+msgstr "`{0}`フィールドはチケットに存在しない"
+
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.py:41
+msgid "Field `{0}` is not allowed in Ticket Template"
+msgstr "`{0}`フィールドはチケットテンプレートで許されない"
+
+#: desk/src/components/Settings/FieldDependency/FieldDependencyList.vue:160
+msgid "Field dependency deleted successfully."
+msgstr "フィールド依存関係を削除しました。"
+
+#: desk/src/components/Settings/FieldDependency/FieldDependencyList.vue:180
+msgid "Field dependency updated successfully."
+msgstr "フィールド依存関係を更新しました。"
+
+#. Label of the fields (Table) field in DocType 'HD Ticket Template'
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:24
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+msgid "Fields"
+msgstr "フィールド"
+
+#. Label of the filters_tab (Tab Break) field in DocType 'HD View'
+#. Label of the filters (Code) field in DocType 'HD View'
+#: desk/src/components/view-controls/filter/Filter.vue:201
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "Filters"
+msgstr "フィルター"
+
+#: desk/src/components/Settings/EmailNotifications/Notification.vue:70
+#: desk/src/components/Settings/General/components/TicketSettings.vue:229
+msgid "Find out all of the variables that can be used in the content"
+msgstr "コンテンツで使用できるすべての変数を調べる"
+
+#: desk/src/pages/PersonaForm.vue:186
+msgid "Finding past conversations"
+msgstr "過去の会話を検索"
+
+#: desk/src/components/Questionnaire.vue:129
+msgid "Finish"
+msgstr "完成する"
+
+#: desk/src/components/contact/EditContactDialog.vue:34
+#: desk/src/components/customer/NewCustomerDialog.vue:67
+msgid "First Name"
+msgstr "ファーストネーム"
+
+#. Label of the first_responded_on (Datetime) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "First Responded On"
+msgstr "初回応答日時"
+
+#: desk/src/components/customer/TicketsTab.vue:221
+msgid "First Response"
+msgstr "初回応答"
+
+#. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "First Response Due"
+msgstr "初回応答期限"
+
+#. Label of the first_response_failed_by (Duration) field in DocType 'HD
+#. Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "First Response Failed By"
+msgstr "初回応答の超過時間"
+
+#. Label of the response_time (Duration) field in DocType 'HD Service Level
+#. Priority'
+#. Label of the first_response_time (Duration) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "First Response Time"
+msgstr "初回応答時間"
+
+#. Name of a report
+#: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.json
+msgid "First Response Time for Tickets"
+msgstr "チケットの初回応答時間"
+
+#. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+msgid "Form"
+msgstr "フォーム"
+
+#: desk/src/pages/PersonaForm.vue:215
+msgid "Frappe Discuss"
+msgstr "Frappe Discuss"
+
+#: desk/src/components/layouts/Sidebar.vue:427
+msgid "Frappe Helpdesk Mobile"
+msgstr "Frappe Helpdesk Mobile"
+
+#: desk/src/pages/PersonaForm.vue:128
+msgid "Freshdesk"
+msgstr "フレッシュデスク"
+
+#. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
+#. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
+#. List'
+#: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
+msgid "Friday"
+msgstr "金曜日"
+
+#. Label of the user_from (Link) field in DocType 'HD Notification'
+#: desk/src/components/EmailEditor.vue:17 desk/src/pages/call-logs/CallLogModal.vue:44
+#: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
+msgid "From"
+msgstr "差出人"
+
+#. Label of the from_date (Date) field in DocType 'HD Service Holiday List'
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
+#: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.js:9
+#: helpdesk/helpdesk/report/support_hour_distribution/support_hour_distribution.js:8
+#: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:17
+#: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:17
+msgid "From Date"
+msgstr "開始日"
+
+#: desk/src/components/Settings/Holiday/HolidayView.vue:72
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:161
+msgid "From date"
+msgstr "開始日"
+
+#: desk/src/pages/call-logs/CallLogModal.vue:374
+msgid "From is required"
+msgstr "差出人は必須です"
+
+#. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
+#: desk/src/pages/ticket/Tickets.vue:268 helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Fulfilled"
+msgstr "達成"
+
+#: desk/src/components/Settings/General/General.vue:6
+#: desk/src/components/command-palette/CommandPalette.vue:419
+#: desk/src/components/layouts/Sidebar.vue:318 desk/src/components/modals/ShortcutsModal.vue:76
+msgid "General"
+msgstr "一般"
+
+#. Label of a Link in the Helpdesk Workspace
+#: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
+msgid "General Settings"
+msgstr "一般設定"
+
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.py:40
+msgid "General category can't be deleted"
+msgstr "一般カテゴリーは削除できません"
+
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.py:36
+msgid "General category name can't be changed"
+msgstr "一般カテゴリー名変更できません"
+
+#: helpdesk/api/knowledge_base.py:56
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.py:23
+msgid "General is a reserved category name. Please use a different name to proceed."
+msgstr "「一般」は予約済みのカテゴリ名です。別の名前を使用してください。"
+
+#: desk/src/components/layouts/Sidebar.vue:368
+msgid "Getting Started"
+msgstr "はじめに"
+
+#: desk/src/pages/PersonaForm.vue:212
+msgid "GitHub"
+msgstr "GitHub"
+
+#. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
+#: desk/src/components/SavedRepliesSelectorModal.vue:179
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:305
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:345
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:200
+#: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
+msgid "Global"
+msgstr "グローバル"
+
+#: desk/src/pages/PersonaForm.vue:213
+msgid "Google Ads"
+msgstr "グーグル広告"
+
+#: desk/src/components/customer/ContactCard.vue:220
+msgid "Grant Manager Access"
+msgstr "マネージャー権限を付与"
+
+#. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
+#. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+msgid "Gray"
+msgstr "灰色"
+
+#: desk/src/pages/home/components/PendingTickets.vue:247
+msgid "Great! All your tickets are within SLA"
+msgstr "すべてのチケットがSLA内です"
+
+#. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
+#. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+msgid "Green"
+msgstr "緑"
+
+#. Label of the group_by_tab (Tab Break) field in DocType 'HD View'
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "Group By"
+msgstr "グループ別"
+
+#. Label of the group_by_field (Data) field in DocType 'HD View'
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "Group By Field"
+msgstr "グループ化するフィールド"
+
+#: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:13
+msgid "Guide users to articles before tickets."
+msgstr "チケットを起票する前にユーザーを記事へ案内します。"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
+msgid "HD Agent"
+msgstr "HD担当者"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+msgid "HD Agent Status"
+msgstr "HD担当者ステータス"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+msgid "HD Article"
+msgstr "HD 記事"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+msgid "HD Article Category"
+msgstr "HD 記事カテゴリー"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
+msgid "HD Article Feedback"
+msgstr "HD記事フィードバック"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
+msgid "HD Comment Reaction"
+msgstr "HDコメントリアクション"
+
+#. Name of a role
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "HD Customer"
+msgstr "HD 顧客"
+
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "HD Customer Manager"
+msgstr "HD 顧客管理者"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "HD Customer Member"
+msgstr "HD 顧客メンバー"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
+msgid "HD Email Feedback"
+msgstr "HD メールフィードバック"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
+msgid "HD Field Layout"
+msgstr "HDフィールドレイアウト"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+msgid "HD Form Script"
+msgstr "HDフォームスクリプト"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_holiday/hd_holiday.json
+msgid "HD Holiday"
+msgstr "HDホリデー"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
+msgid "HD Notification"
+msgstr "HD通知"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
+msgid "HD Saved Reply"
+msgstr "HD定型返信"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
+msgid "HD Saved Reply Team"
+msgstr "HD定型返信チーム"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
+msgid "HD Service Day"
+msgstr "HDサービス日"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list_calendar.js:20
+msgid "HD Service Holiday List"
+msgstr "HDサービス休暇リスト"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+msgid "HD Service Level Agreement"
+msgstr "HDサービスレベル協定"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
+msgid "HD Service Level Priority"
+msgstr "HDサービスレベル優先度"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "HD Settings"
+msgstr "HD設定"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
+msgid "HD Stopword"
+msgstr "HD ストップワード"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_synonym/hd_synonym.json
+msgid "HD Synonym"
+msgstr "HDの同義語"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_synonyms/hd_synonyms.json
+msgid "HD Synonyms"
+msgstr "HDの同義詞"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+msgid "HD Team"
+msgstr "HDチーム"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
+msgid "HD Team Member"
+msgstr "HD チームメンバー"
+
+#. Name of a DocType
+#. Label of the ticket (Link) field in DocType 'HD Ticket Activity'
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement_dashboard.py:7
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_activity/hd_ticket_activity.json
+msgid "HD Ticket"
+msgstr "HDチケット"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_ticket_activity/hd_ticket_activity.json
+msgid "HD Ticket Activity"
+msgstr "HDチケット活動"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
+msgid "HD Ticket Comment"
+msgstr "HDチケットコメント"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+msgid "HD Ticket Feedback Option"
+msgstr "HDチケットフィードバックオプション"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "HD Ticket Priority"
+msgstr "HDチケットの優先度"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+msgid "HD Ticket Status"
+msgstr "HDチケットステータス"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+msgid "HD Ticket Template"
+msgstr "HDチケットテンプレート"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
+msgid "HD Ticket Template Field"
+msgstr "HDチケットテンプレートフィールド"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
+msgid "HD Ticket Type"
+msgstr "HDチケットタイプ"
+
+#. Name of a DocType
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "HD View"
+msgstr "HD ビュー"
+
+#. Label of the headings_weight (Int) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Headings Weight"
+msgstr "見出しの重み"
+
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:101
+msgid ""
+"Hello {{ contact }}, \\n\\nWe are sorry for the inconvenience, we will get back to you soon. "
+"\\n\\nRegards, \\n{{ full_name }}"
+msgstr "{{ contact }} 様、\\n\\nご不便をおかけして申し訳ございません。担当者より折り返しご連絡いたします。\\n\\nよろしくお願いいたします。\\n{{ full_name }}"
+
+#: desk/src/components/layouts/Sidebar.vue:26
+msgid "Help"
+msgstr "ヘルプ"
+
+#: helpdesk/config/desktop.py:11
+msgid "HelpDesk"
+msgstr "ヘルプデスク"
+
+#. Name of a Workspace
+#: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
+msgid "Helpdesk"
+msgstr "Helpdesk"
+
+#. Label of a Card Break in the Helpdesk Workspace
+#: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
+msgid "Helpdesk Reports"
+msgstr "Helpdeskレポート"
+
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:53
+msgid ""
+"Here, your weekly offs are pre-populated based on the previous selections. You can add more rows "
+"to also add public and national holidays individually."
+msgstr "前回の選択に基づいて週休日があらかじめ入力されています。行を追加して、祝日や国民の休日を個別に登録することもできます。"
+
+#: desk/src/pages/home/Home.vue:79
+msgid "Hey"
+msgstr "こんにちは"
+
+#: desk/src/components/HistoryBox.vue:10
+msgid "Hide "
+msgstr "非表示 "
+
+#. Label of the hide_from_customer (Check) field in DocType 'HD Ticket Template
+#. Field'
+#: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
+msgid "Hide from customer"
+msgstr "顧客には非表示"
+
+#. Option for the 'Level' (Select) field in DocType 'HD Ticket Priority'
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "High"
+msgstr "高"
+
+#. Option in a Select field in the tickets Web Form
+#: helpdesk/helpdesk/web_form/tickets/tickets.json
+msgid "Hold"
+msgstr "保留"
+
+#. Label of the holiday_list (Link) field in DocType 'HD Service Level
+#. Agreement'
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+msgid "Holiday List"
+msgstr "休日のリスト"
+
+#. Label of the holiday_list_name (Data) field in DocType 'HD Service Holiday
+#. List'
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
+msgid "Holiday List Name"
+msgstr "休日のリスト名"
+
+#: desk/src/components/Settings/Holiday/HolidayView.vue:365
+msgid "Holiday list created successfully."
+msgstr "休日リストを作成しました。"
+
+#: desk/src/components/Settings/Holiday/HolidayListItem.vue:153
+msgid "Holiday list deleted successfully."
+msgstr "休日リストを削除しました。"
+
+#: desk/src/components/Settings/Holiday/HolidayListItem.vue:126
+msgid "Holiday list duplicated successfully."
+msgstr "休日リストを複製しました。"
+
+#: desk/src/components/Settings/Holiday/HolidayView.vue:427
+msgid "Holiday list updated successfully."
+msgstr "休日リストを更新しました。"
+
+#. Label of the holidays_section (Section Break) field in DocType 'HD Service
+#. Holiday List'
+#. Label of the holidays (Table) field in DocType 'HD Service Holiday List'
+#: desk/src/components/Settings/Holiday/HolidayView.vue:142
+#: desk/src/components/Settings/Holiday/HolidayView.vue:182
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
+msgid "Holidays"
+msgstr "休日"
+
+#: desk/src/pages/home/Home.vue:5
+msgid "Home"
+msgstr "ホーム"
+
+#: desk/src/pages/PersonaForm.vue:108
+msgid "How big is your support team?"
+msgstr "サポートチームは何人ですか？"
+
+#: desk/src/pages/PersonaForm.vue:209
+msgid "How did you hear about Frappe Helpdesk?"
+msgstr "Frappe Helpdeskをどこで知りましたか？"
+
+#: desk/src/pages/PersonaForm.vue:144
+msgid "How do your customers currently contact your support team?"
+msgstr "顧客は現在どのようにサポートチームへ連絡していますか？"
+
+#: desk/src/pages/PersonaForm.vue:162
+msgid "How would you like your customers to create support tickets in Frappe Helpdesk?"
+msgstr "顧客にFrappe Helpdeskでどのようにサポートチケットを作成してほしいですか？"
+
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:136
+msgid "I understand, add conditions"
+msgstr "条件を追加する"
+
+#: desk/src/pages/PersonaForm.vue:172
+msgid "I'm not sure yet"
+msgstr "まだ確信がない"
+
+#: desk/src/pages/home/components/PendingTickets.vue:24
+msgid "ID"
+msgstr "ID"
+
+#. Label of the icon (Data) field in DocType 'HD Article Category'
+#. Label of the icon (Data) field in DocType 'HD View'
+#: desk/src/components/ViewModal.vue:17
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "Icon"
+msgstr "アイコン"
+
+#. Description of the 'Enabled' (Check) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid ""
+"If enabled, a ticket creation acknowledgement email will be sent to the user right after creating"
+" an email ticket"
+msgstr "有効にすると、メールからチケットを作成した直後にユーザーへ受付確認メールを送信します。"
+
+#. Description of the 'Enabled' (Check) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "If enabled, an email is sent to all of the recipients associated with an agent's reply"
+msgstr "有効にすると、担当者が返信した際に関連するすべての受信者へメールが送信されます"
+
+#. Description of the 'Enabled' (Check) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid ""
+"If enabled, an email will be sent to all of the assigned agents after a reply from one of the "
+"contacts"
+msgstr "有効にすると、連絡先から返信があった際に割り当てられたすべての担当者へメールが送信されます。"
+
+#. Description of the 'Allow anyone to create tickets' (Check) field in DocType
+#. 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "If enabled, anyone will be able to create tickets (without any permission). "
+msgstr "チケットの作成は誰でも可能になります (許可なしに). "
+
+#. Description of the 'Enabled' (Check) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid ""
+"If enabled, feedback email will be sent to the customer when you mark a ticket as the status "
+"selected below.\n"
+msgstr "有効にすると、チケットを以下で選択したステータスに変更した際に顧客へフィードバックメールを送信します。\n"
+
+#. Description of the 'Enable feedback for Customer Portal' (Check) field in
+#. DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "If enabled, the feedback dialog will be shown, when a user tries to close a ticket. \n"
+msgstr "有効にすると、ユーザーがチケットをクローズする際にフィードバックダイアログを表示します。 \n"
+
+#: desk/src/components/knowledge-base/ArticleFeedback.vue:15
+msgid "If your issue isn't resolved, raise a support ticket"
+msgstr "問題が解決しない場合は、サポートチケットを起票してください"
+
+#. Label of the ignore_restrictions (Check) field in DocType 'HD Team'
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+msgid "Ignore Restrictions"
+msgstr "制限を無視"
+
+#. Label of the user_image (Attach Image) field in DocType 'HD Agent'
+#. Label of the image (Attach Image) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Image"
+msgstr "画像"
+
+#: desk/src/components/Settings/General/components/Branding.vue:80
+msgid "Image removed successfully."
+msgstr "画像を削除しました。"
+
+#. Description of the 'Logo' (Attach Image) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid ""
+"Image to be used in various places, including Login and Signup pages. An image with transparent "
+"background and 160 x 32 is preferred"
+msgstr "ログイン画面やユーザー登録画面などで使用する画像です。背景が透明な160 x 32 pxの画像を推奨します。"
+
+#: desk/src/components/Settings/General/components/Branding.vue:83
+msgid "Image updated successfully."
+msgstr "画像を更新しました。"
+
+#: desk/src/pages/call-logs/CallLogModal.vue:217
+msgid "In Progress"
+msgstr "対応中"
+
+#: desk/src/pages/PersonaForm.vue:155
+msgid "In person"
+msgstr "対面"
+
+#: desk/src/components/Settings/Agents.vue:126
+msgid "Inactive"
+msgstr "無効"
+
+#: desk/src/components/CallArea.vue:36
+msgid "Inbound Call"
+msgstr "着信"
+
+#: desk/src/components/Settings/EmailAccountCard.vue:59
+msgid "Inbox"
+msgstr "受信トレイ"
+
+#: desk/src/pages/call-logs/CallLogModal.vue:203
+msgid "Incoming"
+msgstr "受信"
+
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Individual"
+msgstr "個別"
+
+#: desk/src/pages/call-logs/CallLogModal.vue:212
+msgid "Initiated"
+msgstr "開始"
+
+#: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:59
+msgid "Install the"
+msgstr "インストール："
+
+#. Label of the instantly_send_email (Check) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Instantly send e-mail"
+msgstr "すぐにメールを送信する"
+
+#: helpdesk/utils.py:31
+msgid "Insufficient Permission for {0}"
+msgstr "{0}の許可が不足している"
+
+#: desk/src/pages/PersonaForm.vue:129
+msgid "Intercom"
+msgstr "インターコム"
+
+#: desk/src/components/layouts/Sidebar.vue:360 desk/src/components/layouts/Sidebar.vue:363
+msgid "Introduction"
+msgstr "はじめに"
+
+#: helpdesk/helpdesk/doctype/hd_agent/hd_agent.py:63
+msgid "Invalid availability"
+msgstr "有効でない可用性"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:186
+msgid "Invalid email address"
+msgstr "無効なメールアドレス"
+
+#: Rules/AssignmentRuleView.vue:478 desk/src/components/Settings/Assignment
+#: desk/src/components/Settings/Holiday/HolidayView.vue:335
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:405
+msgid "Invalid fields, check if all are filled in and values are correct."
+msgstr "入力内容が正しくありません。必須項目がすべて入力され、値が正しいことを確認してください。"
+
+#: helpdesk/api/settings/email_notifications.py:112
+msgid "Invalid notification"
+msgstr "無効な通知"
+
+#: desk/src/components/ticket/SetContactPhoneModal.vue:67
+msgid "Invalid phone number"
+msgstr "無効な電話番号"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:264
+msgid "Invalid role {0}"
+msgstr "無効な役割 {0}"
+
+#: desk/src/pages/contact/Contact.vue:253
+msgid "Invitation Expired"
+msgstr "招待の有効期限切れ"
+
+#: desk/src/components/Settings/InviteAgents.vue:246
+#: desk/src/components/customer/RevokeInviteButton.vue:40
+msgid "Invitation cancelled successfully"
+msgstr "招待をキャンセルしました"
+
+#: desk/src/pages/contact/Contact.vue:255
+msgid "Invitation expired. Resend to invite again."
+msgstr "招待の有効期限が切れました。再度招待を送信してください。"
+
+#: desk/src/components/customer/CustomerContactTab.vue:7
+#: desk/src/components/customer/InviteContactDialog.vue:77
+msgid "Invite"
+msgstr "招待する"
+
+#: desk/src/components/Settings/InviteAgents.vue:3
+msgid "Invite Agents"
+msgstr "担当者を招待"
+
+#: desk/src/components/customer/InviteContactDialog.vue:2
+msgid "Invite Contact"
+msgstr "連絡先を招待"
+
+#: Rules/AssigneeSearch.vue:87 desk/src/components/Settings/Assignment
+msgid "Invite agent"
+msgstr "担当者を招待"
+
+#: desk/src/components/layouts/Sidebar.vue:240
+msgid "Invite agents"
+msgstr "担当者を招待"
+
+#: desk/src/components/contact/NewContactDialog.vue:97 desk/src/pages/contact/Contact.vue:271
+msgid "Invite as User"
+msgstr "ユーザーとして招待"
+
+#: desk/src/components/Settings/InviteAgents.vue:11
+msgid "Invite by email"
+msgstr "メールで招待する"
+
+#: desk/src/pages/PersonaForm.vue:238
+msgid "Invite my support team"
+msgstr "私のサポートチームを招待してください"
+
+#: desk/src/pages/contact/Contact.vue:261
+msgid "Invite sent. Waiting for the user to accept."
+msgstr "招待を送信しました。ユーザーの承認を待っています。"
+
+#: desk/src/components/EmailMultiSelect.vue:145
+msgid "Invite via email"
+msgstr "メールで招待する"
+
+#: desk/src/pages/contact/Contact.vue:259
+msgid "Invited"
+msgstr "招待された"
+
+#: desk/src/components/customer/InviteContactDialog.vue:57
+msgid "Invited by"
+msgstr "招待された"
+
+#. Label of the is_active (Check) field in DocType 'HD Agent'
+#: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
+msgid "Is Active"
+msgstr "活動している"
+
+#. Label of the is_customer_portal (Check) field in DocType 'HD View'
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "Is Customer Portal"
+msgstr "顧客ポータル"
+
+#. Label of the is_default (Check) field in DocType 'HD View'
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "Is Default"
+msgstr "デフォルトで"
+
+#. Label of the is_manager (Check) field in DocType 'HD Customer Member'
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+msgid "Is Manager"
+msgstr "マネージャー権限"
+
+#. Label of the is_standard (Check) field in DocType 'HD Form Script'
+#. Label of the is_standard (Check) field in DocType 'HD View'
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "Is Standard"
+msgstr "標準です"
+
+#. Label of the apply_to_system (Check) field in DocType 'HD Field Layout'
+#: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
+msgid "Is applied to system"
+msgstr "システムに適用される"
+
+#. Label of the initial_helpdesk_name_setup_skipped (Check) field in DocType
+#. 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Is name setup skipped"
+msgstr "名前設定をスキップしました"
+
+#. Label of the is_pinned (Check) field in DocType 'HD Ticket Comment'
+#: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
+msgid "Is pinned"
+msgstr "固定"
+
+#. Label of the setup_complete (Check) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Is setup complete"
+msgstr "設定が完了しました"
+
+#: desk/src/pages/PersonaForm.vue:130
+msgid "Jira Service Management"
+msgstr "ジラサービス管理"
+
+#: desk/src/components/contact/EditContactDialog.vue:37
+msgid "John"
+msgstr "ジョン"
+
+#: desk/src/pages/knowledge-base/Article.vue:667
+msgid "KB"
+msgstr "KB"
+
+#: desk/src/pages/PersonaForm.vue:196
+msgid "Keeping track of customer requests"
+msgstr "顧客の要求を追跡する"
+
+#. Label of the key (Data) field in DocType 'HD Email Feedback'
+#. Label of the key (Data) field in DocType 'HD Ticket'
+#. Label of a field in the email-feedback Web Form
+#: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
+msgid "Key"
+msgstr "キー"
+
+#: desk/src/components/modals/ShortcutsModal.vue:2
+msgid "Keyboard Shortcuts"
+msgstr "キーボードショートカット"
+
+#. Label of the knowledge_base_section (Section Break) field in DocType 'HD
+#. Settings'
+#: desk/src/components/layouts/Sidebar.vue:389 desk/src/components/layouts/Sidebar.vue:406
+#: desk/src/pages/knowledge-base/Article.vue:667 desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:6
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:462
+#: desk/src/pages/knowledge-base/NewArticle.vue:170
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Knowledge Base"
+msgstr "ナレッジベース"
+
+#. Label of the label (Data) field in DocType 'HD Ticket Feedback Option'
+#. Label of the label_agent (Data) field in DocType 'HD Ticket Status'
+#. Label of the label (Data) field in DocType 'HD View'
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "Label"
+msgstr "ラベル"
+
+#. Label of the label_customer (Data) field in DocType 'HD Ticket Status'
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+msgid "Label (customer view)"
+msgstr "ラベル (顧客表示)"
+
+#. Option for the 'Type' (Select) field in DocType 'HD Field Layout'
+#: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
+msgid "Landing Page"
+msgstr "ランディングページ"
+
+#: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:6
+msgid "Language"
+msgstr "言語"
+
+#: desk/src/components/Settings/Preferences/Preferences.vue:36
+msgid "Language & Time"
+msgstr "言語と時間"
+
+#: Rules/AssigneeRules.vue:102 desk/src/components/Settings/Assignment
+msgid "Last"
+msgstr "最後は"
+
+#: desk/src/pages/home/components/RecentFeedback.vue:372
+#: desk/src/pages/home/components/RecentFeedback.vue:401
+msgid "Last 3 Months"
+msgstr "過去3ヶ月"
+
+#: desk/src/components/ChartCardBase.vue:177 desk/src/components/ChartCardBase.vue:179
+#: desk/src/components/ChartCardBase.vue:180
+msgid "Last 3 months"
+msgstr "過去3ヶ月"
+
+#: desk/src/pages/dashboard/Dashboard.vue:518 desk/src/pages/dashboard/Dashboard.vue:551
+#: desk/src/pages/dashboard/Dashboard.vue:553 desk/src/pages/dashboard/Dashboard.vue:589
+msgid "Last 30 Days"
+msgstr "過去30日"
+
+#: desk/src/pages/dashboard/Dashboard.vue:558 desk/src/pages/dashboard/Dashboard.vue:560
+msgid "Last 60 Days"
+msgstr "過去60日"
+
+#: desk/src/pages/dashboard/Dashboard.vue:544 desk/src/pages/dashboard/Dashboard.vue:546
+msgid "Last 7 Days"
+msgstr "過去7日"
+
+#: desk/src/pages/dashboard/Dashboard.vue:565 desk/src/pages/dashboard/Dashboard.vue:567
+msgid "Last 90 Days"
+msgstr "過去90日"
+
+#. Label of the last_agent_response (Datetime) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Last Agent Response"
+msgstr "担当者の最終応答"
+
+#. Label of the last_customer_response (Datetime) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Last Customer Response"
+msgstr "顧客の最終応答"
+
+#: desk/src/pages/home/components/RecentFeedback.vue:368
+#: desk/src/pages/home/components/RecentFeedback.vue:400
+msgid "Last Month"
+msgstr "先月"
+
+#: desk/src/components/contact/EditContactDialog.vue:41
+#: desk/src/components/customer/NewCustomerDialog.vue:73
+msgid "Last Name"
+msgstr "姓"
+
+#: desk/src/pages/home/components/RecentFeedback.vue:364
+#: desk/src/pages/home/components/RecentFeedback.vue:399
+msgid "Last Week"
+msgstr "先週"
+
+#: desk/src/components/BarChartCard.vue:79 desk/src/components/ChartCardBase.vue:143
+#: desk/src/components/ChartCardBase.vue:170 desk/src/components/ChartCardBase.vue:172
+#: desk/src/components/ChartCardBase.vue:173 desk/src/components/LineChartCard.vue:74
+#: desk/src/pages/home/components/AgentTicketsCard.vue:30
+msgid "Last month"
+msgstr "先月"
+
+#: desk/src/components/customer/ContactCard.vue:134
+msgid "Last seen"
+msgstr "最後に見た"
+
+#: Rules/AssigneeRules.vue:95 desk/src/components/Settings/Assignment
+msgid "Last user assigned by this rule"
+msgstr "このルールが最後に割り当てたユーザー"
+
+#: desk/src/components/ChartCardBase.vue:163 desk/src/components/ChartCardBase.vue:165
+#: desk/src/components/ChartCardBase.vue:166
+msgid "Last week"
+msgstr "先週"
+
+#: desk/src/components/contact/FeedbackList.vue:119
+msgid "Latest"
+msgstr "最新"
+
+#. Label of the layout (Code) field in DocType 'HD Field Layout'
+#: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
+msgid "Layout"
+msgstr "レイアウト"
+
+#: Rules/AssignmentRuleView.vue:135 Rules/AssignmentRuleView.vue:212
+#: desk/src/components/Settings/Assignment
+msgid "Learn about conditions"
+msgstr "条件について学び"
+
+#: desk/src/components/layouts/CustomerPortalPermissionBanner.vue:17
+msgid "Learn more"
+msgstr "詳しくみる"
+
+#: desk/src/components/layouts/CustomerPortalPermissionDialog.vue:23
+msgid "Learn more in the"
+msgstr "詳しくは"
+
+#. Description of the 'Apply outside working hours' (Check) field in DocType
+#. 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid ""
+"Let customers know they're raising a ticket outside working hours, and when they can expect a "
+"reply."
+msgstr "営業時間外にチケットを起票していることと、返信予定時刻を顧客に案内します。"
+
+#. Label of the level (Select) field in DocType 'HD Ticket Priority'
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "Level"
+msgstr "レベル"
+
+#: desk/src/pages/PersonaForm.vue:220
+msgid "LinkedIn"
+msgstr "リンクイン"
+
+#. Option for the 'Apply To' (Select) field in DocType 'HD Form Script'
+#. Label of the list_tab (Tab Break) field in DocType 'HD View'
+#: desk/src/components/ListViewBuilder.vue:806 desk/src/components/ListViewBuilder.vue:897
+#: desk/src/pages/ticket/Tickets.vue:456 helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "List"
+msgstr "リスト"
+
+#: desk/src/pages/ticket/Tickets.vue:372
+msgid "List View"
+msgstr "リスト表示"
+
+#: desk/src/components/CallArea.vue:72
+msgid "Listen"
+msgstr "聞く"
+
+#: desk/src/pages/PersonaForm.vue:152 desk/src/pages/PersonaForm.vue:171
+msgid "Live chat"
+msgstr "ライブチャット"
+
+#. Label of the load_default_columns (Check) field in DocType 'HD View'
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "Load Default Columns"
+msgstr "デフォルト列を読み込む"
+
+#: desk/src/components/Settings/Agents.vue:174 desk/src/components/Settings/Teams/TeamsList.vue:88
+#: desk/src/components/contact/FeedbackList.vue:81 desk/src/components/customer/TicketsTab.vue:142
+msgid "Load More"
+msgstr "さらに読み込む"
+
+#: desk/src/components/ticket-agent/AssignTo.vue:106
+msgid "Loading..."
+msgstr "読み込み中..."
+
+#: desk/src/components/ticket/ActivityHeader.vue:65
+msgid "Log a Call"
+msgstr "呼び出しを記録する"
+
+#: desk/src/components/layouts/MobileSidebar.vue:99 desk/src/components/layouts/MobileSidebar.vue:128
+#: desk/src/components/layouts/Sidebar.vue:139 desk/src/components/layouts/Sidebar.vue:188
+msgid "Log out"
+msgstr "ログアウト"
+
+#: desk/src/components/layouts/Sidebar.vue:168
+msgid "Login to Frappe Cloud"
+msgstr "Frappe Cloudにログイン"
+
+#. Label of the brand_logo (Attach Image) field in DocType 'HD Settings'
+#: desk/src/components/Settings/General/components/Branding.vue:15
+#: desk/src/components/customer/EditCustomerDialog.vue:29
+#: desk/src/components/customer/NewCustomerDialog.vue:13
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Logo"
+msgstr "ロゴ"
+
+#. Option for the 'Level' (Select) field in DocType 'HD Ticket Priority'
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "Low"
+msgstr "低"
+
+#. Description of the 'Rank' (Int) field in DocType 'HD Service Level
+#. Agreement'
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+msgid "Lower rank is applied first. 0 means unranked, and is applied last."
+msgstr "順位の小さいものから適用されます。0は順位なしとして最後に適用されます。"
+
+#: desk/src/pages/ticket/MobileTicketAgent.vue:125
+msgid "Mail"
+msgstr "メール"
+
+#: desk/src/components/ticket/ActivityHeader.vue:60
+msgid "Make a Call"
+msgstr "電話する"
+
+#: desk/src/components/layouts/CustomerPortalPermissionDialog.vue:34
+msgid "Make all existing contacts customer managers"
+msgstr "既存のすべての連絡先を顧客マネージャーにする"
+
+#: desk/src/components/Settings/General/components/TicketSettings.vue:10
+msgid "Make feedback mandatory"
+msgstr "フィードバックを必須にする"
+
+#: desk/src/components/ViewModal.vue:50
+msgid "Make it public"
+msgstr "公開する"
+
+#: desk/src/components/Settings/General/General.vue:2
+msgid "Manage general settings of your app."
+msgstr "アプリの基本設定を管理します。"
+
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:5
+msgid "Manage pre-defined responses that can be used to respond to customer queries."
+msgstr "顧客の問い合わせへの返信に使用できる定型返信を管理します。"
+
+#: desk/src/components/Settings/Profile/Profile.vue:136
+msgid "Manage your account emails and email signature for communication."
+msgstr "通信のためにアカウントのメールとメール署名を管理します"
+
+#: desk/src/components/Settings/EmailAccountList.vue:5
+msgid "Manage your email accounts and configure incoming and outgoing settings."
+msgstr "メールアカウントと受信・送信設定を管理します。"
+
+#: desk/src/components/Settings/Profile/UserEmailSettings.vue:25
+msgid "Manage your email signature."
+msgstr "メール署名を管理します。"
+
+#: desk/src/components/Settings/Preferences/Preferences.vue:2
+msgid "Manage your personal preferences."
+msgstr "個人的な好みを管理する"
+
+#: desk/src/components/Settings/Profile/Profile.vue:4
+msgid "Manage your profile information."
+msgstr "プロフィール情報を管理する"
+
+#: desk/src/components/customer/ContactCard.vue:25
+msgid "Manager"
+msgstr "管理者"
+
+#: desk/src/pages/PersonaForm.vue:182
+msgid "Managing customer conversations across channels"
+msgstr "チャンネル間の顧客会話の管理"
+
+#: desk/src/pages/MobileNotifications.vue:11 desk/src/pages/MobileNotifications.vue:14
+msgid "Mark all as read"
+msgstr "すべて既読にする"
+
+#: desk/src/components/layouts/Sidebar.vue:398
+msgid "Masters"
+msgstr "マスターズ"
+
+#: desk/src/pages/PersonaForm.vue:190
+msgid "Measuring team performance"
+msgstr "チームパフォーマンスの測定"
+
+#. Option for the 'Level' (Select) field in DocType 'HD Ticket Priority'
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "Medium"
+msgstr "中間"
+
+#: desk/src/components/Settings/Teams/NewTeam.vue:38
+msgid "Members"
+msgstr "メンバー"
+
+#: desk/src/components/Settings/Teams/TeamEdit.vue:56
+msgid "Members ({0})"
+msgstr "メンバー ({0})"
+
+#. Option for the 'Type' (Select) field in DocType 'HD Notification'
+#: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
+msgid "Mention"
+msgstr "メンション"
+
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:158
+msgid "Merge"
+msgstr "統合"
+
+#: desk/src/components/ticket-agent/TicketHeader.vue:250
+msgid "Merge Ticket"
+msgstr "チケットを統合"
+
+#. Label of the merged_with (Link) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Merged With"
+msgstr "統合先"
+
+#. Label of the message (Text) field in DocType 'HD Notification'
+#. Label of the message (Text Editor) field in DocType 'HD Saved Reply'
+#: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
+#: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
+msgid "Message"
+msgstr "メッセージ"
+
+#. Label of the misc_tab (Tab Break) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Misc"
+msgstr "ミスク"
+
+#: desk/src/pages/PersonaForm.vue:194
+msgid "Missing or delayed responses"
+msgstr "応答の欠落または遅延"
+
+#: desk/src/components/layouts/Sidebar.vue:430
+msgid "Mobile App Installation"
+msgstr "モバイルアプリのインストール"
+
+#. Label of the mobile_no (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile No"
+msgstr "携帯番号"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:89
+msgid "Mobile Number"
+msgstr "携帯電話番号"
+
+#. Description of the 'Mobile No' (Data) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Mobile no. of the primary contact"
+msgstr "主要連絡先の携帯電話番号"
+
+#. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
+#. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
+#. List'
+#: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
+msgid "Monday"
+msgstr "月曜日"
+
+#: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:35
+msgid "Monthly"
+msgstr "月間"
+
+#: desk/src/components/ticket-agent/TicketDetailsTab.vue:81
+msgid "More Details"
+msgstr "詳細"
+
+#: helpdesk/api/dashboard_tags.py:47
+msgid "Most used tags in this period"
+msgstr "この期間で最も使用されたタグ"
+
+#: desk/src/pages/knowledge-base/Article.vue:631
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:191
+msgid "Move To"
+msgstr "移動先"
+
+#: desk/src/pages/dashboard/Dashboard.vue:263
+msgid "My Dashboard"
+msgstr "私のダッシュボード"
+
+#: desk/src/pages/dashboard/Dashboard.vue:359
+msgid "My Organization"
+msgstr "所属組織"
+
+#: desk/src/pages/home/Home.vue:365 desk/src/pages/home/components/RecentActivity.vue:6
+msgid "My Recent Activity"
+msgstr "最近のアクティビティ"
+
+#: desk/src/pages/dashboard/Dashboard.vue:364
+msgid "My Stats"
+msgstr "私の統計"
+
+#: desk/src/components/SavedRepliesSelectorModal.vue:178
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:304
+msgid "My Team(s)"
+msgstr "自分のチーム"
+
+#: desk/src/pages/home/Home.vue:293 desk/src/pages/home/components/AgentTicketsCard.vue:4
+msgid "My Tickets"
+msgstr "私のチケット"
+
+#. Label of the category_name (Data) field in DocType 'HD Article Category'
+#. Label of the contact_name (Link) field in DocType 'HD Customer Member'
+#. Label of the brand_name (Data) field in DocType 'HD Settings'
+#. Label of the team_name (Data) field in DocType 'HD Team'
+#: Rules/AssignmentRuleView.vue:46 Rules/AssignmentRuleView.vue:47
+#: desk/src/components/Settings/Assignment
+#: desk/src/components/Settings/FieldDependency/FieldDependencyList.vue:68
+#: desk/src/components/Settings/Holiday/HolidayView.vue:37
+#: desk/src/components/Settings/Holiday/HolidayView.vue:38
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:47
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:43
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:44 desk/src/components/ViewModal.vue:7
+#: desk/src/components/customer/NewCustomerDialog.vue:21
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_customer_member/hd_customer_member.json
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+msgid "Name"
+msgstr "名前"
+
+#. Label of the name_weight (Int) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Name Weight"
+msgstr "名前の重み"
+
+#: desk/src/components/customer/NewCustomerDialog.vue:151
+msgid "Name is required"
+msgstr "名前が必要"
+
+#. Description of the 'Label (customer view)' (Data) field in DocType 'HD
+#. Ticket Status'
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+msgid "Name shown on the customer portal<br> (e.g., Replied → Awaiting Response)."
+msgstr "顧客ポータルに表示する名前<br>（例：返信済み → 応答待ち）"
+
+#: desk/src/components/command-palette/CommandPalette.vue:146
+msgid "Navigate"
+msgstr "移動"
+
+#: desk/src/components/modals/ShortcutsModal.vue:106
+msgid "Navigation"
+msgstr "ナビゲーション"
+
+#: desk/src/components/contact/FeedbackList.vue:121
+msgid "Negative"
+msgstr "低評価"
+
+#: desk/src/pages/home/components/RecentFeedback.vue:392
+#: desk/src/pages/home/components/RecentFeedback.vue:410
+msgid "Negative first"
+msgstr "低評価を先に表示"
+
+#: desk/src/components/customer/ContactCard.vue:137
+msgid "Never"
+msgstr "なし"
+
+#: Rules/AssignmentRulesList.vue:19 desk/src/components/SavedRepliesSelectorModal.vue:16
+#: desk/src/components/Settings/Assignment desk/src/components/Settings/EmailAccountList.vue:12
+#: desk/src/components/Settings/FieldDependency/FieldDependencyList.vue:27
+#: desk/src/components/Settings/Holiday/Holidays.vue:12
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:12
+#: desk/src/components/Settings/Sla/SlaPolicies.vue:25
+#: desk/src/components/Settings/Teams/TeamsList.vue:10 desk/src/components/ticket/ActivityHeader.vue:19
+#: desk/src/pages/home/Home.vue:55
+msgid "New"
+msgstr "新規"
+
+#: desk/src/pages/knowledge-base/NewArticle.vue:175 desk/src/pages/knowledge-base/NewArticle.vue:182
+msgid "New Article"
+msgstr "新しい記事"
+
+#: Rules/AssignmentRuleView.vue:4 desk/src/components/Settings/Assignment
+msgid "New Assignment Rule"
+msgstr "新しい割り当てルール"
+
+#: Rules/AssignmentRuleListItem.vue:59 desk/src/components/Settings/Assignment
+msgid "New Assignment Rule Name"
+msgstr "新しい割り当てルール名"
+
+#: desk/src/components/Settings/Holiday/HolidayView.vue:3
+msgid "New Business Holiday"
+msgstr "新しいビジネス休暇"
+
+#: desk/src/pages/call-logs/CallLogModal.vue:221
+msgid "New Call Log"
+msgstr "新しい通話履歴"
+
+#: desk/src/components/Settings/FieldDependency/FieldDependency.vue:104
+msgid "New Field Dependency"
+msgstr "新しいフィールド依存"
+
+#: desk/src/components/Settings/Holiday/HolidayListItem.vue:36
+msgid "New Holiday List Name"
+msgstr "新しい休日リスト名"
+
+#: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:8
+msgid "New Password"
+msgstr "新しいパスワード"
+
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:3
+msgid "New SLA Policy"
+msgstr "新しいSLAポリシー"
+
+#: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:46
+msgid "New SLA Policy Name"
+msgstr "新しいSLAポリシー名"
+
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:3
+msgid "New Saved Reply"
+msgstr "新しい定型返信"
+
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:164
+msgid "New Saved reply Name"
+msgstr "新しい定型返信名"
+
+#: desk/src/pages/ticket/MobileTicketAgent.vue:191
+msgid "New Subject"
+msgstr "新しい件名"
+
+#: desk/src/components/Settings/Teams/NewTeam.vue:3
+msgid "New Team"
+msgstr "新しいチーム"
+
+#: desk/src/pages/ticket/TicketNew.vue:304 desk/src/pages/ticket/TicketNew.vue:314
+msgid "New Ticket"
+msgstr "新しいチケット"
+
+#: desk/src/components/Settings/Teams/RenameTeamModal.vue:53
+msgid "New and old title cannot be same"
+msgstr "新しいタイトルと古いタイトルは同じではない"
+
+#: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:86
+msgid "New and updated customers sync automatically between Helpdesk and ERPNext."
+msgstr "新規または更新された顧客は、HelpdeskとERPNextの間で自動的に同期されます。"
+
+#: desk/src/components/Settings/NewTeamModal.vue:4
+msgid "New team"
+msgstr "新しいチーム"
+
+#: desk/src/components/Settings/Teams/RenameTeamModal.vue:51
+msgid "New title is required"
+msgstr "新しいタイトルが必要"
+
+#: desk/src/components/Settings/General/General.vue:50
+msgid "New users will have to be manually registered by system managers."
+msgstr "新しいユーザーはシステム管理者が手動で登録する必要があります。"
+
+#: desk/src/components/Questionnaire.vue:129
+msgid "Next"
+msgstr "次へ"
+
+#: desk/src/components/modals/ShortcutsModal.vue:108
+msgid "Next ticket"
+msgstr "次のチケット"
+
+#: desk/src/pages/call-logs/CallLogModal.vue:216
+msgid "No Answer"
+msgstr "応答なし"
+
+#: desk/src/components/ListViewBuilder.vue:357
+msgid "No Data Found"
+msgstr "データは見つかりませんでした"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:590
+msgid "No Email Account found for {0}"
+msgstr "{0}のメールアカウントが見つかりませんでした"
+
+#: desk/src/components/Settings/Holiday/HolidayList.vue:20
+msgid "No Holiday list found"
+msgstr "休日のリストが見つかりませんでした"
+
+#: desk/src/components/Settings/Sla/SlaPolicyList.vue:20
+msgid "No SLA found"
+msgstr "SLAが見つかりませんでした"
+
+#: helpdesk/api/dashboard.py:459
+msgid "No Team"
+msgstr "チームなし"
+
+#: desk/src/components/customer/ContactCard.vue:115 desk/src/components/customer/ContactCard.vue:144
+#: desk/src/components/customer/ContactCard.vue:148
+msgid "No active tickets"
+msgstr "アクティブチケットはない"
+
+#: desk/src/pages/home/components/RecentFeedback.vue:206
+msgid "No additional comments"
+msgstr "追加コメントなし"
+
+#: desk/src/components/ticket-agent/AssignTo.vue:159
+msgid "No agents found"
+msgstr "担当者が見つかりませんでした"
+
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:425
+msgid "No articles found for the applied filters. Try adjusting or clearing your filters."
+msgstr "指定したフィルターに一致する記事が見つかりません。フィルターを調整またはクリアしてください。"
+
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:428
+msgid "No articles found in the following category."
+msgstr "このカテゴリには記事がありません。"
+
+#: Rules/AssignmentRulesListView.vue:20 desk/src/components/Settings/Assignment
+msgid "No assignment rule found"
+msgstr "割り当てルールが見つかりませんでした"
+
+#: desk/src/pages/home/components/AvgTimeMetrics.vue:105
+msgid "No average metrics"
+msgstr "平均指標はない"
+
+#: desk/src/components/knowledge-base/CategoryFolderContainer.vue:17
+msgid "No categories available"
+msgstr "カテゴリーはありません"
+
+#: desk/src/components/Settings/EmailEdit.vue:344
+msgid "No changes made"
+msgstr "変更はありません"
+
+#: desk/src/pages/home/Home.vue:88
+msgid "No charts added"
+msgstr "図は追加されていません"
+
+#: desk/src/components/command-palette/CommandPalette.vue:246
+msgid "No commands found"
+msgstr "コマンドが見つかりませんでした"
+
+#: desk/src/components/customer/CustomerContactTab.vue:29
+msgid "No contacts found"
+msgstr "連絡先は見つかりませんでした"
+
+#: desk/src/pages/contact/Contacts.vue:66
+msgid "No contacts found for the applied filters. Try adjusting or clearing your filters."
+msgstr "指定したフィルターに一致する連絡先が見つかりません。フィルターを調整またはクリアしてください。"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:247
+msgid "No contacts to add"
+msgstr "追加できる連絡先がありません"
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:110
+msgid "No country found"
+msgstr "国が見つかりませんでした"
+
+#: desk/src/pages/customer/Customers.vue:69
+msgid "No customers found for the applied filters. Try adjusting or clearing your filters."
+msgstr "指定したフィルターに一致する顧客が見つかりません。フィルターを調整またはクリアしてください。"
+
+#: desk/src/components/Settings/EmailAccountList.vue:52
+msgid "No email account found"
+msgstr "メールアカウントが見つかりませんでした"
+
+#: desk/src/pages/home/components/RecentFeedback.vue:283
+msgid "No feedback"
+msgstr "フィードバックなし"
+
+#: desk/src/components/contact/ContactFeedback.vue:16
+msgid "No feedback yet"
+msgstr "まだフィードバックはありません"
+
+#: desk/src/components/view-controls/filter/FilterFieldList.vue:50
+msgid "No fields found"
+msgstr "フィールドが見つかりませんでした"
+
+#: desk/src/components/Settings/Teams/TeamEdit.vue:94
+msgid "No members found"
+msgstr "メンバーが見つかりませんでした"
+
+#: desk/src/pages/MobileNotifications.vue:71
+msgid "No new notifications"
+msgstr "新しい通知はありません"
+
+#: desk/src/pages/home/components/PendingTickets.vue:251
+msgid "No new tickets assigned to you in the last 7 days"
+msgstr "過去7日間で新チケットが割り当てられていません"
+
+#: desk/src/components/ticket-agent/AssignTo.vue:221
+msgid "No one"
+msgstr "誰もいない"
+
+#: desk/src/pages/home/components/PendingTickets.vue:254
+msgid "No pending tickets"
+msgstr "保留中のチケットはありません"
+
+#: desk/src/pages/home/components/PendingTickets.vue:89
+msgid "No reason"
+msgstr "理由はない"
+
+#: desk/src/pages/home/components/RecentActivity.vue:57
+msgid "No recent activity"
+msgstr "最近の活動がない"
+
+#: desk/src/pages/home/components/PendingTickets.vue:250
+msgid "No recently assigned tickets"
+msgstr "最近割り当てられたチケットはありません"
+
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:87
+msgid "No results"
+msgstr "結果がありません"
+
+#: desk/src/components/command-palette/CommandPalette.vue:244
+msgid "No results for \"{0}\""
+msgstr "\"{0}\"に関する結果は見つかりませんでした"
+
+#: Rules/AssigneeSearch.vue:79 desk/src/components/EmailMultiSelect.vue:137
+#: desk/src/components/Settings/Assignment
+msgid "No results found"
+msgstr "結果が見つかりませんでした"
+
+#: desk/src/components/contact/FeedbackList.vue:28
+msgid "No reviews found"
+msgstr "レビューが見つかりませんでした"
+
+#: desk/src/components/SavedRepliesSelectorModal.vue:122
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:73
+msgid "No saved replies found"
+msgstr "定型返信が見つかりませんでした"
+
+#: desk/src/components/tag/Tags.vue:78
+msgid "No tags yet, type to create one"
+msgstr "タグはまだありません。入力して作成してください"
+
+#: desk/src/components/customer/TicketsTab.vue:51 desk/src/pages/ticket/Tickets.vue:222
+msgid "No tickets found"
+msgstr "チケットが見つかりませんでした"
+
+#: desk/src/pages/ticket/Tickets.vue:232
+msgid "No tickets found for the applied filters. Try adjusting or clearing your filters."
+msgstr "指定したフィルターに一致するチケットが見つかりません。フィルターを調整またはクリアしてください。"
+
+#: desk/src/pages/ticket/Tickets.vue:228
+msgid "No tickets found for this view. Try adjusting your filters or creating a new view."
+msgstr "このビューに該当するチケットはありません。フィルターを調整するか、新しいビューを作成してください。"
+
+#: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:104
+msgid "No tickets found to preview."
+msgstr "プレビューのチケットは見つかりませんでした"
+
+#: desk/src/components/ticket-agent/BulkReplyModal.vue:84
+msgid "No tickets selected"
+msgstr "チケットは選択されていません"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:166
+msgid "No user linked to contact {0}"
+msgstr "連絡先{0}に関連付けられたユーザーがいません"
+
+#: helpdesk/api/ticket.py:83 helpdesk/utils.py:187 helpdesk/utils.py:215
+msgid "Not Allowed"
+msgstr "許されない"
+
+#: desk/src/pages/home/components/PendingTickets.vue:64
+msgid "Not Assigned"
+msgstr "割り当てられていない"
+
+#: desk/src/pages/call-logs/CallLogModal.vue:10
+msgid "Not Saved"
+msgstr "未保存"
+
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:233
+msgid "Not Set"
+msgstr "設定されていない"
+
+#: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:250
+#: helpdesk/helpdesk/report/ticket_summary/ticket_summary.py:270
+#: helpdesk/helpdesk/report/ticket_summary/ticket_summary.py:363
+msgid "Not Specified"
+msgstr "指定されていない"
+
+#: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:14
+msgid "Not installed"
+msgstr "インストールされていない"
+
+#: desk/src/components/command-palette/CommandPalette.vue:245
+msgid "Nothing left in {0}"
+msgstr "{0}に何も残っていない"
+
+#. Label of a Link in the Helpdesk Workspace
+#: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
+msgid "Notification Settings"
+msgstr "通知設定"
+
+#: desk/src/components/layouts/AppSidebar.vue:229 desk/src/components/layouts/AppSidebar.vue:238
+#: desk/src/components/notifications/Notifications.vue:16 desk/src/pages/MobileNotifications.vue:6
+msgid "Notifications"
+msgstr "通知"
+
+#: desk/src/pages/PersonaForm.vue:126
+msgid "Notion"
+msgstr "Notion"
+
+#: Rules/AssignmentRuleView.vue:146 Rules/AssignmentRuleView.vue:227
+#: desk/src/components/Settings/Assignment
+msgid "Old Condition"
+msgstr "以前の条件"
+
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:109
+msgid "Old Conditions"
+msgstr "旧条件"
+
+#. Label of the on_hold_since (Datetime) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "On Hold Since"
+msgstr "待ち続けています"
+
+#: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:20
+msgid "On ticket status"
+msgstr "チケットのステータス時"
+
+#: helpdesk/api/ticket.py:82
+msgid "Only administrators can delete tickets."
+msgstr "チケットを削除できるのは管理者のみです。"
+
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.py:29
+msgid "Only one default view is allowed per user for {0}"
+msgstr "{0}では、ユーザーごとに設定できるデフォルトビューは1つだけです。"
+
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:29
+msgid "Only the 'color' and 'order' fields of the 'Closed' status can be modified."
+msgstr "「クローズ」ステータスでは「色」と「順序」のフィールドのみ変更できます。"
+
+#: desk/src/components/layouts/CustomerPortalPermissionDialog.vue:16
+msgid "Only users with the role of "
+msgstr "役割を持つユーザーのみ "
+
+#. Option for the 'Category' (Select) field in DocType 'HD Ticket Status'
+#. Option in a Select field in the tickets Web Form
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/web_form/tickets/tickets.json
+msgid "Open"
+msgstr "オープン"
+
+#: desk/src/components/command-palette/CommandPalette.vue:418
+#: desk/src/components/modals/ShortcutsModal.vue:78
+msgid "Open command palette"
+msgstr "コマンドパレットを開く"
+
+#: desk/src/components/modals/ShortcutsModal.vue:101
+msgid "Open comment box"
+msgstr "コメントボックスを開く"
+
+#: desk/src/components/contact/EditContactDialog.vue:145
+msgid "Open customer"
+msgstr "顧客を開く"
+
+#: desk/src/components/modals/ShortcutsModal.vue:81
+msgid "Open help"
+msgstr "ヘルプを開く"
+
+#: desk/src/components/Settings/EmailEdit.vue:37
+msgid "Open in Desk"
+msgstr "デスクで開く"
+
+#: desk/src/components/modals/ShortcutsModal.vue:100
+msgid "Open reply box"
+msgstr "返信欄を開く"
+
+#: desk/src/components/modals/ShortcutsModal.vue:79
+msgid "Open settings"
+msgstr "設定を開く"
+
+#. Description of the 'Category' (Select) field in DocType 'HD Ticket Status'
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+msgid ""
+"Open: SLA continues. <br>\n"
+"Paused: SLA is paused. <br>\n"
+"Resolved: SLA timer stops."
+msgstr "対応中：SLAの計測を継続します。 <br>\n一時停止：SLAの計測を一時停止します。 <br>\n解決済み：SLAタイマーを停止します。"
+
+#. Label of the opening_date (Date) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Opening Date"
+msgstr "オープン日"
+
+#. Label of the opening_time (Time) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Opening Time"
+msgstr "営業時間"
+
+#. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
+#. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+msgid "Orange"
+msgstr "オレンジ"
+
+#. Label of the order (Int) field in DocType 'HD Ticket Status'
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+msgid "Order"
+msgstr "順序"
+
+#. Label of the order_by_tab (Tab Break) field in DocType 'HD View'
+#. Label of the order_by (Code) field in DocType 'HD View'
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "Order By"
+msgstr "並べ替え"
+
+#: desk/src/pages/dashboard/Dashboard.vue:263
+msgid "Organization Dashboard"
+msgstr "組織ダッシュボード"
+
+#: desk/src/pages/PersonaForm.vue:138 desk/src/pages/PersonaForm.vue:156
+#: desk/src/pages/PersonaForm.vue:203 desk/src/pages/PersonaForm.vue:226
+#: desk/src/pages/ticket/TicketFeedback.vue:52
+msgid "Other"
+msgstr "その他"
+
+#: desk/src/components/CallArea.vue:37
+msgid "Outbound Call"
+msgstr "発信"
+
+#: desk/src/pages/call-logs/CallLogModal.vue:204
+msgid "Outgoing"
+msgstr "送信"
+
+#: desk/src/components/Settings/General/components/TicketSettings.vue:199
+msgid "Outside working hours notice"
+msgstr "営業時間外の通知"
+
+#: desk/src/components/ticket-agent/TicketDetailsTab.vue:30
+msgid "Overview"
+msgstr "概要"
+
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:87
+msgid "Owner"
+msgstr "オーナー"
+
+#: desk/src/pages/InvalidPage.vue:11
+msgid "Page not found"
+msgstr "ページが見つかりませんでした"
+
+#: desk/src/components/Settings/FieldDependency/FieldDependencyFieldsSelection.vue:5
+msgid "Parent field"
+msgstr "親フィールド"
+
+#: helpdesk/api/settings/field_dependency.py:47
+msgid "Parent field, child field, and parent-child mapping are required."
+msgstr "親フィールド、子フィールド、親子マッピングは必須です。"
+
+#. Option for the 'Customer Type' (Select) field in DocType 'HD Customer'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Partnership"
+msgstr "パートナーシップ"
+
+#: desk/src/components/Settings/Profile/Profile.vue:150
+msgid "Password"
+msgstr "パスワード"
+
+#: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:104
+msgid "Password must be at least 8 characters"
+msgstr "パスワードは少なくとも8文字でなければならない"
+
+#: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:107
+msgid "Password must contain lowercase, uppercase, number, and symbol"
+msgstr "パスワードには英小文字、英大文字、数字、記号を含める必要があります"
+
+#: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:87
+msgid "Password updated successfully."
+msgstr "パスワードを更新しました。"
+
+#: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:117
+msgid "Passwords do not match"
+msgstr "パスワードが一致しない"
+
+#: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:36
+#: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:123
+msgid "Passwords match"
+msgstr "パスワードが一致する"
+
+#. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
+#. Option for the 'Category' (Select) field in DocType 'HD Ticket Status'
+#: desk/src/pages/ticket/Tickets.vue:279 helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+msgid "Paused"
+msgstr "一時停止"
+
+#: desk/src/pages/home/components/PendingTickets.vue:215
+msgid "Pending"
+msgstr "保留中"
+
+#: desk/src/components/Settings/InviteAgents.vue:42
+#: desk/src/components/customer/InviteContactDialog.vue:38
+msgid "Pending Invites"
+msgstr "承認待ちの招待"
+
+#: desk/src/pages/home/Home.vue:353 desk/src/pages/home/components/PendingTickets.vue:227
+#: desk/src/pages/home/components/PendingTickets.vue:231
+msgid "Pending Tickets"
+msgstr "保留中のチケット"
+
+#: helpdesk/api/dashboard.py:578
+msgid "Percentage of total tickets by channel"
+msgstr "チャンネル別総チケットの割合"
+
+#: helpdesk/api/dashboard.py:536
+msgid "Percentage of total tickets by priority"
+msgstr "優先度別の全チケット割合"
+
+#: helpdesk/api/dashboard.py:466
+msgid "Percentage of total tickets by team"
+msgstr "チームごとに合計チケットの割合"
+
+#: helpdesk/api/dashboard.py:501
+msgid "Percentage of total tickets by type"
+msgstr "タイプ別の全チケット割合"
+
+#: desk/src/pages/dashboard/Dashboard.vue:46
+msgid "Period"
+msgstr "期間"
+
+#. Label of the persona_captured (Check) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Persona Captured"
+msgstr "ペルソナ回答済み"
+
+#. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
+#: desk/src/components/SavedRepliesSelectorModal.vue:177
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:303
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:337
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:190
+#: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
+msgid "Personal"
+msgstr "個人"
+
+#: desk/src/components/Settings/Telephony/ExotelSettings.vue:54
+msgid "Personal mobile no"
+msgstr "携帯番号"
+
+#: desk/src/components/contact/EditContactDialog.vue:80
+#: desk/src/components/ticket/SetContactPhoneModal.vue:25
+msgid "Phone"
+msgstr "電話"
+
+#: desk/src/pages/PersonaForm.vue:151
+msgid "Phone calls"
+msgstr "電話"
+
+#: desk/src/components/contact/EditContactDialog.vue:24
+#: desk/src/components/contact/NewContactDialog.vue:41
+msgid "Photo"
+msgstr "写真"
+
+#: desk/src/pages/ticket/TicketFeedback.vue:38
+msgid "Pick an option"
+msgstr "選択する"
+
+#: desk/src/components/ViewModal.vue:43
+msgid "Pin to sidebar"
+msgstr "サイドバーに固定"
+
+#. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
+#. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+msgid "Pink"
+msgstr "ピンク"
+
+#. Label of the pinned (Check) field in DocType 'HD View'
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "Pinned"
+msgstr "固定された"
+
+#. Label of the placeholder (Data) field in DocType 'HD Ticket Template Field'
+#: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
+msgid "Placeholder"
+msgstr "プレースホルダー"
+
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.py:23
+msgid ""
+"Please add this priority in the <a href='/app/hd-service-level-agreement'>required SLA "
+"documents</a>"
+msgstr "この優先度を<a href='/app/hd-service-level-agreement'>必要なSLAドキュメント</a>に追加してください。"
+
+#: desk/src/components/Settings/Telephony/Telephony.vue:219
+msgid "Please configure your Exotel settings correctly"
+msgstr "エクソテルの設定を正しく設定してください"
+
+#: desk/src/components/Settings/Telephony/Telephony.vue:215
+msgid "Please configure your Twilio settings correctly"
+msgstr "Twilioを正しく設定してください。"
+
+#: desk/src/components/layouts/Sidebar.vue:448
+msgid "Please create a new ticket to proceed with the next step."
+msgstr "次のステップへ進むには、新しいチケットを作成してください。"
+
+#: desk/src/pages/ticket/TicketNew.vue:83
+msgid "Please enter a subject to continue"
+msgstr "続行するには件名を入力してください"
+
+#: desk/src/pages/call-logs/CallLogModal.vue:368 desk/src/pages/call-logs/CallLogModal.vue:376
+msgid "Please enter a valid phone number"
+msgstr "有効な電話番号を入力してください"
+
+#: desk/src/components/Settings/InviteAgents.vue:187
+msgid "Please enter at least one valid email to send an invite."
+msgstr "招待を送信するには、有効なメールアドレスを1件以上入力してください。"
+
+#: desk/src/components/Settings/Teams/NewTeam.vue:129 desk/src/pages/call-logs/CallLogModal.vue:264
+#: desk/src/pages/call-logs/CallLogModal.vue:310
+msgid "Please fill all required fields"
+msgstr "必要なすべてのフィールドを記入してください"
+
+#: desk/src/components/Settings/Telephony/ExotelSettings.vue:240
+msgid "Please fill all required fields for Exotel"
+msgstr "Exotelの必須項目をすべて入力してください。"
+
+#: desk/src/components/Settings/Telephony/ExotelSettings.vue:236
+#: desk/src/components/Settings/Telephony/TwilioSettings.vue:204
+msgid "Please fill all required fields for Twilio"
+msgstr "Twilioの必須フィールドをすべて入力してください"
+
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:303
+msgid "Please fill all the required fields"
+msgstr "必要なすべてのフィールドを記入してください"
+
+#: desk/src/components/Settings/Sla/Modals/WorkDayModal.vue:244
+msgid "Please fix the errors in the form"
+msgstr "フォームのエラーを修正してください"
+
+#: helpdesk/api/saved_replies.py:11
+msgid "Please provide saved_reply_id"
+msgstr "save_reply_id を入力してください"
+
+#: desk/src/components/Settings/General/General.vue:239
+msgid "Please select at least one restriction option for teams in the settings."
+msgstr "設定で、チームの制限オプションを1つ以上選択してください。"
+
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.py:41
+msgid "Please select weekly off day"
+msgstr "週休日を選択してください"
+
+#: desk/src/components/Settings/Sla/SlaPolicyList.vue:32
+msgid "Policy name"
+msgstr "ポリシー名"
+
+#: desk/src/pages/ticket/MobileTicketAgent.vue:124
+msgid "Portal"
+msgstr "ポータル"
+
+#: desk/src/components/contact/FeedbackList.vue:120
+msgid "Positive"
+msgstr "ポジティブ"
+
+#: desk/src/pages/home/components/RecentFeedback.vue:388
+#: desk/src/pages/home/components/RecentFeedback.vue:411
+#: desk/src/pages/home/components/RecentFeedback.vue:415
+msgid "Positive first"
+msgstr "まずポジティブ"
+
+#. Label of the prefer_knowledge_base (Check) field in DocType 'HD Settings'
+#: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:10
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Prefer knowledge base"
+msgstr "ナレッジベースを好む"
+
+#: desk/src/components/Settings/Preferences/Preferences.vue:6
+msgid "Preferences"
+msgstr "設定"
+
+#: desk/src/components/Settings/Preferences/Preferences.vue:75
+msgid "Preferences updated successfully."
+msgstr "設定を更新しました。"
+
+#: desk/src/pages/dashboard/Dashboard.vue:533
+msgid "Presets"
+msgstr "プリセット"
+
+#: desk/src/pages/SearchAgent.vue:108
+msgid "Press enter to search"
+msgstr "検索するには Enter を押す"
+
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:11
+#: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:4
+#: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:26
+msgid "Preview"
+msgstr "プレビュー"
+
+#: desk/src/components/modals/ShortcutsModal.vue:109
+msgid "Previous ticket"
+msgstr "前のチケット"
+
+#: desk/src/components/contact/ContactInputRow.vue:20 desk/src/components/customer/ContactCard.vue:31
+#: desk/src/components/customer/ContactCard.vue:36
+msgid "Primary"
+msgstr "プライマリ"
+
+#. Label of the primary_contact (Link) field in DocType 'HD Customer'
+#: desk/src/components/customer/NewCustomerDialog.vue:62
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+msgid "Primary Contact"
+msgstr "主要な連絡先"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:83
+msgid "Primary contact must be one of the listed contacts"
+msgstr "主連絡先は一覧にある連絡先から選択してください。"
+
+#: desk/src/components/customer/ContactCard.vue:280
+msgid "Primary contact updated"
+msgstr "主要連絡先の更新"
+
+#. Label of the priorities (Table) field in DocType 'HD Service Level
+#. Agreement'
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+msgid "Priorities"
+msgstr "優先度"
+
+#. Label of the priority (Link) field in DocType 'HD Service Level Priority'
+#. Label of the priority_section (Section Break) field in DocType 'HD Settings'
+#. Label of the priority (Link) field in DocType 'HD Ticket'
+#. Label of the priority (Link) field in DocType 'HD Ticket Type'
+#. Label of a field in the tickets Web Form
+#: Rules/AssignmentRuleView.vue:59 Rules/AssignmentRulesListView.vue:30
+#: desk/src/components/Settings/Assignment desk/src/components/customer/TicketsTab.vue:218
+#: desk/src/components/customer/TicketsTab.vue:251 desk/src/pages/SearchAgent.vue:68
+#: desk/src/pages/SearchAgent.vue:69 desk/src/pages/home/components/PendingTickets.vue:33
+#: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
+#: helpdesk/helpdesk/web_form/tickets/tickets.json
+msgid "Priority"
+msgstr "優先度"
+
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:95
+msgid "Priority in use"
+msgstr "使用中の優先度"
+
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:77
+msgid "Priority {0} has been repeated."
+msgstr "優先度{0}が重複しています。"
+
+#: desk/src/components/layouts/AppSidebar.vue:266 desk/src/pages/ticket/Tickets.vue:392
+msgid "Private Views"
+msgstr "プライベートビュー"
+
+#: desk/src/components/Settings/Teams/NewTeam.vue:30
+#: desk/src/components/Settings/Teams/RenameTeamModal.vue:11
+msgid "Product Experts"
+msgstr "製品専門家"
+
+#: desk/src/components/Settings/NewTeamModal.vue:20
+msgid "Product experts"
+msgstr "製品専門家"
+
+#: desk/src/components/Settings/Profile/Profile.vue:3
+msgid "Profile"
+msgstr "プロフィール"
+
+#: desk/src/components/Settings/Profile/Profile.vue:232
+msgid "Profile updated successfully."
+msgstr "プロフィールを更新しました。"
+
+#. Label of the public (Check) field in DocType 'HD View'
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "Public"
+msgstr "公開"
+
+#: desk/src/components/layouts/AppSidebar.vue:259 desk/src/pages/ticket/Tickets.vue:407
+msgid "Public Views"
+msgstr "公開ビュー"
+
+#: desk/src/pages/knowledge-base/Article.vue:21
+msgid "Publish"
+msgstr "公開"
+
+#. Option for the 'Status' (Select) field in DocType 'HD Article'
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:443
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+msgid "Published"
+msgstr "公開済み"
+
+#. Label of the published_on (Datetime) field in DocType 'HD Article'
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+msgid "Published On"
+msgstr "公開日"
+
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.py:24
+msgid "Published articles must have content."
+msgstr "公開する記事には本文が必要です。"
+
+#: desk/src/components/Settings/EmailEdit.vue:149
+msgid "Pull Emails"
+msgstr "メールを取得"
+
+#: desk/src/components/Settings/EmailEdit.vue:407
+msgid "Pulling emails, this may take a few minutes."
+msgstr "メールを取得しています。数分かかる場合があります。"
+
+#. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+msgid "Purple"
+msgstr "紫色"
+
+#: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:36
+msgid "Quarterly"
+msgstr "四半期ごと"
+
+#: desk/src/pages/call-logs/CallLogModal.vue:213
+msgid "Queued"
+msgstr "キュー済み"
+
+#. Label of the raised_by (Data) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Raised By (Email)"
+msgstr "起票者（メール）"
+
+#: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:31
+msgid "Range"
+msgstr "範囲"
+
+#. Label of the rank (Int) field in DocType 'HD Service Level Agreement'
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:57
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+msgid "Rank"
+msgstr "ランク"
+
+#. Title of the email-feedback Web Form
+#: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
+msgid "Rate Your Support Experience"
+msgstr "サポート対応を評価"
+
+#: desk/src/pages/ticket/TicketFeedback.vue:4
+msgid "Rate this ticket"
+msgstr "このチケットを評価する"
+
+#: helpdesk/api/dashboard.py:390
+msgid "Rated Tickets"
+msgstr "評価されたチケット"
+
+#. Label of the feedback_rating (Rating) field in DocType 'HD Ticket'
+#. Label of the rating (Rating) field in DocType 'HD Ticket Feedback Option'
+#: desk/src/pages/home/components/RecentFeedback.vue:318 helpdesk/api/dashboard.py:401
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+msgid "Rating"
+msgstr "評価"
+
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.py:23
+msgid "Rating must be between 0.2 and 1.0"
+msgstr "評価は0.2から1.0の範囲で指定してください。"
+
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.py:19
+msgid "Rating {0} is not allowed"
+msgstr "{0}の評価は許されない"
+
+#. Option for the 'Type' (Select) field in DocType 'HD Notification'
+#: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
+msgid "Reaction"
+msgstr "反応"
+
+#. Label of the reactions (Table) field in DocType 'HD Ticket Comment'
+#: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
+msgid "Reactions"
+msgstr "反応"
+
+#. Label of the read (Check) field in DocType 'HD Notification'
+#: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
+msgid "Read"
+msgstr "読む"
+
+#: desk/src/pages/home/components/PendingTickets.vue:39
+msgid "Reason"
+msgstr "理由"
+
+#: desk/src/pages/home/components/PendingTickets.vue:219
+msgid "Recent"
+msgstr "最近"
+
+#: desk/src/components/ticket-agent/TicketDetailsTab.vue:284
+#: desk/src/pages/home/components/PendingTickets.vue:226
+msgid "Recent Tickets"
+msgstr "最近のチケット"
+
+#: desk/src/components/Settings/Telephony/ExotelSettings.vue:30
+#: desk/src/components/Settings/Telephony/TwilioSettings.vue:29
+msgid "Record Calls"
+msgstr "通話を録音"
+
+#: desk/src/components/Settings/Holiday/HolidayView.vue:124
+msgid "Recurring Holidays"
+msgstr "定期的な休日"
+
+#. Label of the recurring_holidays (JSON) field in DocType 'HD Service Holiday
+#. List'
+#: desk/src/components/Settings/Holiday/HolidayView.vue:188
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
+msgid "Recurring holidays"
+msgstr "繰り返される休日"
+
+#. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
+#. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+msgid "Red"
+msgstr "赤"
+
+#: desk/src/pages/PersonaForm.vue:222
+msgid "Reddit"
+msgstr "レディット"
+
+#. Label of the reference_tab (Tab Break) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Reference"
+msgstr "参照"
+
+#. Label of the reference_ticket (Link) field in DocType 'HD Ticket Comment'
+#: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
+msgid "Reference Ticket"
+msgstr "参照チケット"
+
+#. Label of the references_tab (Tab Break) field in DocType 'HD Customer'
+#. Label of the references_section (Section Break) field in DocType 'HD
+#. Notification'
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
+msgid "References"
+msgstr "参照"
+
+#: desk/src/pages/home/Home.vue:11
+msgid "Refresh"
+msgstr "リフレッシュ"
+
+#: desk/src/components/Settings/Telephony/TwilioSettings.vue:75
+msgid "Refresh Apps"
+msgstr "アプリをリフレッシュする"
+
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.js:6
+msgid "Regenerate Search Index"
+msgstr "検索インデックスを再生成"
+
+#: desk/src/components/Settings/General/components/LogoUpload.vue:48
+#: desk/src/components/Settings/Profile/UserEmailSettings.vue:73
+#: desk/src/components/contact/ContactInputRow.vue:45
+#: desk/src/components/contact/ContactInputRow.vue:50
+msgid "Remove"
+msgstr "削除する"
+
+#: desk/src/components/customer/ContactCard.vue:190 desk/src/components/customer/ContactCard.vue:294
+msgid "Remove Contact"
+msgstr "連絡を取り除く"
+
+#: desk/src/components/Settings/General/components/Branding.vue:110
+msgid "Remove Logo"
+msgstr "ロゴを削除する"
+
+#: desk/src/components/Settings/Profile/Profile.vue:201
+msgid "Remove Photo"
+msgstr "写真を削除する"
+
+#: desk/src/components/command-palette/CommandPalette.vue:263
+msgid "Remove context"
+msgstr "文脈を削除する"
+
+#: desk/src/components/view-controls/filter/Filter.vue:74
+#: desk/src/components/view-controls/filter/Filter.vue:75
+msgid "Remove filter"
+msgstr "フィルターを削除する"
+
+#: desk/src/components/ImageAvatar.vue:25
+msgid "Remove image"
+msgstr "画像を削除する"
+
+#: desk/src/components/contact/ContactInputRow.vue:20
+#: desk/src/components/contact/ContactInputRow.vue:24
+msgid "Remove primary"
+msgstr "プライマリを削除する"
+
+#: desk/src/components/Settings/Teams/TeamEdit.vue:252
+#: desk/src/components/Settings/Teams/TeamsList.vue:161
+#: desk/src/components/ticket-agent/TicketSubjectModal.vue:21
+#: desk/src/pages/ticket/MobileTicketAgent.vue:182
+msgid "Rename"
+msgstr "名前変更"
+
+#: desk/src/components/ticket-agent/TicketSubjectModal.vue:24
+msgid "Rename (Ctrl + ⏎)"
+msgstr "名前変更（Ctrl + ⏎）"
+
+#: desk/src/components/ticket-agent/TicketSubjectModal.vue:23
+msgid "Rename (⌘ + ⏎)"
+msgstr "名前変更（⌘ + ⏎）"
+
+#: desk/src/components/Settings/Teams/RenameTeamModal.vue:63
+msgid "Rename team"
+msgstr "チーム名を変更"
+
+#: desk/src/components/view-controls/filter/Filter.vue:66
+#: desk/src/components/view-controls/filter/Filter.vue:67
+msgid "Replace filter"
+msgstr "フィルターを置換"
+
+#: desk/src/components/ImageAvatar.vue:17
+msgid "Replace image"
+msgstr "画像を交換する"
+
+#: desk/src/components/ViewModal.vue:32
+msgid "Replace with an icon..."
+msgstr "アイコンに置き換える..."
+
+#. Option in a Select field in the tickets Web Form
+#: desk/src/pages/home/components/RecentActivity.vue:102
+#: helpdesk/helpdesk/web_form/tickets/tickets.json
+msgid "Replied"
+msgstr "返信済み"
+
+#: desk/src/components/EmailArea.vue:54 desk/src/components/ticket-agent/BulkReplyModal.vue:2
+#: desk/src/pages/ticket/Tickets.vue:130
+msgid "Reply"
+msgstr "返信"
+
+#: desk/src/components/EmailArea.vue:59
+msgid "Reply All"
+msgstr "全員に返信"
+
+#. Label of the reply_from_agent_section (Section Break) field in DocType 'HD
+#. Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Reply From Agent"
+msgstr "担当者からの返信"
+
+#. Label of the reply_from_contact_section (Section Break) field in DocType 'HD
+#. Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Reply From Contact"
+msgstr "連絡先からの返信"
+
+#: desk/src/components/Settings/EmailNotifications/NotificationList.vue:84
+msgid "Reply from agent"
+msgstr "担当者からの返信"
+
+#: desk/src/components/Settings/EmailNotifications/NotificationList.vue:77
+msgid "Reply from contact"
+msgstr "連絡先からの返信"
+
+#: desk/src/components/layouts/Sidebar.vue:284
+msgid "Reply on a ticket"
+msgstr "チケットで返信する"
+
+#. Label of the required (Check) field in DocType 'HD Ticket Template Field'
+#: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
+msgid "Required"
+msgstr "必須"
+
+#: desk/src/pages/contact/Contact.vue:281
+msgid "Resend Invite"
+msgstr "招待を再送"
+
+#: desk/src/components/SelectDropdown.vue:47 desk/src/pages/home/Home.vue:19
+msgid "Reset"
+msgstr "リセット"
+
+#: desk/src/components/Settings/EmailNotifications/Notification.vue:89
+#: desk/src/components/Settings/General/components/TicketSettings.vue:252
+msgid "Reset Content"
+msgstr "コンテンツをリセットする"
+
+#: desk/src/components/Settings/EmailNotifications/Notification.vue:114
+msgid "Reset content"
+msgstr "コンテンツをリセットする"
+
+#: desk/src/components/view-controls/ColumnSettings.vue:93
+msgid "Reset to Default"
+msgstr "デフォルトにリセット"
+
+#. Label of the resolution_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/customer/TicketsTab.vue:227 helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Resolution"
+msgstr "解決"
+
+#. Label of the resolution_by (Datetime) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Resolution By"
+msgstr "解決期限"
+
+#. Label of the resolution_date (Datetime) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Resolution Date"
+msgstr "解決日"
+
+#. Label of the resolution_details (Text Editor) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Resolution Details"
+msgstr "解決の詳細"
+
+#. Option for the 'SLA Status' (Select) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Resolution Due"
+msgstr "解決期限"
+
+#. Label of the resolution_failed_by (Duration) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Resolution Failed By"
+msgstr "解決期限の超過時間"
+
+#. Label of the resolution_time (Duration) field in DocType 'HD Service Level
+#. Priority'
+#. Label of the resolution_time (Duration) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_service_level_priority/hd_service_level_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Resolution Time"
+msgstr "解決時間"
+
+#. Option for the 'Category' (Select) field in DocType 'HD Ticket Status'
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+msgid "Resolved"
+msgstr "解決済み"
+
+#. Label of the response_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:90
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Response"
+msgstr "応答"
+
+#. Label of the response_by (Datetime) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Response By"
+msgstr "応答期限"
+
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:67
+msgid "Response Time for {0} priority in row {1} can't be greater than Resolution Time."
+msgstr "優先度{0}について、行{1}の応答時間を解決時間より長く設定できません。"
+
+#. Label of the response_and_resolution_time_section (Section Break) field in
+#. DocType 'HD Service Level Agreement'
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:200
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+msgid "Response and Resolution"
+msgstr "対応と解決"
+
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:407
+msgid "Response is required"
+msgstr "対応が必要"
+
+#. Label of the assign_within_team (Check) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Restrict agent assignment to selected Team"
+msgstr "担当者の割り当てを選択したチームに制限する"
+
+#: desk/src/components/Settings/General/components/TicketSettings.vue:57
+msgid "Restrict agent assignment to selected team"
+msgstr "担当者の割り当てを選択したチームに制限する"
+
+#. Label of the restrict_tickets_by_agent_group (Check) field in DocType 'HD
+#. Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Restrict tickets by Team"
+msgstr "チケットをチームごとに制限する"
+
+#: desk/src/components/Settings/General/components/TicketSettings.vue:35
+msgid "Restrict tickets by team"
+msgstr "チームごとにチケットを制限する"
+
+#: desk/src/components/Settings/General/components/TicketSettings.vue:38
+msgid "Restrict tickets to be viewed and managed by team members only."
+msgstr "チケットを閲覧・管理できるユーザーをチームメンバーに限定します。"
+
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:84
+msgid "Restrict visibility to these teams"
+msgstr "表示をこれらのチームに制限する"
+
+#: desk/src/pages/home/Home.vue:341 desk/src/pages/home/components/RecentFeedback.vue:7
+#: desk/src/pages/home/components/RecentFeedback.vue:22
+msgid "Reviews"
+msgstr "レビュー"
+
+#: desk/src/components/customer/RevokeInviteButton.vue:12
+msgid "Revoke Invite"
+msgstr "招待状を取り消す"
+
+#: desk/src/components/customer/ContactCard.vue:221
+msgid "Revoke Manager Access"
+msgstr "マネージャー権限を取り消す"
+
+#: desk/src/pages/call-logs/CallLogModal.vue:215
+msgid "Ringing"
+msgstr "呼び出し中"
+
+#: desk/src/components/Settings/InviteAgents.vue:19 desk/src/components/customer/ContactCard.vue:165
+#: desk/src/components/customer/InviteContactDialog.vue:32
+msgid "Role"
+msgstr "役割"
+
+#: desk/src/components/customer/ContactCard.vue:248
+msgid "Role updated successfully"
+msgstr "役割を更新しました"
+
+#. Label of the route_name (Data) field in DocType 'HD View'
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "Route Name"
+msgstr "経路名"
+
+#. Label of the rows (Code) field in DocType 'HD View'
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "Rows"
+msgstr "行"
+
+#: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:108
+msgid "Run an initial sync to reconcile existing records. New ones update automatically."
+msgstr "既存レコードを整合させるために初回同期を実行します。以後の新規レコードは自動的に更新されます。"
+
+#. Label of the sla (Link) field in DocType 'HD Ticket'
+#. Label of the sla_tab (Tab Break) field in DocType 'HD Ticket'
+#: desk/src/pages/home/components/PendingTickets.vue:211
+#: desk/src/pages/ticket/MobileTicketAgent.vue:109 helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "SLA"
+msgstr "SLA"
+
+#: desk/src/pages/home/components/PendingTickets.vue:225
+msgid "SLA Alerts"
+msgstr "SLA アラート"
+
+#. Label of the service_level_agreement_creation (Datetime) field in DocType
+#. 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "SLA Creation"
+msgstr "SLA作成"
+
+#. Label of the sla_mapping_section (Section Break) field in DocType 'HD Ticket
+#. Status'
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+msgid "SLA Mapping"
+msgstr "SLA マッピング"
+
+#. Label of the agreement_status (Select) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "SLA Status"
+msgstr "SLAステータス"
+
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:33
+msgid "SLA disabled"
+msgstr "SLAが無効"
+
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:451
+msgid "SLA policy created successfully."
+msgstr "SLAポリシーを作成しました。"
+
+#: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:165
+msgid "SLA policy deleted successfully."
+msgstr "SLAポリシーを削除しました。"
+
+#: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:137
+msgid "SLA policy duplicated successfully."
+msgstr "SLAポリシーを複製しました。"
+
+#: desk/src/components/Settings/Sla/SlaPolicyListItem.vue:178
+msgid "SLA policy status updated successfully."
+msgstr "SLAポリシーのステータスを更新しました。"
+
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:490
+msgid "SLA policy updated successfully."
+msgstr "SLAポリシーを更新しました。"
+
+#: desk/src/components/Settings/Sla/SlaPolicies.vue:11
+msgid ""
+"SLAs align your team and customers with defined timelines for a reliable experience. Learn more "
+"about SLA "
+msgstr "SLAで対応期限を明確にし、チームと顧客の双方に安定したサポート体験を提供します。SLAの詳細 "
+
+#: desk/src/pages/PersonaForm.vue:132
+msgid "Salesforce Service Cloud"
+msgstr "セールスフォースサービスクラウド"
+
+#. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
+#. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
+#. List'
+#: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
+msgid "Saturday"
+msgstr "土曜日"
+
+#. Button label of the email-feedback Web Form
+#: Rules/AssignmentRuleView.vue:20 desk/src/components/ListViewBuilder.vue:730
+#: desk/src/components/Settings/Assignment
+#: desk/src/components/Settings/EmailNotifications/Notification.vue:39
+#: desk/src/components/Settings/FieldDependency/FieldDependency.vue:19
+#: desk/src/components/Settings/General/General.vue:15
+#: desk/src/components/Settings/Holiday/HolidayView.vue:9
+#: desk/src/components/Settings/Preferences/Preferences.vue:16
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:22
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:19
+#: desk/src/components/Settings/Teams/NewTeam.vue:16
+#: desk/src/components/Settings/Telephony/ExotelSettings.vue:10
+#: desk/src/components/Settings/Telephony/Telephony.vue:17
+#: desk/src/components/Settings/Telephony/TwilioSettings.vue:10
+#: desk/src/components/contact/EditContactDialog.vue:166
+#: desk/src/components/customer/EditCustomerDialog.vue:73 desk/src/pages/call-logs/CallLogModal.vue:225
+#: desk/src/pages/home/Home.vue:27 desk/src/pages/knowledge-base/Article.vue:152
+#: helpdesk/helpdesk/web_form/email_feedback/email_feedback.json
+msgid "Save"
+msgstr "保存する"
+
+#: desk/src/components/ListViewBuilder.vue:17
+msgid "Save Changes"
+msgstr "変更を保存する"
+
+#: desk/src/components/SavedRepliesSelectorModal.vue:12
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:3
+#: desk/src/components/layouts/Sidebar.vue:407
+msgid "Saved Replies"
+msgstr "定型返信"
+
+#: desk/src/pages/ticket/Tickets.vue:386
+msgid "Saved Views"
+msgstr "保存済みビュー"
+
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:266
+msgid "Saved reply deleted successfully."
+msgstr "定型返信を削除しました。"
+
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:283
+msgid "Saved reply duplicated successfully."
+msgstr "定型返信を複製しました。"
+
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:326
+msgid "Saved reply saved successfully."
+msgstr "定型返信を保存しました。"
+
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:389
+msgid "Saved reply updated successfully."
+msgstr "定型返信を更新しました。"
+
+#: desk/src/pages/PersonaForm.vue:193
+msgid "Scaling support as we grow"
+msgstr "成長に合わせてサポートを拡大する"
+
+#: desk/src/components/Settings/Holiday/HolidayList.vue:29
+msgid "Schedule name"
+msgstr "スケジュール名"
+
+#. Label of the scope (Select) field in DocType 'HD Saved Reply'
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:88
+#: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
+msgid "Scope"
+msgstr "適用範囲"
+
+#. Label of the script (Code) field in DocType 'HD Form Script'
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+msgid "Script"
+msgstr "スクリプト"
+
+#. Label of the search_tab (Tab Break) field in DocType 'HD Settings'
+#: Rules/AssigneeSearch.vue:29 Rules/AssignmentRulesList.vue:38
+#: desk/src/components/SavedRepliesSelectorModal.vue:27 desk/src/components/Settings/Agents.vue:24
+#: desk/src/components/Settings/Assignment desk/src/components/Settings/Holiday/Holidays.vue:28
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:26
+#: desk/src/components/Settings/Sla/SlaPolicies.vue:41
+#: desk/src/components/Settings/Teams/TeamsList.vue:26 desk/src/components/layouts/AppSidebar.vue:217
+#: desk/src/pages/SearchAgent.vue:7 helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Search"
+msgstr "検索"
+
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.js:10
+msgid "Search Index Regenerated"
+msgstr "検索インデックスを再生成しました"
+
+#: helpdesk/helpdesk/report/ticket_search_analysis/ticket_search_analysis.py:40
+msgid "Search Score"
+msgstr "検索スコア"
+
+#: desk/src/components/ticket-agent/AssignTo.vue:86
+msgid "Search agents..."
+msgstr "担当者を検索..."
+
+#: desk/src/components/customer/TicketsTab.vue:9
+msgid "Search by ID or Subject"
+msgstr "IDまたは件名で検索"
+
+#: desk/src/components/command-palette/CommandPalette.vue:60
+msgid "Search commands"
+msgstr "検索コマンド"
+
+#: desk/src/components/command-palette/CommandPalette.vue:59
+msgid "Search commands for {0}"
+msgstr "{0}の検索コマンド"
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:73
+msgid "Search country"
+msgstr "国を検索"
+
+#: desk/src/components/view-controls/filter/Filter.vue:120
+msgid "Search fields..."
+msgstr "検索フィールド..."
+
+#: desk/src/pages/SearchAgent.vue:100
+msgid "Search index does not exist. Please build the index first."
+msgstr "検索インデックスがありません。先にインデックスを作成してください。"
+
+#: helpdesk/api/search.py:41
+msgid "Search index not available. Please contact administrator."
+msgstr "検索インデックスを利用できません。管理者に連絡してください。"
+
+#: desk/src/components/tag/Tags.vue:15
+msgid "Search or create tags"
+msgstr "タグを検索または作成"
+
+#: helpdesk/api/search.py:17
+msgid "Search query must be at least 2 characters"
+msgstr "検索クエリは少なくとも2文字でなければならない"
+
+#: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:20
+msgid "Search ticket"
+msgstr "チケットを検索"
+
+#: desk/src/components/command-palette/CommandPalette.vue:266
+msgid "Search tickets or type a command…"
+msgstr "チケットを検索するか、コマンドを入力…"
+
+#: desk/src/pages/SearchAgent.vue:16
+msgid "Search tickets, comments, and communications..."
+msgstr "チケット、コメント、コミュニケーションを検索..."
+
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:37
+msgid "Search..."
+msgstr "検索..."
+
+#: desk/src/pages/SearchAgent.vue:137
+msgid "Searched for:"
+msgstr "検索キーワード："
+
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:81 desk/src/pages/SearchAgent.vue:111
+msgid "Searching..."
+msgstr "検索中..."
+
+#: desk/src/components/command-palette/CommandPalette.vue:243
+#: desk/src/components/command-palette/CommandPalette.vue:250
+msgid "Searching…"
+msgstr "検索中..."
+
+#: desk/src/components/command-palette/CommandPalette.vue:266
+msgid "Search…"
+msgstr "検索..."
+
+#: desk/src/pages/home/components/PendingTickets.vue:142
+msgid "See all {0} tickets"
+msgstr "{0}のチケットをすべて参照"
+
+#: desk/src/components/command-palette/CommandPalette.vue:150
+#: desk/src/pages/call-logs/CallLogModal.vue:28 desk/src/pages/call-logs/CallLogModal.vue:57
+#: desk/src/pages/call-logs/CallLogModal.vue:80 desk/src/pages/call-logs/CallLogModal.vue:92
+#: desk/src/pages/call-logs/CallLogModal.vue:101
+msgid "Select"
+msgstr "選択する"
+
+#: desk/src/pages/knowledge-base/NewArticle.vue:19
+msgid "Select Category"
+msgstr "カテゴリーを選択する"
+
+#: desk/src/components/contact/EditContactDialog.vue:159
+msgid "Select Customer"
+msgstr "顧客を選択する"
+
+#: desk/src/pages/dashboard/Dashboard.vue:25
+msgid "Select Range"
+msgstr "範囲を選択する"
+
+#: desk/src/components/ticket/TicketMergeModal.vue:55
+msgid "Select Ticket"
+msgstr "チケットを選択する"
+
+#: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:31
+msgid "Select Timezone"
+msgstr "タイムゾーンを選択する"
+
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:187
+msgid "Select a Default Priority."
+msgstr "デフォルト優先度を選択してください。"
+
+#: desk/src/components/ticket-agent/BulkEditModal.vue:9
+#: desk/src/components/ticket-agent/BulkEditModal.vue:121
+msgid "Select a field"
+msgstr "フィールドを選択"
+
+#: desk/src/pages/ticket/TicketFeedback.vue:27
+msgid "Select a rating"
+msgstr "評価を選択する"
+
+#: desk/src/components/ticket-agent/AssignTo.vue:221
+msgid "Select agents"
+msgstr "担当者を選択"
+
+#: desk/src/components/ViewModal.vue:33
+msgid "Select an icon..."
+msgstr "アイコンを選択します..."
+
+#: desk/src/components/frappe-ui/PhoneControl/PhoneControl.vue:17
+msgid "Select country"
+msgstr "国の選択"
+
+#: desk/src/pages/home/components/AvgTimeMetrics.vue:37
+#: desk/src/pages/home/components/RecentFeedback.vue:151
+msgid "Select range"
+msgstr "範囲を選択"
+
+#: desk/src/pages/PersonaForm.vue:109
+msgid "Select team size"
+msgstr "チームサイズを選択する"
+
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:79
+msgid "Select teams"
+msgstr "チームを選択する"
+
+#: desk/src/components/Settings/SavedReplies/components/PreviewDialog.vue:17
+msgid "Select ticket to preview"
+msgstr "プレビューのチケットを選択"
+
+#: desk/src/components/TimezoneControl.vue:5
+msgid "Select timezone"
+msgstr "時間帯を選択"
+
+#: desk/src/components/Settings/General/components/TicketSettings.vue:132
+msgid "Select what type all tickets get by default."
+msgstr "すべてのチケットに初期設定するタイプを選択します。"
+
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.js:41
+msgid "Select your weekly off day"
+msgstr "週休日を選択する"
+
+#: desk/src/components/ticket-agent/BulkEditModal.vue:115
+msgid "Select {0}"
+msgstr "{0}を選択する"
+
+#: desk/src/pages/ticket/TicketCustomer.vue:78
+msgid "Send"
+msgstr "送信する"
+
+#: desk/src/components/Settings/InviteAgents.vue:37
+msgid "Send Invites"
+msgstr "招待を送信"
+
+#: desk/src/components/ticket-agent/BulkReplyModal.vue:32
+msgid "Send Reply"
+msgstr "フィードバックの送信条件"
+
+#. Label of the send_email_feedback_on_status (Link) field in DocType 'HD
+#. Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Send feedback when"
+msgstr "返信を送信する"
+
+#: desk/src/pages/contact/Contact.vue:296
+msgid "Send reset password email"
+msgstr "パスワードリセットメールを送信する"
+
+#: desk/src/components/ticket-agent/BulkReplyModal.vue:33
+msgid "Send to {0} tickets"
+msgstr "{0}件のチケットに送信"
+
+#: desk/src/components/Settings/EmailNotifications/NotificationList.vue:78
+msgid "Sent to all of the agents assigned to the ticket whenever a contact has replied."
+msgstr "連絡先が返信するたびに、チケットへ割り当てられたすべての担当者に送信されます。"
+
+#: desk/src/components/Settings/EmailNotifications/NotificationList.vue:85
+msgid "Sent to all of the recipients associated with the ticket whenever an agent has replied."
+msgstr "担当者が返信するたびに、チケットに関連するすべての受信者へ送信されます。"
+
+#: desk/src/components/Settings/EmailNotifications/NotificationList.vue:73
+msgid "Sent to the user right after creating an email ticket."
+msgstr "メールからチケットを作成した直後にユーザーへ送信します。"
+
+#: desk/src/components/Settings/EmailNotifications/NotificationList.vue:66
+msgid "Sent to the user who has raised the ticket after the ticket is closed or resolved."
+msgstr "チケットのクローズまたは解決後、起票したユーザーへ送信します。"
+
+#: desk/src/components/layouts/Sidebar.vue:408
+msgid "Service Level Agreement"
+msgstr "サービスレベル協定"
+
+#: desk/src/components/Settings/Sla/SlaPolicies.vue:5
+msgid "Service Level Agreements (SLAs)"
+msgstr "サービスレベル協定 (SLA)"
+
+#. Label of the service_level (Data) field in DocType 'HD Service Level
+#. Agreement'
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+msgid "Service Level Name"
+msgstr "サービスレベル名"
+
+#: helpdesk/api/settings/email.py:14
+msgid "Service not supported"
+msgstr "サポートされていないサービス"
+
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:232
+msgid "Set"
+msgstr "セット"
+
+#: desk/src/components/ticket-agent/AssignTo.vue:45
+msgid "Set Assignee"
+msgstr "担当者を設定"
+
+#: desk/src/components/ticket/SetContactPhoneModal.vue:4
+#: desk/src/components/ticket/SetContactPhoneModal.vue:7
+msgid "Set Phone Number"
+msgstr "電話番号を設定する"
+
+#: desk/src/components/customer/ContactCard.vue:265
+msgid "Set Primary Contact"
+msgstr "主要な連絡先を設定する"
+
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:58
+msgid "Set Resolution Time for Priority {0} in row {1}."
+msgstr "優先度{0}の解決時間を行{1}に設定してください。"
+
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:50
+msgid "Set Response Time for Priority {0} in row {1}."
+msgstr "優先度{0}の応答時間を行{1}に設定してください。"
+
+#: desk/src/components/customer/ContactCard.vue:156
+msgid "Set as Primary"
+msgstr "プライマリとして設定"
+
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:96
+msgid "Set as default SLA"
+msgstr "デフォルト SLA と設定"
+
+#: desk/src/components/contact/ContactInputRow.vue:32
+#: desk/src/components/contact/ContactInputRow.vue:36
+msgid "Set as primary"
+msgstr "プライマリとして設定"
+
+#. Description of the 'Persona Captured' (Check) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Set once an admin completes the onboarding persona questionnaire"
+msgstr "管理者がオンボードパーソナに関するアンケートを完了すると設定します"
+
+#: desk/src/components/AvailabilityMenu.vue:5 desk/src/components/layouts/MobileSidebar.vue:81
+msgid "Set status"
+msgstr "ステータスを設定"
+
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:252
+msgid ""
+"Set the default status assigned when a ticket is created, and the status to apply when a ticket "
+"is reopened. If not specified, the default status from HD Settings will be used."
+msgstr "チケット作成時のデフォルトステータスと、再開時に適用するステータスを設定します。未指定の場合はHD設定のデフォルトステータスが使用されます。"
+
+#: desk/src/pages/PersonaForm.vue:236
+msgid "Set up a customer portal"
+msgstr "顧客ポータルを設定する"
+
+#: desk/src/components/Settings/Sla/SlaHolidays.vue:9
+msgid "Set working days, hours, and holidays by selecting a predefined schedule or creating a new one."
+msgstr "定義済みのスケジュールを選択するか、新規作成して営業日、営業時間、休日を設定してください。"
+
+#: desk/src/components/Settings/Profile/Profile.vue:121
+msgid "Set your availability so your team knows when you're reachable."
+msgstr "チームに連絡できる時を知らせてください"
+
+#: desk/src/components/Settings/Holiday/Holidays.vue:5
+msgid "Set your team’s working days, hours, and holidays using a template or custom schedule."
+msgstr "テンプレートまたはカスタムスケジュールを使用して、チームの営業日、営業時間、休日を設定します。"
+
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:155
+msgid ""
+"Setting <strong>{0}</strong> as the default SLA removes <strong>{1}</strong> as the default SLA. "
+"You’ll need to add a condition in <strong>{1}</strong> for the SLA to work."
+msgstr "<strong>{0}</strong>をデフォルトSLAにすると、<strong>{1}</strong>はデフォルトから外れます。<strong>{1}</strong>を適用するには条件を追加してください。"
+
+#: desk/src/components/layouts/Sidebar.vue:364
+msgid "Setting up"
+msgstr "設定する"
+
+#. Label of the column_break_feto (Column Break) field in DocType 'HD Team'
+#: desk/src/components/layouts/Sidebar.vue:179 desk/src/components/layouts/Sidebar.vue:422
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+msgid "Settings"
+msgstr "設定"
+
+#: desk/src/components/Settings/General/General.vue:253
+#: desk/src/components/Settings/General/General.vue:291
+#: desk/src/components/Settings/General/General.vue:300
+msgid "Settings updated"
+msgstr "アップデートされた設定"
+
+#: desk/src/components/Settings/EmailNotifications/Acknowledgement.vue:47
+#: desk/src/components/Settings/EmailNotifications/ReplyToAgents.vue:47
+#: desk/src/components/Settings/EmailNotifications/ReplyViaAgent.vue:47
+#: desk/src/components/Settings/EmailNotifications/ShareFeedback.vue:77
+msgid "Settings updated successfully."
+msgstr "設定を更新しました。"
+
+#. Label of the setup_section (Section Break) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Setup"
+msgstr "設定"
+
+#: desk/src/components/Settings/EmailAdd.vue:3
+msgid "Setup Email"
+msgstr "メール設定"
+
+#: desk/src/components/layouts/Sidebar.vue:251
+msgid "Setup SLA"
+msgstr "設定 SLA"
+
+#: desk/src/pages/knowledge-base/Article.vue:644
+#: desk/src/pages/knowledge-base/KnowledgeBaseAgent.vue:167
+msgid "Share"
+msgstr "共有する"
+
+#. Label of the share_feedback_section (Section Break) field in DocType 'HD
+#. Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Share Feedback"
+msgstr "意見を共有する"
+
+#: desk/src/components/Settings/EmailNotifications/NotificationList.vue:65
+msgid "Share feedback"
+msgstr "感想を共有する"
+
+#: desk/src/pages/PersonaForm.vue:135
+msgid "Shared email inbox (Gmail, Outlook, etc.)"
+msgstr "共有メール受信箱 (Gmail,Outlookなど)"
+
+#: desk/src/components/layouts/Sidebar.vue:174
+msgid "Shortcuts"
+msgstr "ショートカット"
+
+#: desk/src/components/HistoryBox.vue:10
+msgid "Show "
+msgstr "展示 "
+
+#. Label of the show_customer_portal_permission_notice (Check) field in DocType
+#. 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Show Customer Portal Permission Notice"
+msgstr "顧客ポータル許可通知を表示する"
+
+#. Label of the different_view (Check) field in DocType 'HD Ticket Status'
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+msgid "Show end users a different view"
+msgstr "エンドユーザーに異なるビューを表示する"
+
+#: desk/src/components/modals/ShortcutsModal.vue:80
+msgid "Show keyboard shortcuts"
+msgstr "キーボードショートカット表示"
+
+#: desk/src/components/ticket-agent/TicketFeedback.vue:20
+msgid "Show less"
+msgstr "少なく表示する"
+
+#: desk/src/components/ticket-agent/TicketFeedback.vue:20
+msgid "Show more"
+msgstr "もっと見る"
+
+#: desk/src/pages/home/components/PendingTickets.vue:149
+msgid "Showing {0} of {1} {2}"
+msgstr "{0}の{1}の{2}を表示する"
+
+#: desk/src/components/Settings/Profile/UserEmailSettings.vue:22
+msgid "Signature"
+msgstr "署名"
+
+#: desk/src/components/ticket-agent/TicketDetailsTab.vue:293
+msgid "Similar Tickets"
+msgstr "類似のチケット"
+
+#. Description of the 'Condition' (Code) field in DocType 'HD Service Level
+#. Agreement'
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+msgid "Simple Python Expression, Example: doc.status == 'Open' and doc.ticket_type == 'Bug'"
+msgstr "簡単なPython式（例：doc.status == 'Open' and doc.ticket_type == 'Bug'）"
+
+#. Label of the skip_email_workflow (Check) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Skip e-mail workflow"
+msgstr "メールワークフローをスキップする"
+
+#: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:26
+msgid "Skip email workflow"
+msgstr "メールワークフローをスキップする"
+
+#: desk/src/components/Questionnaire.vue:138
+msgid "Skip for now"
+msgstr "今はスキップ"
+
+#: desk/src/pages/PersonaForm.vue:154
+msgid "Social media"
+msgstr "ソーシャルメディア"
+
+#: Rules/AssignmentRuleView.vue:617 desk/src/components/Settings/Assignment
+msgid "Some error occurred while renaming assignment rule"
+msgstr "割り当てルールの名前変更中にエラーが発生しました"
+
+#: desk/src/components/Settings/Holiday/HolidayView.vue:409
+msgid "Some error occurred while renaming holiday list"
+msgstr "休日リストの名前変更でエラーが発生しました"
+
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:368
+msgid "Some error occurred while renaming saved reply"
+msgstr "定型返信の名前変更中にエラーが発生しました"
+
+#: Rules/AssignmentRuleView.vue:601 desk/src/components/Settings/Assignment
+msgid "Some error occurred while updating assignment rule"
+msgstr "割り当てルールの更新中にエラーが発生しました"
+
+#: desk/src/components/Settings/Holiday/HolidayView.vue:399
+msgid "Some error occurred while updating holiday list"
+msgstr "休日リストの更新中にエラーが発生しました"
+
+#: desk/src/components/view-controls/SortBy.vue:10 desk/src/components/view-controls/SortBy.vue:22
+#: desk/src/components/view-controls/SortBy.vue:231
+msgid "Sort"
+msgstr "並べ替え"
+
+#: desk/src/pages/ticket/MobileTicketAgent.vue:119
+msgid "Source"
+msgstr "ソース"
+
+#: helpdesk/api/knowledge_base.py:125
+msgid "Source and target category cannot be same"
+msgstr "移動元と移動先のカテゴリは同じにできません"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/api.py:339
+msgid "Source and target ticket cannot be same"
+msgstr "移動元と移動先のチケットは同じにできません"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/api.py:335
+msgid "Source ticket does not exist"
+msgstr "ソースチケットは存在しない"
+
+#. Label of the split_and_merge_section (Section Break) field in DocType 'HD
+#. Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Split and Merge"
+msgstr "分割と統合"
+
+#: desk/src/pages/PersonaForm.vue:125
+msgid "Spreadsheets"
+msgstr "スプレッドシート"
+
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.js:9
+msgid "Standard Form Scripts can't be modified, duplicate the script instead."
+msgstr "標準フォームスクリプトは変更できません。代わりにスクリプトを複製してください。"
+
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.py:55
+msgid "Standard Views cannot be deleted."
+msgstr "標準ビューは削除できません。"
+
+#. Label of the start_date (Date) field in DocType 'HD Service Level Agreement'
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+msgid "Start Date"
+msgstr "開始日"
+
+#. Label of the start_time (Time) field in DocType 'HD Service Day'
+#: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
+msgid "Start Time"
+msgstr "開始時間"
+
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:130
+msgid "Start Time can't be greater than or equal to End Time in row <u>{0}</u>."
+msgstr "行<u>{0}</u>の開始時刻は終了時刻以降に設定できません。"
+
+#. Label of the status (Select) field in DocType 'HD Article'
+#. Label of the status_section (Section Break) field in DocType 'HD Settings'
+#. Label of the status (Link) field in DocType 'HD Ticket'
+#. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:217 desk/src/components/customer/TicketsTab.vue:246
+#: desk/src/pages/SearchAgent.vue:59 desk/src/pages/SearchAgent.vue:60
+#: desk/src/pages/call-logs/CallLogModal.vue:53 desk/src/pages/home/components/PendingTickets.vue:30
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:44
+#: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:31
+#: helpdesk/helpdesk/web_form/tickets/tickets.json
+msgid "Status"
+msgstr "ステータス"
+
+#. Label of the auto_close_status (Link) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Status "
+msgstr "ステータス "
+
+#. Label of the status_category (Data) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Status Category"
+msgstr "ステータスカテゴリ"
+
+#. Label of the status_details (Section Break) field in DocType 'HD Service
+#. Level Agreement'
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:248
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+msgid "Status Details"
+msgstr "ステータス詳細"
+
+#. Label of the status_order (Int) field in DocType 'HD Agent Status'
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+msgid "Status Order"
+msgstr "ステータスの順序"
+
+#: desk/src/pages/call-logs/CallLogModal.vue:382
+msgid "Status is required"
+msgstr "ステータスが必要"
+
+#. Description of the 'Ticket Reopen status' (Link) field in DocType 'HD
+#. Service Level Agreement'
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+msgid ""
+"Status of the ticket, when a customer replies on the ticket with this SLA.\n"
+"\n"
+"If not selected, the value will be takes from HD Settings DocType."
+msgstr ""
+"このSLAが適用されたチケットに顧客が返信した際のステータスです。\n"
+"\n"
+"未選択の場合は、HD設定DocTypeの値が使用されます。"
+
+#. Description of the 'Ticket Reopen status' (Link) field in DocType 'HD
+#. Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Status of the ticket, when a customer replies on the ticket."
+msgstr "顧客がチケットに返信した際のチケットステータスです。"
+
+#. Description of the 'Default Ticket Status' (Link) field in DocType 'HD
+#. Service Level Agreement'
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+msgid ""
+"Status of the ticket, when it is created in the system with this SLA.\n"
+"If not selected, the value will be taken from HD Settings DocType"
+msgstr ""
+"このSLAを使用してシステム内で作成されたチケットのステータスです。\n"
+"未選択の場合は、HD設定DocTypeの値が使用されます"
+
+#. Description of the 'Default ticket status' (Link) field in DocType 'HD
+#. Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Status of the ticket, when it is created in the system."
+msgstr "システムで作成されたチケットのステータスです。"
+
+#. Label of the subject (Data) field in DocType 'HD Ticket'
+#. Label of a field in the tickets Web Form
+#: desk/src/components/customer/TicketsTab.vue:216 desk/src/pages/home/components/PendingTickets.vue:27
+#: desk/src/pages/ticket/TicketNew.vue:63 helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/report/ticket_search_analysis/ticket_search_analysis.py:30
+#: helpdesk/helpdesk/web_form/tickets/tickets.json
+msgid "Subject"
+msgstr "件名"
+
+#. Label of the subject_weight (Int) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Subject Weight"
+msgstr "件名の重み"
+
+#: desk/src/components/ticket/TicketSplitModal.vue:74
+msgid "Subject is required"
+msgstr "件名は必須です"
+
+#: desk/src/pages/ticket/TicketFeedback.vue:8 desk/src/pages/ticket/TicketNew.vue:96
+#: desk/src/pages/ticket/TicketNew.vue:121
+msgid "Submit"
+msgstr "送信"
+
+#. Label of the summary (Text Editor) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Summary"
+msgstr "概要"
+
+#. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
+#. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
+#. List'
+#: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
+msgid "Sunday"
+msgstr "日曜日"
+
+#: desk/src/components/layouts/MobileSidebar.vue:118 desk/src/components/layouts/Sidebar.vue:159
+msgid "Support"
+msgstr "サポート"
+
+#. Name of a report
+#: helpdesk/helpdesk/report/support_hour_distribution/support_hour_distribution.json
+msgid "Support Hour Distribution"
+msgstr "サポート時間の分布"
+
+#. Label of a Link in the Helpdesk Workspace
+#: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
+msgid "Support Policy"
+msgstr "サポートポリシー"
+
+#. Name of a role
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
+msgid "Support Team"
+msgstr "サポートチーム"
+
+#: desk/src/pages/PersonaForm.vue:149
+msgid "Support portal"
+msgstr "サポートポータル"
+
+#: desk/src/components/Settings/Preferences/components/ThemeSwitcher.vue:9
+msgid "Switch between light, dark, or system theme"
+msgstr "ライト、ダーク、システムテーマを切り替えます"
+
+#: desk/src/components/Settings/Profile/UserEmailSettings.vue:42
+msgid "Switch between outgoing email accounts when sending emails from your configured accounts."
+msgstr "設定済みのアカウントからメールを送信する際に、送信元メールアカウントを切り替えます。"
+
+#: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.js:16
+#: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.js:18
+msgid "Sync Customers"
+msgstr "顧客を同期"
+
+#: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.js:22
+msgid ""
+"Sync all customers between ERPNext and Helpdesk? The sync runs in the background and can take a "
+"few minutes depending on the number of customers."
+msgstr "ERPNextとHelpdesk間のすべての顧客を同期しますか？同期はバックグラウンドで実行され、顧客数によっては数分かかります。"
+
+#: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:218
+msgid "Sync completed successfully"
+msgstr "同期が完了しました"
+
+#: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:3
+#: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:39
+msgid "Sync customers between Helpdesk and ERPNext."
+msgstr "HelpdeskとERPNext間で顧客を同期します。"
+
+#: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:120
+msgid "Sync now"
+msgstr "今すぐ同期"
+
+#: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:199
+#: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.js:35
+msgid "Sync started"
+msgstr "同期開始"
+
+#: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:104
+msgid "Sync your existing customers"
+msgstr "既存の顧客を同期する"
+
+#: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:120
+msgid "Syncing…"
+msgstr "同期中…"
+
+#. Label of the synonyms (Table) field in DocType 'HD Synonyms'
+#: helpdesk/helpdesk/doctype/hd_synonyms/hd_synonyms.json
+msgid "Synonyms"
+msgstr "同義語"
+
+#. Label of the is_system (Check) field in DocType 'HD Ticket Type'
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
+msgid "System"
+msgstr "システム"
+
+#. Name of a role
+#: helpdesk/helpdesk/doctype/erpnext_hd_settings/erpnext_hd_settings.json
+#: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_article_category/hd_article_category.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.json
+#: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
+#: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
+#: helpdesk/helpdesk/doctype/hd_form_script/hd_form_script.json
+#: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
+#: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+#: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
+#: helpdesk/helpdesk/doctype/hd_synonyms/hd_synonyms.json
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/doctype/hd_ticket_activity/hd_ticket_activity.json
+#: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
+#: helpdesk/helpdesk/doctype/hd_ticket_feedback_option/hd_ticket_feedback_option.json
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.json
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "System Manager"
+msgstr "システム管理者"
+
+#: helpdesk/helpdesk/doctype/hd_ticket_type/hd_ticket_type.py:12
+msgid "System types can not be deleted"
+msgstr "システムタイプは削除できません"
+
+#: helpdesk/api/dashboard_tags.py:48
+msgid "Tag"
+msgstr "タグ"
+
+#: helpdesk/api/dashboard_tags.py:72
+msgid "Tag Trend"
+msgstr "タグトレンド"
+
+#: desk/src/components/tag/Tags.vue:234 helpdesk/api/tags.py:58
+msgid "Tag cannot contain commas"
+msgstr "タグにカンマを含めることはできません"
+
+#: helpdesk/api/tags.py:55
+msgid "Tag label is required"
+msgstr "タグラベルが必要"
+
+#: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:22
+msgid "Tampered Access"
+msgstr "不正アクセス"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/api.py:337
+msgid "Target ticket does not exist"
+msgstr "ターゲットのチケットは存在しない"
+
+#. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
+#. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+msgid "Teal"
+msgstr "ティール"
+
+#. Option for the 'Scope' (Select) field in DocType 'HD Saved Reply'
+#. Label of the team (Link) field in DocType 'HD Saved Reply Team'
+#. Label of the agent_group (Link) field in DocType 'HD Ticket'
+#. Label of a Link in the Helpdesk Workspace
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:341
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:195
+#: desk/src/components/layouts/Sidebar.vue:403 desk/src/pages/SearchAgent.vue:50
+#: desk/src/pages/SearchAgent.vue:51 desk/src/pages/dashboard/Dashboard.vue:57
+#: desk/src/pages/home/components/PendingTickets.vue:36 desk/src/pages/ticket/MobileTicketAgent.vue:63
+#: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
+#: helpdesk/helpdesk/doctype/hd_saved_reply_team/hd_saved_reply_team.json
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
+msgid "Team"
+msgstr "チーム"
+
+#: desk/src/components/Settings/Teams/NewTeam.vue:29
+msgid "Team Name"
+msgstr "チーム名"
+
+#. Label of the agent_groups_section (Section Break) field in DocType 'HD
+#. Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Team Restrictions"
+msgstr "チーム制限"
+
+#: desk/src/components/Settings/Teams/TeamEdit.vue:269
+msgid "Team can now access all tickets."
+msgstr "チームはすべてのチケットにアクセスできるようになりました。"
+
+#: desk/src/components/Settings/NewTeamModal.vue:52
+msgid "Team created"
+msgstr "チーム作成"
+
+#: desk/src/components/Settings/Teams/NewTeam.vue:140
+msgid "Team created successfully."
+msgstr "チームを作成しました。"
+
+#: desk/src/components/Settings/Teams/TeamEdit.vue:162
+#: desk/src/components/Settings/Teams/TeamsList.vue:185
+msgid "Team deleted successfully."
+msgstr "チームを削除しました。"
+
+#: desk/src/components/Settings/Teams/TeamEdit.vue:184
+msgid "Team disabled successfully."
+msgstr "チームを無効にしました。"
+
+#: desk/src/components/Settings/Teams/TeamEdit.vue:183
+msgid "Team enabled successfully."
+msgstr "チームを有効にしました。"
+
+#: desk/src/components/Settings/Teams/TeamsList.vue:51
+msgid "Team name"
+msgstr "チーム名"
+
+#: desk/src/components/Settings/Teams/RenameTeamModal.vue:56
+msgid "Team renamed successfully."
+msgstr "チーム名を変更しました。"
+
+#: desk/src/components/Settings/Teams/TeamEdit.vue:270
+msgid "Team will only see their own tickets."
+msgstr "チームは自分たちのチケットのみ閲覧できます。"
+
+#. Label of the teams (Table MultiSelect) field in DocType 'HD Saved Reply'
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:75
+#: desk/src/components/Settings/Teams/TeamsList.vue:3
+#: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
+msgid "Teams"
+msgstr "チーム"
+
+#: desk/src/components/Settings/Telephony/Telephony.vue:6
+msgid "Telephony"
+msgstr "電話"
+
+#: desk/src/components/Settings/Telephony/ExotelSettings.vue:281
+#: desk/src/components/Settings/Telephony/Telephony.vue:260
+#: desk/src/components/Settings/Telephony/TwilioSettings.vue:233
+msgid "Telephony settings updated successfully."
+msgstr "電話設定を更新しました。"
+
+#: desk/src/pages/PersonaForm.vue:101
+msgid "Tell us about your organization"
+msgstr "あなたの組織について教えてください"
+
+#: desk/src/components/Questionnaire.vue:194 desk/src/pages/ticket/TicketFeedback.vue:56
+msgid "Tell us more"
+msgstr "詳しく教えてください"
+
+#. Label of the template (Link) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Template"
+msgstr "テンプレート"
+
+#. Label of the template_name (Data) field in DocType 'HD Ticket Template'
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+msgid "Template Name"
+msgstr "テンプレート名"
+
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.py:12
+msgid "The 'Closed' status cannot be renamed."
+msgstr "「クローズ」ステータスの名前は変更できません。"
+
+#: helpdesk/extends/assignment_rule.py:20
+msgid "The Assign Condition JSON '{0}' is invalid: </br> {1}"
+msgstr "割り当て条件 JSON \"{0}\"は無効です: </br> {1}"
+
+#: helpdesk/extends/assignment_rule.py:28
+msgid "The Unassign Condition JSON '{0}' is invalid: </br> {1}"
+msgstr "割り当て解除条件のJSON「{0}」は無効です：</br> {1}"
+
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:167
+msgid "The assignment condition '{0}' is invalid: {1}"
+msgstr "割り当て条件\"{0}\"は無効: {1}"
+
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:174
+msgid "The assignment condition json '{0}' is invalid: {1}"
+msgstr "割り当て条件のJSON「{0}」が無効です: {1}"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:361
+msgid "The contact {0} is linked to multiple customers. Please select the customer manually."
+msgstr "連絡先{0}は複数の顧客に紐づいています。顧客を手動で選択してください。"
+
+#: desk/src/components/Settings/General/components/TicketSettings.vue:13
+msgid "The feedback dialog will be shown, when a user tries to close a ticket from the customer portal."
+msgstr "ユーザーが顧客ポータルからチケットをクローズする際に、フィードバックダイアログを表示します。"
+
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.py:54
+msgid "The holiday on {0} is not between From Date and To Date"
+msgstr "休日{0}が開始日から終了日の範囲内にありません"
+
+#: desk/src/components/Settings/General/components/TicketSettings.vue:187
+msgid "The number of days must be 1 or more"
+msgstr "日数には1以上を指定してください"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:343
+msgid ""
+"The selected customer {0} is not linked to the contact {1}.Please select a valid customer or "
+"update the contact's linked customers."
+msgstr "選択した顧客{0}は連絡先{1}に関連付けられていません。有効な顧客を選択するか、連絡先に関連付ける顧客を更新してください。"
+
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.py:40
+msgid "The status for sending feedback must be of <u>Resolved</u> category."
+msgstr "フィードバック送信時のステータスは<u>解決</u>カテゴリである必要があります。"
+
+#: desk/src/components/Settings/General/components/TicketSettings.vue:83
+msgid "The ticket status will automatically change whenever the agent respond to a ticket."
+msgstr "担当者がチケットに返信するたびに、チケットのステータスが自動的に変更されます。"
+
+#: desk/src/components/Settings/Preferences/components/ThemeSwitcher.vue:5
+msgid "Theme"
+msgstr "テーマ"
+
+#: desk/src/components/knowledge-base/CategoryFolderContainer.vue:18
+msgid "There are no categories published at the moment."
+msgstr "現在公開されているカテゴリはありません。"
+
+#: helpdesk/extends/assignment_rule.py:14
+msgid "There should be at least 1 assignment rule for ticket"
+msgstr "チケットには少なくとも1つの割り当てルールが必要です"
+
+#: desk/src/components/customer/ContactCard.vue:223
+msgid "They'll get access to tickets raised by everyone in the organisation."
+msgstr "組織内の全員が起票したチケットにアクセスできます。"
+
+#: desk/src/components/customer/ContactCard.vue:226
+msgid "They'll only see their own tickets going forward."
+msgstr "今後は自分が起票したチケットのみ閲覧できます。"
+
+#: helpdesk/extends/assignment_rule.py:51
+msgid ""
+"This Assignment Rule is linked to the Team {0}.</br> User {1} is added in the Assignment Rule but"
+" not in the linked Team. Please add the user in the {2} to ensure proper team structure."
+msgstr "この割り当てルールはチーム{0}に関連付けられています。</br>ユーザー{1}は割り当てルールに追加されていますが、関連するチームには所属していません。適切なチーム構成にするため、ユーザーを{2}に追加してください。"
+
+#: desk/src/components/ticket/TicketMergeModal.vue:79
+#: desk/src/components/ticket/TicketSplitModal.vue:24
+msgid "This action is irreversible."
+msgstr "この操作は取り消せません。"
+
+#: desk/src/components/customer/ContactCard.vue:266
+msgid ""
+"This contact will become the primary point of contact and will be able to view tickets raised by "
+"all other contacts in the organisation."
+msgstr "この連絡先が主連絡先となり、組織内の他の連絡先が起票したすべてのチケットを閲覧できるようになります。"
+
+#: desk/src/components/ticket/TicketCustomerSidebar.vue:75
+msgid "This date is calculated based on configured SLAs, working hours, and holidays."
+msgstr "この日付は、設定済みのSLA、営業時間、休日に基づいて計算されます。"
+
+#. Description of a DocType
+#: helpdesk/helpdesk/doctype/hd_ticket_template/hd_ticket_template.json
+msgid "This doctype will be deprecated in the future"
+msgstr "このDocTypeは将来廃止される予定です"
+
+#. Description of the 'Instantly send e-mail' (Check) field in DocType 'HD
+#. Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid ""
+"This field is used to send an email instantly without adding it into the queue. If this field is "
+"checked, the email will be sent immediately after clicking the \"Send\" button, instead of being "
+"added to the email queue for later processing."
+msgstr "このフィールドは、キューに追加せずメールを即時送信するために使用します。有効にすると、メールは後で処理するキューに追加されず、「送信」ボタンのクリック直後に送信されます。"
+
+#. Description of the 'Skip e-mail workflow' (Check) field in DocType 'HD
+#. Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid ""
+"This field is used to skip email-related workflows for tickets. If this field is checked, no "
+"emails will be sent related to tickets, such as new ticket creation, status updates, or "
+"notifications."
+msgstr "このフィールドは、チケットのメール関連ワークフローをスキップするために使用します。有効にすると、チケットの新規作成、ステータス更新、通知などに関するメールは送信されません。"
+
+#: desk/src/components/Questionnaire.vue:25
+msgid "This helps us personalize your Helpdesk experience."
+msgstr "Helpdeskを利用目的に合わせて最適化するために使用します。"
+
+#: helpdesk/www/helpdesk/index.py:26
+msgid "This method is only meant for developer mode"
+msgstr "このメソッドは開発者モード専用です"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/api.py:373
+msgid "This ticket (#{0}) has been merged with ticket <a href = '/helpdesk/tickets/{1}'>#{1}</a>."
+msgstr "このチケット（#{0}）はチケット<a href = '/helpdesk/tickets/{1}'>#{1}</a>に統合されました。"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/api.py:514
+msgid "This ticket has been split to a new ticket. Please follow up on ticket <a href={0}>#{1}</a>."
+msgstr "このチケットは新しいチケットに分割されました。以後はチケット<a href={0}>#{1}</a>で対応してください。"
+
+#: desk/src/components/ListViewBuilder.vue:725
+msgid "This view is public. Changes made will be visible to everyone."
+msgstr "このビューは公開されています。変更内容はすべてのユーザーに表示されます。"
+
+#: desk/src/components/Settings/General/components/TicketSettings.vue:249
+msgid "This will reset the content to the default message."
+msgstr "内容をデフォルトメッセージに戻します。"
+
+#: desk/src/pages/PersonaForm.vue:169
+msgid "Through a support portal"
+msgstr "サポートポータルを通じて"
+
+#. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
+#. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
+#. List'
+#: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
+msgid "Thursday"
+msgstr "木曜日"
+
+#. Label of the ticket (Link) field in DocType 'HD Email Feedback'
+#. Label of the reference_ticket (Link) field in DocType 'HD Notification'
+#. Label of the ticket_tab (Tab Break) field in DocType 'HD Settings'
+#. Title of the tickets Web Form
+#: desk/src/components/command-palette/CommandPalette.vue:27
+#: desk/src/components/command-palette/CommandPalette.vue:91
+#: desk/src/components/layouts/Sidebar.vue:401 desk/src/components/ticket/TicketMergeModal.vue:57
+#: desk/src/pages/call-logs/CallLogModal.vue:102
+#: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.json
+#: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+#: helpdesk/helpdesk/web_form/tickets/tickets.json
+msgid "Ticket"
+msgstr "チケット"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:939
+msgid "Ticket #{0}: We've received your request"
+msgstr "チケット #{0}: ご依頼が届きました"
+
+#. Name of a report
+#. Label of a Link in the Helpdesk Workspace
+#: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.json
+#: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
+msgid "Ticket Analytics"
+msgstr "チケット分析"
+
+#. Label of a Card Break in the Helpdesk Workspace
+#: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
+msgid "Ticket Configuration"
+msgstr "チケットの設定"
+
+#: desk/src/components/customer/TicketsTab.vue:215
+msgid "Ticket ID"
+msgstr "チケット ID"
+
+#: desk/src/components/modals/ShortcutsModal.vue:85
+msgid "Ticket Management"
+msgstr "チケット管理"
+
+#. Label of the is_merged (Check) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Ticket Merged"
+msgstr "チケットを統合しました"
+
+#: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:40
+msgid "Ticket Not Found"
+msgstr "チケットが見つかりませんでした"
+
+#: desk/src/components/layouts/Sidebar.vue:410
+#: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:50
+#: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:77
+#: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:37
+#: helpdesk/helpdesk/report/ticket_summary/ticket_summary.py:105
+msgid "Ticket Priority"
+msgstr "チケットの優先度"
+
+#. Label of the ticket_reopen_status (Link) field in DocType 'HD Service Level
+#. Agreement'
+#. Label of the ticket_reopen_status (Link) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Ticket Reopen status"
+msgstr "チケット再開時のステータス"
+
+#. Label of the ticket_routing_section (Section Break) field in DocType 'HD
+#. Settings'
+#: Rules/AssigneeRules.vue:18 desk/src/components/Settings/Assignment
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Ticket Routing"
+msgstr "チケットのルーティング"
+
+#: desk/src/components/Settings/General/components/TicketSettings.vue:4
+msgid "Ticket Settings"
+msgstr "チケットの設定"
+
+#. Label of the ticket_split_from (Link) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Ticket Split From"
+msgstr "分割元チケット"
+
+#: desk/src/components/ticket/TicketMergeModal.vue:65
+msgid "Ticket Subject"
+msgstr "チケットの件名"
+
+#. Name of a report
+#. Label of a Link in the Helpdesk Workspace
+#: helpdesk/helpdesk/report/ticket_summary/ticket_summary.json
+#: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
+msgid "Ticket Summary"
+msgstr "チケットの概要"
+
+#: helpdesk/api/dashboard.py:305
+msgid "Ticket Trend"
+msgstr "チケットのトレンド"
+
+#. Label of the ticket_type_section (Section Break) field in DocType 'HD
+#. Settings'
+#. Label of the ticket_type (Link) field in DocType 'HD Ticket'
+#. Label of a Link in the Helpdesk Workspace
+#: desk/src/components/layouts/Sidebar.vue:409 helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+#: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:66
+#: helpdesk/helpdesk/report/ticket_summary/ticket_summary.py:94
+#: helpdesk/helpdesk/workspace/helpdesk/helpdesk.json
+msgid "Ticket Type"
+msgstr "チケットタイプ"
+
+#: desk/src/pages/ticket/TicketCustomer.vue:325
+msgid "Ticket closed successfully."
+msgstr "チケットをクローズしました。"
+
+#: desk/src/components/ticket-agent/TicketHeader.vue:214
+msgid "Ticket deleted successfully."
+msgstr "チケットを削除しました。"
+
+#: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:21
+msgid "Ticket does not exist."
+msgstr "チケットが存在しません。"
+
+#: desk/src/components/ticket/TicketMergeModal.vue:192
+msgid "Ticket merged successfully."
+msgstr "チケットを統合しました。"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:423
+msgid "Ticket must be resolved with a feedback"
+msgstr "チケットはフィードバックで解決する必要があります"
+
+#: desk/src/pages/ticket/TicketAgent.vue:33 helpdesk/helpdesk/doctype/hd_ticket/api.py:63
+msgid "Ticket not found"
+msgstr "チケットが見つかりませんでした"
+
+#: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:40
+msgid "Ticket not found for the provided key."
+msgstr "指定されたキーに対応するチケットが見つかりませんでした"
+
+#: desk/src/pages/ticket/TicketCustomer.vue:164
+msgid "Ticket not found."
+msgstr "チケットが見つかりませんでした"
+
+#. Label of the raised_outside_working_hours (Check) field in DocType 'HD
+#. Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Ticket raised outside working hours"
+msgstr "営業時間外に起票されたチケット"
+
+#: desk/src/components/ticket/TicketSplitModal.vue:79
+msgid "Ticket split successfully."
+msgstr "チケットを分割しました。"
+
+#: desk/src/components/Settings/General/components/TicketSettings.vue:155
+msgid "Ticket status"
+msgstr "チケットのステータス"
+
+#: desk/src/components/ticket/TicketMergeModal.vue:189
+msgid "Ticket to merged with is required"
+msgstr "統合先のチケットは必須です"
+
+#: desk/src/pages/ticket/TicketCustomer.vue:298
+msgid "Ticket updated successfully."
+msgstr "チケットを更新しました。"
+
+#. Name of a report
+#: helpdesk/helpdesk/report/ticket_search_analysis/ticket_search_analysis.json
+msgid "Ticket-Search Analysis"
+msgstr "チケット検索分析"
+
+#: desk/src/components/ticket-agent/TicketHeader.vue:169 desk/src/pages/SearchAgent.vue:351
+#: desk/src/pages/contact/Contact.vue:73 desk/src/pages/contact/Contact.vue:175
+#: desk/src/pages/customer/Customer.vue:68 desk/src/pages/customer/Customer.vue:147
+#: desk/src/pages/ticket/MobileTicketAgent.vue:472 desk/src/pages/ticket/TicketCustomer.vue:354
+#: desk/src/pages/ticket/TicketNew.vue:298 desk/src/pages/ticket/Tickets.vue:6
+#: desk/src/pages/ticket/Tickets.vue:475 helpdesk/api/dashboard.py:159 helpdesk/api/dashboard.py:308
+#: helpdesk/api/dashboard_tags.py:49 helpdesk/api/dashboard_tags.py:75
+msgid "Tickets"
+msgstr "チケット"
+
+#: desk/src/pages/home/components/PendingTickets.vue:235
+msgid "Tickets approaching or breached SLA"
+msgstr "SLA期限間近または期限超過のチケット"
+
+#: desk/src/pages/home/components/PendingTickets.vue:236
+msgid "Tickets assigned to you in the last 7 days"
+msgstr "過去7日間に割り当てられたチケット"
+
+#: helpdesk/api/dashboard.py:577
+msgid "Tickets by Channel"
+msgstr "チャンネルによるチケット"
+
+#: helpdesk/api/dashboard.py:535 helpdesk/api/dashboard.py:544
+msgid "Tickets by Priority"
+msgstr "優先度別チケット"
+
+#: helpdesk/api/dashboard.py:465 helpdesk/api/dashboard.py:474
+msgid "Tickets by Team"
+msgstr "チームごとにチケット"
+
+#: helpdesk/api/dashboard.py:500 helpdesk/api/dashboard.py:509
+msgid "Tickets by Type"
+msgstr "タイプ別チケット"
+
+#: helpdesk/api/ticket.py:72
+msgid "Tickets can only be assigned to agents"
+msgstr "チケットは担当者にのみ割り当てられます"
+
+#: desk/src/components/ticket/TicketMergeModal.vue:29
+msgid "Tickets must meet the following conditions:"
+msgstr "チケットは次の条件を満たす必要があります："
+
+#: desk/src/components/ticket-agent/TicketDetailsTab.vue:285
+msgid "Tickets recently raised by this contact/customer"
+msgstr "この連絡先または顧客が最近起票したチケット"
+
+#: desk/src/pages/home/components/PendingTickets.vue:237
+msgid "Tickets that are awaiting your response"
+msgstr "あなたの返信を待っているチケット"
+
+#: desk/src/components/ticket-agent/TicketDetailsTab.vue:294
+msgid "Tickets with similar queries"
+msgstr "類似の問い合わせのあるチケット"
+
+#: desk/src/pages/home/components/RecentActivity.vue:58
+msgid "Tickets you act on will show up here"
+msgstr "チケットはここに表示されます"
+
+#: desk/src/components/Settings/Preferences/components/LanguageTimezoneSetting.vue:22
+#: desk/src/components/contact/EditContactDialog.vue:109
+msgid "Timezone"
+msgstr "タイムゾーン"
+
+#. Label of the title (Data) field in DocType 'HD Article'
+#. Label of the title (Data) field in DocType 'HD Saved Reply'
+#: desk/src/components/Settings/NewTeamModal.vue:19
+#: desk/src/components/Settings/SavedReplies/SavedRepliesList.vue:86
+#: desk/src/components/Settings/Teams/RenameTeamModal.vue:10
+#: desk/src/pages/knowledge-base/Article.vue:48 desk/src/pages/knowledge-base/NewArticle.vue:39
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+#: helpdesk/helpdesk/doctype/hd_saved_reply/hd_saved_reply.json
+msgid "Title"
+msgstr "タイトル"
+
+#. Label of the title_slug (Data) field in DocType 'HD Article'
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+msgid "Title Slug"
+msgstr "タイトルスラッグ"
+
+#: desk/src/components/Settings/NewTeamModal.vue:48
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:397
+msgid "Title is required"
+msgstr "タイトルが必要"
+
+#. Label of the user_to (Link) field in DocType 'HD Notification'
+#: desk/src/components/EmailEditor.vue:28 desk/src/pages/call-logs/CallLogModal.vue:33
+#: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
+msgid "To"
+msgstr "宛先"
+
+#. Label of the to_date (Date) field in DocType 'HD Service Holiday List'
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
+#: helpdesk/helpdesk/report/first_response_time_for_tickets/first_response_time_for_tickets.js:16
+#: helpdesk/helpdesk/report/support_hour_distribution/support_hour_distribution.js:15
+#: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:24
+#: helpdesk/helpdesk/report/ticket_summary/ticket_summary.js:24
+msgid "To Date"
+msgstr "終了日"
+
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.py:45
+msgid "To Date cannot be before From Date"
+msgstr "終了日は開始日より前に設定できません"
+
+#: desk/src/components/Settings/Holiday/HolidayView.vue:98
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:178
+msgid "To date"
+msgstr "終了日"
+
+#: desk/src/pages/call-logs/CallLogModal.vue:366
+msgid "To is required"
+msgstr "宛先は必須です"
+
+#: desk/src/components/Settings/EmailEdit.vue:268
+msgid "To know more about setting up email accounts, click"
+msgstr "メールアカウント設定の詳細はこちらをクリック"
+
+#: desk/src/pages/dashboard/Dashboard.vue:537 desk/src/pages/dashboard/Dashboard.vue:539
+msgid "Today"
+msgstr "今日"
+
+#: desk/src/components/layouts/MobileSidebar.vue:91 desk/src/components/layouts/Sidebar.vue:125
+msgid "Toggle theme"
+msgstr "テーマを切り替え"
+
+#: helpdesk/helpdesk/report/ticket_search_analysis/ticket_search_analysis.py:35
+msgid "Top Result"
+msgstr "最高の結果"
+
+#: helpdesk/api/dashboard_tags.py:46
+msgid "Top Tags"
+msgstr "上位タグ"
+
+#: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:98
+msgid "Total"
+msgstr "合計"
+
+#. Label of the total_hold_time (Duration) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "Total Hold Time"
+msgstr "総待機時間"
+
+#. Label of the total_holidays (Int) field in DocType 'HD Service Holiday List'
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
+msgid "Total Holidays"
+msgstr "総休日"
+
+#: helpdesk/helpdesk/report/ticket_summary/ticket_summary.py:126
+msgid "Total Ticket"
+msgstr "チケット合計"
+
+#: helpdesk/api/dashboard.py:164
+msgid "Total number of tickets created"
+msgstr "作成されたチケットの総数"
+
+#: helpdesk/api/dashboard.py:545
+msgid "Total tickets by priority"
+msgstr "優先度別チケット合計"
+
+#: helpdesk/api/dashboard.py:475
+msgid "Total tickets by team"
+msgstr "チームごとにチケットの合計"
+
+#: helpdesk/api/dashboard.py:510
+msgid "Total tickets by type"
+msgstr "タイプ別チケット合計"
+
+#. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
+#. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
+#. List'
+#: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
+msgid "Tuesday"
+msgstr "火曜日"
+
+#: desk/src/components/Settings/Telephony/Telephony.vue:72
+#: desk/src/components/Settings/Telephony/TwilioSettings.vue:4
+msgid "Twilio"
+msgstr "ツイリオ"
+
+#. Label of the type (Select) field in DocType 'HD Field Layout'
+#. Label of the notification_type (Select) field in DocType 'HD Notification'
+#. Label of the type (Select) field in DocType 'HD View'
+#: desk/src/pages/SearchAgent.vue:77 desk/src/pages/SearchAgent.vue:78
+#: desk/src/pages/call-logs/CallLogModal.vue:24
+#: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
+#: helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "Type"
+msgstr "タイプ"
+
+#: desk/src/pages/ticket/TicketCustomer.vue:69
+msgid "Type a message"
+msgstr "メッセージを入力する"
+
+#: desk/src/components/customer/InviteContactDialog.vue:19
+msgid "Type an email address"
+msgstr "メールアドレスを入力する"
+
+#: desk/src/pages/call-logs/CallLogModal.vue:360
+msgid "Type is required"
+msgstr "タイプが必要"
+
+#. Label of the url_method (Data) field in DocType 'HD Ticket Template Field'
+#: helpdesk/helpdesk/doctype/hd_ticket_template_field/hd_ticket_template_field.json
+msgid "URL/Method"
+msgstr "URL/メソッド"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:751
+msgid "Unable to send email. Please setup default outgoing email account."
+msgstr "メールを送信できません。デフォルトの送信メールアカウントを設定してください。"
+
+#: Rules/AssignmentRuleView.vue:199 desk/src/components/Settings/Assignment
+msgid "Unassignment Condition"
+msgstr "割り当て解除条件"
+
+#: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:16
+msgid "Unauthorized Access"
+msgstr "無許可アクセス"
+
+#: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:16
+msgid "Unauthorized access."
+msgstr "許可のないアクセス"
+
+#. Option for the 'Category' (Select) field in DocType 'HD Agent Status'
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+msgid "Unavailable"
+msgstr "不在"
+
+#: desk/src/components/layouts/Sidebar.vue:377
+msgid "Understanding ticket view"
+msgstr "チケットビューを理解する"
+
+#: desk/src/pages/knowledge-base/Article.vue:21
+msgid "Unpublish"
+msgstr "非公開にする"
+
+#: desk/src/components/UnsavedBadge.vue:8 desk/src/components/contact/EditContactDialog.vue:12
+#: desk/src/components/customer/EditCustomerDialog.vue:18
+msgid "Unsaved"
+msgstr "保存されていない"
+
+#: Rules/AssigneeSearch.vue:164 Rules/AssignmentRuleView.vue:449
+#: desk/src/components/Settings/Assignment
+#: desk/src/components/Settings/EmailNotifications/Notification.vue:101
+#: desk/src/components/Settings/FieldDependency/FieldDependency.vue:66
+#: desk/src/components/Settings/Holiday/HolidayView.vue:200
+#: desk/src/components/Settings/Profile/UserEmailSettings.vue:217
+#: desk/src/components/Settings/SavedReplies/SavedReplyView.vue:279
+#: desk/src/components/Settings/SettingsModal.vue:72
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:375
+#: desk/src/components/Settings/Teams/NewTeam.vue:108
+#: desk/src/components/Settings/Telephony/ExotelSettings.vue:214
+#: desk/src/components/Settings/Telephony/TwilioSettings.vue:183
+msgid "Unsaved changes"
+msgstr "保存されていない変更"
+
+#: helpdesk/api/ticket_stats.py:26
+msgid "Unsupported doctype '{0}' for ticket stats."
+msgstr "チケット統計ではDocType「{0}」はサポートされていません。"
+
+#: desk/src/pages/call-logs/CallLogModal.vue:8 desk/src/pages/home/components/RecentActivity.vue:33
+msgid "Untitled"
+msgstr "タイトルなし"
+
+#: desk/src/components/Settings/Profile/UserEmailSettings.vue:12
+#: desk/src/components/Settings/Profile/components/ChangePasswordModal.vue:47
+msgid "Update"
+msgstr "アップデート"
+
+#: desk/src/components/Settings/EmailEdit.vue:142
+msgid "Update Account"
+msgstr "アカウントの更新"
+
+#. Label of the update_status_to (Link) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Update status to"
+msgstr "ステータスを更新"
+
+#: desk/src/components/ticket-agent/BulkEditModal.vue:27
+msgid "Update {0} tickets"
+msgstr "{0}チケットの更新"
+
+#: desk/src/components/ticket-agent/BulkEditModal.vue:155
+msgid "Updated {0} of {1} tickets"
+msgstr "{0}の更新された {1}チケット"
+
+#: desk/src/components/ticket-agent/BulkEditModal.vue:158
+#: desk/src/components/ticket-agent/BulkEditModal.vue:170
+msgid "Updated {0} tickets"
+msgstr "更新された {0}チケット"
+
+#: desk/src/components/ticket-agent/BulkEditModal.vue:148
+msgid "Updating {0} tickets…"
+msgstr "{0}件のチケットを更新中…"
+
+#: desk/src/components/Settings/General/components/LogoUpload.vue:41
+msgid "Upload"
+msgstr "アップロード"
+
+#: desk/src/components/Settings/Profile/Profile.vue:202
+msgid "Upload Photo"
+msgstr "写真をアップロードする"
+
+#: desk/src/components/ImageAvatar.vue:78
+msgid "Upload an image in PNG or JPG format"
+msgstr "PNGまたはJPG形式で画像をアップロードする"
+
+#: desk/src/components/ImageAvatar.vue:39
+msgid "Upload image"
+msgstr "画像をアップロードする"
+
+#: desk/src/components/Settings/General/components/LogoUpload.vue:38
+msgid "Uploading {0}%"
+msgstr "{0}%をアップロードする"
+
+#. Option for the 'Level' (Select) field in DocType 'HD Ticket Priority'
+#: helpdesk/helpdesk/doctype/hd_ticket_priority/hd_ticket_priority.json
+msgid "Urgent"
+msgstr "緊急"
+
+#. Label of the user (Link) field in DocType 'HD Agent'
+#. Label of the user (Link) field in DocType 'HD Article Feedback'
+#. Label of the user (Data) field in DocType 'HD Comment Reaction'
+#. Label of the user (Link) field in DocType 'HD Field Layout'
+#. Label of the user (Link) field in DocType 'HD Team Member'
+#. Label of the user (Link) field in DocType 'HD View'
+#: helpdesk/helpdesk/doctype/hd_agent/hd_agent.json
+#: helpdesk/helpdesk/doctype/hd_article_feedback/hd_article_feedback.json
+#: helpdesk/helpdesk/doctype/hd_comment_reaction/hd_comment_reaction.json
+#: helpdesk/helpdesk/doctype/hd_field_layout/hd_field_layout.json
+#: helpdesk/helpdesk/doctype/hd_team_member/hd_team_member.json
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+#: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.py:55
+#: helpdesk/helpdesk/report/ticket_summary/ticket_summary.py:83
+msgid "User"
+msgstr "ユーザー"
+
+#. Label of the user_resolution_time (Duration) field in DocType 'HD Ticket'
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json
+msgid "User Resolution Time"
+msgstr "ユーザー解決時間"
+
+#: desk/src/components/contact/FeedbackList.vue:6
+msgid "User Reviews"
+msgstr "ユーザーレビュー"
+
+#: desk/src/components/Settings/General/General.vue:42
+msgid "User Signup"
+msgstr "ユーザー登録"
+
+#. Label of the users (Table MultiSelect) field in DocType 'HD Team'
+#: helpdesk/helpdesk/doctype/hd_team/hd_team.json
+msgid "Users"
+msgstr "ユーザー"
+
+#. Label of the agreement_details_section (Section Break) field in DocType 'HD
+#. Service Level Agreement'
+#: desk/src/components/Settings/Holiday/HolidayView.vue:63
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:153
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+msgid "Valid From"
+msgstr "有効開始日"
+
+#: desk/src/components/ticket-agent/BulkEditModal.vue:114
+#: desk/src/components/view-controls/filter/FilterValueEditor.vue:113
+msgid "Value"
+msgstr "値"
+
+#. Label of the via_customer_portal (Check) field in DocType 'HD Ticket'
+#. Label of a field in the tickets Web Form
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.json helpdesk/helpdesk/web_form/tickets/tickets.json
+msgid "Via Customer Portal"
+msgstr "顧客ポータル"
+
+#: desk/src/pages/PersonaForm.vue:170
+msgid "Via WhatsApp"
+msgstr "WhatsApp 経由で"
+
+#: desk/src/pages/PersonaForm.vue:168
+msgid "Via email"
+msgstr "メールで"
+
+#: desk/src/components/Settings/Teams/TeamEdit.vue:241
+msgid "View Assignment rule"
+msgstr "割り当てルールを表示"
+
+#: desk/src/pages/home/components/RecentActivity.vue:104
+msgid "Viewed"
+msgstr "閲覧"
+
+#. Label of the views (Int) field in DocType 'HD Article'
+#: helpdesk/helpdesk/doctype/hd_article/hd_article.json
+msgid "Views"
+msgstr "ビュー"
+
+#. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
+#. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+msgid "Violet"
+msgstr "バイオレット"
+
+#: desk/src/components/knowledge-base/ArticleFeedback.vue:10
+msgid "Was this article Helpful?"
+msgstr "この記事は役に立ちましたか？"
+
+#: desk/src/pages/PersonaForm.vue:133
+msgid "We don't use any helpdesk yet"
+msgstr "まだヘルプデスクを使用していません"
+
+#: desk/src/components/layouts/CustomerPortalPermissionBanner.vue:13
+msgid "We have changed how customer portal permissions work"
+msgstr "顧客ポータル許可の仕組みを変えました"
+
+#: desk/src/pages/PersonaForm.vue:153
+msgid "Web form"
+msgstr "ウェブフォーム"
+
+#. Option for the 'Workday' (Select) field in DocType 'HD Service Day'
+#. Option for the 'Weekly Off' (Select) field in DocType 'HD Service Holiday
+#. List'
+#: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
+msgid "Wednesday"
+msgstr "水曜日"
+
+#: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:34
+msgid "Weekly"
+msgstr "毎週"
+
+#. Label of the weekly_off (Check) field in DocType 'HD Holiday'
+#. Label of the weekly_off (Select) field in DocType 'HD Service Holiday List'
+#: helpdesk/helpdesk/doctype/hd_holiday/hd_holiday.json
+#: helpdesk/helpdesk/doctype/hd_service_holiday_list/hd_service_holiday_list.json
+msgid "Weekly Off"
+msgstr "週休"
+
+#: desk/src/pages/PersonaForm.vue:244
+msgid "Welcome to Frappe Helpdesk"
+msgstr "Frappe Helpdeskへようこそ"
+
+#: desk/src/pages/PersonaForm.vue:122
+msgid "What do you currently use to manage customer support?"
+msgstr "現在、顧客サポートの管理に何を使用していますか？"
+
+#: desk/src/pages/PersonaForm.vue:103
+msgid "What is your organization's name?"
+msgstr "組織名を入力してください。"
+
+#: desk/src/pages/PersonaForm.vue:205
+msgid "What makes support hard right now?"
+msgstr "現在サポート業務で困っていることは何ですか？"
+
+#: desk/src/pages/PersonaForm.vue:232
+msgid "What would you like to do first in Frappe Helpdesk?"
+msgstr "Frappe Helpdeskで最初に何をしたいですか？"
+
+#: desk/src/pages/PersonaForm.vue:177
+msgid "What's your biggest support challenge today?"
+msgstr "現在のサポートにおける最大の課題は何ですか？"
+
+#: desk/src/pages/PersonaForm.vue:150
+msgid "WhatsApp"
+msgstr "WhatsApp"
+
+#. Description of the 'Auto update status' (Check) field in DocType 'HD
+#. Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid ""
+"When enabled, the ticket status will automatically change to the status selected below whenever "
+"the agent responds to a ticket.\n"
+msgstr "有効にすると、担当者がチケットに返信するたびに、チケットのステータスが下で選択したステータスへ自動的に変更されます。\n"
+
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:65
+msgid ""
+"When more than one policy matches, the lower rank is applied first. 0 means unranked, and is "
+"applied last."
+msgstr "複数のポリシーが一致した場合は、順位の小さいものから適用されます。0は順位なしとして最後に適用されます。"
+
+#: desk/src/pages/PersonaForm.vue:228
+msgid "Where did you hear about us?"
+msgstr "Frappe Helpdeskをどこで知りましたか？"
+
+#: desk/src/pages/PersonaForm.vue:158
+msgid "Which channel do they use?"
+msgstr "どのチャネルを利用していますか？"
+
+#: desk/src/pages/PersonaForm.vue:140
+msgid "Which tool does your team use?"
+msgstr "チームではどのツールを使用していますか？"
+
+#. Label of the word (Data) field in DocType 'HD Stopword'
+#. Label of the word (Data) field in DocType 'HD Synonyms'
+#: helpdesk/helpdesk/doctype/hd_stopword/hd_stopword.json
+#: helpdesk/helpdesk/doctype/hd_synonyms/hd_synonyms.json
+msgid "Word"
+msgstr "単語"
+
+#: desk/src/components/Settings/Sla/SlaHolidays.vue:5
+msgid "Work Schedule and Holidays"
+msgstr "勤務スケジュールと休日"
+
+#. Label of the workday (Select) field in DocType 'HD Service Day'
+#: helpdesk/helpdesk/doctype/hd_service_day/hd_service_day.json
+msgid "Workday"
+msgstr "営業日"
+
+#: desk/src/components/Settings/Sla/Modals/WorkDayModal.vue:274
+msgid "Workday added successfully."
+msgstr "営業日を追加しました。"
+
+#: desk/src/components/Settings/Sla/Modals/WorkDayModal.vue:259
+msgid "Workday updated successfully."
+msgstr "営業日を更新しました。"
+
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:141
+msgid "Workday {0} has been repeated."
+msgstr "営業日{0}が重複しています。"
+
+#. Label of the workflow_tab (Tab Break) field in DocType 'HD Settings'
+#: helpdesk/helpdesk/doctype/hd_settings/hd_settings.json
+msgid "Workflow"
+msgstr "ワークフロー"
+
+#: desk/src/components/Settings/General/components/WorkflowKnowledgebaseSettings.vue:4
+msgid "Workflow & Knowledge Base Settings"
+msgstr "ワークフローとナレッジベース設定"
+
+#. Label of the support_and_resolution_section_break (Section Break) field in
+#. DocType 'HD Service Level Agreement'
+#. Label of the support_and_resolution (Table) field in DocType 'HD Service
+#. Level Agreement'
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.json
+msgid "Working Hours"
+msgstr "営業時間"
+
+#: desk/src/pages/knowledge-base/Article.vue:170 desk/src/pages/knowledge-base/NewArticle.vue:56
+msgid "Write your article here..."
+msgstr "記事を書いてください..."
+
+#: desk/src/components/Settings/Profile/UserEmailSettings.vue:31
+msgid "Write your email signature here."
+msgstr "ここにメール署名を入力してください。"
+
+#: desk/src/components/ticket-agent/BulkReplyModal.vue:13
+msgid "Write your reply..."
+msgstr "返信を入力..."
+
+#: desk/src/pages/PersonaForm.vue:221
+msgid "X (Twitter)"
+msgstr "X (ツイッター)"
+
+#: helpdesk/helpdesk/report/ticket_analytics/ticket_analytics.js:37
+msgid "Yearly"
+msgstr "年間"
+
+#. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
+#. Option for the 'Color' (Select) field in DocType 'HD Ticket Status'
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+#: helpdesk/helpdesk/doctype/hd_ticket_status/hd_ticket_status.json
+msgid "Yellow"
+msgstr "黄色"
+
+#: helpdesk/api/ticket_stats.py:35
+msgid "You are not allowed to view another agent's stats."
+msgstr "他の担当者の統計を閲覧することはできません。"
+
+#: helpdesk/api/dashboard.py:36
+msgid "You are not allowed to view this dashboard data."
+msgstr "このダッシュボードデータを閲覧する権限がありません。"
+
+#: helpdesk/utils.py:186 helpdesk/utils.py:214
+msgid "You are not permitted to access this resource."
+msgstr "このリソースへのアクセス権がありません。"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:674
+msgid "You are not permitted to add a comment"
+msgstr "コメントを追加する権限がありません"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:700
+msgid "You are not permitted to reply as an agent"
+msgstr "担当者として返信する権限がありません"
+
+#: desk/src/App.vue:40
+msgid "You are now offline."
+msgstr "オフラインになりました。"
+
+#: desk/src/App.vue:33
+msgid "You are now online."
+msgstr "オンラインになりました。"
+
+#: desk/src/components/telephony/CallUI.vue:33
+msgid "You can change the default calling medium from the settings"
+msgstr "設定からデフォルト通話媒体を変更できます"
+
+#: helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py:296
+msgid "You can only raise tickets for your own contact."
+msgstr "チケットは自分の連絡先としてのみ起票できます。"
+
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:43
+msgid "You cannot set more than one Default Priority."
+msgstr "デフォルト優先度は複数設定できません。"
+
+#: helpdesk/api/assignment_rule.py:8
+msgid "You do not have permission to access Assignment Rules"
+msgstr "割り当てルールにアクセスする許可はありません"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:338
+msgid "You do not have permission to access this resource"
+msgstr "このリソースへのアクセス権がありません"
+
+#: helpdesk/helpdesk/doctype/hd_customer/hd_customer.py:268
+msgid "You do not have permission to update contacts"
+msgstr "連絡先を更新する許可はありません"
+
+#: desk/src/pages/ticket/TicketAgent.vue:37
+msgid "You don't have access to this ticket, or it no longer exists."
+msgstr "このチケットへのアクセス権がないか、チケットが存在しません。"
+
+#: desk/src/pages/InvalidPage.vue:15
+msgid "You don't have permission to view this page, or it no longer exists."
+msgstr "このページを閲覧する権限がないか、ページが存在しません。"
+
+#: helpdesk/helpdesk/doctype/hd_email_feedback/hd_email_feedback.py:29
+msgid "You have already provided feedback for this ticket."
+msgstr "このチケットには既にフィードバックを送信しています。"
+
+#: desk/src/components/layouts/CustomerPortalPermissionDialog.vue:37
+msgid "You won't see this notice again."
+msgstr "もうこの通知を見ない"
+
+#: desk/src/pages/PersonaForm.vue:214
+msgid "YouTube"
+msgstr "YouTube"
+
+#: desk/src/components/Settings/Sla/SlaPolicyView.vue:415
+msgid "Your old conditions will be overwritten. Are you sure you want to save?"
+msgstr "以前の条件は上書きされます。保存しますか？"
+
+#: desk/src/pages/home/components/RecentFeedback.vue:51
+msgid "Your performance is"
+msgstr "あなたのパフォーマンス："
+
+#: desk/src/pages/PersonaForm.vue:127
+msgid "Zendesk"
+msgstr "ゼンドスク"
+
+#: desk/src/pages/PersonaForm.vue:131
+msgid "Zoho Desk"
+msgstr "ゾホ・デスク"
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active ticket"
+msgstr "アクティブチケット"
+
+#: desk/src/components/customer/ContactCard.vue:116
+msgid "active tickets"
+msgstr "アクティブチケット"
+
+#: desk/src/pages/MobileNotifications.vue:46
+msgid "assigned you a ticket"
+msgstr "チケットを割り当てた"
+
+#: desk/src/components/ticket-agent/AssignTo.vue:40
+msgid "assignees"
+msgstr "担当者"
+
+#: desk/src/pages/home/components/RecentFeedback.vue:477
+msgid "average"
+msgstr "平均"
+
+#: desk/src/components/Settings/EmailNotifications/Notification.vue:13
+msgid "back to email event list"
+msgstr "メールイベントリストに戻る"
+
+#: desk/src/components/layouts/CustomerPortalPermissionDialog.vue:21
+msgid "can see every ticket of their company and manage its contacts."
+msgstr "会社のすべてのチケットを閲覧し、連絡先を管理できます。"
+
+#: desk/src/components/HistoryBox.vue:12
+msgid "changes from"
+msgstr "変更から"
+
+#: desk/src/components/Settings/EmailNotifications/NotificationList.vue:42
+msgid "customize {0}"
+msgstr "カスタマイズ {0}"
+
+#: helpdesk/api/dashboard.py:223 helpdesk/api/dashboard.py:225
+msgid "days"
+msgstr "日"
+
+#: desk/src/components/layouts/CustomerPortalPermissionDialog.vue:28
+msgid "documentation"
+msgstr "文書"
+
+#: desk/src/pages/PersonaForm.vue:104
+msgid "e.g. Acme Inc."
+msgstr "例えば Acme Inc."
+
+#: desk/src/components/ticket/TicketSplitModal.vue:7
+msgid "emails/ comments"
+msgstr "メール/コメント"
+
+#: desk/src/pages/home/components/RecentFeedback.vue:473
+msgid "excellent"
+msgstr "素晴らしい"
+
+#: desk/src/components/ticket/TicketSplitModal.vue:8
+msgid "from this email onwards will be moved to new ticket."
+msgstr "このメールから新しいチケットに移動します"
+
+#: desk/src/pages/home/components/RecentFeedback.vue:475
+msgid "good"
+msgstr "よい"
+
+#. Option for the 'Type' (Select) field in DocType 'HD View'
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "group_by"
+msgstr "グループ_バイ"
+
+#: desk/src/components/CallArea.vue:16
+msgid "has made a call"
+msgstr "呼び出しをした"
+
+#: desk/src/components/CallArea.vue:15
+msgid "has reached out"
+msgstr "手を差し伸べた"
+
+#: desk/src/pages/MobileNotifications.vue:49
+msgid "has reopened the ticket"
+msgstr "チケットを再開した"
+
+#: desk/src/components/Settings/EmailNotifications/Notification.vue:78
+#: desk/src/components/Settings/General/components/TicketSettings.vue:237
+msgid "here"
+msgstr "ここに"
+
+#: desk/src/components/Settings/FieldDependency/FieldDependencyList.vue:21
+#: desk/src/components/Settings/Sla/SlaPolicies.vue:19
+msgid "here."
+msgstr "やってみよう"
+
+#: helpdesk/api/dashboard.py:206 helpdesk/api/dashboard.py:208
+msgid "hrs"
+msgstr "時間"
+
+#: desk/src/components/ticket-agent/TicketSLA.vue:95 desk/src/pages/knowledge-base/NewArticle.vue:15
+msgid "in"
+msgstr "中"
+
+#: desk/src/components/ticket-agent/AssignTo.vue:438
+msgid "just now"
+msgstr "たった今"
+
+#. Option for the 'Type' (Select) field in DocType 'HD View'
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "kanban"
+msgstr "カンバン"
+
+#. Option for the 'Type' (Select) field in DocType 'HD View'
+#: helpdesk/helpdesk/doctype/hd_view/hd_view.json
+msgid "list"
+msgstr "リスト"
+
+#: desk/src/pages/MobileNotifications.vue:43
+msgid "mentioned you in ticket"
+msgstr "チケットで言及した"
+
+#: desk/src/pages/home/components/RecentFeedback.vue:479
+msgid "poor"
+msgstr "低評価"
+
+#: desk/src/pages/knowledge-base/Article.vue:195
+msgid "published by"
+msgstr "発行された"
+
+#. Option for the 'Color' (Select) field in DocType 'HD Agent Status'
+#: helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.json
+msgid "purple"
+msgstr "紫色"
+
+#: desk/src/components/customer/TicketStats.vue:32
+msgid "reviews"
+msgstr "レビュー"
+
+#: helpdesk/api/dashboard.py:247
+msgid "stars"
+msgstr "星"
+
+#. Label of the synonym (Data) field in DocType 'HD Synonym'
+#: helpdesk/helpdesk/doctype/hd_synonym/hd_synonym.json
+msgid "synonym"
+msgstr "同義語"
+
+#: desk/src/pages/home/components/PendingTickets.vue:153
+msgid "ticket"
+msgstr "チケット"
+
+#: desk/src/components/erpnext-integration/ERPNextIntegrationSettings.vue:68
+msgid "to enable this integration."
+msgstr "すると、この連携が有効になります。"
+
+#: desk/src/components/ticket-agent/TicketContact.vue:33
+msgid "via Email"
+msgstr "メールで"
+
+#: desk/src/components/ticket-agent/TicketContact.vue:33
+msgid "via Portal"
+msgstr "ポータルを通じて"
+
+#: desk/src/pages/ticket/MobileTicketAgent.vue:581
+msgid "viewed this"
+msgstr "これを見た"
+
+#: desk/src/pages/knowledge-base/Article.vue:85
+msgid "views"
+msgstr "ビュー"
+
+#: desk/src/components/contact/ContactCustomers.vue:69
+msgid "{0} Customers"
+msgstr "{0} 顧客"
+
+#: desk/src/components/EmailMultiSelect.vue:270
+msgid "{0} is already added"
+msgstr "{0} は既に追加されています"
+
+#: desk/src/components/EmailMultiSelect.vue:148
+msgid "{0} is an Invalid Email Address"
+msgstr "{0} は無効なメールアドレスです"
+
+#: desk/src/components/ticket-agent/AssignTo.vue:570
+msgid "{0} is currently away."
+msgstr "{0}は現在不在です。"
+
+#: desk/src/components/ticket-agent/AssignTo.vue:569
+msgid "{0} is currently unavailable."
+msgstr "{0}は現在利用できません。"
+
+#: desk/src/components/EmailMultiSelect.vue:265
+msgid "{0} is not an existing contact"
+msgstr "{0}は既存の連絡先ではない"
+
+#: desk/src/components/EmailMultiSelect.vue:264
+msgid "{0} is not an existing user"
+msgstr "{0}は登録済みのユーザーではありません"
+
+#: desk/src/components/ticket-agent/BulkEditModal.vue:126
+msgid "{0} is required"
+msgstr "{0}は必須"
+
+#: desk/src/components/ListViewBuilder.vue:319
+msgid "{0} item(s) deleted successfully"
+msgstr "{0}件の項目を削除しました"
+
+#: desk/src/components/ListViewBuilder.vue:333
+msgid "{0} item(s) queued for deletion"
+msgstr "{0}件の項目を削除キューに追加しました"
+
+#: desk/src/pages/SearchAgent.vue:117
+msgid "{0} matches"
+msgstr "{0}マッチ"
+
+#: helpdesk/overrides/user_invitation.py:18
+msgid "{0} on {1}"
+msgstr "{0} に {1}"
+
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:92
+msgid "{0} open tickets use priority {1}. They lose this SLA the next time they are updated."
+msgstr "{0}件の未解決チケットで優先度{1}が使用されています。次回更新時にこのSLAが適用されなくなります。"
+
+#: helpdesk/helpdesk/doctype/hd_service_level_agreement/hd_service_level_agreement.py:107
+msgid ""
+"{0} open tickets will lose this SLA the next time they are updated, unless another policy matches"
+" them."
+msgstr "{0}件の未解決チケットは、別のポリシーが適用されない限り、次回更新時にこのSLAが適用されなくなります。"
+
+#: desk/src/components/command-palette/CommandPalette.vue:252
+msgid "{0} results"
+msgstr "{0}結果"
+
+#: desk/src/pages/home/components/RecentFeedback.vue:46
+msgid "{0} reviews"
+msgstr "{0}レビュー"
+
+#: desk/src/components/ticket-agent/AssignTo.vue:439
+msgid "{0} · Last active {1}"
+msgstr "{0} · 最後のアクティブ {1}"
+
+#: helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.py:156
+msgid "{} people reacted to your comment"
+msgstr "{}人があなたのコメントにリアクションしました"


### PR DESCRIPTION
## What

Adds `helpdesk/locale/ja.po`, a complete Japanese translation of the current `main.pot`.

Japanese is the only major locale missing from `helpdesk/locale/` — `ko.po` and `zh.po` are already there, `ja.po` is not.

- **1,499 / 1,499 messages translated**, no empty `msgstr`
- 18 entries are intentionally left as the source string: `Bcc`, `Bcc:`, `Cc`, `Cc:`, `CSV`, `DocType`, `ERPNext`, `Frappe Discuss`, `Frappe Helpdesk Mobile`, `GitHub`, `Helpdesk`, `ID`, `KB`, `Notion`, `SLA`, `WhatsApp`, `YouTube`, `Doe` — proper nouns and acronyms that are normally left in English in Japanese UIs
- msgids match `main.pot` exactly: no missing entries, no stale ones

## About Crowdin

The README points contributors to <https://crowdin.com/project/frappe>, and the sibling `.po` files carry `X-Crowdin-*` metadata, so I assume translations normally flow in from there. I could not find Japanese in the project, so I am opening this PR directly rather than letting the work sit unused.

**If you would rather receive this through Crowdin, please say so and I will move it there and close this PR.** I did not fabricate any `X-Crowdin-*` headers on this file, since it was not produced by Crowdin.

## Related

#3712 fixes CJK search, which is what makes a Japanese UI actually usable — the two are independent and can be reviewed separately.