### PR TITLE
fix: skip folder sync when get_incoming_server returns no connection

### DIFF
--- a/helpdesk/overrides/email_account.py
+++ b/helpdesk/overrides/email_account.py
@@ -118,6 +118,11 @@ class CustomEmailAccount(EmailAccount):
                 email_server = self.get_incoming_server(
                     in_receive=True, email_sync_rule=email_sync_rule
                 )
+                if not email_server:
+                    # @dokos: the failure was already logged/handled in
+                    # get_incoming_server() - avoid select_imap_folder() on a dead
+                    # (NONAUTH) connection.
+                    return []
                 if self.use_imap:
                     # process all given imap folder
                     for folder in self.imap_folder:

--- a/helpdesk/overrides/test_email_account.py
+++ b/helpdesk/overrides/test_email_account.py
@@ -1,0 +1,31 @@
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from helpdesk.overrides.email_account import CustomEmailAccount
+
+
+class TestCustomEmailAccountInboundMails(FrappeTestCase):
+    def base_email_account(self):
+        """A CustomEmailAccount instance built from the shared "_Test Comm Account 1" fixture."""
+        account = CustomEmailAccount(
+            frappe.get_doc("Email Account", "_Test Comm Account 1").as_dict()
+        )
+        account.enable_incoming = 1
+        account.use_imap = 1
+        return account
+
+    def test_get_inbound_mails_skips_folder_loop_when_incoming_server_returns_none(self):
+        # @dokos: get_inbound_mails must not call select_imap_folder on a connection that
+        # failed to authenticate - that's what produced the confusing NONAUTH SELECT error.
+        email_account = self.base_email_account()
+
+        with (
+            patch.object(email_account, "get_incoming_server", return_value=None),
+            patch("frappe.email.receive.EmailServer.select_imap_folder") as mocked_select,
+        ):
+            mails = email_account.get_inbound_mails()
+
+        self.assertEqual(mails, [])
+        mocked_select.assert_not_called()


### PR DESCRIPTION
## Problem

Background IMAP fetching for a helpdesk email account can log a confusing secondary error when the underlying IMAP OAuth login fails:

```
imaplib.IMAP4.error: command SELECT illegal in state NONAUTH, only allowed in states AUTH, SELECTED
```

## Root cause

`CustomEmailAccount.get_inbound_mails()` calls `get_incoming_server(...)` and then immediately calls `email_server.select_imap_folder(...)` without checking whether the connection actually authenticated. A companion frappe-side fix (dodock!10798 / dodock!10799) changes `get_incoming_server()` to return `None` when the connection/authentication failed instead of handing back a half-connected `EmailServer`. Without this change, the helpdesk override would instead crash on `None.select_imap_folder(...)`.

## Fix

`get_inbound_mails()` now returns `[]` early when `get_incoming_server()` returns `None`, matching the base `EmailAccount.get_inbound_mails()` behavior. Added a test verifying `select_imap_folder()` is never called in that case.

Depends on the frappe-side fix (dodock!10798 for `develop`, dodock!10799 for `v5-fix`) landing first.