### PR TITLE
fix(build): dedupe vue-router and dompurify for the linked @framework/ui

### DIFF
--- a/desk/vite.config.js
+++ b/desk/vite.config.js
@@ -112,8 +112,12 @@ export default defineConfig(async ({ mode }) => {
       dedupe: [
         // @framework/ui imports from vue/frappe-ui; force a single instance of
         // each so its Combobox shares helpdesk's frappe-ui, not a second copy.
+        // vue-router and dompurify are peers of @framework/ui, so they have
+        // to come from helpdesk's copies
         "vue",
+        "vue-router",
         "frappe-ui",
+        "dompurify",
         "reka-ui",
         "@tiptap/core",
         "@tiptap/pm",


### PR DESCRIPTION
## Problem

Building the desk against a frappe checkout that has `ui/src/components/DataImport/DataImport.vue` (in `develop` since `6196453c8f`, Aug 7) can fail with:

```
[vite]: Rollup failed to resolve import "vue-router" from
".../apps/frappe/ui/src/components/DataImport/DataImport.vue"
```

`@framework/ui` is compiled from source out of `apps/frappe/ui`, and `vue-router` is only a peer dependency in its `package.json` — nothing installs it next to that source, so Rollup has nowhere to resolve it from. The `frameworkUI()` vite plugin normally covers this by injecting its own dedupe list, but a build where frappe's `ui/vite/index.js` is older (docker layer caches make that easy to hit) fails exactly like the log above.

## Fix

Add `vue-router` and `dompurify` to helpdesk's own `resolve.dedupe`, so they resolve from `desk/node_modules` regardless of what the linked plugin injects — `dompurify` is the other `@framework/ui` peer in the plugin's `SINGLETONS` that helpdesk's list was missing.

Harmless when the plugin's dedupe is also present: vite concatenates the lists.

## Testing

- Reproduced the failure in a docker `bench get-app` build; production build passes with this change.
- Local `yarn build` of the desk against current frappe `develop`: passes before and after (the plugin covers it there), so this changes nothing for up-to-date benches.
