### PR TITLE
fix: assignment notification backlog, deprecate replaced doctypes

### DIFF
--- a/desk/src/components/command-palette/tagCommands.ts
+++ b/desk/src/components/command-palette/tagCommands.ts
@@ -1,5 +1,5 @@
 import { useTags, type Tag } from "@/composables/useTags";
-import { useTicket } from "@/composables/useTicket";
+import { reloadTicketFeed, useTicket } from "@/composables/useTicket";
 import { __ } from "@/translation";
 import { call, toast } from "frappe-ui";
 import type { Command } from "./paletteTypes";
@@ -44,10 +44,10 @@ async function toggleTag(ticketId: string, tag: Tag): Promise<void> {
       added: applied ? [] : [{ name: tag.name, color: tag.color || "Gray" }],
       removed: applied ? [tag.name] : [],
     });
-    const { ticket, activities } = useTicket(ticketId);
+    const { ticket } = useTicket(ticketId);
     // The response carries the new _user_tags: one round trip, no doc reload.
     if (ticket.doc) ticket.doc._user_tags = userTags;
-    activities.reload();
+    reloadTicketFeed(ticketId);
   } catch (error: any) {
     toast.error(error?.messages?.join(", ") || __("Failed to update tags"));
     throw error; // the palette flips the optimistic tick back

--- a/desk/src/components/command-palette/ticketCommands.ts
+++ b/desk/src/components/command-palette/ticketCommands.ts
@@ -1,5 +1,5 @@
 import { useNotifyTicketUpdate } from "@/composables/realtime";
-import { useTicket } from "@/composables/useTicket";
+import { reloadTicketFeed, useTicket } from "@/composables/useTicket";
 import {
   canNavigateTickets,
   getNextTicket,
@@ -17,7 +17,7 @@ import { getMeta } from "@/stores/meta";
 import { capture } from "@/telemetry";
 import { __ } from "@/translation";
 import { copyToClipboard } from "@/utils";
-import { call, createListResource, createResource, toast } from "frappe-ui";
+import { createListResource, createResource, toast } from "frappe-ui";
 import { priorityOptions, statusOptions } from "./optionCommands";
 import {
   CONTEXT_WEIGHT,
@@ -340,7 +340,7 @@ function fieldLabel(fieldname: string): string {
 function updateTicket(ticketId: string, changes: Record<string, string>): void {
   const [field, value] = Object.entries(changes)[0] ?? [];
   if (!field || value === undefined) return;
-  const { ticket, activities } = useTicket(ticketId);
+  const { ticket } = useTicket(ticketId);
   const current = ticket.doc as unknown as Record<string, unknown> | undefined;
   // The drill-down already ticks the current value, so picking it again just
   // closes quietly.
@@ -348,16 +348,16 @@ function updateTicket(ticketId: string, changes: Record<string, string>): void {
   // Same order as the details tab: tell co-viewers, then write.
   useNotifyTicketUpdate(ticketId).notifyTicketUpdate(fieldLabel(field), value);
   ticket.setValue.submit(changes, {
-    onSuccess: () => activities.reload(),
+    onSuccess: () => reloadTicketFeed(ticketId),
   });
 }
 
 const addAssignee = createResource({ url: "frappe.desk.form.assign_to.add" });
 
 /** Adds without dropping existing assignees; unassigning stays with the AssignTo
- * widget. Mirrors the popover's activity log so both surfaces leave one trail. */
+ * widget. */
 async function assignTicket(ticketId: string, agent: string): Promise<void> {
-  const { assignees, activities } = useTicket(ticketId);
+  const { assignees } = useTicket(ticketId);
   if (assignedNames(ticketId).includes(agent)) {
     toast.success(__("Already assigned to {0}", agent));
     return;
@@ -371,21 +371,10 @@ async function assignTicket(ticketId: string, agent: string): Promise<void> {
     capture("ticket_assigned", {
       data: { doctype: "HD Ticket", source: "command_palette" },
     });
-    await logAssignment(ticketId, agent);
     toast.success(__("Assignees updated successfully."));
     assignees.reload();
-    activities.reload();
+    reloadTicketFeed(ticketId);
   } catch {
     toast.error(__("Failed to update Assignees."));
   }
-}
-
-function logAssignment(ticketId: string, agent: string): Promise<unknown> {
-  return call("frappe.client.insert", {
-    doc: {
-      doctype: "HD Ticket Activity",
-      ticket: ticketId,
-      action: `assigned ${agent}`,
-    },
-  });
 }

--- a/desk/src/components/layouts/AppSidebar.vue
+++ b/desk/src/components/layouts/AppSidebar.vue
@@ -45,7 +45,7 @@
                   <component :is="item.icon" class="size-4" />
                   <span
                     v-if="item.key === 'notifications' && item.badge"
-                    class="absolute -right-0.5 -top-0.5 size-1.5 rounded-full bg-surface-blue-5"
+                    class="absolute -right-0.5 -top-0.5 size-1.5 rounded-full bg-surface-gray-9"
                   />
                 </span>
               </template>

--- a/desk/src/components/ticket-agent/AssignTo.vue
+++ b/desk/src/components/ticket-agent/AssignTo.vue
@@ -186,7 +186,6 @@ import {
   Popover,
   TextInput,
   Tooltip,
-  call,
   createListResource,
   createResource,
   dayjsLocal,
@@ -513,16 +512,6 @@ watch(searchText, () => {
   highlightedIndex.value = 0;
 });
 
-async function logActivity(action: string) {
-  await call("frappe.client.insert", {
-    doc: {
-      doctype: "HD Ticket Activity",
-      ticket: ticket?.value?.name,
-      action,
-    },
-  });
-}
-
 // triggered when the popover is closed
 const addAssigneesResource = createResource({
   url: "frappe.desk.form.assign_to.add",
@@ -587,11 +576,7 @@ async function saveAssignees(added: string[], removed: string[]) {
       if (addResult?.exc) throw new Error(addResult.exc);
     }
 
-    // Log activity only after API calls succeed
-    const logParts: string[] = [];
-    if (added.length) logParts.push(`assigned ${added.join(", ")}`);
-    if (removed.length) logParts.push(`unassigned ${removed.join(", ")}`);
-    await logActivity(logParts.join(" & "));
+    // core assign_to writes the timeline entry itself
 
     // Delay the success toast when warnings were shown so they land first.
     const successDelay = hasUnavailable ? 1000 : 0;

--- a/desk/src/types.ts
+++ b/desk/src/types.ts
@@ -288,17 +288,6 @@ export type File = {
   attached_to_name?: string;
 };
 
-export type Notification = {
-  creation: string;
-  name: string;
-  notification_type: string;
-  read: boolean;
-  reference_comment: string;
-  reference_ticket: string;
-  user_from: UserInfo;
-  user_to: UserInfo;
-};
-
 export type UserInfo = {
   email: string;
   image: string;

--- a/helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py
+++ b/helpdesk/helpdesk/doctype/hd_agent_status/hd_agent_status.py
@@ -42,8 +42,8 @@ class HDAgentStatus(Document):
         """Move agents off a disabled status, else they get stuck on a status
         the picker no longer shows.
 
-        TODO: send an in-app notification too, HD Notification only supports
-        ticket notifications right now. The toast covers it for now.
+        TODO: send an in-app notification too. Every helpdesk Notification Log
+        row references a ticket, and this one has none. The toast covers it.
         """
         if self.enabled or not self.has_value_changed("enabled"):
             return

--- a/helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
+++ b/helpdesk/helpdesk/doctype/hd_notification/hd_notification.json
@@ -2,6 +2,7 @@
  "actions": [],
  "allow_rename": 1,
  "creation": "2023-08-31 00:12:12.326536",
+ "deprecated": 1,
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",

--- a/helpdesk/helpdesk/doctype/hd_ticket/api.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/api.py
@@ -442,18 +442,6 @@ def split_ticket(subject: str, communication_id: str):
         update_modified=False,
     )
 
-    # update activities
-    frappe.db.set_value(
-        "HD Ticket Activity",
-        {
-            "ticket": ticket_id,
-            "creation": [">=", communicaton_creation_time],
-        },
-        "ticket",
-        new_ticket,
-        update_modified=False,
-    )
-
     # update attachments
     frappe.db.set_value(
         "File",

--- a/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket/hd_ticket.py
@@ -518,17 +518,6 @@ class HDTicket(Document):
 
         return None
 
-    def on_trash(self):
-        activities = frappe.db.get_all("HD Ticket Activity", {"ticket": self.name})
-        for activity in activities:
-            frappe.db.delete("HD Ticket Activity", activity)
-
-        comments = frappe.db.get_all(
-            "HD Ticket Comment", {"reference_ticket": self.name}
-        )
-        for comment in comments:
-            frappe.db.delete("HD Ticket Comment", comment)
-
     def skip_email_workflow(self):
         skip: str = frappe.get_value("HD Settings", None, "skip_email_workflow") or "0"
 

--- a/helpdesk/helpdesk/doctype/hd_ticket_activity/hd_ticket_activity.json
+++ b/helpdesk/helpdesk/doctype/hd_ticket_activity/hd_ticket_activity.json
@@ -2,6 +2,7 @@
  "actions": [],
  "autoname": "hash",
  "creation": "2022-03-20 22:12:24.118862",
+ "deprecated": 1,
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",

--- a/helpdesk/helpdesk/doctype/hd_ticket_activity/hd_ticket_activity.py
+++ b/helpdesk/helpdesk/doctype/hd_ticket_activity/hd_ticket_activity.py
@@ -1,15 +1,8 @@
 # Copyright (c) 2022, Frappe Technologies and contributors
 # For license information, please see license.txt
 
-import frappe
 from frappe.model.document import Document
 
 
 class HDTicketActivity(Document):
     pass
-
-
-def log_ticket_activity(ticket, action):
-    return frappe.get_doc(
-        {"doctype": "HD Ticket Activity", "ticket": ticket, "action": action}
-    ).insert(ignore_permissions=True)

--- a/helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
+++ b/helpdesk/helpdesk/doctype/hd_ticket_comment/hd_ticket_comment.json
@@ -2,6 +2,7 @@
  "actions": [],
  "autoname": "hash",
  "creation": "2022-08-25 23:50:58.598316",
+ "deprecated": 1,
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",

--- a/helpdesk/overrides/email_account.py
+++ b/helpdesk/overrides/email_account.py
@@ -152,12 +152,9 @@ class CustomEmailAccount(EmailAccount):
                 )
             )
 
-        comment = frappe.new_doc("HD Ticket Comment")
+        ticket = frappe.get_doc("HD Ticket", communication.reference_name)
         # a system note, not the pulling user's
-        comment.commented_by = "Administrator"
-        comment.reference_ticket = communication.reference_name
-        comment.content = content
-        comment.save(ignore_permissions=True)
+        ticket.add_comment("Comment", content, comment_email="Administrator")
 
     def get_inbound_mails(self) -> list[InboundMail]:
         """retrive and return inbound mails."""

--- a/helpdesk/overrides/test_email_account.py
+++ b/helpdesk/overrides/test_email_account.py
@@ -168,8 +168,12 @@ class TestParkedMailTicketComment(IntegrationTestCase):
 
     def ticket_comments(self):
         return frappe.get_all(
-            "HD Ticket Comment",
-            filters={"reference_ticket": self.ticket.name},
+            "Comment",
+            filters={
+                "reference_doctype": "HD Ticket",
+                "reference_name": self.ticket.name,
+                "comment_type": "Comment",
+            },
             pluck="content",
         )
 

--- a/helpdesk/patches.txt
+++ b/helpdesk/patches.txt
@@ -59,3 +59,4 @@ helpdesk.patches.migrate_ticket_activities_to_info_comments
 helpdesk.patches.repoint_comment_reactions_and_files
 helpdesk.patches.migrate_hd_notifications_to_notification_log
 helpdesk.patches.relabel_comment_search_index
+helpdesk.patches.mark_old_assignment_notifications_read

--- a/helpdesk/patches/mark_old_assignment_notifications_read.py
+++ b/helpdesk/patches/mark_old_assignment_notifications_read.py
@@ -1,0 +1,24 @@
+"""Clear the one-time backlog of unread assignment notifications.
+
+Helpdesk used to notify only when an agent assigned a ticket by hand.
+Assignments made by an Assignment Rule notified nobody. Core ``assign_to``
+now owns assignments and notifies on every one, so the first load after the
+upgrade shows an unread row for every ticket the rule had ever routed.
+
+Those are history, not news. This marks them read once. Assignments made
+after the patch runs still arrive unread.
+"""
+
+import frappe
+
+
+def execute():
+    # One statement: the filter is narrow and Notification Log is not a table
+    # anyone accumulates millions of rows in.
+    frappe.db.set_value(
+        "Notification Log",
+        {"app": "helpdesk", "type": "Assignment", "read": 0},
+        "read",
+        1,
+        update_modified=False,
+    )

--- a/helpdesk/patches/mark_old_assignment_notifications_read.py
+++ b/helpdesk/patches/mark_old_assignment_notifications_read.py
@@ -1,20 +1,14 @@
-"""Clear the one-time backlog of unread assignment notifications.
+"""Clear the backlog of assignment notifications the upgrade surfaced.
 
-Helpdesk used to notify only when an agent assigned a ticket by hand.
-Assignments made by an Assignment Rule notified nobody. Core ``assign_to``
-now owns assignments and notifies on every one, so the first load after the
-upgrade shows an unread row for every ticket the rule had ever routed.
-
-Those are history, not news. This marks them read once. Assignments made
-after the patch runs still arrive unread.
+Rule-driven assignments notified nobody before core ``assign_to`` took over,
+so every ticket one had ever routed turns up unread. Later ones still arrive
+unread.
 """
 
 import frappe
 
 
 def execute():
-    # One statement: the filter is narrow and Notification Log is not a table
-    # anyone accumulates millions of rows in.
     frappe.db.set_value(
         "Notification Log",
         {"app": "helpdesk", "type": "Assignment", "read": 0},

--- a/helpdesk/test_utils.py
+++ b/helpdesk/test_utils.py
@@ -621,3 +621,26 @@ def upload_test_file(file_name: str) -> str:
         }
     ).insert(ignore_permissions=True)
     return file_doc.name
+
+
+def make_notification_log(name: str, ticket: str, user: str, **values) -> None:
+    """Write a Notification Log row straight to the table under a fixed name.
+
+    Inserted rather than raised through the real producers so a test can state
+    the exact type, app and read flag it needs.
+    """
+    frappe.db.delete("Notification Log", {"name": name})
+    doc = frappe.new_doc("Notification Log")
+    doc.name = name
+    doc.update(
+        {
+            "for_user": user,
+            "from_user": user,
+            "document_type": "HD Ticket",
+            "document_name": ticket,
+            "subject": "seeded notification",
+            "read": 0,
+            **values,
+        }
+    )
+    doc.db_insert()

--- a/helpdesk/tests/test_core_comments.py
+++ b/helpdesk/tests/test_core_comments.py
@@ -15,6 +15,7 @@ from helpdesk.api.timeline import get_comment_extras
 from helpdesk.helpdesk.doctype.hd_ticket.api import get_one
 from helpdesk.overrides import realtime
 from helpdesk.patches import (
+    mark_old_assignment_notifications_read,
     migrate_hd_notifications_to_notification_log,
     migrate_hd_ticket_comment_to_comment,
     migrate_ticket_activities_to_info_comments,
@@ -497,6 +498,43 @@ class TestMigrationPatches(FrappeTestCase):
         cls.remove_leftovers()
         cls.ticket = make_ticket()
 
+    def test_assignment_backlog_is_cleared_without_touching_anything_else(self):
+        """Only helpdesk assignments. A mention, or another app's row, is
+        somebody else's unread."""
+        rows = {
+            "bklogassign": {"type": "Assignment", "app": "helpdesk"},
+            "bklogmention": {"type": "Mention", "app": "helpdesk"},
+            "bklogother": {"type": "Assignment", "app": "frappe"},
+        }
+        for name, values in rows.items():
+            self.seed_notification_log(name, **values)
+
+        mark_old_assignment_notifications_read.execute()
+
+        read_flags = {
+            name: frappe.db.get_value("Notification Log", name, "read") for name in rows
+        }
+        self.assertTrue(read_flags["bklogassign"])
+        self.assertFalse(read_flags["bklogmention"], "a mention is still news")
+        self.assertFalse(read_flags["bklogother"], "not helpdesk's to clear")
+
+    def seed_notification_log(self, name: str, **values) -> None:
+        frappe.db.delete("Notification Log", {"name": name})
+        doc = frappe.new_doc("Notification Log")
+        doc.name = name
+        doc.update(
+            {
+                "for_user": AGENT_ONE,
+                "from_user": AGENT_ONE,
+                "document_type": "HD Ticket",
+                "document_name": self.ticket.name,
+                "subject": "backlog row",
+                "read": 0,
+                **values,
+            }
+        )
+        doc.db_insert()
+
     @classmethod
     def remove_leftovers(cls):
         """The patches commit, so seeds from previous runs survive on the
@@ -514,6 +552,10 @@ class TestMigrationPatches(FrappeTestCase):
         frappe.db.delete("Comment", {"name": ["in", seeded_names]})
         frappe.db.delete("Comment", {"content": ["in", cls.SEEDED_CONTENTS]})
         frappe.db.delete("HD Comment Reaction", {"user": AGENT_ONE})
+        frappe.db.delete(
+            "Notification Log",
+            {"name": ["in", ["bklogassign", "bklogmention", "bklogother"]]},
+        )
 
     def seed_legacy_comment(self, name: str, content: str = "legacy words") -> None:
         if frappe.db.exists("HD Ticket Comment", name):

--- a/helpdesk/tests/test_core_comments.py
+++ b/helpdesk/tests/test_core_comments.py
@@ -25,6 +25,7 @@ from helpdesk.test_utils import (
     create_agent,
     create_contact,
     create_user,
+    make_notification_log,
     make_team,
     make_ticket,
 )
@@ -507,7 +508,7 @@ class TestMigrationPatches(FrappeTestCase):
             "bklogother": {"type": "Assignment", "app": "frappe"},
         }
         for name, values in rows.items():
-            self.seed_notification_log(name, **values)
+            make_notification_log(name, self.ticket.name, AGENT_ONE, **values)
 
         mark_old_assignment_notifications_read.execute()
 
@@ -517,23 +518,6 @@ class TestMigrationPatches(FrappeTestCase):
         self.assertTrue(read_flags["bklogassign"])
         self.assertFalse(read_flags["bklogmention"], "a mention is still news")
         self.assertFalse(read_flags["bklogother"], "not helpdesk's to clear")
-
-    def seed_notification_log(self, name: str, **values) -> None:
-        frappe.db.delete("Notification Log", {"name": name})
-        doc = frappe.new_doc("Notification Log")
-        doc.name = name
-        doc.update(
-            {
-                "for_user": AGENT_ONE,
-                "from_user": AGENT_ONE,
-                "document_type": "HD Ticket",
-                "document_name": self.ticket.name,
-                "subject": "backlog row",
-                "read": 0,
-                **values,
-            }
-        )
-        doc.db_insert()
 
     @classmethod
     def remove_leftovers(cls):


### PR DESCRIPTION
Follow-up to #3700.

1. **Patch** `mark_old_assignment_notifications_read`. Helpdesk only notified on manual assignment before core `assign_to` took over, so the first load after upgrading shows an unread row for every ticket the Assignment Rule had ever routed. Marks that backlog read once. New assignments still arrive unread.

2. **Deprecate** `HD Ticket Comment`, `HD Ticket Activity` and `HD Notification`, and stop writing to them:
   - Bounce and auto-reply notes went to `HD Ticket Comment`, which nothing displays, so agents never saw that their reply had bounced. Core `Comment` now.
   - Assignment was logged as an `HD Ticket Activity` row from two places in the SPA. Core `assign_to` already writes that timeline entry, so both were invisible duplicates.
   - Drops the dead `HD Notification` type from the SPA, the unused `log_ticket_activity`, and the `split_ticket` / `on_trash` blocks that only ever touched legacy rows.

3. **Sidebar notification dot** is black instead of blue.

Also fixes two SPA call sites that destructured `activities` off `useTicket`, which no longer provides it. They use `reloadTicketFeed` now.

Customization upgrade guide: [wiki](https://github.com/frappe/helpdesk/wiki/Migrating-customizations-from-HD-Ticket-Comment-to-Comment)

