### PR TITLE
fix: avoid  improper reply box closing for Grammarly suggestions

### DIFF
--- a/desk/src/components/CommunicationArea.vue
+++ b/desk/src/components/CommunicationArea.vue
@@ -234,6 +234,10 @@ const IGNORED_SELECTORS = [
   '[role="presentation"]',
   '[role="menu"]',
   ".dialog-overlay",
+  // Grammarly suggestions appear outside the box, allow them to stop collapsing.
+  "grammarly-extension",
+  "grammarly-popups",
+  "[data-grammarly-part]",
 ];
 
 // `ignore` is only consulted on pointerdown, which dialogs stop, so the click


### PR DESCRIPTION
## Problem

Accepting a Grammarly suggestion while writing a reply closes the reply box.

The email and comment boxes in `CommunicationArea.vue` close on any click outside them (`onClickOutside`). There is already an `IGNORED_SELECTORS` allowlist for UI that legitimately renders outside the box — tippy tooltips, popovers, dialogs, menus.

Grammarly's suggestion card is not part of the app. It renders in Grammarly's own element on the body, outside `emailBoxRef`, so clicking **Accept** registers as a click outside and the box folds shut via the existing `.slide-*` transition. The draft survives (the box is `v-show`, not `v-if`), but the writer loses their place mid-sentence.

## Fix

Add Grammarly's elements to the allowlist that already exists for this exact case.

```js
// Grammarly suggestions appear outside the box, allow them to stop collapsing.
"grammarly-extension",
"grammarly-popups",
"[data-grammarly-part]",
```

`onClickOutside` matches `ignore` selectors against `composedPath()`, which reaches the host element of Grammarly's shadow DOM, so a click inside the card is correctly attributed to it.

## Before / After

<!-- TODO: attach a short screen recording of writing a reply, accepting a
     Grammarly suggestion, and the box staying open. -->

## Testing

Needs a browser with the Grammarly extension installed:

1. Open a ticket and start a reply with a typo Grammarly flags.
2. Click the suggestion and accept it.
3. The reply box stays open, with the corrected text and the caret still in place.
