### PR TITLE
feat(sidebar): add Helpdesk menu option to customer portal

### DIFF
--- a/desk/src/components/layouts/MobileSidebar.vue
+++ b/desk/src/components/layouts/MobileSidebar.vue
@@ -45,6 +45,7 @@ import { useTheme } from "frappe-ui";
 import LucideMoon from "~icons/lucide/moon";
 import LucideSun from "~icons/lucide/sun";
 
+import HDLogo from "@/assets/logos/HDLogo.vue";
 import { mobileSidebarOpened as sidebarOpened } from "@/composables/mobile";
 import { useApps } from "@/composables/useApps";
 import { __ } from "@/translation";
@@ -93,8 +94,15 @@ const themeMenuItem = computed(() => ({
   onClick: () => toggleTheme(),
 }));
 
+const helpdeskMenuItem = computed(() => ({
+  label: __("Helpdesk"),
+  icon: HDLogo,
+  onClick: () => router.push({ name: "Home" }),
+}));
+
 const customerPortalDropdown = computed(() => [
   themeMenuItem.value,
+  helpdeskMenuItem.value,
   {
     label: __("Log out"),
     icon: "lucide-log-out",

--- a/desk/src/components/layouts/Sidebar.vue
+++ b/desk/src/components/layouts/Sidebar.vue
@@ -127,10 +127,17 @@ const themeMenuItem = computed(() => ({
   onClick: () => toggleTheme(),
 }));
 
+const helpdeskMenuItem = computed(() => ({
+  label: __("Helpdesk"),
+  icon: HDLogo,
+  onClick: () => router.push({ name: "Home" }),
+}));
+
 const isFCSite = ref(window.is_fc_site);
 
 const customerPortalDropdown = computed(() => [
   themeMenuItem.value,
+  helpdeskMenuItem.value,
   {
     group: __("Danger"),
     hideLabel: true,


### PR DESCRIPTION
Fixes: #3756 
Added a dropdown option in Customer Portal dropdown menu that navigates to /helpdesk/home

https://github.com/user-attachments/assets/7a71dad4-1cda-4a86-b043-6177d5dbc2e3


