### PR TITLE
fix: preserve customer manager ticket visibility for agents

### DIFF
--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -1396,14 +1396,13 @@ def permission_query(user: str | None = None):
 def _customer_query(user: str) -> str:
     """Non-agents see their own tickets, plus all tickets of customers they manage."""
     query = _get_base_visibility(user)
-    managed_customers = _get_managed_customers(user)
-    if managed_customers:
-        query += " OR " + _build_in_clause("customer", managed_customers)
+    query = _add_managed_customer_visibility(query, user)
     return query
 
 
 def _agent_query(user: str) -> str | None:
     query = _get_base_visibility(user)
+    query = _add_managed_customer_visibility(query, user)
 
     if not frappe.db.get_single_value("HD Settings", "restrict_tickets_by_agent_group"):
         return  # Restrictions disabled, return all tickets
@@ -1448,6 +1447,13 @@ def _get_managed_customers(user: str) -> list[str]:
         for c in get_customers(user, get_roles=True)
         if c.get("is_manager")
     ]
+
+
+def _add_managed_customer_visibility(query: str, user: str) -> str:
+    managed_customers = _get_managed_customers(user)
+    if managed_customers:
+        query += " OR " + _build_in_clause("customer", managed_customers)
+    return query
 
 
 def _build_in_clause(field: str, values: list[str]) -> str:

--- a/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/test_hd_ticket.py
@@ -2328,6 +2328,27 @@ class TestHDTicket(IntegrationTestCase):
         self.assertFalse(has_permission(ticket, user=agent))
         self.assertNotIn("Team B", permission_query(agent))
 
+    def test_customer_managers_see_their_tickets_in_lists(self):
+        """Customer-link access must survive both doc checks and list queries."""
+        contact = create_contact("Account Manager", agent, user=True, role="Agent")
+        customer = create_customer("Manager Visibility Customer")
+        add_contact_in_customer(customer, contact["contact"], is_manager=True)
+        make_team("Team B", members=[agent2])
+        frappe.db.set_single_value("HD Settings", "restrict_tickets_by_agent_group", 1)
+        self.addCleanup(
+            frappe.db.set_single_value,
+            "HD Settings",
+            "restrict_tickets_by_agent_group",
+            0,
+        )
+
+        ticket = make_ticket(customer=customer.name, agent_group="Team B")
+
+        frappe.set_user(agent)
+        self.assertTrue(has_permission(ticket, user=agent))
+        self.assertIn(ticket.name, frappe.get_list("HD Ticket", pluck="name"))
+        self.assertIn(customer.name, permission_query(agent))
+
     def tearDown(self):
         frappe.set_user("Administrator")
         remove_holidays()


### PR DESCRIPTION
## Summary

- Restore managed-customer visibility for agents in ticket list queries.
- Keep list-level visibility consistent with `has_permission()`.
- Add a regression test for agents who manage customers whose tickets belong to another team.

## Testing

Verified the regression test fails on the original implementation and passes with the fix:

`bench --site helpdesk.test run-tests --app helpdesk --module helpdesk.helpdesk.doctype.hd_ticket.test_hd_ticket --test test_customer_managers_see_their_tickets_in_lists`