### PR TITLE
fix(settings): blank empty states, always-visible Update Account, false typing indicator

### DIFF
--- a/desk/src/components/EmailEditor.vue
+++ b/desk/src/components/EmailEditor.vue
@@ -623,7 +623,14 @@ function handleKeydown(e: KeyboardEvent) {
 }
 
 watch(newEmail, (newValue, oldValue) => {
-  if (newValue !== oldValue && newValue) {
+  // The signature drops into an empty editor on load and on every reply. That
+  // is not the agent typing, and broadcasting it would show a typing indicator
+  // to everyone else on the ticket.
+  if (
+    newValue !== oldValue &&
+    !isContentEmpty(newValue) &&
+    !isOnlySignature(newValue)
+  ) {
     onUserType();
   }
   cachedEmail.value = isOnlySignature(newValue) ? null : newValue;

--- a/desk/src/components/Settings/Agents.vue
+++ b/desk/src/components/Settings/Agents.vue
@@ -179,6 +179,7 @@
 </template>
 
 <script setup lang="ts">
+import EmptyState from "@/components/EmptyState.vue";
 import SettingsLayoutBase from "@/components/layouts/SettingsLayoutBase.vue";
 import { useAuthStore } from "@/stores/auth";
 import { useUserStore } from "@/stores/user";

--- a/desk/src/components/Settings/EmailAccountList.vue
+++ b/desk/src/components/Settings/EmailAccountList.vue
@@ -46,7 +46,7 @@
       </div>
       <!-- fallback if no email accounts -->
       <EmptyState
-        v-else
+        v-else-if="!emailAccounts.loading"
         variant="badge"
         :icon="EmailIcon"
         :title="__('No email account found')"
@@ -57,6 +57,7 @@
 </template>
 
 <script setup lang="ts">
+import EmptyState from "@/components/EmptyState.vue";
 import SettingsLayoutBase from "@/components/layouts/SettingsLayoutBase.vue";
 import { EmailAccount } from "@/types";
 import { createListResource } from "frappe-ui";

--- a/desk/src/components/Settings/EmailEdit.vue
+++ b/desk/src/components/Settings/EmailEdit.vue
@@ -139,6 +139,7 @@
           />
           <div class="flex gap-2">
             <Button
+              v-if="hasChanges"
               :label="__('Update Account')"
               variant="solid"
               @click="updateAccount"
@@ -229,7 +230,7 @@ const props = withDefaults(defineProps<P>(), {
 
 const emit = defineEmits<E>();
 
-const state = reactive<EmailAccountProviderAuthState>({
+const getInitialState = (): EmailAccountProviderAuthState => ({
   email_account_name: props.accountData.email_account_name || "",
   service: props.accountData.service || "",
   email_id: props.accountData.email_id || "",
@@ -242,6 +243,8 @@ const state = reactive<EmailAccountProviderAuthState>({
   default_outgoing: props.accountData.default_outgoing || false,
   default_incoming: props.accountData.default_incoming || false,
 });
+
+const state = reactive<EmailAccountProviderAuthState>(getInitialState());
 
 const getInitialCustomState = (): CustomEmailAccountState => ({
   domain: props.accountData?.domain || "",
@@ -328,26 +331,8 @@ async function updateAccount() {
     : currentServiceName.value;
   error.value = validateInputs(validationState, validationService, true);
   if (error.value) return;
-  const old = { ...props.accountData };
-  const updatedEmailAccount = { ...state };
 
-  const nameChanged =
-    old.email_account_name !== updatedEmailAccount.email_account_name;
-  delete old.email_account_name;
-  delete updatedEmailAccount.email_account_name;
-
-  const otherFieldsChanged = isDirty.value;
-  const values = buildUpdatePayload();
-
-  if (!nameChanged && !otherFieldsChanged) {
-    toast.create({
-      message: __("No changes made"),
-      icon: h(CircleAlert, { class: "text-ink-blue-5" }),
-    });
-    return;
-  }
-
-  if (nameChanged) {
+  if (nameChanged.value) {
     try {
       loading.value = true;
       await callRenameDoc();
@@ -356,10 +341,10 @@ async function updateAccount() {
       errorHandler();
     }
   }
-  if (otherFieldsChanged) {
+  if (isDirty.value) {
     try {
       loading.value = true;
-      await callSetValue(values);
+      await callSetValue(buildUpdatePayload());
       succesHandler();
     } catch (err) {
       errorHandler();
@@ -423,31 +408,31 @@ function pullEmails() {
     });
 }
 
+// Compare against the initial values rather than the account itself. The form
+// normalises what the server sends (a 0 becomes false, a null becomes ""), so
+// comparing straight to the account reported every custom account as changed.
+// Renaming goes through a separate API, so it is tracked by nameChanged.
 const isDirty = computed(() => {
-  const customDirty = isCustomProvider.value
-    ? customState.domain !== props.accountData.domain ||
-      customState.email_server !== props.accountData.email_server ||
-      customState.smtp_server !== props.accountData.smtp_server ||
-      customState.incoming_port !== props.accountData.incoming_port ||
-      customState.smtp_port !== props.accountData.smtp_port ||
-      customState.use_ssl !== props.accountData.use_ssl ||
-      customState.use_starttls !== props.accountData.use_starttls
-    : false;
-
-  return (
-    customDirty ||
-    state.service !== props.accountData.service ||
-    state.email_id !== props.accountData.email_id ||
-    state.api_key !== props.accountData.api_key ||
-    state.api_secret !== props.accountData.api_secret ||
-    state.password !== props.accountData.password ||
-    state.enable_incoming !== props.accountData.enable_incoming ||
-    state.enable_outgoing !== props.accountData.enable_outgoing ||
-    state.default_outgoing !== props.accountData.default_outgoing ||
-    state.default_incoming !== props.accountData.default_incoming ||
-    state.frappe_mail_site !== props.accountData.frappe_mail_site
+  const initialState = getInitialState();
+  const baseChanged = (
+    Object.keys(initialState) as (keyof EmailAccountProviderAuthState)[]
+  ).some(
+    (field) =>
+      field !== "email_account_name" && state[field] !== initialState[field]
   );
+  if (baseChanged || !isCustomProvider.value) return baseChanged;
+
+  const initialCustomState = getInitialCustomState();
+  return (
+    Object.keys(initialCustomState) as (keyof CustomEmailAccountState)[]
+  ).some((field) => customState[field] !== initialCustomState[field]);
 });
+
+const nameChanged = computed(
+  () => state.email_account_name !== getInitialState().email_account_name
+);
+
+const hasChanges = computed(() => nameChanged.value || isDirty.value);
 
 async function callRenameDoc() {
   return call("frappe.client.rename_doc", {

--- a/desk/src/components/Settings/FieldDependency/FieldDependencyList.vue
+++ b/desk/src/components/Settings/FieldDependency/FieldDependencyList.vue
@@ -138,6 +138,7 @@ import {
   Switch,
   toast,
 } from "frappe-ui";
+import EmptyState from "@/components/EmptyState.vue";
 import { getFieldDependencyLabel, ConfirmDelete } from "@/utils";
 import { onMounted, ref } from "vue";
 import { fieldDependenciesList } from "./fieldDependency";

--- a/desk/src/components/Settings/SavedReplies/SavedRepliesList.vue
+++ b/desk/src/components/Settings/SavedReplies/SavedRepliesList.vue
@@ -178,6 +178,7 @@
 </template>
 
 <script setup lang="ts">
+import EmptyState from "@/components/EmptyState.vue";
 import { useConfigStore } from "@/stores/config";
 import { __ } from "@/translation";
 import { ConfirmDelete } from "@/utils";


### PR DESCRIPTION
Three small fixes in the agent settings screens and the email editor. Each is one commit.

## 1. Empty settings screens rendered blank

`Agents`, `Email Accounts`, `Saved Replies` and `Field Dependencies` all use `<EmptyState>` in their template but never import it. There is no component auto-import plugin in `vite.config.js`, so Vue cannot resolve the tag and renders nothing. Every one of those four screens showed a blank pane instead of an empty state.

`Email Accounts` also rendered its empty state through a plain `v-else`, so "No email account found" flashed while the list was still loading. It now guards on `loading`, matching the other three screens.

## 2. "Update Account" was always visible

The button showed even with no edits, and clicking it only produced a "No changes made" toast.

The existing `isDirty` could not simply be reused. The form normalises what the server sends (a `0` becomes `false`, a `null` becomes `""`) and then compared those normalised values back against the raw account, so `false !== 0` made **every custom-provider account report itself as changed**. The check now compares against values built by the same initialisers.

Iterating the fields instead of listing them also fixes a second bug: the old comparison chain omitted `use_tls`, `use_ssl_for_outgoing`, `validate_ssl_certificate` and three more. Editing only those fields said "No changes made" and silently discarded the edit.

Renaming still routes separately, since it uses `rename_doc` rather than `set_value`.

## 3. Opening a ticket showed "is typing" to everyone

The watcher on `newEmail` called `onUserType()` for any change, including programmatic ones. An agent with a signature configured has it dropped into the empty editor on load, which emitted `helpdesk_ticket_typing` over the socket. Simply opening a ticket told every other agent viewing it that you were typing.

The guard now skips content that is empty or only the signature, reusing the `isOnlySignature` and `isContentEmpty` predicates already in the file. This also covers agents with no signature, whose editor is filled with an empty paragraph.

## Before / after

**Email Accounts with no accounts configured**

| Before | After |
| --- | --- |
| Blank pane below the header | "No email account found — Add one to get started." |

<!-- drop before/after screenshots here -->

**Edit Email with no changes made**

| Before | After |
| --- | --- |
| "Update Account" always shown | Button appears only after an edit |

<!-- drop before/after screenshots here -->

## Verification

- `vue-tsc --noEmit` clean, prettier clean, pre-commit hooks pass.
- The dirty comparison was replayed against real `Email Account` rows: an untouched custom account reported dirty under the old logic and clean under the new one, while every editable field still flips it to dirty.
- The typing guard was checked across eight cases (signature on load, signature refilled on reply, typing above the signature, no signature configured, clearing back down to the signature, whitespace-only edits).
