### PR TITLE
fix: enforce agent assignment within the ticket's team

### DIFF
--- a/desk/src/components/ticket-agent/AssignTo.vue
+++ b/desk/src/components/ticket-agent/AssignTo.vue
@@ -169,6 +169,7 @@
 import ShortcutKey from "@/components/ShortcutKey.vue";
 import { useShortcut } from "@/composables/shortcuts";
 import { useAgentStatusStore } from "@/stores/agentStatus.ts";
+import { useConfigStore } from "@/stores/config";
 import { useUserStore } from "@/stores/user";
 import { capture } from "@/telemetry";
 import { __ } from "@/translation";
@@ -225,6 +226,20 @@ const { getUser } = useUserStore();
 const currentUser = computed(() => getUser("")); // empty string returns current user
 const agentStatusStore = useAgentStatusStore();
 const currentAgentName = window.agent;
+const configStore = useConfigStore();
+
+// Empty unless both team settings are on and the ticket has a team, mirroring
+// the server guard in helpdesk/extends/todo.py.
+const restrictedTeam = computed(() =>
+  configStore.teamRestrictionApplied && configStore.assignWithinTeam
+    ? ticket?.value?.doc?.agent_group || ""
+    : ""
+);
+
+const teamMembersResource = createResource({
+  url: "helpdesk.helpdesk.doctype.hd_team.hd_team.get_team_members",
+  makeParams: () => ({ team: restrictedTeam.value }),
+});
 
 const searchText = ref("");
 const highlightedIndex = ref(0);
@@ -278,6 +293,7 @@ watch(popoverIsOpen, (isOpen) => {
     nextTick(() => {
       inputRef.value?.el?.focus();
     });
+    loadAgents();
   } else if (hasBeenOpened.value) {
     // Closing after a real open: compute diff and save
     hasBeenOpened.value = false;
@@ -302,20 +318,28 @@ const agentResource = createListResource({
   ],
   filters: { is_active: true },
   pageLength: 20,
-  auto: true,
 });
 
-const debouncedSearch = useDebounceFn((text: string) => {
+async function loadAgents(text = "") {
   const filters: Record<string, any> = { is_active: true };
   if (text) {
     filters.agent_name = ["like", `%${text}%`];
   }
+  if (restrictedTeam.value) {
+    const members: string[] = (await teamMembersResource.fetch()) || [];
+    // [""] rather than [] so an empty team yields no rows instead of `IN ()`.
+    filters.name = ["in", members.length ? members : [""]];
+  }
   agentResource.filters = filters;
-  agentResource.reload();
+  await agentResource.reload();
+}
+
+const debouncedSearch = useDebounceFn((text: string) => {
+  loadAgents(text);
 }, 300);
 
 watch(searchText, (text) => {
-  debouncedSearch(text);
+  if (popoverIsOpen.value) debouncedSearch(text);
 });
 
 // Prefer the live status pushed over the socket (agentStatusStore.liveStatuses)
@@ -337,9 +361,13 @@ const agentOptions = computed<AgentOption[]>(() => {
   const agents: AgentOption[] = [];
   const seen = new Set<string>();
 
+  const currentAgentAllowed =
+    !restrictedTeam.value ||
+    !!teamMembersResource.data?.includes(currentAgentName);
+
   // Include current agent only when not searching. Built from the session user
   // and the store's live status (seeded from auth.get_user) — no extra fetch.
-  if (!searchText.value && currentAgentName) {
+  if (!searchText.value && currentAgentName && currentAgentAllowed) {
     agents.push({
       value: currentAgentName,
       label: currentUser.value.full_name || currentAgentName,

--- a/helpdesk/extends/test_team_assignment.py
+++ b/helpdesk/extends/test_team_assignment.py
@@ -1,8 +1,16 @@
 import frappe
-from frappe.desk.form.assign_to import add as assign
 from frappe.tests import IntegrationTestCase
 
-from helpdesk.test_utils import make_agent, make_team, make_ticket
+from helpdesk.test_utils import (
+    assign_ticket,
+    clear_ticket_assignments,
+    disable_team_assignment_restriction,
+    enable_team_assignment_restriction,
+    get_ticket_assignees,
+    make_agent,
+    make_team,
+    make_ticket,
+)
 
 TEAM_A = "Assignment Team A"
 TEAM_B = "Assignment Team B"
@@ -16,57 +24,88 @@ class TestTeamAssignmentRestriction(IntegrationTestCase):
     def setUp(self):
         self.agent_a = make_agent("assign_a@test.com")
         self.agent_b = make_agent("assign_b@test.com")
-        make_team(TEAM_A, members=[self.agent_a])
+        self.team_a = make_team(TEAM_A, members=[self.agent_a])
         make_team(TEAM_B, members=[self.agent_b])
-        self.set_settings(restrict_tickets_by_agent_group=1, assign_within_team=1)
+        enable_team_assignment_restriction()
+        self.addCleanup(disable_team_assignment_restriction)
         frappe.set_user(self.agent_a)
 
     def test_agent_outside_team_is_rejected(self):
         ticket = self.make_teamed_ticket()
-        self.assertRaises(frappe.ValidationError, self.assign_to, ticket, self.agent_b)
-        self.assertEqual(self.assignees(ticket), [])
+        self.assertRaises(frappe.ValidationError, assign_ticket, ticket, self.agent_b)
+        self.assertEqual(get_ticket_assignees(ticket), [])
 
     def test_agent_within_team_is_allowed(self):
         ticket = self.make_teamed_ticket()
-        self.assign_to(ticket, self.agent_a)
-        self.assertEqual(self.assignees(ticket), [self.agent_a])
+        assign_ticket(ticket, self.agent_a)
+        self.assertEqual(get_ticket_assignees(ticket), [self.agent_a])
 
     def test_bulk_assign_rejects_when_any_agent_is_outside_the_team(self):
         ticket = self.make_teamed_ticket()
         self.assertRaises(
-            frappe.ValidationError, self.assign_to, ticket, self.agent_a, self.agent_b
+            frappe.ValidationError, assign_ticket, ticket, self.agent_a, self.agent_b
         )
 
+    def test_caller_supplied_assignment_rule_does_not_bypass(self):
+        """`assign_to.add` copies the caller's `assignment_rule` onto the ToDo,
+        so the exemption must key off a server-set flag, not that field."""
+        rule = self.team_a.assignment_rule
+
+        # the field really does reach the ToDo from the caller
+        enable_team_assignment_restriction(within_team=0)
+        unguarded = self.make_teamed_ticket()
+        assign_ticket(unguarded, self.agent_b, assignment_rule=rule)
+        self.assertEqual(
+            frappe.db.get_value(
+                "ToDo",
+                {"reference_name": unguarded, "allocated_to": self.agent_b},
+                "assignment_rule",
+            ),
+            rule,
+        )
+
+        # and carrying it must not buy an exemption
+        enable_team_assignment_restriction()
+        ticket = self.make_teamed_ticket()
+        self.assertRaises(
+            frappe.ValidationError,
+            assign_ticket,
+            ticket,
+            self.agent_b,
+            assignment_rule=rule,
+        )
+        self.assertEqual(get_ticket_assignees(ticket), [])
+
     def test_ticket_without_a_team_is_unrestricted(self):
-        ticket = make_ticket(raised_by=CUSTOMER_EMAIL)
-        self.assign_to(ticket, self.agent_b)
-        self.assertEqual(self.assignees(ticket), [self.agent_b])
+        ticket = make_ticket(raised_by=CUSTOMER_EMAIL).name
+        assign_ticket(ticket, self.agent_b)
+        self.assertEqual(get_ticket_assignees(ticket), [self.agent_b])
 
     def test_setting_off_is_unrestricted(self):
-        self.set_settings(assign_within_team=0)
+        enable_team_assignment_restriction(within_team=0)
         ticket = self.make_teamed_ticket()
-        self.assign_to(ticket, self.agent_b)
-        self.assertEqual(self.assignees(ticket), [self.agent_b])
+        assign_ticket(ticket, self.agent_b)
+        self.assertEqual(get_ticket_assignees(ticket), [self.agent_b])
 
     def test_parent_setting_off_is_unrestricted(self):
         """The child setting keeps its stored value when team restrictions are
         switched off, so the parent alone must be enough to disable it."""
-        self.set_settings(restrict_tickets_by_agent_group=0)
+        enable_team_assignment_restriction(restrict_by_team=0)
         ticket = self.make_teamed_ticket()
-        self.assign_to(ticket, self.agent_b)
-        self.assertEqual(self.assignees(ticket), [self.agent_b])
+        assign_ticket(ticket, self.agent_b)
+        self.assertEqual(get_ticket_assignees(ticket), [self.agent_b])
 
     def test_administrator_bypasses_the_restriction(self):
         ticket = self.make_teamed_ticket()
         frappe.set_user("Administrator")
-        self.assign_to(ticket, self.agent_b)
-        self.assertEqual(self.assignees(ticket), [self.agent_b])
+        assign_ticket(ticket, self.agent_b)
+        self.assertEqual(get_ticket_assignees(ticket), [self.agent_b])
 
     def test_assignment_rule_is_exempt(self):
         """A team's own rule auto-assigns on insert; the guard must not break
         ticket creation."""
-        ticket = make_ticket(agent_group=TEAM_A, raised_by=CUSTOMER_EMAIL)
-        self.assertEqual(self.assignees(ticket), [self.agent_a])
+        ticket = make_ticket(agent_group=TEAM_A, raised_by=CUSTOMER_EMAIL).name
+        self.assertEqual(get_ticket_assignees(ticket), [self.agent_a])
 
     def test_other_doctypes_are_untouched(self):
         todo = frappe.get_doc(
@@ -80,32 +119,10 @@ class TestTeamAssignmentRestriction(IntegrationTestCase):
         ).insert(ignore_permissions=True)
         self.assertEqual(todo.allocated_to, self.agent_b)
 
-    def make_teamed_ticket(self):
-        ticket = make_ticket(agent_group=TEAM_A, raised_by=CUSTOMER_EMAIL)
-        # The team's own assignment rule auto-assigns on insert; start clean.
-        frappe.db.delete(
-            "ToDo", {"reference_type": "HD Ticket", "reference_name": ticket.name}
-        )
+    def make_teamed_ticket(self) -> str:
+        ticket = make_ticket(agent_group=TEAM_A, raised_by=CUSTOMER_EMAIL).name
+        clear_ticket_assignments(ticket)
         return ticket
-
-    def assign_to(self, ticket, *users: str):
-        assign({"doctype": "HD Ticket", "name": ticket.name, "assign_to": list(users)})
-
-    def assignees(self, ticket) -> list[str]:
-        return frappe.get_all(
-            "ToDo",
-            filters={
-                "reference_type": "HD Ticket",
-                "reference_name": ticket.name,
-                "status": "Open",
-            },
-            pluck="allocated_to",
-        )
-
-    def set_settings(self, **values):
-        for field, value in values.items():
-            frappe.db.set_single_value("HD Settings", field, value)
-            self.addCleanup(frappe.db.set_single_value, "HD Settings", field, 0)
 
     def tearDown(self):
         frappe.set_user("Administrator")

--- a/helpdesk/extends/test_team_assignment.py
+++ b/helpdesk/extends/test_team_assignment.py
@@ -1,0 +1,111 @@
+import frappe
+from frappe.desk.form.assign_to import add as assign
+from frappe.tests import IntegrationTestCase
+
+from helpdesk.test_utils import make_agent, make_team, make_ticket
+
+TEAM_A = "Assignment Team A"
+TEAM_B = "Assignment Team B"
+CUSTOMER_EMAIL = "assign_customer@test.com"
+
+
+class TestTeamAssignmentRestriction(IntegrationTestCase):
+    """Covers `assign_within_team`, which blocks assigning a ticket to an agent
+    outside the ticket's team."""
+
+    def setUp(self):
+        self.agent_a = make_agent("assign_a@test.com")
+        self.agent_b = make_agent("assign_b@test.com")
+        make_team(TEAM_A, members=[self.agent_a])
+        make_team(TEAM_B, members=[self.agent_b])
+        self.set_settings(restrict_tickets_by_agent_group=1, assign_within_team=1)
+        frappe.set_user(self.agent_a)
+
+    def test_agent_outside_team_is_rejected(self):
+        ticket = self.make_teamed_ticket()
+        self.assertRaises(frappe.ValidationError, self.assign_to, ticket, self.agent_b)
+        self.assertEqual(self.assignees(ticket), [])
+
+    def test_agent_within_team_is_allowed(self):
+        ticket = self.make_teamed_ticket()
+        self.assign_to(ticket, self.agent_a)
+        self.assertEqual(self.assignees(ticket), [self.agent_a])
+
+    def test_bulk_assign_rejects_when_any_agent_is_outside_the_team(self):
+        ticket = self.make_teamed_ticket()
+        self.assertRaises(
+            frappe.ValidationError, self.assign_to, ticket, self.agent_a, self.agent_b
+        )
+
+    def test_ticket_without_a_team_is_unrestricted(self):
+        ticket = make_ticket(raised_by=CUSTOMER_EMAIL)
+        self.assign_to(ticket, self.agent_b)
+        self.assertEqual(self.assignees(ticket), [self.agent_b])
+
+    def test_setting_off_is_unrestricted(self):
+        self.set_settings(assign_within_team=0)
+        ticket = self.make_teamed_ticket()
+        self.assign_to(ticket, self.agent_b)
+        self.assertEqual(self.assignees(ticket), [self.agent_b])
+
+    def test_parent_setting_off_is_unrestricted(self):
+        """The child setting keeps its stored value when team restrictions are
+        switched off, so the parent alone must be enough to disable it."""
+        self.set_settings(restrict_tickets_by_agent_group=0)
+        ticket = self.make_teamed_ticket()
+        self.assign_to(ticket, self.agent_b)
+        self.assertEqual(self.assignees(ticket), [self.agent_b])
+
+    def test_administrator_bypasses_the_restriction(self):
+        ticket = self.make_teamed_ticket()
+        frappe.set_user("Administrator")
+        self.assign_to(ticket, self.agent_b)
+        self.assertEqual(self.assignees(ticket), [self.agent_b])
+
+    def test_assignment_rule_is_exempt(self):
+        """A team's own rule auto-assigns on insert; the guard must not break
+        ticket creation."""
+        ticket = make_ticket(agent_group=TEAM_A, raised_by=CUSTOMER_EMAIL)
+        self.assertEqual(self.assignees(ticket), [self.agent_a])
+
+    def test_other_doctypes_are_untouched(self):
+        todo = frappe.get_doc(
+            {
+                "doctype": "ToDo",
+                "allocated_to": self.agent_b,
+                "reference_type": "HD Team",
+                "reference_name": TEAM_A,
+                "description": "unrelated",
+            }
+        ).insert(ignore_permissions=True)
+        self.assertEqual(todo.allocated_to, self.agent_b)
+
+    def make_teamed_ticket(self):
+        ticket = make_ticket(agent_group=TEAM_A, raised_by=CUSTOMER_EMAIL)
+        # The team's own assignment rule auto-assigns on insert; start clean.
+        frappe.db.delete(
+            "ToDo", {"reference_type": "HD Ticket", "reference_name": ticket.name}
+        )
+        return ticket
+
+    def assign_to(self, ticket, *users: str):
+        assign({"doctype": "HD Ticket", "name": ticket.name, "assign_to": list(users)})
+
+    def assignees(self, ticket) -> list[str]:
+        return frappe.get_all(
+            "ToDo",
+            filters={
+                "reference_type": "HD Ticket",
+                "reference_name": ticket.name,
+                "status": "Open",
+            },
+            pluck="allocated_to",
+        )
+
+    def set_settings(self, **values):
+        for field, value in values.items():
+            frappe.db.set_single_value("HD Settings", field, value)
+            self.addCleanup(frappe.db.set_single_value, "HD Settings", field, 0)
+
+    def tearDown(self):
+        frappe.set_user("Administrator")

--- a/helpdesk/extends/todo.py
+++ b/helpdesk/extends/todo.py
@@ -13,9 +13,11 @@ def validate_team_assignment(doc, event=None):
     """
     if doc.reference_type != "HD Ticket" or not doc.allocated_to:
         return
-    # Assignment rules pick from an admin-configured user list and run inside
-    # the ticket's own save, so throwing here would break saving the ticket.
-    if doc.assignment_rule or is_admin():
+    # Rule-driven assignments pick from an admin-configured user list and run
+    # inside the ticket's own save, so throwing here would break saving the
+    # ticket. The flag is set server-side; `doc.assignment_rule` comes from the
+    # caller and would let anyone opt out of the check.
+    if frappe.flags.in_assignment_rule or is_admin():
         return
     if not is_assignment_restricted_to_team():
         return

--- a/helpdesk/extends/todo.py
+++ b/helpdesk/extends/todo.py
@@ -1,0 +1,43 @@
+import frappe
+from frappe import _
+
+from helpdesk.helpdesk.doctype.hd_team.hd_team import get_team_members
+from helpdesk.utils import is_admin
+
+
+def validate_team_assignment(doc, event=None):
+    """Block assigning an HD Ticket to an agent outside the ticket's team.
+
+    Every assignment path (picker, command palette, bulk assign, raw API) ends
+    up inserting a ToDo, so guarding here covers all of them at once.
+    """
+    if doc.reference_type != "HD Ticket" or not doc.allocated_to:
+        return
+    # Assignment rules pick from an admin-configured user list and run inside
+    # the ticket's own save, so throwing here would break saving the ticket.
+    if doc.assignment_rule or is_admin():
+        return
+    if not is_assignment_restricted_to_team():
+        return
+
+    team = frappe.db.get_value("HD Ticket", doc.reference_name, "agent_group")
+    if not team or doc.allocated_to in get_team_members(team):
+        return
+
+    frappe.throw(
+        _("{0} is not a member of the team {1}.").format(
+            frappe.bold(doc.allocated_to), frappe.bold(team)
+        ),
+        title=_("Not Allowed"),
+    )
+
+
+def is_assignment_restricted_to_team() -> bool:
+    """`assign_within_team` only applies while team restrictions are on, and it
+    keeps its stored value when the parent setting is switched off."""
+    restrict_by_team, assign_within_team = frappe.db.get_value(
+        "HD Settings",
+        "HD Settings",
+        ["restrict_tickets_by_agent_group", "assign_within_team"],
+    )
+    return bool(restrict_by_team and assign_within_team)

--- a/helpdesk/hooks.py
+++ b/helpdesk/hooks.py
@@ -79,6 +79,9 @@ doc_events = {
         "on_trash": "helpdesk.extends.assignment_rule.on_assignment_rule_trash",
         "validate": "helpdesk.extends.assignment_rule.on_assignment_rule_validate",
     },
+    "ToDo": {
+        "validate": "helpdesk.extends.todo.validate_team_assignment",
+    },
     "Customer": {
         "after_insert": "helpdesk.integrations.erpnext.customer.after_insert",
         "on_update": "helpdesk.integrations.erpnext.customer.on_update",

--- a/helpdesk/overrides/assignment_rule.py
+++ b/helpdesk/overrides/assignment_rule.py
@@ -21,6 +21,16 @@ def get_agents_by_category(category: str) -> set[str]:
 
 
 class HelpdeskAssignmentRule(AssignmentRule):
+    def do_assignment(self, doc):
+        """Mark assignments as rule-driven so the team-assignment guard can tell
+        them apart from a user's own request, which carries a caller-supplied
+        `assignment_rule` and cannot be trusted."""
+        frappe.flags.in_assignment_rule = True
+        try:
+            return super().do_assignment(doc)
+        finally:
+            frappe.flags.in_assignment_rule = False
+
     def get_user(self, doc):
         """
         Override get_user method from framework.

--- a/helpdesk/test_utils.py
+++ b/helpdesk/test_utils.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 import frappe
 from frappe.core.doctype.communication.test_communication import create_email_account
+from frappe.desk.form.assign_to import add as assign
 from frappe.utils import add_to_date, getdate
 
 from helpdesk.api.settings.field_dependency import create_update_field_dependency
@@ -612,3 +613,49 @@ def upload_test_file(file_name: str) -> str:
         }
     ).insert(ignore_permissions=True)
     return file_doc.name
+
+
+def enable_team_assignment_restriction(restrict_by_team: int = 1, within_team: int = 1):
+    """Toggle the two HD Settings that gate assigning a ticket to its own team."""
+    frappe.db.set_single_value(
+        "HD Settings",
+        {
+            "restrict_tickets_by_agent_group": restrict_by_team,
+            "assign_within_team": within_team,
+        },
+    )
+
+
+def disable_team_assignment_restriction():
+    enable_team_assignment_restriction(restrict_by_team=0, within_team=0)
+
+
+def assign_ticket(ticket: str, *users: str, assignment_rule: str | None = None):
+    """Assign a ticket through the whitelisted API, as the session user."""
+    assign(
+        {
+            "doctype": "HD Ticket",
+            "name": ticket,
+            "assign_to": list(users),
+            "assignment_rule": assignment_rule,
+        }
+    )
+
+
+def get_ticket_assignees(ticket: str) -> list[str]:
+    """Users with an open assignment ToDo on the ticket."""
+    return frappe.get_all(
+        "ToDo",
+        filters={
+            "reference_type": "HD Ticket",
+            "reference_name": ticket,
+            "status": "Open",
+        },
+        pluck="allocated_to",
+    )
+
+
+def clear_ticket_assignments(ticket: str):
+    """Drop assignment ToDos, e.g. the ones a team's assignment rule creates on
+    insert, so a test starts from an unassigned ticket."""
+    frappe.db.delete("ToDo", {"reference_type": "HD Ticket", "reference_name": ticket})


### PR DESCRIPTION
### Issue

"Restrict agent assignment to selected Team" did nothing. The dropdown filter lived in `AssignmentModal.vue` and went away with `44dce9e36`, and nothing on the server ever checked — so `assign_to.add` took any agent from any path.

### Solution

Guarded on `ToDo.validate`: picker, command palette, bulk assign and raw API all end in a ToDo insert, so one check covers them. A permission hook can't, `assign_to._add` inserts with `ignore_permissions=True`. Administrator and assignment-rule ToDos are exempt; a team's rule only draws from its own members, so that's not a hole.

`AssignTo.vue` filters the dropdown again, gated on **both** settings — `assign_within_team` keeps its stored `1` when the parent is switched off.

9 tests in `helpdesk/extends/test_team_assignment.py`. Bulk assign from the list view still lists all agents (no ticket in context, can span teams) — the server rejects, the picker doesn't filter.

Supersedes #3754, which restores the dropdown filter only.

### Linked issue

_None; reported via support ticket [#77168](https://support.frappe.io/helpdesk/tickets/77168)._
