### PR TITLE
fix: download attachments the browser cannot preview

### DIFF
--- a/desk/src/components/AttachmentItem.vue
+++ b/desk/src/components/AttachmentItem.vue
@@ -1,6 +1,6 @@
 <template>
   <span>
-    <a :href="isShowable ? undefined : url" target="_blank">
+    <a :href="preview ? undefined : url" target="_blank">
       <Button
         :label="label"
         theme="gray"
@@ -18,14 +18,18 @@
     <Dialog v-model:open="showDialog" :title="label" size="4xl">
       <template #default>
         <div
-          v-if="isText"
+          v-if="preview === 'text'"
           class="prose prose-sm max-w-none whitespace-pre-wrap"
         >
           {{ content }}
         </div>
-        <img v-if="isImage" :src="url" class="m-auto rounded border" />
+        <img
+          v-if="preview === 'image'"
+          :src="url"
+          class="m-auto rounded border"
+        />
         <video
-          v-if="isVideo"
+          v-if="preview === 'video'"
           :src="url"
           controls
           class="m-auto max-h-[70vh] rounded border"
@@ -72,6 +76,24 @@ const ICONS: Record<AttachmentKind, Component> = {
   file: markRaw(LucideFile),
 };
 
+// browsers render only some image/video mimes (.dwg is image/vnd.dwg, .avi is
+// video/x-msvideo) — anything absent here becomes a download link like pdf
+type Preview = "image" | "video" | "text";
+
+const PREVIEWS: Record<string, Preview> = {
+  "image/png": "image",
+  "image/jpeg": "image",
+  "image/gif": "image",
+  "image/webp": "image",
+  "image/svg+xml": "image",
+  "image/avif": "image",
+  "image/bmp": "image",
+  "video/mp4": "video",
+  "video/webm": "video",
+  "video/ogg": "video",
+  "text/plain": "text",
+};
+
 function getKind(mime: string): AttachmentKind {
   if (mime.startsWith("image/")) return "image";
   if (mime.startsWith("video/")) return "video";
@@ -83,17 +105,13 @@ function getKind(mime: string): AttachmentKind {
 
 const showDialog = ref(false);
 const mimeType = getMime(props.label) || "";
-const kind = getKind(mimeType);
-const isImage = kind === "image";
-const isText = kind === "text";
-const isVideo = kind === "video";
-const isShowable = props.url && (isText || isImage || isVideo);
-const icon = ICONS[kind];
+const icon = ICONS[getKind(mimeType)];
+const preview = props.url ? PREVIEWS[mimeType] : undefined;
 const content = ref("");
 
 function toggleDialog() {
-  if (!isShowable) return;
-  if (isText) {
+  if (!preview) return;
+  if (preview === "text") {
     fetch(props.url).then((res) => res.text().then((t) => (content.value = t)));
   }
   showDialog.value = !showDialog.value;

--- a/desk/src/components/AttachmentItem.vue
+++ b/desk/src/components/AttachmentItem.vue
@@ -88,9 +88,13 @@ const PREVIEWS: Record<string, Preview> = {
   "image/svg+xml": "image",
   "image/avif": "image",
   "image/bmp": "image",
+  "image/apng": "image",
+  "image/vnd.microsoft.icon": "image",
   "video/mp4": "video",
   "video/webm": "video",
   "video/ogg": "video",
+  "video/quicktime": "video",
+  "video/x-m4v": "video",
   "text/plain": "text",
 };
 

--- a/desk/src/components/AttachmentItem.vue
+++ b/desk/src/components/AttachmentItem.vue
@@ -93,7 +93,6 @@ const PREVIEWS: Record<string, Preview> = {
   "video/mp4": "video",
   "video/webm": "video",
   "video/ogg": "video",
-  "video/quicktime": "video",
   "video/x-m4v": "video",
   "text/plain": "text",
 };


### PR DESCRIPTION
## Problem

Attachments whose mime type the browser cannot render get stuck in the preview dialog. A `.dwg` upload resolves to `image/vnd.dwg`, so `AttachmentItem` treats it as a previewable image: the dialog opens with a broken `<img>` and the chip carries no link, so the file cannot be downloaded at all. Non-playable video types (`.avi`, `.mov`) hit the same dead end with an empty `<video>` player.

## Fix

Preview eligibility is now an explicit allowlist of mime types the browser can actually render (common image formats, mp4/webm/ogg video, plain text). Any attachment outside the allowlist renders as a regular link and downloads on click, the same way PDFs already behave. Icon selection by file kind is unchanged.
