### PR TITLE
fix(email-select): truncate long recipient names in the popover (backport #3677)

### DIFF
--- a/desk/src/components/EmailMultiSelect.vue
+++ b/desk/src/components/EmailMultiSelect.vue
@@ -83,15 +83,15 @@
                   @mousedown.prevent="onSelect(option.value)"
                 >
                   <UserAvatar
-                    class="mr-0.5"
+                    class="mr-0.5 shrink-0"
                     :name="getUsernameLabel(option.label)"
                     size="lg"
                   />
-                  <div class="flex flex-col gap-1 p-1 text-ink-gray-8">
-                    <div class="text-base-medium">
+                  <div class="flex min-w-0 flex-col gap-1 p-1 text-ink-gray-8">
+                    <div class="truncate text-base-medium">
                       {{ getUsernameLabel(option.label) }}
                     </div>
-                    <div class="text-sm text-ink-gray-5">
+                    <div class="truncate text-sm text-ink-gray-5">
                       {{ option.isCustom ? customEmailLabel : option.value }}
                     </div>
                   </div>


### PR DESCRIPTION
Manual backport of #3677 to `main-hotfix`.

Replaces #3722 — the automatic Mergify backport cherry-picked the branch's intermediate commits, both conflicted, and the committed result left conflict markers in the file and then deleted `EmailMultiSelect.vue` entirely. This PR applies the final merged diff of #3677 instead, which applies cleanly; the file ends up identical to develop's fixed version.

Original fix: a long contact name or address made the option row wider than the popover's max-width, so the recipient list scrolled sideways. `min-w-0` lets the text column shrink, `truncate` clips the name and address with an ellipsis, and `shrink-0` keeps the avatar from being squeezed.

### Before

![before](https://raw.githubusercontent.com/aerodeval/helpdesk/pr-assets/email-popover-width/before-clipped.png)

### After

![after](https://raw.githubusercontent.com/aerodeval/helpdesk/pr-assets/email-popover-width/after-truncated.png)
