### PR TITLE
fix: write portal defaults without saving the whole document

### DIFF
--- a/helpdesk/patches/set_default_portal_settings.py
+++ b/helpdesk/patches/set_default_portal_settings.py
@@ -1,15 +1,9 @@
-import frappe
+from helpdesk.setup.install import set_portal_defaults
 
 
 def execute():
-    portal_settings = frappe.get_single("Portal Settings")
+    """Set the portal's default role and home page for helpdesk.
 
-    defaults = {
-        "default_role": "HD Customer",
-        "default_portal_home": "/helpdesk",
-    }
-    for field, value in defaults.items():
-        if not portal_settings.get(field):
-            portal_settings.set(field, value)
-
-    portal_settings.save()
+    Safe to re-run: only fills values that are still empty.
+    """
+    set_portal_defaults()

--- a/helpdesk/setup/install.py
+++ b/helpdesk/setup/install.py
@@ -224,10 +224,27 @@ def setup_customer_role(fresh_install=True):
         role_doc.save()
 
     if fresh_install:
-        portal_settings = frappe.get_single("Portal Settings")
-        portal_settings.default_role = "HD Customer"
-        portal_settings.default_portal_home = "/helpdesk"
-        portal_settings.save()
+        set_portal_defaults(overwrite=True)
+
+
+def set_portal_defaults(overwrite=False):
+    """Point the portal at helpdesk. Installing claims the settings outright;
+    the upgrade patch only fills what a site left empty.
+
+    Writes straight into the Single rather than saving the document. A save
+    also validates the portal menu rows, and a row left behind by a deleted
+    doctype fails that validation and takes the whole migration down.
+    """
+    defaults = {"default_role": "HD Customer", "default_portal_home": "/helpdesk"}
+    if overwrite:
+        to_set = defaults
+    else:
+        current = frappe.db.get_singles_dict("Portal Settings")
+        to_set = {
+            field: value for field, value in defaults.items() if not current.get(field)
+        }
+    if to_set:
+        frappe.db.set_single_value("Portal Settings", to_set)
 
 
 def add_website_settings_permission():


### PR DESCRIPTION
## Problem

`helpdesk.patches.set_default_portal_settings` calls `portal_settings.save()` unconditionally. That save runs `_validate_links()` over the entire Single — including the `menu` / `custom_menu` child rows the patch never touches.

`Portal Menu Item.reference_doctype` is a Link to DocType. A site that created a custom doctype and later deleted it is left with a menu row pointing at nothing, so the save fails and takes the whole migration with it:

```
File "apps/helpdesk/helpdesk/patches/set_default_portal_settings.py", line 15, in execute
    portal_settings.save()
...
File "apps/frappe/frappe/model/document.py", line 1221, in _validate_links
    frappe.throw(_("Could not find {0}").format(msg), frappe.LinkValidationError)

frappe.exceptions.LinkValidationError: Could not find Row #1: Reference Document Type: Library Transaction
```

Any helpdesk site that has ever deleted a doctype with a portal menu entry cannot migrate, and it re-fails on every deploy.

Hit by two separate Frappe Cloud sites upgrading Frappe Framework to 15.107.1, with the same traceback and different leftover doctypes.

## Root cause

Writing two scalar values should not require validating the rest of the document. Frappe itself tolerates these rows — `PortalSettings.remove_deleted_doctype_items()` strips them — but that only runs from `sync_menu()`, never from `validate()`. So a plain `.save()` is the one path through Portal Settings that hard-fails on a dead menu row, and this patch was taking it.

`helpdesk/setup/install.py` had the same unguarded `.save()`, so `bench install-app helpdesk` onto such a site would have failed identically.

## Fix

One shared `set_portal_defaults()` in `helpdesk/setup/install.py`, used by both install and the patch, writing through `frappe.db.set_single_value`. No document load, no link validation, no child tables.

The patch is now a three-line delegation with a docstring (it prints to the migrate console).

## No annotation bump

`execute_patch` calls `update_patch_log` only on the success branch; the `except` rolls back and re-raises, and `--skip-failing` records `skipped=1`, which does not count as executed. Affected sites therefore never logged this patch and pick the fix up on their next migrate. Bumping the annotation would only re-run it on sites that were already fine.

## Behaviour

Unchanged. Install still claims `default_role` / `default_portal_home` outright (`overwrite=True`); the patch still fills only values a site left empty. Only the write mechanism differs.

## Verification

Reproduced locally by inserting a `Portal Menu Item` row on `Portal Settings` whose `reference_doctype` points at a deleted doctype, then running the patch:

- **old implementation** — fails with `LinkValidationError: Could not find Row #1: Reference Document Type: Library Transaction`, matching the reported traceback exactly
- **this change** — writes both values and returns; re-running it is a no-op
- **`Portal Settings.sync_menu()`** (which `migrate.py:198` runs immediately after patches, and is the next thing to touch this doc) also completes on the same row, so nothing later in the migration trips on it
- pre-existing values are left alone by the patch; install still overwrites them
