### PR TITLE
Fix saved view updates in Helpdesk

### DIFF
--- a/desk/src/composables/useView.ts
+++ b/desk/src/composables/useView.ts
@@ -139,7 +139,10 @@ export function useView(dt: string = null) {
   function updateView(view: any, successCB: Function = () => {}) {
     if (view.name !== "default") {
       // handle custom view
-      debouncedSetValue("HD View", view.name, view, successCB);
+      // `frappe.client.set_value` should only receive mutable fields; keeping
+      // the docname out of the payload avoids a no-op or rejected save.
+      const { name, doctype, ...fields } = view;
+      debouncedSetValue("HD View", name, fields, successCB);
     } else {
       // handle default view
       createOrUpdateDefaultView(view);
@@ -162,9 +165,9 @@ export function useView(dt: string = null) {
     );
     view.is_customer_portal = isCustomerPortal.value;
     if (defaultView) {
-      delete view["name"];
-
-       debouncedSetValue("HD View", defaultView.name, view);
+      // Same rule as above: update only editable fields, not the docname.
+      const { name, doctype, ...fields } = view as any;
+      debouncedSetValue("HD View", defaultView.name, fields);
     } else {
       view["doctype"] = "HD View";
       // create default view


### PR DESCRIPTION
## Summary
Strip immutable docname fields before saving HD View records so edited views persist across fresh sessions.

## Root cause
The view updater was sending the full view object to `frappe.client.set_value`, including `name`. The current tab updated optimistically, but the backend save path did not reliably persist the mutable fields.

## Change
- Narrow `updateView()` payloads to editable fields only.
- Narrow default-view updates the same way.
- Add inline comments so the save contract is explicit.